### PR TITLE
Update release instructions

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -31,17 +31,9 @@ jobs:
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-mod-
-    - name: Install staticcheck
+    - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: go get -v -u honnef.co/go/tools/cmd/staticcheck
-      shell: bash
-    - name: Install golint
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: go get -v -u golang.org/x/lint/golint
-      shell: bash
-    - name: Install gosec
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: go get github.com/securego/gosec/cmd/gosec
+      run: make dependencies
       shell: bash
     - name: Fmt
       run: make fmt

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,13 @@ fastly:
 	@go build -trimpath $(LDFLAGS) -o "$@" ./cmd/fastly
 
 .PHONY: all
-all: fmt vet staticcheck lint gosec test build install
+all: dependencies fmt vet staticcheck lint gosec test build install
+
+.PHONY: dependencies
+dependencies:
+	go get -v -u github.com/securego/gosec/cmd/gosec
+	go get -v -u honnef.co/go/tools/cmd/staticcheck
+	go get -v -u golang.org/x/lint/golint
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,11 @@ ifndef CHANGELOG_GITHUB_TOKEN
 	@echo "WARNING: No \$$CHANGELOG_GITHUB_TOKEN in environment, set one to avoid hitting rate limit."
 	@echo ""
 endif
+ifeq ($(SEMVER_TAG),)
+	$(error "You must set $$SEMVER_TAG to your desired release semver version.")
+endif
 	github_changelog_generator -u fastly -p cli \
+		--future-release $(SEMVER_TAG) \
 		--no-pr-wo-labels \
 		--no-author \
 		--enhancement-label "**Enhancements:**" \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ fastly:
 	@go build -trimpath $(LDFLAGS) -o "$@" ./cmd/fastly
 
 .PHONY: all
-all: dependencies fmt vet staticcheck lint gosec test build install
+all: fmt vet staticcheck lint gosec test build install
 
 .PHONY: dependencies
 dependencies:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ make
 ./fastly version
 ```
 
+The `make` task requires the following executables to exist in your `$PATH`:
+
+- golint
+- gosec
+- staticcheck
+
+If you have none of them installed, or don't mind them being upgraded automatically, you can run `make dependencies` to install them.
+
 ## Contributing
 
 We're happy to receive feature requests and PRs. If your change is nontrivial,

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ make
 
 The `make` task requires the following executables to exist in your `$PATH`:
 
-- golint
-- gosec
-- staticcheck
+- [golint](https://github.com/golang/lint)
+- [gosec](https://github.com/securego/gosec)
+- [staticcheck](https://staticcheck.io/)
 
 If you have none of them installed, or don't mind them being upgraded automatically, you can run `make dependencies` to install them.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,23 +6,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 1. Merge all PRs intended for the release into the `master` branch
 1. Checkout and update the master branch and ensure all tests are passing:
-	* `git checkout master`
-	* `git pull`
+    * `git checkout master`
+    * `git pull`
     * `make all`
 1. Update the [`CHANGELOG.md`](https://github.com/fastly/cli/blob/master/CHANGELOG.md):
-	* Apply necessary labels (`enchancement`, `bug`, `documentation` etc) to all PRs intended for the release that you wish to appear in the `CHANGELOG.md`
-	* **Only add labels for relevant changes**
+    * Apply necessary labels (`enchancement`, `bug`, `documentation` etc) to all PRs intended for the release that you wish to appear in the `CHANGELOG.md`
+    * **Only add labels for relevant changes**
     * `git checkout -b vx.x.x` where `vx.x.x` is your target version tag
     * `make changelog`
     * `git add CHANGELOG.md && git commit -m "vX.X.X"`
 1. Send PR for the `CHANGELOG.md`
 1. Once approved and merged, checkout and update the `master` branch:
-	* `git checkout master`
-	* `git pull`
+    * `git checkout master`
+    * `git pull`
 1. Create a new tag for `master`:
-	* `git tag -s vx.x.x -m "vx.x.x"`
+    * `git tag -s vx.x.x -m "vx.x.x"`
 1. Push the new tag:
-	* `git push origin vx.x.x`
+    * `git push origin vx.x.x`
 1. Go to GitHub and check that the release was successful:
     * Check the release CI job status via the [Actions](https://github.com/fastly/cli/actions?query=workflow%3ARelease) tab
     * Check the release exists with valid assets and changelog: https://github.com/fastly/cli/releases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     * Apply necessary labels (`enchancement`, `bug`, `documentation` etc) to all PRs intended for the release that you wish to appear in the `CHANGELOG.md`
     * **Only add labels for relevant changes**
     * `git checkout -b vx.x.x` where `vx.x.x` is your target version tag
-    * `CHANGELOG_GITHUB_TOKEN=xxxx SEMVER_TAG=vx.x.x make changelo`
+    * `CHANGELOG_GITHUB_TOKEN=xxxx SEMVER_TAG=vx.x.x make changelog`
     * `git add CHANGELOG.md && git commit -m "vx.x.x`
 1. Send PR for the `CHANGELOG.md`
 1. Once approved and merged, checkout and update the `master` branch:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,8 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     * Apply necessary labels (`enchancement`, `bug`, `documentation` etc) to all PRs intended for the release that you wish to appear in the `CHANGELOG.md`
     * **Only add labels for relevant changes**
     * `git checkout -b vx.x.x` where `vx.x.x` is your target version tag
-    * `make changelog`
-    * `git add CHANGELOG.md && git commit -m "vX.X.X"`
+    * `CHANGELOG_GITHUB_TOKEN=xxxx SEMVER_TAG=vx.x.x make changelo`
+    * `git add CHANGELOG.md && git commit -m "vx.x.x`
 1. Send PR for the `CHANGELOG.md`
 1. Once approved and merged, checkout and update the `master` branch:
     * `git checkout master`


### PR DESCRIPTION
As part of the 0.7.0 release, I noticed that the release instructions assume a working development environment as well as a GPG-configured `git`. I didn't have either ahead of the release so this PR updates the RELEASE.md with additional instructions.

Certainly open to linking elsewhere for the development environment dependencies instead of listing them explicitly in RELEASE.md.