### PR TITLE
Publish to homebrew

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -35,7 +35,7 @@ jobs:
         args: release --rm-dist --release-notes=RELEASE_CHANGELOG.md
       env:
         GOVERSION: ${{ env.GOVERSION }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     - name: Generate changelog
       run: make changelog
       env:
@@ -45,7 +45,7 @@ jobs:
         echo "::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}"
     - name: Commit CHANGELOG.md
       env:
-        GITHUB_TOKEN: ${{ secrets.github_token }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         COMMIT_MSG: |
           Release ${GIT_TAG}
 
@@ -54,7 +54,7 @@ jobs:
       run: |
         git config user.email "oss@fastly.com"
         git config user.name "Release bot"
-        git remote set-url origin https://x-access-token:${RELEASE_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
         git checkout master
         git add CHANGELOG.md
         git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,29 @@ archives:
     <<: *archive_defaults
     wrap_in_directory: false
     format: zip
+brews:
+  - name: fastly
+    ids: [nix]
+    github:
+      owner: fastly
+      name: homebrew-tap
+    skip_upload: auto
+    description: Fastly CLI
+    homepage: https://github.com/fastly/cli
+    folder: Formula
+    custom_block: |
+      head do
+        url "https://github.com/fastly/cli.git"
+        depends_on "go"
+      end
+    install: |
+      system "make" if build.head?
+      bin.install "fastly"
+      (bash_completion/"fastly.sh").write `#{bin}/fastly --completion-script-bash`
+      (zsh_completion/"_fastly").write `#{bin}/fastly --completion-script-zsh`
+    test: |
+      help_text = shell_output("#{bin}/fastly --help")
+      assert_includes help_text, "Usage:"
 checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS"
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 SHELL := /bin/bash -o pipefail
 
 PREVIOUS_SEMVER_TAG := $(shell git tag | sort -r --version-sort | egrep '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$$' | head -n2 | tail -n1)
+VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
+LDFLAGS = -ldflags "\
+ -X 'github.com/fastly/cli/pkg/version.AppVersion=${VERSION}' \
+ -X 'github.com/fastly/cli/pkg/version.GitRevision=$(shell git rev-parse --short HEAD || echo unknown)' \
+ -X 'github.com/fastly/cli/pkg/version.GoVersion=$(shell go version)' \
+ "
+
+fastly:
+	@go build -trimpath $(LDFLAGS) -o "$@" ./cmd/fastly
 
 .PHONY: all
 all: fmt vet staticcheck lint gosec test build install

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ A CLI for interacting with the Fastly platform.
 
 ## Install
 
+### Homebrew
+
+Install: `brew install fastly/tap/fastly`
+
+Upgrade: `brew upgrade fastly`
+
+### From a prebuilt binary
 [Download the latest release][latest] from the [releases page][releases].
 Unarchive the binary and place it in your $PATH. You can verify the integrity
 of the binary using the SHA256 checksums file `fastly_x.x.x_SHA256SUMS` provided 


### PR DESCRIPTION
### TL;DR
Adds the required goreleaser configuration to publish to a Homebrew tap formula to https://github.com/fastly/homebrew-tap during the release CI workflow. This allows users to install the CLI via `brew` using `brew install fastly/tap/fastly`. 

### Notes:
- We can submit the forumla to https://github.com/Homebrew/homebrew-core to facilitate the `brew install fastly` default style naming and invocation install.
- We will need to create a wider scoped GITHUB_TOKEN secret for the CI job to enable the job to push to the tap repo. 