### PR TITLE
Publish scoop package manifest during release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,14 @@ nfpms:
     formats:
       - deb
       - rpm
+scoop:
+  bucket:
+    owner: fastly
+    name: scoop-cli
+  homepage: https://github.com/fastly/cli
+  skip_upload: auto
+  description: Fastly CLI
+  license: Apache 2.0
 checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS"
 snapshot:

--- a/README.md
+++ b/README.md
@@ -17,28 +17,39 @@ Install: `brew install fastly/tap/fastly`
 
 Upgrade: `brew upgrade fastly`
 
-### Debian/Ubuntu Linux
+### Windows
+#### scoop
+Install:
+
+```
+scoop bucket add fastly-cli https://github.com/fastly/scoop-cli.git
+scoop install fastly
+```
+Upgrade: `scoop update fastly`
+
+### Linux
+#### Debian/Ubuntu Linux
 
 Install and upgrade:
 
 1. Download the `.deb` file from the [releases page][releases]
 2. `sudo apt install ./fastly_*_linux_amd64.deb` install the downloaded file
 
-### Fedora Linux
+#### Fedora Linux
 
 Install and upgrade:
 
 1. Download the `.rpm` file from the [releases page][releases]
 2. `sudo dnf install fastly_*_linux_amd64.rpm` install the downloaded file
 
-### Centos Linux
+#### Centos Linux
 
 Install and upgrade:
 
 1. Download the `.rpm` file from the [releases page][releases]
 2. `sudo yum localinstall fastly_*_linux_amd64.rpm` install the downloaded file
 
-### openSUSE/SUSE Linux
+#### openSUSE/SUSE Linux
 
 Install and upgrade:
 


### PR DESCRIPTION
### TL;DR
Publishes an app manifest for the Windows [Scoop](https://scoop.sh/) package manager during the release process. The manifest is published to a Fastly owned public repo: [github.com/fastly/scoop-cli](https://github.com/fastly/scoop-cli).