### PR TITLE
Ensure compute deploy selects the most ideal version to clone/activate 

### DIFF
--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/app"
@@ -897,54 +896,63 @@ func TestGetIdealPackage(t *testing.T) {
 		{
 			name: "active",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: makeDate(2000, 1, 1)},
-				{Number: 2, Active: true, UpdatedAt: makeDate(2001, 1, 2)},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
 			},
 			wantVersion: 2,
 		},
 		{
 			name: "active not latest",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: makeDate(2000, 1, 1)},
-				{Number: 2, Active: true, UpdatedAt: makeDate(2001, 1, 2)},
-				{Number: 3, Active: false, UpdatedAt: makeDate(2001, 1, 3)},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
 			},
 			wantVersion: 2,
 		},
 		{
 			name: "active and locked",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: makeDate(2000, 1, 1)},
-				{Number: 2, Active: true, UpdatedAt: makeDate(2001, 1, 2)},
-				{Number: 3, Active: false, Locked: true, UpdatedAt: makeDate(2001, 1, 3)},
-			},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")}},
 			wantVersion: 2,
 		},
 		{
 			name: "locked",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: makeDate(2000, 1, 1)},
-				{Number: 2, Active: false, Locked: true, UpdatedAt: makeDate(2001, 1, 2)},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
 			},
 			wantVersion: 2,
 		},
 		{
 			name: "locked not latest",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: makeDate(2000, 1, 1)},
-				{Number: 2, Active: false, Locked: true, UpdatedAt: makeDate(2001, 1, 2)},
-				{Number: 3, Active: false, UpdatedAt: makeDate(2001, 1, 3)},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
 			},
 			wantVersion: 2,
 		},
 		{
 			name: "no active or locked",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: makeDate(2000, 1, 1)},
-				{Number: 2, Active: false, UpdatedAt: makeDate(2001, 1, 2)},
-				{Number: 3, Active: false, UpdatedAt: makeDate(2001, 1, 3)},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
 			},
 			wantVersion: 3,
+		},
+		{
+			name: "not sorted",
+			inputVersions: []*fastly.Version{
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 4, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z")},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+			},
+			wantVersion: 4,
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
@@ -955,11 +963,6 @@ func TestGetIdealPackage(t *testing.T) {
 			}
 		})
 	}
-}
-
-func makeDate(year, month, day int) *time.Time {
-	t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
-	return &t
 }
 
 func makeInitEnvironment(t *testing.T) (rootdir string) {
@@ -1147,15 +1150,36 @@ func deleteBackendOK(i *fastly.DeleteBackendInput) error {
 
 func listVersionsInactiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
-		{ServiceID: i.Service, Number: 1, Active: false, UpdatedAt: makeDate(2001, 1, 1)},
-		{ServiceID: i.Service, Number: 2, Active: false, UpdatedAt: makeDate(2001, 1, 2)},
+		{
+			ServiceID: i.Service,
+			Number:    1,
+			Active:    false,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.Service,
+			Number:    2,
+			Active:    false,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
 	}, nil
 }
 
 func listVersionsActiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
-		{ServiceID: i.Service, Number: 1, Active: true, UpdatedAt: makeDate(2001, 1, 1)},
-		{ServiceID: i.Service, Number: 2, Active: false, Locked: true, UpdatedAt: makeDate(2001, 1, 2)},
+		{
+			ServiceID: i.Service,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.Service,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
 	}, nil
 }
 

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -393,9 +393,9 @@ func TestDeploy(t *testing.T) {
 		{
 			name:      "latest version error",
 			args:      []string{"compute", "deploy"},
-			api:       mock.API{LatestVersionFn: latestVersionError},
+			api:       mock.API{ListVersionsFn: listVersionsError},
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
-			wantError: "error getting latest service version: fixture error",
+			wantError: "error getting listing service versions: fixture error",
 			wantOutput: []string{
 				"Reading package manifest...",
 				"Validating package...",
@@ -406,8 +406,8 @@ func TestDeploy(t *testing.T) {
 			name: "clone version error",
 			args: []string{"compute", "deploy"},
 			api: mock.API{
-				LatestVersionFn: latestVersionActiveOk,
-				CloneVersionFn:  cloneVersionError,
+				ListVersionsFn: listVersionsActiveOk,
+				CloneVersionFn: cloneVersionError,
 			},
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
 			wantError: "error cloning latest service version: fixture error",
@@ -422,8 +422,8 @@ func TestDeploy(t *testing.T) {
 			name: "no token",
 			args: []string{"compute", "deploy"},
 			api: mock.API{
-				LatestVersionFn: latestVersionActiveOk,
-				CloneVersionFn:  cloneVersionOk,
+				ListVersionsFn: listVersionsActiveOk,
+				CloneVersionFn: cloneVersionOk,
 			},
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
 			wantError: "no token provided",
@@ -438,8 +438,8 @@ func TestDeploy(t *testing.T) {
 			name: "package API error",
 			args: []string{"compute", "deploy", "-t", "123"},
 			api: mock.API{
-				LatestVersionFn: latestVersionActiveOk,
-				CloneVersionFn:  cloneVersionOk,
+				ListVersionsFn: listVersionsActiveOk,
+				CloneVersionFn: cloneVersionOk,
 			},
 			client:    errorClient{err: errors.New("some network failure")},
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
@@ -456,8 +456,8 @@ func TestDeploy(t *testing.T) {
 			name: "package API error",
 			args: []string{"compute", "deploy", "-t", "123"},
 			api: mock.API{
-				LatestVersionFn: latestVersionActiveOk,
-				CloneVersionFn:  cloneVersionOk,
+				ListVersionsFn: listVersionsActiveOk,
+				CloneVersionFn: cloneVersionOk,
 			},
 			client:    errorClient{err: errors.New("some network failure")},
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
@@ -474,8 +474,8 @@ func TestDeploy(t *testing.T) {
 			name: "package API server error",
 			args: []string{"compute", "deploy", "-t", "123"},
 			api: mock.API{
-				LatestVersionFn: latestVersionActiveOk,
-				CloneVersionFn:  cloneVersionOk,
+				ListVersionsFn: listVersionsActiveOk,
+				CloneVersionFn: cloneVersionOk,
 			},
 			client:    codeClient{http.StatusInternalServerError},
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
@@ -492,7 +492,7 @@ func TestDeploy(t *testing.T) {
 			name: "activate error",
 			args: []string{"compute", "deploy", "-t", "123"},
 			api: mock.API{
-				LatestVersionFn:   latestVersionActiveOk,
+				ListVersionsFn:    listVersionsActiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionError,
 			},
@@ -512,7 +512,7 @@ func TestDeploy(t *testing.T) {
 			name: "list domains error",
 			args: []string{"compute", "deploy", "-t", "123"},
 			api: mock.API{
-				LatestVersionFn:   latestVersionActiveOk,
+				ListVersionsFn:    listVersionsActiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionOk,
 				ListDomainsFn:     listDomainsError,
@@ -535,7 +535,7 @@ func TestDeploy(t *testing.T) {
 			name: "success",
 			args: []string{"compute", "deploy", "-t", "123"},
 			api: mock.API{
-				LatestVersionFn:   latestVersionActiveOk,
+				ListVersionsFn:    listVersionsActiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionOk,
 				ListDomainsFn:     listDomainsOk,
@@ -560,7 +560,7 @@ func TestDeploy(t *testing.T) {
 			name: "success with path",
 			args: []string{"compute", "deploy", "-t", "123", "-p", "pkg/package.tar.gz", "-s", "123"},
 			api: mock.API{
-				LatestVersionFn:   latestVersionActiveOk,
+				ListVersionsFn:    listVersionsActiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionOk,
 				ListDomainsFn:     listDomainsOk,
@@ -579,7 +579,7 @@ func TestDeploy(t *testing.T) {
 			name: "success with inactive version",
 			args: []string{"compute", "deploy", "-t", "123", "-p", "pkg/package.tar.gz", "-s", "123"},
 			api: mock.API{
-				LatestVersionFn:   latestVersionInactiveOk,
+				ListVersionsFn:    listVersionsInactiveOk,
 				CloneVersionFn:    cloneVersionOk,
 				ActivateVersionFn: activateVersionOk,
 				ListDomainsFn:     listDomainsOk,
@@ -590,7 +590,7 @@ func TestDeploy(t *testing.T) {
 				"Fetching latest version...",
 				"Uploading package...",
 				"Activating version...",
-				"Deployed package (service 123, version 1)",
+				"Deployed package (service 123, version 2)",
 			},
 		},
 		{
@@ -887,6 +887,76 @@ func TestUploadPackage(t *testing.T) {
 	}
 }
 
+func TestGetIdealPackage(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+	}{
+		{
+			name: "active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false},
+				{Number: 2, Active: true},
+				{Number: 3, Active: false},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "active not latest",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false},
+				{Number: 2, Active: true},
+				{Number: 3, Active: false},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "active and locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false},
+				{Number: 2, Active: true},
+				{Number: 3, Active: false, Locked: true},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false},
+				{Number: 2, Active: false, Locked: true},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "locked not latest",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false},
+				{Number: 2, Active: false, Locked: true},
+				{Number: 3, Active: false},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "no active or locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false},
+				{Number: 2, Active: false},
+				{Number: 3, Active: false},
+			},
+			wantVersion: 3,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			v, err := compute.GetLatestIdealVersion(testcase.inputVersions)
+			testutil.AssertNoError(t, err)
+			if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
+		})
+	}
+}
+
 func makeInitEnvironment(t *testing.T) (rootdir string) {
 	t.Helper()
 
@@ -1070,15 +1140,21 @@ func deleteBackendOK(i *fastly.DeleteBackendInput) error {
 	return nil
 }
 
-func latestVersionInactiveOk(i *fastly.LatestVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.Service, Number: 1, Active: false}, nil
+func listVersionsInactiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{ServiceID: i.Service, Number: 1, Active: false},
+		{ServiceID: i.Service, Number: 2, Active: false},
+	}, nil
 }
 
-func latestVersionActiveOk(i *fastly.LatestVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.Service, Number: 1, Active: true}, nil
+func listVersionsActiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{ServiceID: i.Service, Number: 1, Active: true},
+		{ServiceID: i.Service, Number: 2, Active: false, Locked: true},
+	}, nil
 }
 
-func latestVersionError(i *fastly.LatestVersionInput) (*fastly.Version, error) {
+func listVersionsError(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return nil, errTest
 }
 

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -232,7 +232,7 @@ func (c *Client) UpdatePackage(serviceID string, v int, path string) error {
 // - If no active version, find the latest locked version and return
 // - Otherwise return the latest version
 //
-// Note: assumes that the provided list is chronoligically sorted, such as that
+// Note: assumes that the provided list is chronologically sorted, such as that
 // provided from fastly.ListVersions().
 func GetLatestIdealVersion(versions []*fastly.Version) (*fastly.Version, error) {
 	var active, locked, latest *fastly.Version

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -84,14 +84,19 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	if c.version == 0 {
 		progress.Step("Fetching latest version...")
-		version, err := c.Globals.Client.LatestVersion(&fastly.LatestVersionInput{
+		versions, err := c.Globals.Client.ListVersions(&fastly.ListVersionsInput{
 			Service: serviceID,
 		})
 		if err != nil {
-			return fmt.Errorf("error getting latest service version: %w", err)
+			return fmt.Errorf("error getting listing service versions: %w", err)
 		}
 
-		if version.Active {
+		version, err := GetLatestIdealVersion(versions)
+		if err != nil {
+			return fmt.Errorf("error finding latest service version")
+		}
+
+		if version.Active || version.Locked {
 			progress.Step("Cloning latest version...")
 			version, err = c.Globals.Client.CloneVersion(&fastly.CloneVersionInput{
 				Service: serviceID,
@@ -220,4 +225,40 @@ func (c *Client) UpdatePackage(serviceID string, v int, path string) error {
 	}
 
 	return nil
+}
+
+// GetLatestIdealVersion gets the most ideal service version using the following logic:
+// - Find the active version and return
+// - If no active version, find the latest locked version and return
+// - Otherwise return the latest version
+//
+// Note: assumes that the provided list is chronoligically sorted, such as that
+// provided from fastly.ListVersions().
+func GetLatestIdealVersion(versions []*fastly.Version) (*fastly.Version, error) {
+	var active, locked, latest *fastly.Version
+	for i := 0; i < len(versions); i++ {
+		v := versions[i]
+		if v.Active {
+			active = v
+		}
+		if v.Locked {
+			locked = v
+		}
+		latest = v
+	}
+
+	var version *fastly.Version
+	if active != nil {
+		version = active
+	} else if locked != nil {
+		version = locked
+	} else {
+		version = latest
+	}
+
+	if version == nil {
+		return nil, fmt.Errorf("error finding latest service version")
+	}
+
+	return version, nil
 }

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/fastly/cli/pkg/api"
@@ -231,10 +232,11 @@ func (c *Client) UpdatePackage(serviceID string, v int, path string) error {
 // - Find the active version and return
 // - If no active version, find the latest locked version and return
 // - Otherwise return the latest version
-//
-// Note: assumes that the provided list is chronologically sorted, such as that
-// provided from fastly.ListVersions().
 func GetLatestIdealVersion(versions []*fastly.Version) (*fastly.Version, error) {
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].UpdatedAt.Before(*versions[j].UpdatedAt)
+	})
+
 	var active, locked, latest *fastly.Version
 	for i := 0; i < len(versions); i++ {
 		v := versions[i]

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -88,7 +88,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Service: serviceID,
 		})
 		if err != nil {
-			return fmt.Errorf("error getting listing service versions: %w", err)
+			return fmt.Errorf("error listing service versions: %w", err)
 		}
 
 		version, err := GetLatestIdealVersion(versions)


### PR DESCRIPTION
### TL;DR
As reported by @deweerdt, the current implementation will cause an API error to be returned if the latest service version is locked/deactivated. This PR updates `compute deploy` to use a more robust way of selecting and cloning the "ideal latest version". It uses the following logic:

- Find the active version and return
- If no active version, find the latest locked version and return
- Otherwise return the latest version

### Note:
If we think this logic is useful / common, we should upstream it to `go-fastly`.