### PR TITLE
Fix goreleaser version in release github action workflow.

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -18,13 +18,10 @@ jobs:
     - name: Set GOVERSION
       run: |
         echo "::set-env name=GOVERSION::$(go version)"
-    - name: Set GIT_TAG
-      run: |
-        echo "::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}"
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:
-        version: ${{ env.GIT_TAG }}
+        version: "v0.131.1"
         args: release --rm-dist
       env:
         GOVERSION: ${{ env.GOVERSION }}


### PR DESCRIPTION
### TL;DR
It seems I misunderstood what the `version` field was in the ` goreleaser/goreleaser-action@v1` action configuration in #17 . It is in-fact the version of the `goreleaser` binary and not the release version you intend to release. Which is great, as it allows us to pin the version, which we were concerned about. 

See more: https://github.com/goreleaser/goreleaser-action#customizing