### PR TITLE
Use GoReleaser for build and release automation in CI

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,114 +1,31 @@
+name: Release
 on:
   push:
     tags:
       - 'v*'
-name: Release
 jobs:
-  release:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-    - name: Create GitHub release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: true
-        prerelease: false
-    - name: Output upload URL to file
-      env:
-        UPLOAD_URL: ${{ steps.create_release.outputs.upload_url }}
-      run: |
-        echo $UPLOAD_URL > upload_url.txt
-    - name: Persist release upload URL
-      uses: actions/upload-artifact@v1
-      with:
-        name: release
-        path: upload_url.txt
-  upload:
-    needs: release
-    strategy:
-      matrix:
-        pair: [linux-amd64, linux-386, darwin-amd64, windows-amd64, windows-386]
-    runs-on: ubuntu-latest
-    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Unshallow
+      run: git fetch --prune --unshallow
     - name: Install Go
       uses: actions/setup-go@v1
       with:
         go-version: '1.14.x'
-    - name: Checkout code
-      uses: actions/checkout@v1
-    - name: Get version
+    - name: Set GOVERSION
       run: |
-        echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\//}
-    - name: Build release binaries
-      env:
-        PAIR: ${{ matrix.pair }}
-      shell: bash
+        echo "::set-env name=GOVERSION::$(go version)"
+    - name: Set GIT_TAG
       run: |
-        GOOS=$(echo $PAIR | cut -d'-' -f1)
-        GOARCH=$(echo $PAIR | cut -d'-' -f2)
-        if [[ $GOOS =~ "windows" ]]
-        then
-          env VERSION=$VERSION GOOS=$GOOS GOARCH=$GOARCH make release-exe
-        else
-          env VERSION=$VERSION GOOS=$GOOS GOARCH=$GOARCH make release
-        fi
-    - name: Get upload URL
-      uses: actions/download-artifact@v1
+        echo "::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}"
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v1
       with:
-        name: release
-    - name: Set upload URL env var
-      run: |
-        value=`cat release/upload_url.txt`
-        echo ::set-env name=UPLOAD_URL::$value
-    - name: Upload release asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: "${{ env.UPLOAD_URL }}"
-        asset_path: "./fastly_${{ env.VERSION }}_${{ matrix.pair }}.tar.gz"
-        asset_name: "fastly_${{ env.VERSION }}_${{ matrix.pair }}.tar.gz"
-        asset_content_type: application/gzip
-    - name: Persist binary
-      uses: actions/upload-artifact@v1
-      with:
-        name: bin
-        path: ./fastly_${{ env.VERSION }}_${{ matrix.pair }}.tar.gz
-  checksums:
-    needs: upload
-    runs-on: ubuntu-latest
-    steps:
-    - name: Get binaries
-      uses: actions/download-artifact@v1
-      with:
-        name: bin
-    - name: Set version env var
-      run: |
-        echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\//}
-    - name: Get upload URL
-      uses: actions/download-artifact@v1
-      with:
-        name: release
-    - name: Set upload URL env var
-      run: |
-        value=`cat release/upload_url.txt`
-        echo ::set-env name=UPLOAD_URL::$value
-    - name: Generate checksums
-      run: |
-        cd bin
-        for filename in *; do
-          echo -e "$(sha256sum $filename)" >> fastly_${{ env.VERSION }}_SHA256SUMS
-        done
-    - name: Upload checksums asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ env.UPLOAD_URL }}
-        asset_path: ./bin/fastly_${{ env.VERSION }}_SHA256SUMS
-        asset_name: fastly_${{ env.VERSION }}_SHA256SUMS
-        asset_content_type: text/plain
+        version: ${{ .env.GIT_TAG }}
+        args: release --rm-dist
+        env:
+          GOVERSION: ${{ env.GOVERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ fastly
 .idea
 
 # Ignore binaries
+dist/
 build/
 !pkg/compute/testdata/build/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,47 @@
+project_name: fastly
+release:
+  prerelease: auto
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+builds:
+  - <<: &build_defaults
+      main: ./cmd/fastly
+      ldflags:
+        - -s -w -X "github.com/fastly/cli/pkg/version.AppVersion={{ .Version }}"
+        - -X "github.com/fastly/cli/pkg/version.GitRevision={{ .ShortCommit }}"
+        - -X "github.com/fastly/cli/pkg/version.GoVersion={{ .Env.GOVERSION }}"
+    id: macos
+    goos: [darwin]
+    goarch: [amd64]
+  - <<: *build_defaults
+    id: linux
+    goos: [linux]
+    goarch: [386, amd64, arm64]
+  - <<: *build_defaults
+    id: windows
+    goos: [windows]
+    goarch: [386, amd64]
+archives:
+  - id: nix
+    builds: [macos, linux]
+    <<: &archive_defaults
+      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    wrap_in_directory: true
+    replacements:
+      darwin: macOS
+      386: i386
+      amd64: x86_64
+    format: tar.gz
+  - id: windows
+    builds: [windows]
+    <<: *archive_defaults
+    wrap_in_directory: false
+    format: zip
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc

--- a/Makefile
+++ b/Makefile
@@ -40,21 +40,3 @@ build:
 .PHONY: install
 install:
 	go install ./cmd/fastly
-
-LDFLAGS = -ldflags "\
- -X 'github.com/fastly/cli/pkg/version.AppVersion=${VERSION}' \
- -X 'github.com/fastly/cli/pkg/version.GitRevision=$(shell git rev-parse --short HEAD || echo unknown)' \
- -X 'github.com/fastly/cli/pkg/version.GoVersion=$(shell go version)' \
- "
-
-.PHONY: release
-release:
-	go build -o fastly $(LDFLAGS) ./cmd/fastly
-	tar czf fastly_${VERSION}_$(shell go env GOOS)-$(shell go env GOARCH).tar.gz fastly
-	rm fastly
-
-.PHONY: release-exe
-release-exe:
-	go build -o fastly.exe $(LDFLAGS) ./cmd/fastly
-	tar czf fastly_${VERSION}_$(shell go env GOOS)-$(shell go env GOARCH).tar.gz fastly.exe
-	rm fastly.exe


### PR DESCRIPTION
### TL;DR
Replaces our custom make targets and CI GitHub actions that build and release binaries with [GoReleaser](https://goreleaser.com/). This greatly reduces complexity whilst increasing possibilities for future customisation. 

### Notes
We're planning to phase the roll out of this in these steps.
1. Replace current release and checksumming process with GoReleaser
1. Use goreleaser to generate a changelog.md
1. Use goreleaser to sign packages with gpg key
1. Use goreleaser to produce homebrew recipe
1. Use goreleaser to produce other package manager packages
1. Use goreleaser to signed and notarize MacOS binaries 

This PR is the first step :)