### PR TITLE
Move the fossa security scan to master CI jobs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches:
+      - master
+name: Test
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14.x
+    - name: Install fossa
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+      shell: bash
+    - name: Set GOPATH
+      # Temporary fix, see: https://github.com/actions/setup-go/issues/14
+      run: |
+        echo "::set-env name=GOPATH::$(go env GOPATH)"
+        echo "::add-path::$(go env GOPATH)/bin"
+      shell: bash
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Fossa
+      run: make fossa
+      shell: bash
+      env:
+        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        FOSSA_API_ENDPOINT: ${{ secrets.FOSSA_API_ENDPOINT }}
+

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -95,28 +95,3 @@ jobs:
       env:
         TEST_COMPUTE_INIT: true
         TEST_COMPUTE_BUILD: true
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.14.x
-    - name: Install fossa
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
-      shell: bash
-    - name: Set GOPATH
-      # Temporary fix, see: https://github.com/actions/setup-go/issues/14
-      run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
-    - name: Checkout code
-      uses: actions/checkout@v1
-    - name: Fossa
-      run: make fossa
-      shell: bash
-      env:
-        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-        FOSSA_API_ENDPOINT: ${{ secrets.FOSSA_API_ENDPOINT }}


### PR DESCRIPTION
### TL;DR
The `scan` job  in our current PR Action workflow is preventing external contributions from succeeding the workflow, thus giving false positives and making us force the merge with admin privileges. This is due to the way Actions (correctly) suppresses secrets on fork based builds to prevent them from leaking, which is causing the scan job to fail as it requires a secret. Therefore, we've decided to run this job on master pushes instead. Its a tradeoff as if a PR introduces a vulnerability we won't find out until its merged, however at least they will  be caught before a release.