### PR TITLE
logging: adds sumo logic logging endpoint

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -82,6 +82,12 @@ type Interface interface {
 	UpdatePapertrail(*fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
 	DeletePapertrail(*fastly.DeletePapertrailInput) error
 
+	CreateSumologic(*fastly.CreateSumologicInput) (*fastly.Sumologic, error)
+	ListSumologics(*fastly.ListSumologicsInput) ([]*fastly.Sumologic, error)
+	GetSumologic(*fastly.GetSumologicInput) (*fastly.Sumologic, error)
+	UpdateSumologic(*fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
+	DeleteSumologic(*fastly.DeleteSumologicInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 }
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/papertrail"
 	"github.com/fastly/cli/pkg/logging/s3"
+	"github.com/fastly/cli/pkg/logging/sumologic"
 	"github.com/fastly/cli/pkg/logging/syslog"
 	"github.com/fastly/cli/pkg/service"
 	"github.com/fastly/cli/pkg/serviceversion"
@@ -158,6 +159,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	papertrailUpdate := papertrail.NewUpdateCommand(papertrailRoot.CmdClause, &globals)
 	papertrailDelete := papertrail.NewDeleteCommand(papertrailRoot.CmdClause, &globals)
 
+	sumologicRoot := sumologic.NewRootCommand(loggingRoot.CmdClause, &globals)
+	sumologicCreate := sumologic.NewCreateCommand(sumologicRoot.CmdClause, &globals)
+	sumologicList := sumologic.NewListCommand(sumologicRoot.CmdClause, &globals)
+	sumologicDescribe := sumologic.NewDescribeCommand(sumologicRoot.CmdClause, &globals)
+	sumologicUpdate := sumologic.NewUpdateCommand(sumologicRoot.CmdClause, &globals)
+	sumologicDelete := sumologic.NewDeleteCommand(sumologicRoot.CmdClause, &globals)
+
 	commands := []common.Command{
 		configureRoot,
 		whoamiRoot,
@@ -243,6 +251,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		papertrailDescribe,
 		papertrailUpdate,
 		papertrailDelete,
+
+		sumologicRoot,
+		sumologicCreate,
+		sumologicList,
+		sumologicDescribe,
+		sumologicUpdate,
+		sumologicDelete,
 	}
 
 	// Handle parse errors and display contextal usage if possible. Due to bugs

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -987,6 +987,85 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Papertrail logging object
 
+  logging sumologic create --name=NAME --version=VERSION --url=URL [<flags>]
+    Create a Sumologic logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Sumologic logging object. Used
+                                 as a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --url=URL                The URL to POST to
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --message-type=MESSAGE-TYPE  
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug. This field
+                                 is not required and has no default value
+
+  logging sumologic list --version=VERSION [<flags>]
+    List Sumologic endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging sumologic describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Sumologic logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Sumologic logging object
+
+  logging sumologic update --version=VERSION --name=NAME [<flags>]
+    Update a Sumologic logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Sumologic logging object
+        --new-name=NEW-NAME      New name of the Sumologic logging object
+        --url=URL                The URL to POST to
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --message-type=MESSAGE-TYPE  
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug. This field
+                                 is not required and has no default value
+
+  logging sumologic delete --version=VERSION --name=NAME [<flags>]
+    Delete a Sumologic logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Sumologic logging object
+
 For help on a specific command, try e.g.
 
 	fastly help configure

--- a/pkg/common/command.go
+++ b/pkg/common/command.go
@@ -86,8 +86,14 @@ type OptionalBool struct {
 	Value bool
 }
 
-// OptionalUint models an optional unit flag value.
+// OptionalUint models an optional uint flag value.
 type OptionalUint struct {
 	Optional
 	Value uint
+}
+
+// OptionalInt models an optional int flag value.
+type OptionalInt struct {
+	Optional
+	Value int
 }

--- a/pkg/logging/sumologic/create.go
+++ b/pkg/logging/sumologic/create.go
@@ -1,0 +1,57 @@
+package sumologic
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Sumologic logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.CreateSumologicInput
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Sumologic logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Sumologic logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+
+	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.Input.URL)
+	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").IntVar(&c.Input.FormatVersion)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").StringVar(&c.Input.MessageType)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").StringVar(&c.Input.Placement)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	d, err := c.Globals.Client.CreateSumologic(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Sumologic logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/sumologic/delete.go
+++ b/pkg/logging/sumologic/delete.go
@@ -1,0 +1,47 @@
+package sumologic
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Sumologic logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteSumologicInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Sumologic logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteSumologic(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Sumologic logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/sumologic/describe.go
+++ b/pkg/logging/sumologic/describe.go
@@ -1,0 +1,57 @@
+package sumologic
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Sumologic logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetSumologicInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Sumologic logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	sumologic, err := c.Globals.Client.GetSumologic(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", sumologic.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", sumologic.Version)
+	fmt.Fprintf(out, "Name: %s\n", sumologic.Name)
+	fmt.Fprintf(out, "URL: %s\n", sumologic.URL)
+	fmt.Fprintf(out, "Format: %s\n", sumologic.Format)
+	fmt.Fprintf(out, "Format version: %d\n", sumologic.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", sumologic.ResponseCondition)
+	fmt.Fprintf(out, "Message type: %s\n", sumologic.MessageType)
+	fmt.Fprintf(out, "Placement: %s\n", sumologic.Placement)
+
+	return nil
+}

--- a/pkg/logging/sumologic/doc.go
+++ b/pkg/logging/sumologic/doc.go
@@ -1,0 +1,3 @@
+// Package sumologic contains commands to inspect and manipulate Fastly service Sumologic
+// logging endpoints.
+package sumologic

--- a/pkg/logging/sumologic/list.go
+++ b/pkg/logging/sumologic/list.go
@@ -1,0 +1,73 @@
+package sumologic
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Sumologic logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListSumologicsInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Sumologic endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	sumologics, err := c.Globals.Client.ListSumologics(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, sumologic := range sumologics {
+			tw.AddLine(sumologic.ServiceID, sumologic.Version, sumologic.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, sumologic := range sumologics {
+		fmt.Fprintf(out, "\tSumologic %d/%d\n", i+1, len(sumologics))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", sumologic.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", sumologic.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", sumologic.Name)
+		fmt.Fprintf(out, "\t\tURL: %s\n", sumologic.URL)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", sumologic.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", sumologic.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", sumologic.ResponseCondition)
+		fmt.Fprintf(out, "\t\tMessage type: %s\n", sumologic.MessageType)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", sumologic.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/sumologic/root.go
+++ b/pkg/logging/sumologic/root.go
@@ -1,0 +1,28 @@
+package sumologic
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("sumologic", "Manipulate Fastly service version Sumologic logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/sumologic/sumologic_test.go
+++ b/pkg/logging/sumologic/sumologic_test.go
@@ -1,0 +1,386 @@
+package sumologic_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestSumologicCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --url not provided",
+		},
+		{
+			args:       []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:        mock.API{CreateSumologicFn: createSumologicOK},
+			wantOutput: "Created Sumologic logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:       mock.API{CreateSumologicFn: createSumologicError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSumologicList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsShortOutput,
+		},
+		{
+			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "sumologic", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "sumologic", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListSumologicsFn: listSumologicsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSumologicDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetSumologicFn: getSumologicError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetSumologicFn: getSumologicOK},
+			wantOutput: describeSumologicOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSumologicUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSumologicFn:    getSumologicError,
+				UpdateSumologicFn: updateSumologicOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSumologicFn:    getSumologicOK,
+				UpdateSumologicFn: updateSumologicError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSumologicFn:    getSumologicOK,
+				UpdateSumologicFn: updateSumologicOK,
+			},
+			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSumologicDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteSumologicFn: deleteSumologicError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteSumologicFn: deleteSumologicOK},
+			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createSumologicOK(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+	return &fastly.Sumologic{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createSumologicError(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+func listSumologicsOK(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+	return []*fastly.Sumologic{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			URL:               "example.com",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			URL:               "bar.com",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			ResponseCondition: "Prevent default logging",
+			MessageType:       "classic",
+			FormatVersion:     2,
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listSumologicsError(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+var listSumologicsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listSumologicsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Sumologic 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		URL: example.com
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Placement: none
+	Sumologic 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		URL: bar.com
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Placement: none
+`) + "\n\n"
+
+func getSumologicOK(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+	return &fastly.Sumologic{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		URL:               "example.com",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getSumologicError(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+var describeSumologicOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+URL: example.com
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Message type: classic
+Placement: none
+`) + "\n"
+
+func updateSumologicOK(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+	return &fastly.Sumologic{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		URL:               "example.com",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateSumologicError(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+func deleteSumologicOK(i *fastly.DeleteSumologicInput) error {
+	return nil
+}
+
+func deleteSumologicError(i *fastly.DeleteSumologicInput) error {
+	return errTest
+}

--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -1,0 +1,122 @@
+package sumologic
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Sumologic logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	Input fastly.GetSumologicInput
+
+	NewName common.OptionalString
+
+	Address           common.OptionalString
+	URL               common.OptionalString
+	Format            common.OptionalString
+	ResponseCondition common.OptionalString
+	MessageType       common.OptionalString
+	FormatVersion     common.OptionalInt // Inconsistent with other logging endpoints, but remaining as int to avoid breaking changes in fastly/go-fastly.
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Sumologic logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.Input.Name)
+
+	c.CmdClause.Flag("new-name", "New name of the Sumologic logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("url", "The URL to POST to").Action(c.URL.Set).StringVar(&c.URL.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).IntVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	sumologic, err := c.Globals.Client.GetSumologic(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	input := &fastly.UpdateSumologicInput{
+		Service:           sumologic.ServiceID,
+		Version:           sumologic.Version,
+		Name:              sumologic.Name,
+		NewName:           sumologic.Name,
+		Address:           sumologic.Address,
+		URL:               sumologic.URL,
+		Format:            sumologic.Format,
+		ResponseCondition: sumologic.ResponseCondition,
+		MessageType:       sumologic.MessageType,
+		FormatVersion:     sumologic.FormatVersion,
+		Placement:         sumologic.Placement,
+	}
+
+	// Set new values if set by user.
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.Address.Valid {
+		input.Address = c.Address.Value
+	}
+
+	if c.URL.Valid {
+		input.URL = c.URL.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = c.MessageType.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	sumologic, err = c.Globals.Client.UpdateSumologic(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Sumologic logging endpoint %s (service %s version %d)", sumologic.Name, sumologic.ServiceID, sumologic.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -73,6 +73,12 @@ type API struct {
 	UpdatePapertrailFn func(*fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
 	DeletePapertrailFn func(*fastly.DeletePapertrailInput) error
 
+	CreateSumologicFn func(*fastly.CreateSumologicInput) (*fastly.Sumologic, error)
+	ListSumologicsFn  func(*fastly.ListSumologicsInput) ([]*fastly.Sumologic, error)
+	GetSumologicFn    func(*fastly.GetSumologicInput) (*fastly.Sumologic, error)
+	UpdateSumologicFn func(*fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
+	DeleteSumologicFn func(*fastly.DeleteSumologicInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 }
 
@@ -344,6 +350,31 @@ func (m API) UpdatePapertrail(i *fastly.UpdatePapertrailInput) (*fastly.Papertra
 // DeletePapertrail implements Interface.
 func (m API) DeletePapertrail(i *fastly.DeletePapertrailInput) error {
 	return m.DeletePapertrailFn(i)
+}
+
+// CreateSumologic implements Interface.
+func (m API) CreateSumologic(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+	return m.CreateSumologicFn(i)
+}
+
+// ListSumologics implements Interface.
+func (m API) ListSumologics(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+	return m.ListSumologicsFn(i)
+}
+
+// GetSumologic implements Interface.
+func (m API) GetSumologic(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+	return m.GetSumologicFn(i)
+}
+
+// UpdateSumologic implements Interface.
+func (m API) UpdateSumologic(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+	return m.UpdateSumologicFn(i)
+}
+
+// DeleteSumologic implements Interface.
+func (m API) DeleteSumologic(i *fastly.DeleteSumologicInput) error {
+	return m.DeleteSumologicFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Proposed Change(s)

* Add Sumo Logic logging endpoint support
* Add [`common.OptionalInt`](https://github.com/fastly/cli/pull/59/files#diff-9b0fcc67cb04304da1c951ce17a7acf0R96)
* [Document the `FormatVersion` type inconsistency with other logging endpoints.](https://github.com/fastly/cli/pull/59/files#diff-6294a1021af5297b16282e85c38c7c61R28)
   * Noted that this is a breaking change in the `fastly/go-fastly` client library.

## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_sumologic)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/88b210b97743b0bfece81dc3dbbd7e3254e22d97/fastly/sumologic.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
( 
    cd /tmp/cli && \
    git checkout mccurdyc/logging-sumologic && \
    make test && \
    rm -rf /tmp/cli \
)
```