### PR TITLE
Normalize backend name during compute init

### DIFF
--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -887,6 +887,31 @@ func TestUploadPackage(t *testing.T) {
 	}
 }
 
+func TestNormalizeBackendName(t *testing.T) {
+	for _, testcase := range []struct {
+		input      string
+		wantOutput string
+	}{
+		{
+			input:      "www.example.com",
+			wantOutput: "www_example_com",
+		},
+		{
+			input:      "sub.domain.example.com",
+			wantOutput: "sub_domain_example_com",
+		},
+		{
+			input:      "127.0.0.1",
+			wantOutput: "F_127_0_0_1",
+		},
+	} {
+		t.Run(testcase.input, func(t *testing.T) {
+			output := compute.NormalizeBackendName(testcase.input)
+			testutil.AssertString(t, output, testcase.wantOutput)
+		})
+	}
+}
+
 func makeInitEnvironment(t *testing.T) (rootdir string) {
 	t.Helper()
 


### PR DESCRIPTION
### TL;DR
To reduce on-boarding friction `compute init` only asks for a backend address during the interactive initialisation, we then use the same value for both the `address` and `name` fields in the [API call](https://docs.fastly.com/api/config#backend_85c170418ee71191dbb3b5046aeb6c2c) to create the backend. However, we have since discovered these are not valid backend `name` values and therefore we need to normalize the address input before creation. 

### Notes
Backend names must match this regular expression (`^[a-zA-Z][a-zA-Z0-9_]*$`), i.e. they myst conform to these rules:
- cannot start with a number.
- can only contain alpha numeric ASCII characters or underscores.

If the input address is an IP address and therefore starts with a number, we prefix the string with "F_" which follows historic naming convention for backends in Fastly VCL services.