### PR TITLE
Tidy up `fastly configure` text output

### DIFF
--- a/pkg/configure/configure_test.go
+++ b/pkg/configure/configure_test.go
@@ -54,8 +54,9 @@ func TestConfigure(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fastly API endpoint (via --endpoint): http://local.dev",
-				"Fastly API token (via --token): abcdef",
+				"Fastly API token provided via --token",
 				"Validating token...",
+				"Persisting configuration...",
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
@@ -77,8 +78,9 @@ func TestConfigure(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fastly API endpoint (via --endpoint): http://staging.dev",
-				"Fastly API token (via --token): abcdef",
+				"Fastly API token provided via --token",
 				"Validating token...",
+				"Persisting configuration...",
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
@@ -97,8 +99,9 @@ func TestConfigure(t *testing.T) {
 				GetUserFn:      goodUser,
 			},
 			wantOutput: []string{
-				"Fastly API token (via --token): abcdef",
+				"Fastly API token provided via --token",
 				"Validating token...",
+				"Persisting configuration...",
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
@@ -122,6 +125,7 @@ func TestConfigure(t *testing.T) {
 				"https://manage.fastly.com/account/personal/tokens",
 				"Fastly API token: ",
 				"Validating token...",
+				"Persisting configuration...",
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
@@ -133,7 +137,7 @@ func TestConfigure(t *testing.T) {
 			},
 		},
 		{
-			name: "token from flag",
+			name: "token from environment",
 			args: []string{"configure"},
 			env:  config.Environment{Token: "hello"},
 			api: mock.API{
@@ -141,8 +145,9 @@ func TestConfigure(t *testing.T) {
 				GetUserFn:      goodUser,
 			},
 			wantOutput: []string{
-				"Fastly API token (via FASTLY_API_TOKEN): hello",
+				"Fastly API token provided via FASTLY_API_TOKEN",
 				"Validating token...",
+				"Persisting configuration...",
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
@@ -167,6 +172,7 @@ func TestConfigure(t *testing.T) {
 				"https://manage.fastly.com/account/personal/tokens",
 				"Fastly API token: ",
 				"Validating token...",
+				"Persisting configuration...",
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
@@ -185,7 +191,7 @@ func TestConfigure(t *testing.T) {
 				GetUserFn:      badUser,
 			},
 			wantOutput: []string{
-				"Fastly API token (via --token): abcdef",
+				"Fastly API token provided via --token",
 				"Validating token...",
 			},
 			wantError: "error validating token: bad token",


### PR DESCRIPTION
### TL;DR
Fixes #27 to prevent the value of a API token supplied by an environment variable being rendered in the output and clean-up the output to be more consistent with other commands:

- Use progress writer to update progression through validation and persistence steps.
- Use `text.Description` to output the config file location
- Move config file location before success message as this was confusing some users.

### Example:
<img width="778" alt="Screenshot 2020-04-22 at 16 32 16" src="https://user-images.githubusercontent.com/80089/80006016-3a985000-84bc-11ea-8e6c-aa272ead3bc0.png">


