### PR TITLE
Fix release asset inconsistency

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,9 @@ archives:
     builds: [macos, linux]
     <<: &archive_defaults
       name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    wrap_in_directory: true
+      files:
+        - none*
+    wrap_in_directory: false
     format: tar.gz
   - id: windows
     builds: [windows]


### PR DESCRIPTION
### TL;DR
Following on from #39, we discovered another inconsistency between the old release asset format and the new one. `fastly update` assumes the binary is in the root of the tar ball and not in a directory. Whilst the directory is a preferred user experience, this breaks the upgrade flow and will have to wait until a major release to fix. 

### Note 
This PR also attempts to fix the changelog generation by force pushing the commit ot bypass branch protection.  