### PR TITLE
Add the ability to initialise a compute project from a specific branch

### DIFF
--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -158,7 +158,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with from repository and branch",
-			args:       []string{"compute", "init", "--from", "https://github.com/fastly/fastly-template-rust-default.git", "--from-branch", "master"},
+			args:       []string{"compute", "init", "--from", "https://github.com/fastly/fastly-template-rust-default.git", "--branch", "master"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -61,7 +61,7 @@ func TestInit(t *testing.T) {
 				DeleteBackendFn: deleteBackendOK,
 				DeleteDomainFn:  deleteDomainOK,
 			},
-			wantError: "error fetching package template: repository not found",
+			wantError: "error fetching package template:",
 		},
 		{
 			name:       "create service error",
@@ -116,7 +116,7 @@ func TestInit(t *testing.T) {
 			wantOutput: []string{
 				"Initializing...",
 				"Fetching package template...",
-				"Updating package manifest..",
+				"Updating package manifest...",
 			},
 			manifestIncludes: `name = "test"`,
 		},
@@ -134,7 +134,7 @@ func TestInit(t *testing.T) {
 			wantOutput: []string{
 				"Initializing...",
 				"Fetching package template...",
-				"Updating package manifest..",
+				"Updating package manifest...",
 			},
 			manifestIncludes: `description = "test"`,
 		},
@@ -152,9 +152,26 @@ func TestInit(t *testing.T) {
 			wantOutput: []string{
 				"Initializing...",
 				"Fetching package template...",
-				"Updating package manifest..",
+				"Updating package manifest...",
 			},
 			manifestIncludes: `authors = ["test@example.com"]`,
+		},
+		{
+			name:       "with from repository and branch",
+			args:       []string{"compute", "init", "--from", "https://github.com/fastly/fastly-template-rust-default.git", "--from-branch", "master"},
+			configFile: config.File{Token: "123"},
+			api: mock.API{
+				GetTokenSelfFn:  tokenOK,
+				GetUserFn:       getUserOk,
+				CreateServiceFn: createServiceOK,
+				CreateDomainFn:  createDomainOK,
+				CreateBackendFn: createBackendOK,
+			},
+			wantOutput: []string{
+				"Initializing...",
+				"Fetching package template...",
+				"Updating package manifest...",
+			},
 		},
 		{
 			name: "default",
@@ -181,8 +198,11 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Initializing...",
+				"Creating service...",
+				"Creating domain...",
+				"Creating backend...",
 				"Fetching package template...",
-				"Updating package manifest..",
+				"Updating package manifest...",
 			},
 		},
 	} {

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/fastly"
 	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 type template struct {
@@ -30,6 +31,7 @@ type template struct {
 
 const (
 	defaultTemplate       = "https://github.com/fastly/fastly-template-rust-default.git"
+	defaultTemplateBranch = "0.2.0-alpha3"
 	defaultTopLevelDomain = "edgecompute.app"
 	manageServiceBaseURL  = "https://manage.fastly.com/configure/services/"
 )
@@ -54,6 +56,7 @@ type InitCommand struct {
 	description string
 	author      string
 	from        string
+	fromBranch  string
 	path        string
 	domain      string
 	backend     string
@@ -68,6 +71,7 @@ func NewInitCommand(parent common.Registerer, globals *config.Data) *InitCommand
 	c.CmdClause.Flag("description", "Description of the package").Short('d').StringVar(&c.description)
 	c.CmdClause.Flag("author", "Author of the package").Short('a').StringVar(&c.author)
 	c.CmdClause.Flag("from", "Git repository containing package template").Short('f').StringVar(&c.from)
+	c.CmdClause.Flag("from-branch", "Git branch name to clone from package template repository").Hidden().StringVar(&c.fromBranch)
 	c.CmdClause.Flag("path", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.path)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.path)
 	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").StringVar(&c.path)
@@ -144,7 +148,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		var defaultEmail string
 		if email := c.Globals.File.Email; email != "" {
 			defaultEmail = email
-			label = fmt.Sprintf("%s [%s]", label, email)
+			label = fmt.Sprintf("%s[%s]", label, email)
 		}
 
 		c.author, err = text.Input(out, label, in)
@@ -259,10 +263,19 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 	defer os.RemoveAll(tempdir)
 
+	var ref plumbing.ReferenceName
+	if c.from == defaultTemplate {
+		ref = plumbing.NewBranchReferenceName(defaultTemplateBranch)
+	}
+	if c.fromBranch != "" {
+		ref = plumbing.NewBranchReferenceName(c.fromBranch)
+	}
+
 	if _, err := git.PlainClone(tempdir, false, &git.CloneOptions{
-		URL:      c.from,
-		Depth:    1,
-		Progress: progress,
+		URL:           c.from,
+		ReferenceName: ref,
+		Depth:         1,
+		Progress:      progress,
 	}); err != nil {
 		return fmt.Errorf("error fetching package template: %w", err)
 	}

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -56,7 +56,7 @@ type InitCommand struct {
 	description string
 	author      string
 	from        string
-	fromBranch  string
+	branch      string
 	path        string
 	domain      string
 	backend     string
@@ -71,7 +71,7 @@ func NewInitCommand(parent common.Registerer, globals *config.Data) *InitCommand
 	c.CmdClause.Flag("description", "Description of the package").Short('d').StringVar(&c.description)
 	c.CmdClause.Flag("author", "Author of the package").Short('a').StringVar(&c.author)
 	c.CmdClause.Flag("from", "Git repository containing package template").Short('f').StringVar(&c.from)
-	c.CmdClause.Flag("from-branch", "Git branch name to clone from package template repository").Hidden().StringVar(&c.fromBranch)
+	c.CmdClause.Flag("branch", "Git branch name to clone from package template repository").Hidden().StringVar(&c.branch)
 	c.CmdClause.Flag("path", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.path)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.path)
 	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").StringVar(&c.path)
@@ -267,8 +267,8 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if c.from == defaultTemplate {
 		ref = plumbing.NewBranchReferenceName(defaultTemplateBranch)
 	}
-	if c.fromBranch != "" {
-		ref = plumbing.NewBranchReferenceName(c.fromBranch)
+	if c.branch != "" {
+		ref = plumbing.NewBranchReferenceName(c.branch)
 	}
 
 	if _, err := git.PlainClone(tempdir, false, &git.CloneOptions{


### PR DESCRIPTION
### TL;DR
As requested by @katie-martin-fastly, this adds the ability to clone from a specific template repository branch when initialising a new Compute@Edge project via `compute init`. We then use this logic to ensure that the default template is pointing to a named branch. This ensures we maintain compatibility with the `fastly` guest crate API.

### Note
- I'm keeping the `--branch` flag hidden for the time being as we don't want to add confuse to the normal path of supplying templates repo urls. 
- I also cleaned up the `compute init` tests and fixed a rendering issue with author, but are small enough changes that don't warrant their own PR.