### PR TITLE
logging: adds GCS logging endpoint

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -88,6 +88,12 @@ type Interface interface {
 	UpdateSumologic(*fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
 	DeleteSumologic(*fastly.DeleteSumologicInput) error
 
+	CreateGCS(*fastly.CreateGCSInput) (*fastly.GCS, error)
+	ListGCSs(*fastly.ListGCSsInput) ([]*fastly.GCS, error)
+	GetGCS(*fastly.GetGCSInput) (*fastly.GCS, error)
+	UpdateGCS(*fastly.UpdateGCSInput) (*fastly.GCS, error)
+	DeleteGCS(*fastly.DeleteGCSInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 }
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fastly/cli/pkg/healthcheck"
 	"github.com/fastly/cli/pkg/logging"
 	"github.com/fastly/cli/pkg/logging/bigquery"
+	"github.com/fastly/cli/pkg/logging/gcs"
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/papertrail"
 	"github.com/fastly/cli/pkg/logging/s3"
@@ -166,6 +167,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	sumologicUpdate := sumologic.NewUpdateCommand(sumologicRoot.CmdClause, &globals)
 	sumologicDelete := sumologic.NewDeleteCommand(sumologicRoot.CmdClause, &globals)
 
+	gcsRoot := gcs.NewRootCommand(loggingRoot.CmdClause, &globals)
+	gcsCreate := gcs.NewCreateCommand(gcsRoot.CmdClause, &globals)
+	gcsList := gcs.NewListCommand(gcsRoot.CmdClause, &globals)
+	gcsDescribe := gcs.NewDescribeCommand(gcsRoot.CmdClause, &globals)
+	gcsUpdate := gcs.NewUpdateCommand(gcsRoot.CmdClause, &globals)
+	gcsDelete := gcs.NewDeleteCommand(gcsRoot.CmdClause, &globals)
+
 	commands := []common.Command{
 		configureRoot,
 		whoamiRoot,
@@ -258,6 +266,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		sumologicDescribe,
 		sumologicUpdate,
 		sumologicDelete,
+
+		gcsRoot,
+		gcsCreate,
+		gcsList,
+		gcsDescribe,
+		gcsUpdate,
+		gcsDelete,
 	}
 
 	// Handle parse errors and display contextal usage if possible. Due to bugs

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1066,6 +1066,110 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Sumologic logging object
 
+  logging gcs create --name=NAME --version=VERSION --user=USER --bucket=BUCKET --secret-key=SECRET-KEY [<flags>]
+    Create a GCS logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the GCS logging object. Used as a
+                                 primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --user=USER              Your GCS service account email address. The
+                                 client_email field in your service account
+                                 authentication JSON
+        --bucket=BUCKET          The bucket of the GCS bucket
+        --secret-key=SECRET-KEY  Your GCS account secret key. The private_key
+                                 field in your service account authentication
+                                 JSON
+        --period=PERIOD          How frequently log files are finalized so they
+                                 can be available for reading (in seconds,
+                                 default 3600)
+        --path=PATH              The path to upload logs to (default '/')
+        --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
+                                 dumping logs (default 0, no compression)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --message-type=MESSAGE-TYPE  
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --timestamp-format=TIMESTAMP-FORMAT  
+                                 strftime specified timestamp formatting
+                                 (default "%Y-%m-%dT%H:%M:%S.000")
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging gcs list --version=VERSION [<flags>]
+    List GCS endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging gcs describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a GCS logging endpoint on a Fastly service
+    version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the GCS logging object
+
+  logging gcs update --version=VERSION --name=NAME [<flags>]
+    Update a GCS logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the GCS logging object
+        --new-name=NEW-NAME      New name of the GCS logging object
+        --bucket=BUCKET          The bucket of the GCS bucket
+        --user=USER              Your GCS service account email address. The
+                                 client_email field in your service account
+                                 authentication JSON
+        --secret-key=SECRET-KEY  Your GCS account secret key. The private_key
+                                 field in your service account authentication
+                                 JSON
+        --path=PATH              The path to upload logs to (default '/')
+        --period=PERIOD          How frequently log files are finalized so they
+                                 can be available for reading (in seconds,
+                                 default 3600)
+        --format-version=FORMAT-VERSION  
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
+                                 dumping logs (default 0, no compression)
+        --format=FORMAT          Apache style log formatting
+        --response-condition=RESPONSE-CONDITION  
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --timestamp-format=TIMESTAMP-FORMAT  
+                                 strftime specified timestamp formatting
+                                 (default "%Y-%m-%dT%H:%M:%S.000")
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging gcs delete --version=VERSION --name=NAME [<flags>]
+    Delete a GCS logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the GCS logging object
+
 For help on a specific command, try e.g.
 
 	fastly help configure

--- a/pkg/common/command.go
+++ b/pkg/common/command.go
@@ -92,6 +92,12 @@ type OptionalUint struct {
 	Value uint
 }
 
+// OptionalUint8 models an optional unit8 flag value.
+type OptionalUint8 struct {
+	Optional
+	Value uint8
+}
+
 // OptionalInt models an optional int flag value.
 type OptionalInt struct {
 	Optional

--- a/pkg/logging/gcs/create.go
+++ b/pkg/logging/gcs/create.go
@@ -1,0 +1,64 @@
+package gcs
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create GCS logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.CreateGCSInput
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a GCS logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the GCS logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+
+	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Required().StringVar(&c.Input.User)
+	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Required().StringVar(&c.Input.Bucket)
+	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Required().StringVar(&c.Input.SecretKey)
+
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").UintVar(&c.Input.Period)
+	c.CmdClause.Flag("path", "The path to upload logs to (default '/')").StringVar(&c.Input.Path)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Uint8Var(&c.Input.GzipLevel)
+	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").UintVar(&c.Input.FormatVersion)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").StringVar(&c.Input.MessageType)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).StringVar(&c.Input.TimestampFormat)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").StringVar(&c.Input.Placement)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	d, err := c.Globals.Client.CreateGCS(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created GCS logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/gcs/delete.go
+++ b/pkg/logging/gcs/delete.go
@@ -1,0 +1,47 @@
+package gcs
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete GCS logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteGCSInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a GCS logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteGCS(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted GCS logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -1,0 +1,63 @@
+package gcs
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a GCS logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetGCSInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a GCS logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	gcs, err := c.Globals.Client.GetGCS(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", gcs.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", gcs.Version)
+	fmt.Fprintf(out, "Name: %s\n", gcs.Name)
+	fmt.Fprintf(out, "Bucket: %s\n", gcs.Bucket)
+	fmt.Fprintf(out, "User: %s\n", gcs.User)
+	fmt.Fprintf(out, "Secret key: %s\n", gcs.SecretKey)
+	fmt.Fprintf(out, "Path: %s\n", gcs.Path)
+	fmt.Fprintf(out, "Period: %d\n", gcs.Period)
+	fmt.Fprintf(out, "GZip level: %d\n", gcs.GzipLevel)
+	fmt.Fprintf(out, "Format: %s\n", gcs.Format)
+	fmt.Fprintf(out, "Format version: %d\n", gcs.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", gcs.ResponseCondition)
+	fmt.Fprintf(out, "Message type: %s\n", gcs.MessageType)
+	fmt.Fprintf(out, "Timestamp format: %s\n", gcs.TimestampFormat)
+	fmt.Fprintf(out, "Placement: %s\n", gcs.Placement)
+
+	return nil
+}

--- a/pkg/logging/gcs/doc.go
+++ b/pkg/logging/gcs/doc.go
@@ -1,0 +1,3 @@
+// Package gcs contains commands to inspect and manipulate Fastly service GCS
+// logging endpoints.
+package gcs

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -1,0 +1,436 @@
+package gcs_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestGCSCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
+			wantError: "error parsing arguments: required flag --bucket not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
+			wantError: "error parsing arguments: required flag --user not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
+			wantError: "error parsing arguments: required flag --secret-key not provided",
+		},
+		{
+			args:       []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			api:        mock.API{CreateGCSFn: createGCSOK},
+			wantOutput: "Created GCS logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			api:       mock.API{CreateGCSFn: createGCSError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestGCSList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsShortOutput,
+		},
+		{
+			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "gcs", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "gcs", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListGCSsFn: listGCSsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestGCSDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetGCSFn: getGCSError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetGCSFn: getGCSOK},
+			wantOutput: describeGCSOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestGCSUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetGCSFn:    getGCSError,
+				UpdateGCSFn: updateGCSOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetGCSFn:    getGCSOK,
+				UpdateGCSFn: updateGCSError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetGCSFn:    getGCSOK,
+				UpdateGCSFn: updateGCSOK,
+			},
+			wantOutput: "Updated GCS logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestGCSDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteGCSFn: deleteGCSError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteGCSFn: deleteGCSOK},
+			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createGCSOK(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
+	return &fastly.GCS{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createGCSError(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
+	return nil, errTest
+}
+
+func listGCSsOK(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+	return []*fastly.GCS{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Bucket:            "my-logs",
+			User:              "foo@example.com",
+			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+			Path:              "logs/",
+			Period:            3600,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Bucket:            "analytics",
+			User:              "foo@example.com",
+			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+			Path:              "logs/",
+			Period:            86400,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listGCSsError(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+	return nil, errTest
+}
+
+var listGCSsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listGCSsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	GCS 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Bucket: my-logs
+		User: foo@example.com
+		Secret key: -----BEGIN RSA PRIVATE KEY-----foo
+		Path: logs/
+		Period: 3600
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+	GCS 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Bucket: analytics
+		User: foo@example.com
+		Secret key: -----BEGIN RSA PRIVATE KEY-----foo
+		Path: logs/
+		Period: 86400
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+`) + "\n\n"
+
+func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
+	return &fastly.GCS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Bucket:            "my-logs",
+		User:              "foo@example.com",
+		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func getGCSError(i *fastly.GetGCSInput) (*fastly.GCS, error) {
+	return nil, errTest
+}
+
+var describeGCSOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Bucket: my-logs
+User: foo@example.com
+Secret key: -----BEGIN RSA PRIVATE KEY-----foo
+Path: logs/
+Period: 3600
+GZip level: 9
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Message type: classic
+Timestamp format: %Y-%m-%dT%H:%M:%S.000
+Placement: none
+`) + "\n"
+
+func updateGCSOK(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+	return &fastly.GCS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Bucket:            "logs",
+		User:              "foo@example.com",
+		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		MessageType:       "classic",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func updateGCSError(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+	return nil, errTest
+}
+
+func deleteGCSOK(i *fastly.DeleteGCSInput) error {
+	return nil
+}
+
+func deleteGCSError(i *fastly.DeleteGCSInput) error {
+	return errTest
+}

--- a/pkg/logging/gcs/list.go
+++ b/pkg/logging/gcs/list.go
@@ -1,0 +1,79 @@
+package gcs
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list GCS logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListGCSsInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List GCS endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	gcss, err := c.Globals.Client.ListGCSs(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, gcs := range gcss {
+			tw.AddLine(gcs.ServiceID, gcs.Version, gcs.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, gcs := range gcss {
+		fmt.Fprintf(out, "\tGCS %d/%d\n", i+1, len(gcss))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", gcs.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", gcs.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", gcs.Name)
+		fmt.Fprintf(out, "\t\tBucket: %s\n", gcs.Bucket)
+		fmt.Fprintf(out, "\t\tUser: %s\n", gcs.User)
+		fmt.Fprintf(out, "\t\tSecret key: %s\n", gcs.SecretKey)
+		fmt.Fprintf(out, "\t\tPath: %s\n", gcs.Path)
+		fmt.Fprintf(out, "\t\tPeriod: %d\n", gcs.Period)
+		fmt.Fprintf(out, "\t\tGZip level: %d\n", gcs.GzipLevel)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", gcs.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", gcs.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", gcs.ResponseCondition)
+		fmt.Fprintf(out, "\t\tMessage type: %s\n", gcs.MessageType)
+		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", gcs.TimestampFormat)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", gcs.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/gcs/root.go
+++ b/pkg/logging/gcs/root.go
@@ -1,0 +1,28 @@
+package gcs
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("gcs", "Manipulate Fastly service version GCS logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -1,0 +1,151 @@
+package gcs
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update GCS logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	Input fastly.GetGCSInput
+
+	NewName common.OptionalString
+
+	Bucket            common.OptionalString
+	User              common.OptionalString
+	SecretKey         common.OptionalString
+	Path              common.OptionalString
+	Period            common.OptionalUint
+	FormatVersion     common.OptionalUint
+	GzipLevel         common.OptionalUint8
+	Format            common.OptionalString
+	ResponseCondition common.OptionalString
+	TimestampFormat   common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a GCS logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.Input.Name)
+
+	c.CmdClause.Flag("new-name", "New name of the GCS logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Action(c.Bucket.Set).StringVar(&c.Bucket.Value)
+	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Action(c.User.Set).StringVar(&c.User.Value)
+	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Action(c.SecretKey.Set).StringVar(&c.SecretKey.Value)
+	c.CmdClause.Flag("path", "The path to upload logs to (default '/')").Action(c.Path.Set).StringVar(&c.Path.Value)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).Uint8Var(&c.GzipLevel.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	gcs, err := c.Globals.Client.GetGCS(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	input := &fastly.UpdateGCSInput{
+		Service:           gcs.ServiceID,
+		Version:           gcs.Version,
+		Name:              gcs.Name,
+		NewName:           gcs.Name,
+		Bucket:            gcs.Bucket,
+		User:              gcs.User,
+		SecretKey:         gcs.SecretKey,
+		Path:              gcs.Path,
+		Period:            gcs.Period,
+		FormatVersion:     gcs.FormatVersion,
+		GzipLevel:         gcs.GzipLevel,
+		Format:            gcs.Format,
+		ResponseCondition: gcs.ResponseCondition,
+		TimestampFormat:   gcs.TimestampFormat,
+		Placement:         gcs.Placement,
+	}
+
+	// Set new values if set by user.
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.Bucket.Valid {
+		input.Bucket = c.Bucket.Value
+	}
+
+	if c.User.Valid {
+		input.User = c.User.Value
+	}
+
+	if c.SecretKey.Valid {
+		input.SecretKey = c.SecretKey.Value
+	}
+
+	if c.Path.Valid {
+		input.Path = c.Path.Value
+	}
+
+	if c.Period.Valid {
+		input.Period = c.Period.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.GzipLevel.Valid {
+		input.GzipLevel = c.GzipLevel.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.TimestampFormat.Valid {
+		input.TimestampFormat = c.TimestampFormat.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	gcs, err = c.Globals.Client.UpdateGCS(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated GCS logging endpoint %s (service %s version %d)", gcs.Name, gcs.ServiceID, gcs.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -79,6 +79,12 @@ type API struct {
 	UpdateSumologicFn func(*fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
 	DeleteSumologicFn func(*fastly.DeleteSumologicInput) error
 
+	CreateGCSFn func(*fastly.CreateGCSInput) (*fastly.GCS, error)
+	ListGCSsFn  func(*fastly.ListGCSsInput) ([]*fastly.GCS, error)
+	GetGCSFn    func(*fastly.GetGCSInput) (*fastly.GCS, error)
+	UpdateGCSFn func(*fastly.UpdateGCSInput) (*fastly.GCS, error)
+	DeleteGCSFn func(*fastly.DeleteGCSInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 }
 
@@ -375,6 +381,31 @@ func (m API) UpdateSumologic(i *fastly.UpdateSumologicInput) (*fastly.Sumologic,
 // DeleteSumologic implements Interface.
 func (m API) DeleteSumologic(i *fastly.DeleteSumologicInput) error {
 	return m.DeleteSumologicFn(i)
+}
+
+// CreateGCS implements Interface.
+func (m API) CreateGCS(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
+	return m.CreateGCSFn(i)
+}
+
+// ListGCSs implements Interface.
+func (m API) ListGCSs(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+	return m.ListGCSsFn(i)
+}
+
+// GetGCS implements Interface.
+func (m API) GetGCS(i *fastly.GetGCSInput) (*fastly.GCS, error) {
+	return m.GetGCSFn(i)
+}
+
+// UpdateGCS implements Interface.
+func (m API) UpdateGCS(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+	return m.UpdateGCSFn(i)
+}
+
+// DeleteGCS implements Interface.
+func (m API) DeleteGCS(i *fastly.DeleteGCSInput) error {
+	return m.DeleteGCSFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_gcs)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/88b210b97743b0bfece81dc3dbbd7e3254e22d97/fastly/gcs.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-gcs && \
    make test && \
    rm -rf /tmp/cli \
)
```