### PR TITLE
Document release process

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -36,25 +36,3 @@ jobs:
       env:
         GOVERSION: ${{ env.GOVERSION }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-    - name: Generate changelog
-      run: make changelog
-      env:
-        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Set GIT_TAG
-      run: |
-        echo "::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}"
-    - name: Commit CHANGELOG.md
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-        COMMIT_MSG: |
-          Release ${GIT_TAG}
-
-
-          skip-checks: true
-      run: |
-        git config user.email "oss@fastly.com"
-        git config user.name "Release bot"
-        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-        git checkout master
-        git add CHANGELOG.md
-        git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash -o pipefail
 
+GITHUB_CHANGELOG_GENERATOR := $(shell command -v github_changelog_generator 2> /dev/null)
 PREVIOUS_SEMVER_TAG := $(shell git tag | sort -r --version-sort | egrep '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$$' | head -n2 | tail -n1)
 VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 LDFLAGS = -ldflags "\
@@ -54,6 +55,14 @@ install:
 
 .PHONY:
 changelog:
+ifndef GITHUB_CHANGELOG_GENERATOR
+	$(error "No github_changelog_generator in $$PATH, install via `gem install github_changelog_generator`.")
+endif
+ifndef CHANGELOG_GITHUB_TOKEN
+	@echo ""
+	@echo "WARNING: No \$$CHANGELOG_GITHUB_TOKEN in environment, set one to avoid hitting rate limit."
+	@echo ""
+endif
 	github_changelog_generator -u fastly -p cli \
 		--no-pr-wo-labels \
 		--no-author \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+# Releasing
+
+### How to cut a new release of the CLI
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html); therefore first determine the appropriate version tag based on the change set. If in doubt discuss with the team via Slack before releasing.
+
+1. Merge all PRs intended for the release into the `master` branch
+1. Checkout and update the master branch and ensure all tests are passing:
+	* `git checkout master`
+	* `git pull`
+    * `make all`
+1. Update the [`CHANGELOG.md`](https://github.com/fastly/cli/blob/master/CHANGELOG.md):
+	* Apply necessary labels (`enchancement`, `bug`, `documentation` etc) to all PRs intended for the release that you wish to appear in the `CHANGELOG.md`
+	* **Only add labels for relevant changes**
+    * `git checkout -b vx.x.x` where `vx.x.x` is your target version tag
+    * `make changelog`
+    * `git add CHANGELOG.md && git commit -m "vX.X.X"`
+1. Send PR for the `CHANGELOG.md`
+1. Once approved and merged, checkout and update the `master` branch:
+	* `git checkout master`
+	* `git pull`
+1. Create a new tag for `master`:
+	* `git tag -s vx.x.x -m "vx.x.x"`
+1. Push the new tag:
+	* `git push origin vx.x.x`
+1. Go to GitHub and check that the release was successful:
+    * Check the release CI job status via the [Actions](https://github.com/fastly/cli/actions?query=workflow%3ARelease) tab
+    * Check the release exists with valid assets and changelog: https://github.com/fastly/cli/releases
+1. Announce release internally via Slack
+1. Celebrate :tada:


### PR DESCRIPTION
### TL;DR
Removes the failed attempt at automating the `CHANGELOG.md` commit back to master in the CI job (reasons detailed below) and documents the new release process in an `RELEASE.md` file in the root of the project for future releasers.

🔎👉 [View rendered `RELEASE.md here](https://github.com/fastly/cli/blob/a9842caa857ed05396d9ab539144316106038f1d/RELEASE.md)

### Why?
After various attempts (#34, #33, #23) to automate the changelog generation by getting the release CI job to generate and commit back the `CHANGELOG.md` changes to the `master` branch - and a weekend to think it over - I've decided that adding one more manual step to the release process is better than fighting against branch protection:
- Even if we successfully automate the generation in CI the commit would come after the git tag for the release, which is confusing as the changelog in the tag points to the previous release.
- We can maintain strict branch protection in master, security and compliance shouldn't be compromised for developer experience.
- The tag generation to start the release CI job _IS_ and will always be a manual process therefore adding one more step to that didn't seem like too much work.