### PR TITLE
compute/init: make space after Author prompt match other prompts

### DIFF
--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -148,7 +148,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		var defaultEmail string
 		if email := c.Globals.File.Email; email != "" {
 			defaultEmail = email
-			label = fmt.Sprintf("%s[%s]", label, email)
+			label = fmt.Sprintf("%s[%s] ", label, email)
 		}
 
 		c.author, err = text.Input(out, label, in)


### PR DESCRIPTION
Other prompts have a space after the closing bracket:

<img width="157" alt="Screen Shot 2020-04-20 at 11 50 09 AM" src="https://user-images.githubusercontent.com/80111/79709630-aa141100-82fd-11ea-8627-5de0bb9653dd.png">
