### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -24,8 +24,8 @@ jobs:
         ruby-version: '2.7'
     - name: Install github_changelog_generator
       run: gem install github_changelog_generator -v 1.15.0
-    - name: Generate changelogs
-      run: make changelog release-changelog
+    - name: Generate Release changelog
+      run: make release-changelog
       env:
         CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run GoReleaser
@@ -36,6 +36,10 @@ jobs:
       env:
         GOVERSION: ${{ env.GOVERSION }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Generate changelog
+      run: make changelog
+      env:
+        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Set GIT_TAG
       run: |
         echo "::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}"


### PR DESCRIPTION
### TL;DR
The release changelog generation process introduced in #23 is broken, as we were generating the main `CHANGELOG.md` file before running `goreleaaser`. This was causing the git tree to be in a dirty state which in turn causes goreleaser to fail. This change moves that process to after the release, we still generate the smaller `RELEASE_CHANGELOG.md` file first to pass to goreleaser, however this is gitignored and therefore doesn't effect the state.

More info here: https://github.com/fastly/cli/actions/runs/84979834