### PR TITLE
Fix persistence of author string to fastly.toml

### DIFF
--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -157,9 +157,12 @@ func TestInit(t *testing.T) {
 			manifestIncludes: `authors = ["test@example.com"]`,
 		},
 		{
-			name:       "default",
-			args:       []string{"compute", "init"},
-			configFile: config.File{Token: "123"},
+			name: "default",
+			args: []string{"compute", "init"},
+			configFile: config.File{
+				Token: "123",
+				Email: "test@example.com",
+			},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
 				GetUserFn:       getUserOk,
@@ -167,6 +170,7 @@ func TestInit(t *testing.T) {
 				CreateDomainFn:  createDomainOK,
 				CreateBackendFn: createBackendOK,
 			},
+			manifestIncludes: `authors = ["test@example.com"]`,
 			wantFiles: []string{
 				"Cargo.toml",
 				"fastly.toml",

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -140,12 +140,14 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 
 	if c.author == "" {
+		label := "Author: "
 		var defaultEmail string
 		if email := c.Globals.File.Email; email != "" {
-			defaultEmail = fmt.Sprintf(" [%s]", email)
+			defaultEmail = email
+			label = fmt.Sprintf("%s [%s]", label, email)
 		}
 
-		c.author, err = text.Input(out, fmt.Sprintf("Author:%s ", defaultEmail), in)
+		c.author, err = text.Input(out, label, in)
 		if err != nil {
 			return fmt.Errorf("error reading input %w", err)
 		}


### PR DESCRIPTION
### TL;DR
The new interactive init (#5) introduced a rendering bug when the default author email is persisted to the fastly.toml `authors` field which resulted in extraneous square brackets inside the string.

**Before:**
`authors = [" [test@example.com]"]`
 
**After:**
`authors = ["test@example.com"]`