### PR TITLE
logging: adds logentries endpoint

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -70,6 +70,12 @@ type Interface interface {
 	UpdateSyslog(*fastly.UpdateSyslogInput) (*fastly.Syslog, error)
 	DeleteSyslog(*fastly.DeleteSyslogInput) error
 
+	CreateLogentries(*fastly.CreateLogentriesInput) (*fastly.Logentries, error)
+	ListLogentries(*fastly.ListLogentriesInput) ([]*fastly.Logentries, error)
+	GetLogentries(*fastly.GetLogentriesInput) (*fastly.Logentries, error)
+	UpdateLogentries(*fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
+	DeleteLogentries(*fastly.DeleteLogentriesInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 }
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fastly/cli/pkg/healthcheck"
 	"github.com/fastly/cli/pkg/logging"
 	"github.com/fastly/cli/pkg/logging/bigquery"
+	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/s3"
 	"github.com/fastly/cli/pkg/logging/syslog"
 	"github.com/fastly/cli/pkg/service"
@@ -142,6 +143,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	syslogUpdate := syslog.NewUpdateCommand(syslogRoot.CmdClause, &globals)
 	syslogDelete := syslog.NewDeleteCommand(syslogRoot.CmdClause, &globals)
 
+	logentriesRoot := logentries.NewRootCommand(loggingRoot.CmdClause, &globals)
+	logentriesCreate := logentries.NewCreateCommand(logentriesRoot.CmdClause, &globals)
+	logentriesList := logentries.NewListCommand(logentriesRoot.CmdClause, &globals)
+	logentriesDescribe := logentries.NewDescribeCommand(logentriesRoot.CmdClause, &globals)
+	logentriesUpdate := logentries.NewUpdateCommand(logentriesRoot.CmdClause, &globals)
+	logentriesDelete := logentries.NewDeleteCommand(logentriesRoot.CmdClause, &globals)
+
 	commands := []common.Command{
 		configureRoot,
 		whoamiRoot,
@@ -213,6 +221,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		syslogDescribe,
 		syslogUpdate,
 		syslogDelete,
+
+		logentriesRoot,
+		logentriesCreate,
+		logentriesList,
+		logentriesDescribe,
+		logentriesUpdate,
+		logentriesDelete,
 	}
 
 	// Handle parse errors and display contextal usage if possible. Due to bugs

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -831,6 +831,87 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Syslog logging object
 
+  logging logentries create --name=NAME --version=VERSION [<flags>]
+    Create a Logentries logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Logentries logging object. Used
+                                 as a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --port=PORT              The port number
+        --use-tls                Whether to use TLS for secure logging. Can be
+                                 either true or false
+        --auth-token=AUTH-TOKEN  Use token based authentication
+                                 (https://logentries.com/doc/input-token/)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug. This field
+                                 is not required and has no default value
+
+  logging logentries list --version=VERSION [<flags>]
+    List Logentries endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging logentries describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Logentries logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Logentries logging object
+
+  logging logentries update --version=VERSION --name=NAME [<flags>]
+    Update a Logentries logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Logentries logging object
+        --new-name=NEW-NAME      New name of the Logentries logging object
+        --port=PORT              The port number
+        --use-tls                Whether to use TLS for secure logging. Can be
+                                 either true or false
+        --auth-token=AUTH-TOKEN  Use token based authentication
+                                 (https://logentries.com/doc/input-token/)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug. This field
+                                 is not required and has no default value
+
+  logging logentries delete --version=VERSION --name=NAME [<flags>]
+    Delete a Logentries logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Logentries logging object
+
 For help on a specific command, try e.g.
 
 	fastly help configure

--- a/pkg/logging/logentries/create.go
+++ b/pkg/logging/logentries/create.go
@@ -1,0 +1,67 @@
+package logentries
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Logentries logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.CreateLogentriesInput
+
+	// We must store all of the boolean flags seperatly to the input structure
+	// so they can be casted to go-fastly's custom `Compatibool` type later.
+	useTLS bool
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Logentries logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Logentries logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+
+	c.CmdClause.Flag("port", "The port number").UintVar(&c.Input.Port)
+	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").BoolVar(&c.useTLS)
+	c.CmdClause.Flag("auth-token", "Use token based authentication (https://logentries.com/doc/input-token/)").StringVar(&c.Input.Token)
+	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").UintVar(&c.Input.FormatVersion)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").StringVar(&c.Input.Placement)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	// Sadly, go-fastly uses custom a `Compatibool` type as a boolean value that
+	// marshalls to 0/1 instead of true/false for compatability with the API.
+	// Therefore, we need to cast our real flag bool to a fastly.Compatibool.
+	c.Input.UseTLS = fastly.CBool(c.useTLS)
+
+	d, err := c.Globals.Client.CreateLogentries(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Logentries logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/logentries/delete.go
+++ b/pkg/logging/logentries/delete.go
@@ -1,0 +1,47 @@
+package logentries
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Logentries logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteLogentriesInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Logentries logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteLogentries(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Logentries logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/logentries/describe.go
+++ b/pkg/logging/logentries/describe.go
@@ -1,0 +1,58 @@
+package logentries
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Logentries logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetLogentriesInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Logentries logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	logentries, err := c.Globals.Client.GetLogentries(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", logentries.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", logentries.Version)
+	fmt.Fprintf(out, "Name: %s\n", logentries.Name)
+	fmt.Fprintf(out, "Port: %d\n", logentries.Port)
+	fmt.Fprintf(out, "Use TLS: %t\n", logentries.UseTLS)
+	fmt.Fprintf(out, "Token: %s\n", logentries.Token)
+	fmt.Fprintf(out, "Format: %s\n", logentries.Format)
+	fmt.Fprintf(out, "Format version: %d\n", logentries.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", logentries.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", logentries.Placement)
+
+	return nil
+}

--- a/pkg/logging/logentries/doc.go
+++ b/pkg/logging/logentries/doc.go
@@ -1,0 +1,3 @@
+// Package logentries contains commands to inspect and manipulate Fastly service Logentries
+// logging endpoints.
+package logentries

--- a/pkg/logging/logentries/list.go
+++ b/pkg/logging/logentries/list.go
@@ -1,0 +1,74 @@
+package logentries
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Logentries logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListLogentriesInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Logentries endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	logentriess, err := c.Globals.Client.ListLogentries(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, logentries := range logentriess {
+			tw.AddLine(logentries.ServiceID, logentries.Version, logentries.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, logentries := range logentriess {
+		fmt.Fprintf(out, "\tLogentries %d/%d\n", i+1, len(logentriess))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", logentries.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", logentries.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", logentries.Name)
+		fmt.Fprintf(out, "\t\tPort: %d\n", logentries.Port)
+		fmt.Fprintf(out, "\t\tUse TLS: %t\n", logentries.UseTLS)
+		fmt.Fprintf(out, "\t\tToken: %s\n", logentries.Token)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", logentries.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", logentries.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", logentries.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", logentries.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/logentries/logentries_test.go
+++ b/pkg/logging/logentries/logentries_test.go
@@ -1,0 +1,389 @@
+package logentries_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestLogentriesCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
+			api:        mock.API{CreateLogentriesFn: createLogentriesOK},
+			wantOutput: "Created Logentries logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
+			api:       mock.API{CreateLogentriesFn: createLogentriesError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestLogentriesList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			wantOutput: listLogentriesShortOutput,
+		},
+		{
+			args:       []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			wantOutput: listLogentriesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			wantOutput: listLogentriesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "logentries", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			wantOutput: listLogentriesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "logentries", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			wantOutput: listLogentriesVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListLogentriesFn: listLogentriesError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestLogentriesDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetLogentriesFn: getLogentriesError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetLogentriesFn: getLogentriesOK},
+			wantOutput: describeLogentriesOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestLogentriesUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetLogentriesFn:    getLogentriesError,
+				UpdateLogentriesFn: updateLogentriesOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetLogentriesFn:    getLogentriesOK,
+				UpdateLogentriesFn: updateLogentriesError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetLogentriesFn:    getLogentriesOK,
+				UpdateLogentriesFn: updateLogentriesOK,
+			},
+			wantOutput: "Updated Logentries logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestLogentriesDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteLogentriesFn: deleteLogentriesError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteLogentriesFn: deleteLogentriesOK},
+			wantOutput: "Deleted Logentries logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createLogentriesOK(i *fastly.CreateLogentriesInput) (*fastly.Logentries, error) {
+	return &fastly.Logentries{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createLogentriesError(i *fastly.CreateLogentriesInput) (*fastly.Logentries, error) {
+	return nil, errTest
+}
+
+func listLogentriesOK(i *fastly.ListLogentriesInput) ([]*fastly.Logentries, error) {
+	return []*fastly.Logentries{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Port:              20000,
+			UseTLS:            true,
+			Token:             "tkn",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Port:              20001,
+			UseTLS:            false,
+			Token:             "tkn1",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listLogentriesError(i *fastly.ListLogentriesInput) ([]*fastly.Logentries, error) {
+	return nil, errTest
+}
+
+var listLogentriesShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listLogentriesVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Logentries 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Port: 20000
+		Use TLS: true
+		Token: tkn
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Logentries 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Port: 20001
+		Use TLS: false
+		Token: tkn1
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getLogentriesOK(i *fastly.GetLogentriesInput) (*fastly.Logentries, error) {
+	return &fastly.Logentries{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Port:              20000,
+		UseTLS:            true,
+		Token:             "tkn",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getLogentriesError(i *fastly.GetLogentriesInput) (*fastly.Logentries, error) {
+	return nil, errTest
+}
+
+var describeLogentriesOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Port: 20000
+Use TLS: true
+Token: tkn
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateLogentriesOK(i *fastly.UpdateLogentriesInput) (*fastly.Logentries, error) {
+	return &fastly.Logentries{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Port:              20000,
+		UseTLS:            true,
+		Token:             "tkn",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateLogentriesError(i *fastly.UpdateLogentriesInput) (*fastly.Logentries, error) {
+	return nil, errTest
+}
+
+func deleteLogentriesOK(i *fastly.DeleteLogentriesInput) error {
+	return nil
+}
+
+func deleteLogentriesError(i *fastly.DeleteLogentriesInput) error {
+	return errTest
+}

--- a/pkg/logging/logentries/root.go
+++ b/pkg/logging/logentries/root.go
@@ -1,0 +1,28 @@
+package logentries
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("logentries", "Manipulate Fastly service version Logentries logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/logentries/update.go
+++ b/pkg/logging/logentries/update.go
@@ -1,0 +1,127 @@
+package logentries
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Logentries logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	Input fastly.GetLogentriesInput
+
+	NewName common.OptionalString
+
+	Port              common.OptionalUint
+	UseTLS            common.OptionalBool
+	Token             common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Logentries logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('n').Required().StringVar(&c.Input.Name)
+
+	c.CmdClause.Flag("new-name", "New name of the Logentries logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
+	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)
+	c.CmdClause.Flag("auth-token", "Use token based authentication (https://logentries.com/doc/input-token/)").Action(c.Token.Set).StringVar(&c.Token.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	logentries, err := c.Globals.Client.GetLogentries(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	input := &fastly.UpdateLogentriesInput{
+		Service:           logentries.ServiceID,
+		Version:           logentries.Version,
+		Name:              logentries.Name,
+		NewName:           logentries.Name,
+		Port:              logentries.Port,
+		UseTLS:            fastly.CBool(logentries.UseTLS),
+		Token:             logentries.Token,
+		Format:            logentries.Format,
+		FormatVersion:     logentries.FormatVersion,
+		ResponseCondition: logentries.ResponseCondition,
+		Placement:         logentries.Placement,
+	}
+
+	// Set new values if set by user.
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.Port.Valid {
+		input.Port = c.Port.Value
+	}
+
+	if c.UseTLS.Valid {
+		input.UseTLS = fastly.CBool(c.UseTLS.Value)
+	}
+
+	if c.Token.Valid {
+		input.Token = c.Token.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	logentries, err = c.Globals.Client.UpdateLogentries(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Logentries logging endpoint %s (service %s version %d)", logentries.Name, logentries.ServiceID, logentries.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -61,6 +61,12 @@ type API struct {
 	UpdateSyslogFn func(*fastly.UpdateSyslogInput) (*fastly.Syslog, error)
 	DeleteSyslogFn func(*fastly.DeleteSyslogInput) error
 
+	CreateLogentriesFn func(*fastly.CreateLogentriesInput) (*fastly.Logentries, error)
+	ListLogentriesFn   func(*fastly.ListLogentriesInput) ([]*fastly.Logentries, error)
+	GetLogentriesFn    func(*fastly.GetLogentriesInput) (*fastly.Logentries, error)
+	UpdateLogentriesFn func(*fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
+	DeleteLogentriesFn func(*fastly.DeleteLogentriesInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 }
 
@@ -282,6 +288,31 @@ func (m API) UpdateSyslog(i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
 // DeleteSyslog implements Interface.
 func (m API) DeleteSyslog(i *fastly.DeleteSyslogInput) error {
 	return m.DeleteSyslogFn(i)
+}
+
+// CreateLogentries implements Interface.
+func (m API) CreateLogentries(i *fastly.CreateLogentriesInput) (*fastly.Logentries, error) {
+	return m.CreateLogentriesFn(i)
+}
+
+// ListLogentries implements Interface.
+func (m API) ListLogentries(i *fastly.ListLogentriesInput) ([]*fastly.Logentries, error) {
+	return m.ListLogentriesFn(i)
+}
+
+// GetLogentries implements Interface.
+func (m API) GetLogentries(i *fastly.GetLogentriesInput) (*fastly.Logentries, error) {
+	return m.GetLogentriesFn(i)
+}
+
+// UpdateLogentries implements Interface.
+func (m API) UpdateLogentries(i *fastly.UpdateLogentriesInput) (*fastly.Logentries, error) {
+	return m.UpdateLogentriesFn(i)
+}
+
+// DeleteLogentries implements Interface.
+func (m API) DeleteLogentries(i *fastly.DeleteLogentriesInput) error {
+	return m.DeleteLogentriesFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_logentries)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/88b210b97743b0bfece81dc3dbbd7e3254e22d97/fastly/logentries.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
( 
    cd /tmp/cli && \
    git checkout mccurdyc/logging-logentries && \
    make test && \
    rm -rf /tmp/cli \
)
```