### PR TITLE
logging: adds papertrail endpoint

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -76,6 +76,12 @@ type Interface interface {
 	UpdateLogentries(*fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
 	DeleteLogentries(*fastly.DeleteLogentriesInput) error
 
+	CreatePapertrail(*fastly.CreatePapertrailInput) (*fastly.Papertrail, error)
+	ListPapertrails(*fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error)
+	GetPapertrail(*fastly.GetPapertrailInput) (*fastly.Papertrail, error)
+	UpdatePapertrail(*fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
+	DeletePapertrail(*fastly.DeletePapertrailInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 }
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fastly/cli/pkg/logging"
 	"github.com/fastly/cli/pkg/logging/bigquery"
 	"github.com/fastly/cli/pkg/logging/logentries"
+	"github.com/fastly/cli/pkg/logging/papertrail"
 	"github.com/fastly/cli/pkg/logging/s3"
 	"github.com/fastly/cli/pkg/logging/syslog"
 	"github.com/fastly/cli/pkg/service"
@@ -150,6 +151,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	logentriesUpdate := logentries.NewUpdateCommand(logentriesRoot.CmdClause, &globals)
 	logentriesDelete := logentries.NewDeleteCommand(logentriesRoot.CmdClause, &globals)
 
+	papertrailRoot := papertrail.NewRootCommand(loggingRoot.CmdClause, &globals)
+	papertrailCreate := papertrail.NewCreateCommand(papertrailRoot.CmdClause, &globals)
+	papertrailList := papertrail.NewListCommand(papertrailRoot.CmdClause, &globals)
+	papertrailDescribe := papertrail.NewDescribeCommand(papertrailRoot.CmdClause, &globals)
+	papertrailUpdate := papertrail.NewUpdateCommand(papertrailRoot.CmdClause, &globals)
+	papertrailDelete := papertrail.NewDeleteCommand(papertrailRoot.CmdClause, &globals)
+
 	commands := []common.Command{
 		configureRoot,
 		whoamiRoot,
@@ -228,6 +236,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		logentriesDescribe,
 		logentriesUpdate,
 		logentriesDelete,
+
+		papertrailRoot,
+		papertrailCreate,
+		papertrailList,
+		papertrailDescribe,
+		papertrailUpdate,
+		papertrailDelete,
 	}
 
 	// Handle parse errors and display contextal usage if possible. Due to bugs

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -912,6 +912,81 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Logentries logging object
 
+  logging papertrail create --name=NAME --version=VERSION --address=ADDRESS [<flags>]
+    Create a Papertrail logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Papertrail logging object. Used
+                                 as a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --address=ADDRESS        A hostname or IPv4 address
+        --port=PORT              The port number
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --format=FORMAT          Apache style log formatting
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug. This field
+                                 is not required and has no default value
+
+  logging papertrail list --version=VERSION [<flags>]
+    List Papertrail endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging papertrail describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Papertrail logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Papertrail logging object
+
+  logging papertrail update --version=VERSION --name=NAME [<flags>]
+    Update a Papertrail logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Papertrail logging object
+        --new-name=NEW-NAME      New name of the Papertrail logging object
+        --address=ADDRESS        A hostname or IPv4 address
+        --port=PORT              The port number
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --format=FORMAT          Apache style log formatting
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug. This field
+                                 is not required and has no default value
+
+  logging papertrail delete --version=VERSION --name=NAME [<flags>]
+    Delete a Papertrail logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Papertrail logging object
+
 For help on a specific command, try e.g.
 
 	fastly help configure

--- a/pkg/logging/papertrail/create.go
+++ b/pkg/logging/papertrail/create.go
@@ -1,0 +1,57 @@
+package papertrail
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Papertrail logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.CreatePapertrailInput
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Papertrail logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Papertrail logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+
+	c.CmdClause.Flag("address", "A hostname or IPv4 address").Required().StringVar(&c.Input.Address)
+	c.CmdClause.Flag("port", "The port number").UintVar(&c.Input.Port)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").UintVar(&c.Input.FormatVersion)
+	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").StringVar(&c.Input.Placement)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	d, err := c.Globals.Client.CreatePapertrail(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Papertrail logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/papertrail/delete.go
+++ b/pkg/logging/papertrail/delete.go
@@ -1,0 +1,47 @@
+package papertrail
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Papertrail logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeletePapertrailInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Papertrail logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeletePapertrail(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Papertrail logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/papertrail/describe.go
+++ b/pkg/logging/papertrail/describe.go
@@ -1,0 +1,57 @@
+package papertrail
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Papertrail logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetPapertrailInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Papertrail logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	papertrail, err := c.Globals.Client.GetPapertrail(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", papertrail.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", papertrail.Version)
+	fmt.Fprintf(out, "Name: %s\n", papertrail.Name)
+	fmt.Fprintf(out, "Address: %s\n", papertrail.Address)
+	fmt.Fprintf(out, "Port: %d\n", papertrail.Port)
+	fmt.Fprintf(out, "Format: %s\n", papertrail.Format)
+	fmt.Fprintf(out, "Format version: %d\n", papertrail.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", papertrail.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", papertrail.Placement)
+
+	return nil
+}

--- a/pkg/logging/papertrail/doc.go
+++ b/pkg/logging/papertrail/doc.go
@@ -1,0 +1,3 @@
+// Package papertrail contains commands to inspect and manipulate Fastly service Papertrail
+// logging endpoints.
+package papertrail

--- a/pkg/logging/papertrail/list.go
+++ b/pkg/logging/papertrail/list.go
@@ -1,0 +1,73 @@
+package papertrail
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Papertrail logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListPapertrailsInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Papertrail endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	papertrails, err := c.Globals.Client.ListPapertrails(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, papertrail := range papertrails {
+			tw.AddLine(papertrail.ServiceID, papertrail.Version, papertrail.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, papertrail := range papertrails {
+		fmt.Fprintf(out, "\tPapertrail %d/%d\n", i+1, len(papertrails))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", papertrail.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", papertrail.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", papertrail.Name)
+		fmt.Fprintf(out, "\t\tAddress: %s\n", papertrail.Address)
+		fmt.Fprintf(out, "\t\tPort: %d\n", papertrail.Port)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", papertrail.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", papertrail.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", papertrail.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", papertrail.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/papertrail/papertrail_test.go
+++ b/pkg/logging/papertrail/papertrail_test.go
@@ -1,0 +1,386 @@
+package papertrail_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestPapertrailCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --address not provided",
+		},
+		{
+			args:       []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
+			api:        mock.API{CreatePapertrailFn: createPapertrailOK},
+			wantOutput: "Created Papertrail logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
+			api:       mock.API{CreatePapertrailFn: createPapertrailError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestPapertrailList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			wantOutput: listPapertrailsShortOutput,
+		},
+		{
+			args:       []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			wantOutput: listPapertrailsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			wantOutput: listPapertrailsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "papertrail", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			wantOutput: listPapertrailsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "papertrail", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			wantOutput: listPapertrailsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListPapertrailsFn: listPapertrailsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestPapertrailDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetPapertrailFn: getPapertrailError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetPapertrailFn: getPapertrailOK},
+			wantOutput: describePapertrailOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestPapertrailUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetPapertrailFn:    getPapertrailError,
+				UpdatePapertrailFn: updatePapertrailOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetPapertrailFn:    getPapertrailOK,
+				UpdatePapertrailFn: updatePapertrailError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetPapertrailFn:    getPapertrailOK,
+				UpdatePapertrailFn: updatePapertrailOK,
+			},
+			wantOutput: "Updated Papertrail logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestPapertrailDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeletePapertrailFn: deletePapertrailError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeletePapertrailFn: deletePapertrailOK},
+			wantOutput: "Deleted Papertrail logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createPapertrailOK(i *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
+	return &fastly.Papertrail{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createPapertrailError(i *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
+	return nil, errTest
+}
+
+func listPapertrailsOK(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
+	return []*fastly.Papertrail{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Address:           "example.com:123",
+			Port:              123,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Address:           "127.0.0.1:456",
+			Port:              456,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listPapertrailsError(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
+	return nil, errTest
+}
+
+var listPapertrailsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listPapertrailsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Papertrail 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Address: example.com:123
+		Port: 123
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Papertrail 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Address: 127.0.0.1:456
+		Port: 456
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getPapertrailOK(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
+	return &fastly.Papertrail{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Address:           "example.com:123",
+		Port:              123,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getPapertrailError(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
+	return nil, errTest
+}
+
+var describePapertrailOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Address: example.com:123
+Port: 123
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updatePapertrailOK(i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
+	return &fastly.Papertrail{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Address:           "example.com:123",
+		Port:              123,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updatePapertrailError(i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
+	return nil, errTest
+}
+
+func deletePapertrailOK(i *fastly.DeletePapertrailInput) error {
+	return nil
+}
+
+func deletePapertrailError(i *fastly.DeletePapertrailInput) error {
+	return errTest
+}

--- a/pkg/logging/papertrail/root.go
+++ b/pkg/logging/papertrail/root.go
@@ -1,0 +1,28 @@
+package papertrail
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("papertrail", "Manipulate Fastly service version Papertrail logging endpoints.")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/papertrail/update.go
+++ b/pkg/logging/papertrail/update.go
@@ -1,0 +1,120 @@
+package papertrail
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Papertrail logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	Input fastly.GetPapertrailInput
+
+	NewName common.OptionalString
+
+	Address           common.OptionalString
+	Port              common.OptionalUint
+	FormatVersion     common.OptionalUint
+	Format            common.OptionalString
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Papertrail logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.Input.Name)
+
+	c.CmdClause.Flag("new-name", "New name of the Papertrail logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("address", "A hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
+	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	papertrail, err := c.Globals.Client.GetPapertrail(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	input := &fastly.UpdatePapertrailInput{
+		Service:           papertrail.ServiceID,
+		Version:           papertrail.Version,
+		Name:              papertrail.Name,
+		NewName:           papertrail.Name,
+		Address:           papertrail.Address,
+		Port:              papertrail.Port,
+		FormatVersion:     papertrail.FormatVersion,
+		Format:            papertrail.Format,
+		ResponseCondition: papertrail.ResponseCondition,
+		Placement:         papertrail.Placement,
+	}
+
+	// Set new values if set by user.
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.Address.Valid {
+		input.Address = c.Address.Value
+	}
+
+	if c.Port.Valid {
+		input.Port = c.Port.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	papertrail, err = c.Globals.Client.UpdatePapertrail(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Papertrail logging endpoint %s (service %s version %d)", papertrail.Name, papertrail.ServiceID, papertrail.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -67,6 +67,12 @@ type API struct {
 	UpdateLogentriesFn func(*fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
 	DeleteLogentriesFn func(*fastly.DeleteLogentriesInput) error
 
+	CreatePapertrailFn func(*fastly.CreatePapertrailInput) (*fastly.Papertrail, error)
+	ListPapertrailsFn  func(*fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error)
+	GetPapertrailFn    func(*fastly.GetPapertrailInput) (*fastly.Papertrail, error)
+	UpdatePapertrailFn func(*fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
+	DeletePapertrailFn func(*fastly.DeletePapertrailInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 }
 
@@ -313,6 +319,31 @@ func (m API) UpdateLogentries(i *fastly.UpdateLogentriesInput) (*fastly.Logentri
 // DeleteLogentries implements Interface.
 func (m API) DeleteLogentries(i *fastly.DeleteLogentriesInput) error {
 	return m.DeleteLogentriesFn(i)
+}
+
+// CreatePapertrail implements Interface.
+func (m API) CreatePapertrail(i *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
+	return m.CreatePapertrailFn(i)
+}
+
+// ListPapertrails implements Interface.
+func (m API) ListPapertrails(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
+	return m.ListPapertrailsFn(i)
+}
+
+// GetPapertrail implements Interface.
+func (m API) GetPapertrail(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
+	return m.GetPapertrailFn(i)
+}
+
+// UpdatePapertrail implements Interface.
+func (m API) UpdatePapertrail(i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
+	return m.UpdatePapertrailFn(i)
+}
+
+// DeletePapertrail implements Interface.
+func (m API) DeletePapertrail(i *fastly.DeletePapertrailInput) error {
+	return m.DeletePapertrailFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_papertrail)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/88b210b97743b0bfece81dc3dbbd7e3254e22d97/fastly/papertrail.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
( 
    cd /tmp/cli && \
    git checkout mccurdyc/logging-papertrail && \
    make test && \
    rm -rf /tmp/cli \
)
```