### PR TITLE
Persist version to manifest file when deploying compute services

### DIFF
--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -126,6 +126,15 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return fmt.Errorf("error activating version: %w", err)
 	}
 
+	progress.Step("Updating package manifest...")
+
+	fmt.Fprintf(progress, "Setting version in manifest to %d...\n", c.version)
+	c.manifest.File.Version = c.version
+
+	if err := c.manifest.File.Write(ManifestFilename); err != nil {
+		return fmt.Errorf("error saving package manifest: %w", err)
+	}
+
 	progress.Done()
 	text.Success(out, "Deployed package (service %s, version %v)", serviceID, c.version)
 	return nil


### PR DESCRIPTION
### TL;DR
Persist version to manifest file when deploying compute services.

### Why?
Since #5 we are now correctly persisting the service version to the local `fastly.toml` manifest file. The intention is for other commands to infer the service id and version from the manifest to avoid a user having to manually pass them as flags. However this version state isn't being kept up-to-date when a deploy occurs and therefore causing drift. This fixes that.