### PR TITLE
Add useful next step links to compute deploy

### DIFF
--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -527,7 +527,7 @@ func TestDeploy(t *testing.T) {
 				"Activating version...",
 				"Manage this service at:",
 				"https://manage.fastly.com/configure/services/123",
-				"View the service at:",
+				"View this service at:",
 				"https://directly-careful-coyote.edgecompute.app",
 				"Deployed package (service 123, version 2)",
 			},
@@ -574,6 +574,7 @@ func TestDeploy(t *testing.T) {
 			args: []string{"compute", "deploy", "-t", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "2"},
 			api: mock.API{
 				ActivateVersionFn: activateVersionOk,
+				ListDomainsFn:     listDomainsOk,
 			},
 			client:           codeClient{http.StatusOK},
 			manifestIncludes: "version = 2",

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -485,12 +485,13 @@ func TestDeploy(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "list domains error",
 			args: []string{"compute", "deploy", "-t", "123"},
 			api: mock.API{
 				LatestVersionFn:   latestVersionActiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionOk,
+				ListDomainsFn:     listDomainsError,
 			},
 			client:   codeClient{http.StatusOK},
 			manifest: "name = \"package\"\nservice_id = \"123\"\n",
@@ -501,6 +502,33 @@ func TestDeploy(t *testing.T) {
 				"Cloning latest version...",
 				"Uploading package...",
 				"Activating version...",
+				"Manage this service at:",
+				"https://manage.fastly.com/configure/services/123",
+				"Deployed package (service 123, version 2)",
+			},
+		},
+		{
+			name: "success",
+			args: []string{"compute", "deploy", "-t", "123"},
+			api: mock.API{
+				LatestVersionFn:   latestVersionActiveOk,
+				CloneVersionFn:    cloneVersionOk,
+				ActivateVersionFn: activateVersionOk,
+				ListDomainsFn:     listDomainsOk,
+			},
+			client:   codeClient{http.StatusOK},
+			manifest: "name = \"package\"\nservice_id = \"123\"\n",
+			wantOutput: []string{
+				"Reading package manifest...",
+				"Validating package...",
+				"Fetching latest version...",
+				"Cloning latest version...",
+				"Uploading package...",
+				"Activating version...",
+				"Manage this service at:",
+				"https://manage.fastly.com/configure/services/123",
+				"View the service at:",
+				"https://directly-careful-coyote.edgecompute.app",
 				"Deployed package (service 123, version 2)",
 			},
 		},
@@ -511,6 +539,7 @@ func TestDeploy(t *testing.T) {
 				LatestVersionFn:   latestVersionActiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionOk,
+				ListDomainsFn:     listDomainsOk,
 			},
 			client: codeClient{http.StatusOK},
 			wantOutput: []string{
@@ -529,6 +558,7 @@ func TestDeploy(t *testing.T) {
 				LatestVersionFn:   latestVersionInactiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionOk,
+				ListDomainsFn:     listDomainsOk,
 			},
 			client: codeClient{http.StatusOK},
 			wantOutput: []string{
@@ -1040,6 +1070,16 @@ func activateVersionOk(i *fastly.ActivateVersionInput) (*fastly.Version, error) 
 }
 
 func activateVersionError(i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+	return nil, errTest
+}
+
+func listDomainsOk(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
+	return []*fastly.Domain{
+		&fastly.Domain{Name: "https://directly-careful-coyote.edgecompute.app"},
+	}, nil
+}
+
+func listDomainsError(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	return nil, errTest
 }
 

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -145,7 +145,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		Service: serviceID,
 		Version: c.version,
 	}); err == nil {
-		text.Description(out, "View the service at", fmt.Sprintf("https://%s", domains[0].Name))
+		text.Description(out, "View this service at", fmt.Sprintf("https://%s", domains[0].Name))
 	}
 
 	text.Success(out, "Deployed package (service %s, version %v)", serviceID, c.version)

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -136,6 +136,18 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 
 	progress.Done()
+
+	text.Break(out)
+
+	text.Description(out, "Manage this service at", fmt.Sprintf("%s%s", manageServiceBaseURL, serviceID))
+
+	if domains, err := c.Globals.Client.ListDomains(&fastly.ListDomainsInput{
+		Service: serviceID,
+		Version: c.version,
+	}); err == nil {
+		text.Description(out, "View the service at", fmt.Sprintf("https://%s", domains[0].Name))
+	}
+
 	text.Success(out, "Deployed package (service %s, version %v)", serviceID, c.version)
 	return nil
 }


### PR DESCRIPTION
### TL;DR
Adds additional links to the output of `compute deploy`, to manage the service via the UI and the first domain to view.

### Why?
It's often come up in user testing sessions that the user doesn't want to do next after deploying or know the test domain to `curl` etc. This is an attempt to reduce that friction, it follows the same convention and uses the same output patterns that we introduced in #5 

### Example:
<img width="933" alt="Screenshot 2020-03-17 at 15 31 46" src="https://user-images.githubusercontent.com/80089/76975499-88082700-692a-11ea-85b1-1ce82cec80f5.png">
