### PR TITLE
Use separate GitHub token for changelog release commit

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         git config user.email "oss@fastly.com"
         git config user.name "Release bot"
-        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        git remote set-url origin https://x-access-token:${RELEASE_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
         git checkout master
         git add CHANGELOG.md
         git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)


### PR DESCRIPTION
### TL;DR
The release Action workflow cannot commit the newly generated changelog to the `master` branch as it has branch protection enabled. We are happy for this to be bypassed for this commit, however the default token generated for Action workflows doesn't have admin rights. This updates the workflow to read a scoped token (only for public repo access) from a secret value for this commit. 