### PR TITLE
Improve toolchain installation help messaging

### DIFF
--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -14,6 +14,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
 )
 
 const (
@@ -62,7 +63,7 @@ func (r Rust) Verify(out io.Writer) error {
 	if err != nil {
 		return errors.RemediationError{
 			Inner:       fmt.Errorf("`rustup` not found in $PATH"),
-			Remediation: "Please install rustup via e.g.\n\n\tcurl https://sh.rustup.rs -sSf | sh\n\tbrew install rustup-init ; rustup-init\n",
+			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("curl https://sh.rustup.rs -sSf | sh")),
 		}
 	}
 
@@ -94,7 +95,7 @@ func (r Rust) Verify(out io.Writer) error {
 	if !found {
 		return errors.RemediationError{
 			Inner:       fmt.Errorf("rust toolchain %s not found", RustToolchainVersion),
-			Remediation: fmt.Sprintf("Please install via\n\n\trustup toolchain install %s\n", RustToolchainVersion),
+			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s\n", text.Bold("rustup toolchain install "+RustToolchainVersion)),
 		}
 	}
 
@@ -125,7 +126,7 @@ func (r Rust) Verify(out io.Writer) error {
 	if !found {
 		return errors.RemediationError{
 			Inner:       fmt.Errorf("rust target %s not found", WasmWasiTarget),
-			Remediation: fmt.Sprintf("Please install via\n\n\trustup target add %s --toolchain %s\n", WasmWasiTarget, RustToolchainVersion),
+			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s\n", text.Bold(fmt.Sprintf("rustup target add %s --toolchain %s", WasmWasiTarget, RustToolchainVersion))),
 		}
 	}
 

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -44,7 +44,7 @@ func (re RemediationError) Print(w io.Writer) {
 		fmt.Fprintln(w) // additional "\n" to allow breathing room
 	}
 	if re.Remediation != "" {
-		text.Output(w, "%s\n", strings.TrimRight(re.Remediation, "\r\n"))
+		fmt.Fprintf(w, "%s\n", strings.TrimRight(re.Remediation, "\r\n"))
 	}
 }
 


### PR DESCRIPTION
### TL;DR
Improves the UX of the remediation error messages for Rust toolchain installation.

### Why?
We've noticed in various user testing sessions that the current text wasn't explicit enough and didn't differentiate the command output from the other help text.  It also seems a previous refactor to how remediation messages are printed (via `text.Output()`) was causing the whitespace in the (`\n\t` etc) to be stripped.

### Previous output:
<img width="709" alt="Screenshot 2020-02-20 at 16 58 33" src="https://user-images.githubusercontent.com/80089/74959362-4efb9600-5402-11ea-82bc-3676ee128f53.png">

### New output:
![Screenshot 2020-02-20 at 16 36 15](https://user-images.githubusercontent.com/80089/74959234-1e1b6100-5402-11ea-857b-615f2ff00627.png)
 