### PR TITLE
Generate dep and rpm packages during release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,14 @@ brews:
     test: |
       help_text = shell_output("#{bin}/fastly --help")
       assert_includes help_text, "Usage:"
+nfpms:
+  - license: Apache 2.0
+    maintainer: Fastly
+    homepage: https://github.com/fastly/cli
+    bindir: /usr/local
+    formats:
+      - deb
+      - rpm
 checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS"
 snapshot:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,48 @@
 
 A CLI for interacting with the Fastly platform.
 
-## Install
+## Quick links
+- [Installation](#Installation)
+- [Usage](#Usage)
+- [Development](#Development)
+- [Issues](#Issues)
 
-### Homebrew
+## Installation
+
+### macOS
+#### Homebrew
 
 Install: `brew install fastly/tap/fastly`
 
 Upgrade: `brew upgrade fastly`
+
+### Debian/Ubuntu Linux
+
+Install and upgrade:
+
+1. Download the `.deb` file from the [releases page][releases]
+2. `sudo apt install ./fastly_*_linux_amd64.deb` install the downloaded file
+
+### Fedora Linux
+
+Install and upgrade:
+
+1. Download the `.rpm` file from the [releases page][releases]
+2. `sudo dnf install fastly_*_linux_amd64.rpm` install the downloaded file
+
+### Centos Linux
+
+Install and upgrade:
+
+1. Download the `.rpm` file from the [releases page][releases]
+2. `sudo yum localinstall fastly_*_linux_amd64.rpm` install the downloaded file
+
+### openSUSE/SUSE Linux
+
+Install and upgrade:
+
+1. Download the `.rpm` file from the [releases page][releases]
+2. `sudo zypper in fastly_*_linux_amd64.rpm` install the downloaded file
 
 ### From a prebuilt binary
 [Download the latest release][latest] from the [releases page][releases].
@@ -30,7 +65,7 @@ Built with go version go1.13.1 linux/amd64
 The Fastly CLI will notify you if a new version is available, and can update
 itself via `fastly update`.
 
-## Use
+## Usage
 
 The Fastly CLI interacts with [the Fastly API][api] via an [API token][tokens].
 You'll need to [create an API token][create] for yourself, and then provide it
@@ -49,7 +84,7 @@ Succinct help about any command or subcommand is available via the `-h, --help`
 flag. Verbose help about any command or subcommand is available via the help
 argument, e.g. `fastly help service`.
 
-## Developing
+## Development
 
 The Fastly CLI requires [Go 1.13 or above](https://golang.org). Clone this repo
 to any path and type `make` to run all of the tests and generate a development


### PR DESCRIPTION
### TL;DR
Generates `.deb` and `.rpm` packages during the release process so the program can be easily installed on most Linux distributions. Also updates the `README.md` to include installation instructions for most distros. 

### Note 
As this updates the installation docs, this probably shouldn't be merged until the next release to avoid any confusion. 