### PR TITLE
Don't check for updates when running local builds

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -294,7 +294,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		return errors.RemediationError{Prefix: usage, Inner: fmt.Errorf("command not found")}
 	}
 
-	if versioner != nil && name != "update" {
+	if versioner != nil && name != "update" && version.AppVersion != version.None {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel() // push cancel on the defer stack first...
 		f := update.CheckAsync(ctx, file, configFilePath, version.AppVersion, versioner)

--- a/pkg/version/root.go
+++ b/pkg/version/root.go
@@ -26,9 +26,12 @@ var (
 	UserAgent string
 )
 
+// None is the AppVersion string for local (unversioned) builds.
+const None = "v0.0.0-unknown"
+
 func init() {
 	if AppVersion == "" {
-		AppVersion = "v0.0.0-unknown"
+		AppVersion = None
 	}
 	if GitRevision == "" {
 		GitRevision = "unknown"

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -32,11 +32,5 @@ func TestVersion(t *testing.T) {
 		"Fastly CLI version v0.0.0-unknown (unknown)",
 		"Built with go version unknown",
 		"",
-		"A new version of the Fastly CLI is available.",
-		"Current version: 0.0.0-unknown",
-		"Latest version: 1.2.3",
-		"Run `fastly update` to get the latest version.",
-		"",
-		"",
 	}, "\n"), out.String())
 }


### PR DESCRIPTION
This removes the update portion of TestVersion in pkg/version,
which appears to be tested well enough in pkg/update instead.