### PR TITLE
Interactive init

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -93,6 +93,7 @@ jobs:
       run: make test
       shell: bash
       env:
+        TEST_COMPUTE_INIT: true
         TEST_COMPUTE_BUILD: true
   scan:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/fastly/go-fastly v1.3.0
+	github.com/fastly/go-fastly v1.7.0
 	github.com/fatih/color v1.7.0
 	github.com/frankban/quicktest v1.5.0 // indirect
 	github.com/google/go-cmp v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,13 @@ require (
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/fastly/go-fastly v1.7.0
 	github.com/fatih/color v1.7.0
 	github.com/frankban/quicktest v1.5.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-github/v28 v28.1.1
-	github.com/google/jsonapi v0.0.0-20181016150055-d0428f63eb51 // indirect
+	github.com/google/jsonapi v0.0.0-20200226002910-c8283f632fb7 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fastly/go-fastly v1.3.0 h1:halI6tkEmn5JIeW888P2bNGprGP7OYot+o1akPXvPyY=
 github.com/fastly/go-fastly v1.3.0/go.mod h1:cBtWXhszIFx9xpzgm9L/3PW3Ixszo153xJBEHJghGUk=
+github.com/fastly/go-fastly v1.7.0 h1:IiDMXzoSSJZjQP5VIjv+BU4WMoo3DeMGIy2xm9BDuL8=
+github.com/fastly/go-fastly v1.7.0/go.mod h1:cBtWXhszIFx9xpzgm9L/3PW3Ixszo153xJBEHJghGUk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:90Ly+6UfUypEF6vvvW5rQIv9opIL8CbmW9FT20LDQoY=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fastly/go-fastly v1.3.0 h1:halI6tkEmn5JIeW888P2bNGprGP7OYot+o1akPXvPyY=
@@ -54,6 +56,8 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/jsonapi v0.0.0-20170708005851-46d3ced04344/go.mod h1:XSx4m2SziAqk9DXY9nz659easTq4q6TyrpYd9tHSm0g=
 github.com/google/jsonapi v0.0.0-20181016150055-d0428f63eb51 h1:k+U8IQj6kj659R+Ahq6YsK03GdUo8qQdTsq5HBzfQwM=
 github.com/google/jsonapi v0.0.0-20181016150055-d0428f63eb51/go.mod h1:XSx4m2SziAqk9DXY9nz659easTq4q6TyrpYd9tHSm0g=
+github.com/google/jsonapi v0.0.0-20200226002910-c8283f632fb7 h1:aQ4kMXDAmP9IRIZHcSKB2orXHGwGiSxH4PX1BzKHR50=
+github.com/google/jsonapi v0.0.0-20200226002910-c8283f632fb7/go.mod h1:XSx4m2SziAqk9DXY9nz659easTq4q6TyrpYd9tHSm0g=
 github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -57,6 +57,8 @@ type Interface interface {
 	GetBigQuery(*fastly.GetBigQueryInput) (*fastly.BigQuery, error)
 	UpdateBigQuery(*fastly.UpdateBigQueryInput) (*fastly.BigQuery, error)
 	DeleteBigQuery(*fastly.DeleteBigQueryInput) error
+
+	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 }
 
 // Interface assertion, to catch mismatches early.

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -245,15 +245,17 @@ COMMANDS
   compute init [<flags>]
     Initialize a new Compute@Edge package locally
 
-    -n, --name=NAME              Name of package, defaulting to directory name
-                                 of the --path destination
-    -f, --from="https://github.com/fastly/fastly-template-rust-default"
-                                 Git repository containing package template
-    -p, --path=PATH              Destination to write the new package,
-                                 defaulting to the current directory
-    -s, --service-id=SERVICE-ID  Optional Fastly service ID written to the
-                                 package manifest, where this package will be
-                                 deployed
+    -n, --name=NAME                Name of package, defaulting to directory name
+                                   of the --path destination
+    -d, --description=DESCRIPTION  Description of the package
+    -a, --author=AUTHOR            Author of the package
+    -f, --from=FROM                Git repository containing package template
+    -p, --path=PATH                Destination to write the new package,
+                                   defaulting to the current directory
+        --domain=DOMAIN            The name of the domain associated to the
+                                   package
+        --backend=BACKEND          A hostname, IPv4, or IPv6 address for the
+                                   package backend
 
   compute build [<flags>]
     Build a Compute@Edge package locally

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -55,7 +55,7 @@ func CopyFile(src, dst string) (err error) {
 	if err != nil {
 		return fmt.Errorf("error reading source file: %w", err)
 	}
-	defer in.Close()
+	defer in.Close() // #nosec G307
 
 	// Create destination file for writing.
 	out, err := os.Create(dst)

--- a/pkg/common/undo.go
+++ b/pkg/common/undo.go
@@ -1,0 +1,43 @@
+package common
+
+// UndoFn is a function with no arguments which returns an error or nil.
+type UndoFn func() error
+
+// UndoStack models a simple undo stack which consumers can use to store undo
+// stateful functions, such as a function to teardown API state if something
+// goes wrong during procedural commands, for example deleting a Fastly service
+// after it's been created.
+type UndoStack struct {
+	states []UndoFn
+}
+
+// NewUndoStack constructs a new UndoStack.
+func NewUndoStack() *UndoStack {
+	s := make([]UndoFn, 0, 1)
+	stack := &UndoStack{
+		states: s,
+	}
+	return stack
+}
+
+// Pop method pops last added UndoFn element oof the stack and returns it.
+// If stack is empty Pop() returns nil.
+func (s *UndoStack) Pop() UndoFn {
+	n := len(s.states)
+	if n == 0 {
+		return nil
+	}
+	v := s.states[n-1]
+	s.states = s.states[:n-1]
+	return v
+}
+
+// Push method pushes an Undoer element onto the UndoStack.
+func (s *UndoStack) Push(elem UndoFn) {
+	s.states = append(s.states, elem)
+}
+
+// Len method returns the number of elements in the UndoStack.
+func (s *UndoStack) Len() int {
+	return len(s.states)
+}

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -158,7 +158,7 @@ func (c *Client) UpdatePackage(serviceID string, v int, path string) error {
 	if err != nil {
 		return fmt.Errorf("error reading package: %w", err)
 	}
-	defer file.Close()
+	defer file.Close() // #nosec G307
 
 	var body bytes.Buffer
 	w := multipart.NewWriter(&body)

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -4,32 +4,59 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	mathRand "math/rand"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/dustinkirkland/golang-petname"
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
 	"gopkg.in/src-d/go-git.v4"
 )
 
-const defaultTemplate = "https://github.com/fastly/fastly-template-rust-default"
+type template struct {
+	Name string
+	Path string
+}
+
+const (
+	defaultTemplate       = "https://github.com/fastly/fastly-template-rust-default.git"
+	defaultTopLevelDomain = "edgecompute.app"
+	manageServiceBaseURL  = "https://manage.fastly.com/configure/services/"
+)
 
 var (
+	gitRepositoryRegEx        = regexp.MustCompile(`((git|ssh|http(s)?)|(git@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?`)
+	domainNameRegEx           = regexp.MustCompile(`(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]`)
 	fastlyOrgRegEx            = regexp.MustCompile(`^https:\/\/github\.com\/fastly`)
 	fastlyFileIgnoreListRegEx = regexp.MustCompile(`\.github|LICENSE|SECURITY\.md`)
+	defaultTemplates          = map[int]template{
+		1: {
+			Name: "Starter kit",
+			Path: defaultTemplate,
+		},
+	}
 )
 
 // InitCommand initializes a Compute@Edge project package on the local machine.
 type InitCommand struct {
 	common.Base
-	name      string
-	from      string
-	path      string
-	serviceID string
+	name        string
+	description string
+	author      string
+	from        string
+	path        string
+	domain      string
+	backend     string
 }
 
 // NewInitCommand returns a usable command registered under the parent.
@@ -38,24 +65,49 @@ func NewInitCommand(parent common.Registerer, globals *config.Data) *InitCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("init", "Initialize a new Compute@Edge package locally")
 	c.CmdClause.Flag("name", "Name of package, defaulting to directory name of the --path destination").Short('n').StringVar(&c.name)
-	c.CmdClause.Flag("from", "Git repository containing package template").Short('f').Default(defaultTemplate).StringVar(&c.from)
+	c.CmdClause.Flag("description", "Description of the package").Short('d').StringVar(&c.description)
+	c.CmdClause.Flag("author", "Author of the package").Short('a').StringVar(&c.author)
+	c.CmdClause.Flag("from", "Git repository containing package template").Short('f').StringVar(&c.from)
 	c.CmdClause.Flag("path", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.path)
-	c.CmdClause.Flag("service-id", "Optional Fastly service ID written to the package manifest, where this package will be deployed").Short('s').StringVar(&c.serviceID)
+	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.path)
+	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").StringVar(&c.path)
+
 	return &c
 }
 
 // Exec implements the command interface.
 func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
+	// Exit early if no token configured.
+	_, source := c.Globals.Token()
+	if source == config.SourceUndefined {
+		return errors.ErrNoToken
+	}
+
+	text.Output(out, "This utility will walk you through creating a Compute@Edge project. It only covers the most common items, and tries to guess sensible defaults.")
+	text.Break(out)
+	text.Output(out, "Press ^C at any time to quit.")
+	text.Break(out)
+
 	var progress text.Progress
 	if c.Globals.Verbose() {
 		progress = text.NewVerboseProgress(out)
 	} else {
-		progress = text.NewQuietProgress(out)
+		// Use a null progress writer whilst gathering input.
+		progress = text.NewNullProgress()
 	}
+
+	undoStack := common.NewUndoStack()
 
 	defer func() {
 		if err != nil {
 			progress.Fail() // progress.Done is handled inline
+			// Unwind the undo stack
+			for undoStack.Len() != 0 {
+				if err := undoStack.Pop()(); err != nil {
+					// TODO(phamann): What should we do with the error?!
+					break
+				}
+			}
 		}
 	}()
 
@@ -75,18 +127,142 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	c.path = abspath
 
 	if c.name == "" {
-		name := filepath.Base(c.path)
-		fmt.Fprintf(progress, "--name not specified, using %s\n", name)
-		c.name = name
+		c.name = filepath.Base(c.path)
+		fmt.Fprintf(progress, "--name not specified, using %s\n\n", c.name)
+
+		name, err := text.Input(out, fmt.Sprintf("Name: [%s] ", c.name), in)
+		if err != nil {
+			return fmt.Errorf("error reading input: %w", err)
+		}
+		if name != "" {
+			c.name = name
+		}
 	}
 
+	if c.description == "" {
+		c.description, err = text.Input(out, "Description: ", in)
+		if err != nil {
+			return fmt.Errorf("error reading input: %w", err)
+		}
+	}
+
+	if c.author == "" {
+		var defaultEmail string
+		if email := c.Globals.File.Email; email != "" {
+			defaultEmail = fmt.Sprintf(" [%s]", email)
+		}
+
+		c.author, err = text.Input(out, fmt.Sprintf("Author:%s ", defaultEmail), in)
+		if err != nil {
+			return fmt.Errorf("error reading input %w", err)
+		}
+		if c.author == "" {
+			c.author = defaultEmail
+		}
+	}
+
+	if c.from == "" {
+		text.Output(out, "%s", text.Bold("Template:"))
+		for i, template := range defaultTemplates {
+			text.Output(out, "[%d] %s", i, template.Name)
+		}
+		template, err := text.Input(out, "Choose option or type URL: [1] ", in, validateTemplateOptionOrURL)
+		if err != nil {
+			return fmt.Errorf("error reading input %w", err)
+		}
+		if template == "" {
+			template = "1"
+		}
+		if i, err := strconv.Atoi(template); err == nil {
+			template = defaultTemplates[i].Path
+		}
+		c.from = template
+	}
+
+	if c.domain == "" {
+		mathRand.Seed(time.Now().UnixNano())
+		defaultDomain := fmt.Sprintf("%s.%s", petname.Generate(3, "-"), defaultTopLevelDomain)
+		c.domain, err = text.Input(out, fmt.Sprintf("Domain: [%s] ", defaultDomain), in, validateDomain)
+		if err != nil {
+			return fmt.Errorf("error reading input %w", err)
+		}
+		if c.domain == "" {
+			c.domain = defaultDomain
+		}
+	}
+
+	if c.backend == "" {
+		c.backend, err = text.Input(out, "Backend (originless, hostname or IP address): [originless] ", in, validateBackend)
+		if err != nil {
+			return fmt.Errorf("error reading input %w", err)
+		}
+		if c.backend == "" || c.backend == "originless" {
+			c.backend = "127.0.0.1"
+		}
+	}
+
+	text.Break(out)
+
+	if !c.Globals.Verbose() {
+		progress = text.NewQuietProgress(out)
+	}
+
+	progress.Step("Creating service...")
+	service, err := c.Globals.Client.CreateService(&fastly.CreateServiceInput{
+		Name:    c.name,
+		Type:    "wasm",
+		Comment: c.description,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating service: %w", err)
+	}
+	undoStack.Push(func() error {
+		return c.Globals.Client.DeleteService(&fastly.DeleteServiceInput{
+			ID: service.ID,
+		})
+	})
+
+	progress.Step("Creating domain...")
+	_, err = c.Globals.Client.CreateDomain(&fastly.CreateDomainInput{
+		Service: service.ID,
+		Version: 1,
+		Name:    c.domain,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating domain: %w", err)
+	}
+	undoStack.Push(func() error {
+		return c.Globals.Client.DeleteDomain(&fastly.DeleteDomainInput{
+			Service: service.ID,
+			Version: 1,
+			Name:    c.domain,
+		})
+	})
+
+	progress.Step("Creating backend...")
+	_, err = c.Globals.Client.CreateBackend(&fastly.CreateBackendInput{
+		Service: service.ID,
+		Version: 1,
+		Name:    c.backend,
+		Address: c.backend,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating backend: %w", err)
+	}
+	undoStack.Push(func() error {
+		return c.Globals.Client.DeleteBackend(&fastly.DeleteBackendInput{
+			Service: service.ID,
+			Version: 1,
+			Name:    c.backend,
+		})
+	})
+
+	progress.Step("Fetching package template...")
 	tempdir, err := tempDir("package-init")
 	if err != nil {
 		return fmt.Errorf("error creating temporary path for package template: %w", err)
 	}
 	defer os.RemoveAll(tempdir)
-
-	progress.Step("Fetching package template...")
 
 	if _, err := git.PlainClone(tempdir, false, &git.CloneOptions{
 		URL:      c.from,
@@ -134,22 +310,39 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return fmt.Errorf("error reading package manifest: %w", err)
 	}
 
-	if c.name != "" {
-		fmt.Fprintf(progress, "Setting package name in manifest to %q...\n", c.name)
-		m.Name = c.name
+	fmt.Fprintf(progress, "Setting package name in manifest to %q...\n", c.name)
+	m.Name = c.name
+
+	if c.description != "" {
+		fmt.Fprintf(progress, "Setting description in manifest to %s...\n", c.description)
+		m.Description = c.description
 	}
 
-	if c.serviceID != "" {
-		fmt.Fprintf(progress, "Setting service ID in manifest to %q...\n", c.serviceID)
-		m.ServiceID = c.serviceID
+	if c.author != "" {
+		fmt.Fprintf(progress, "Setting author in manifest to %s...\n", c.author)
+		m.Authors = []string{c.author}
 	}
+
+	fmt.Fprintf(progress, "Setting service ID in manifest to %q...\n", service.ID)
+	m.ServiceID = service.ID
+
+	fmt.Fprintf(progress, "Setting version in manifest to 1...\n")
+	m.Version = 1
 
 	if err := m.Write(filepath.Join(c.path, ManifestFilename)); err != nil {
 		return fmt.Errorf("error saving package manifest: %w", err)
 	}
 
 	progress.Done()
-	text.Success(out, "Initialized package %s to %s", m.Name, abspath)
+
+	text.Break(out)
+
+	fmt.Fprintf(out, "Initialized package %s to:\n\t%s\n\n", text.Bold(m.Name), text.Bold(abspath))
+	fmt.Fprintf(out, "Manage this service at:\n\t%s\n\n", text.Bold(fmt.Sprintf("%s%s", manageServiceBaseURL, service.ID)))
+	fmt.Fprintf(out, "To compile the package, run:\n\t%s\n\n", text.Bold("fastly compute build"))
+	fmt.Fprintf(out, "To deploy the package, run:\n\t%s\n\n", text.Bold("fastly compute deploy"))
+
+	text.Success(out, "Initialized service %s", service.ID)
 	return nil
 }
 
@@ -171,10 +364,6 @@ func verifyDestination(path string, verbose io.Writer) (abspath string, err erro
 		if err := os.MkdirAll(abspath, 0700); err != nil {
 			return abspath, fmt.Errorf("error creating package destination: %w", err)
 		}
-	}
-
-	if _, err := os.Stat(filepath.Join(abspath, ".git")); err == nil {
-		return abspath, fmt.Errorf("package destination already contains git metadata")
 	}
 
 	if _, err := os.Stat(filepath.Join(abspath, ManifestFilename)); err == nil {
@@ -220,4 +409,48 @@ func tempDir(prefix string) (abspath string, err error) {
 	}
 
 	return abspath, nil
+}
+
+func validateTemplateOptionOrURL(input string) error {
+	msg := "must be a valid option or Git URL"
+	if input == "" {
+		return nil
+	}
+	if option, err := strconv.Atoi(input); err == nil {
+		if _, ok := defaultTemplates[option]; !ok {
+			return fmt.Errorf(msg)
+		}
+		return nil
+	}
+	if !gitRepositoryRegEx.MatchString(input) {
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+func validateBackend(input string) error {
+	var isHost bool
+	if _, err := net.LookupHost(input); err == nil {
+		isHost = true
+	}
+	var isAddr bool
+	if _, err := net.LookupAddr(input); err == nil {
+		isHost = true
+	}
+	isEmpty := input == ""
+	isOriginless := strings.ToLower(input) == "originless"
+	if !isEmpty && !isOriginless && !isHost && !isAddr {
+		return fmt.Errorf(`must be "originless" or a valid hostname, IPv4, or IPv6 address`)
+	}
+	return nil
+}
+
+func validateDomain(input string) error {
+	if input == "" {
+		return nil
+	}
+	if !domainNameRegEx.MatchString(input) {
+		return fmt.Errorf("must be valid domain name")
+	}
+	return nil
 }

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -61,7 +61,7 @@ func (d *Data) ServiceID() (string, Source) {
 // File represents all of the configuration parameters in the fastly.toml
 // manifest file schema.
 type File struct {
-	Version     string   `toml:"version"`
+	Version     int      `toml:"version"`
 	Name        string   `toml:"name"`
 	Description string   `toml:"description"`
 	Authors     []string `toml:"authors"`

--- a/pkg/compute/validate.go
+++ b/pkg/compute/validate.go
@@ -22,7 +22,7 @@ func validate(path string) error {
 	if err != nil {
 		return fmt.Errorf("error reading package: %w", err)
 	}
-	defer file.Close()
+	defer file.Close() // #nosec G307
 
 	tar := archiver.NewTarGz()
 	err = tar.Open(file, 0)

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -114,6 +114,7 @@ const DefaultEndpoint = "https://api.fastly.com"
 // config file. At some point, it may expand to include e.g. user profiles.
 type File struct {
 	Token            string `toml:"token"`
+	Email            string `toml:"email"`
 	Endpoint         string `toml:"endpoint"`
 	LastVersionCheck string `toml:"last_version_check"`
 }

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -48,6 +48,8 @@ type API struct {
 	GetBigQueryFn    func(*fastly.GetBigQueryInput) (*fastly.BigQuery, error)
 	UpdateBigQueryFn func(*fastly.UpdateBigQueryInput) (*fastly.BigQuery, error)
 	DeleteBigQueryFn func(*fastly.DeleteBigQueryInput) error
+
+	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 }
 
 // GetTokenSelf implements Interface.
@@ -218,4 +220,9 @@ func (m API) UpdateBigQuery(i *fastly.UpdateBigQueryInput) (*fastly.BigQuery, er
 // DeleteBigQuery implements Interface.
 func (m API) DeleteBigQuery(i *fastly.DeleteBigQueryInput) error {
 	return m.DeleteBigQueryFn(i)
+}
+
+// GetUser implements Interface.
+func (m API) GetUser(i *fastly.GetUserInput) (*fastly.User, error) {
+	return m.GetUserFn(i)
 }

--- a/pkg/text/progress.go
+++ b/pkg/text/progress.go
@@ -234,3 +234,33 @@ func (p *VerboseProgress) Done() {}
 
 // Fail implements the Progress interface. It's a no-op.
 func (p *VerboseProgress) Fail() {}
+
+//
+//
+//
+
+// NullProgress is an implementation of Progress which discards everything
+// written into it and produces no output.
+type NullProgress struct{}
+
+// NewNullProgress returns a NullProgress.
+func NewNullProgress() *NullProgress {
+	return &NullProgress{}
+}
+
+// Tick implements the Progress interface. It's a no-op.
+func (p *NullProgress) Tick(r rune) {}
+
+// Tick implements the Progress interface.
+func (p *NullProgress) Write(buf []byte) (int, error) {
+	return 0, nil
+}
+
+// Step implements the Progress interface.
+func (p *NullProgress) Step(msg string) {}
+
+// Done implements the Progress interface. It's a no-op.
+func (p *NullProgress) Done() {}
+
+// Fail implements the Progress interface. It's a no-op.
+func (p *NullProgress) Fail() {}

--- a/pkg/text/text.go
+++ b/pkg/text/text.go
@@ -150,3 +150,14 @@ func Success(w io.Writer, format string, args ...interface{}) {
 	format = strings.TrimRight(format, "\r\n") + "\n"
 	fmt.Fprintf(w, "\n"+BoldGreen("SUCCESS: ")+format, args...)
 }
+
+// Description formats the output of a description item. A description item
+// consists of a `term` and a `description`. Emphasis is placed on the
+// `description` using Bold(). For example:
+//
+//     To compile the package, run:
+//         fastly compute build
+//
+func Description(w io.Writer, term, description string) {
+	fmt.Fprintf(w, "%s:\n\t%s\n\n", term, Bold(description))
+}


### PR DESCRIPTION
### TL;DR
Refactors `compute init` to accept its input interactively and act as a setup wizard to provision a service, backend and domain.

### Why?
We have observed friction in user testing and feedback that a users has to create a service then attach a domain and backend before a compute package can be deployed and activated. If you are new to Fastly this may be confusing. Therefore, we think that provisioning all of this for you within a single command will reduce this on-boarding friction.

### What?
- Refactor command to take input interactively
- Refactor `fastly configure` to persist user email to global config file so that it can be read by `compute init` for default author email.
- Add a `NullProgress` writer which swallows all writes
- Add an `UndoStack` which we use to teardown any state we have created in the API if an error occurs.
- Add [`golang-petname`](https://github.com/dustinkirkland/golang-petname) dep to randomly generate nice domain names

### Example:
<img width="1152" alt="Screenshot 2020-03-09 at 12 23 28" src="https://user-images.githubusercontent.com/80089/76212810-357b8c00-6201-11ea-96c5-3c05dc1184da.png">
