### PR TITLE
Bump the default template version to 0.2.0-alpha4

### DIFF
--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -31,7 +31,7 @@ type template struct {
 
 const (
 	defaultTemplate       = "https://github.com/fastly/fastly-template-rust-default.git"
-	defaultTemplateBranch = "0.2.0-alpha3"
+	defaultTemplateBranch = "0.2.0-alpha4"
 	defaultTopLevelDomain = "edgecompute.app"
 	manageServiceBaseURL  = "https://manage.fastly.com/configure/services/"
 )


### PR DESCRIPTION
### TL;DR
Bumps the default template version to `0.2.0-alpha4`