### PR TITLE
Fix inconsistency in release asset filename.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ archives:
   - id: nix
     builds: [macos, linux]
     <<: &archive_defaults
-      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+      name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
     format: tar.gz
   - id: windows
@@ -36,7 +36,7 @@ archives:
     wrap_in_directory: false
     format: zip
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: "{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS"
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:


### PR DESCRIPTION
### TL;DR
Fixes an inconsistency in the release asset filename since moving to GoReleaser in #17. This was causing `fastly update` to fail as the [template](https://github.com/fastly/cli/blob/master/pkg/update/versioner.go#L138) it uses to construct the download URL didn't match and thus was 404'ing.