### PR TITLE
Fix release and update process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,10 +29,6 @@ archives:
     <<: &archive_defaults
       name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
-    replacements:
-      darwin: macOS
-      386: i386
-      amd64: x86_64
     format: tar.gz
   - id: windows
     builds: [windows]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash -o pipefail
 
-LAST_SEMVER_TAG := $(shell git tag | sort -r --version-sort | egrep '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$$' | head -n1)
+PREVIOUS_SEMVER_TAG := $(shell git tag | sort -r --version-sort | egrep '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$$' | head -n2 | tail -n1)
 
 .PHONY: all
 all: fmt vet staticcheck lint gosec test build install
@@ -65,4 +65,4 @@ release-changelog:
 		--release-url "https://github.com/fastly/cli/releases/tag/%s" \
 		--exclude-labels documentation \
 		--output RELEASE_CHANGELOG.md \
-		--since-tag $(LAST_SEMVER_TAG)
+		--since-tag $(PREVIOUS_SEMVER_TAG)


### PR DESCRIPTION
### TL;DR
Continues on the theme of the fixing the new release processes in #17 & #23. 

What:
- Ensure we actually get the previous release tag and not the current tag when comparing for changelog generation. (https://github.com/fastly/cli/commit/c6217b93c8f6324481b93168c6b71e4177ebf110)
- Don't rewrite the package tar ball file names, as our `fastly update` process relies on the system architecture being the same as that reported by Go. (https://github.com/fastly/cli/commit/81ce574e00722dc6d2acc6df2442355e254372f3)

Thanks to @fgsch for reporting this issue.