### PR TITLE
logging: adds FTP logging endpoint

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -94,6 +94,12 @@ type Interface interface {
 	UpdateGCS(*fastly.UpdateGCSInput) (*fastly.GCS, error)
 	DeleteGCS(*fastly.DeleteGCSInput) error
 
+	CreateFTP(*fastly.CreateFTPInput) (*fastly.FTP, error)
+	ListFTPs(*fastly.ListFTPsInput) ([]*fastly.FTP, error)
+	GetFTP(*fastly.GetFTPInput) (*fastly.FTP, error)
+	UpdateFTP(*fastly.UpdateFTPInput) (*fastly.FTP, error)
+	DeleteFTP(*fastly.DeleteFTPInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fastly/cli/pkg/healthcheck"
 	"github.com/fastly/cli/pkg/logging"
 	"github.com/fastly/cli/pkg/logging/bigquery"
+	"github.com/fastly/cli/pkg/logging/ftp"
 	"github.com/fastly/cli/pkg/logging/gcs"
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/papertrail"
@@ -175,6 +176,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	gcsUpdate := gcs.NewUpdateCommand(gcsRoot.CmdClause, &globals)
 	gcsDelete := gcs.NewDeleteCommand(gcsRoot.CmdClause, &globals)
 
+	ftpRoot := ftp.NewRootCommand(loggingRoot.CmdClause, &globals)
+	ftpCreate := ftp.NewCreateCommand(ftpRoot.CmdClause, &globals)
+	ftpList := ftp.NewListCommand(ftpRoot.CmdClause, &globals)
+	ftpDescribe := ftp.NewDescribeCommand(ftpRoot.CmdClause, &globals)
+	ftpUpdate := ftp.NewUpdateCommand(ftpRoot.CmdClause, &globals)
+	ftpDelete := ftp.NewDeleteCommand(ftpRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -279,6 +287,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		gcsDescribe,
 		gcsUpdate,
 		gcsDelete,
+
+		ftpRoot,
+		ftpCreate,
+		ftpList,
+		ftpDescribe,
+		ftpUpdate,
+		ftpDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1183,6 +1183,104 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the GCS logging object
 
+  logging ftp create --name=NAME --version=VERSION --address=ADDRESS --user=USER --password=PASSWORD [<flags>]
+    Create an FTP logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the FTP logging object. Used as a
+                                 primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --address=ADDRESS        An hostname or IPv4 address
+        --user=USER              The username for the server (can be anonymous)
+        --password=PASSWORD      The password for the server (for anonymous use
+                                 an email address)
+        --port=PORT              The port number
+        --path=PATH              The path to upload log files to. If the path
+                                 ends in / then it is treated as a directory
+        --period=PERIOD          How frequently log files are finalized so they
+                                 can be available for reading (in seconds,
+                                 default 3600)
+        --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
+                                 dumping logs (default 0, no compression)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --timestamp-format=TIMESTAMP-FORMAT
+                                 strftime specified timestamp formatting
+                                 (default "%Y-%m-%dT%H:%M:%S.000")
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging ftp list --version=VERSION [<flags>]
+    List FTP endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging ftp describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about an FTP logging endpoint on a Fastly service
+    version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the FTP logging object
+
+  logging ftp update --version=VERSION --name=NAME [<flags>]
+    Update an FTP logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the FTP logging object
+        --new-name=NEW-NAME      New name of the FTP logging object
+        --address=ADDRESS        An hostname or IPv4 address
+        --port=PORT              The port number
+        --username=USERNAME      The username for the server (can be anonymous)
+        --password=PASSWORD      The password for the server (for anonymous use
+                                 an email address)
+        --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
+                                 encrypt your log files before writing them to
+                                 disk
+        --path=PATH              The path to upload log files to. If the path
+                                 ends in / then it is treated as a directory
+        --period=PERIOD          How frequently log files are finalized so they
+                                 can be available for reading (in seconds,
+                                 default 3600)
+        --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
+                                 dumping logs (default 0, no compression)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (the default, version 2 log format) or 1 (the
+                                 version 1 log format). The logging call gets
+                                 placed by default in vcl_log if format_version
+                                 is set to 2 and in vcl_deliver if
+                                 format_version is set to 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --timestamp-format=TIMESTAMP-FORMAT
+                                 strftime specified timestamp formatting
+                                 (default "%Y-%m-%dT%H:%M:%S.000")
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging ftp delete --version=VERSION --name=NAME [<flags>]
+    Delete an FTP logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the FTP logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -1,0 +1,63 @@
+package ftp
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create FTP logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.CreateFTPInput
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create an FTP logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the FTP logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+
+	c.CmdClause.Flag("address", "An hostname or IPv4 address").Required().StringVar(&c.Input.Address)
+	c.CmdClause.Flag("user", "The username for the server (can be anonymous)").Required().StringVar(&c.Input.Username)
+	c.CmdClause.Flag("password", "The password for the server (for anonymous use an email address)").Required().StringVar(&c.Input.Password)
+
+	c.CmdClause.Flag("port", "The port number").UintVar(&c.Input.Port)
+	c.CmdClause.Flag("path", "The path to upload log files to. If the path ends in / then it is treated as a directory").StringVar(&c.Input.Path)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").UintVar(&c.Input.Period)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Uint8Var(&c.Input.GzipLevel)
+	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").UintVar(&c.Input.FormatVersion)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).StringVar(&c.Input.TimestampFormat)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").StringVar(&c.Input.Placement)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+	d, err := c.Globals.Client.CreateFTP(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created FTP logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/ftp/delete.go
+++ b/pkg/logging/ftp/delete.go
@@ -1,0 +1,47 @@
+package ftp
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete FTP logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteFTPInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete an FTP logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteFTP(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted FTP logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -1,0 +1,64 @@
+package ftp
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe an FTP logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetFTPInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about an FTP logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	ftp, err := c.Globals.Client.GetFTP(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", ftp.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", ftp.Version)
+	fmt.Fprintf(out, "Name: %s\n", ftp.Name)
+	fmt.Fprintf(out, "Address: %s\n", ftp.Address)
+	fmt.Fprintf(out, "Port: %d\n", ftp.Port)
+	fmt.Fprintf(out, "Username: %s\n", ftp.Username)
+	fmt.Fprintf(out, "Password: %s\n", ftp.Password)
+	fmt.Fprintf(out, "Public key: %s\n", ftp.PublicKey)
+	fmt.Fprintf(out, "Path: %s\n", ftp.Path)
+	fmt.Fprintf(out, "Period: %d\n", ftp.Period)
+	fmt.Fprintf(out, "GZip level: %d\n", ftp.GzipLevel)
+	fmt.Fprintf(out, "Format: %s\n", ftp.Format)
+	fmt.Fprintf(out, "Format version: %d\n", ftp.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", ftp.ResponseCondition)
+	fmt.Fprintf(out, "Timestamp format: %s\n", ftp.TimestampFormat)
+	fmt.Fprintf(out, "Placement: %s\n", ftp.Placement)
+
+	return nil
+}

--- a/pkg/logging/ftp/doc.go
+++ b/pkg/logging/ftp/doc.go
@@ -1,0 +1,3 @@
+// Package ftp contains commands to inspect and manipulate Fastly service FTP
+// logging endpoints.
+package ftp

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -1,0 +1,477 @@
+package ftp_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestFTPCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
+			wantError: "error parsing arguments: required flag --address not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
+			wantError: "error parsing arguments: required flag --user not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
+			wantError: "error parsing arguments: required flag --password not provided",
+		},
+		{
+			args:       []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
+			api:        mock.API{CreateFTPFn: createFTPOK},
+			wantOutput: "Created FTP logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
+			api:       mock.API{CreateFTPFn: createFTPError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestFTPList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsShortOutput,
+		},
+		{
+			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListFTPsFn: listFTPsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestFTPDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetFTPFn: getFTPError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetFTPFn: getFTPOK},
+			wantOutput: describeFTPOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestFTPUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetFTPFn:    getFTPError,
+				UpdateFTPFn: updateFTPOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetFTPFn:    getFTPOK,
+				UpdateFTPFn: updateFTPError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetFTPFn:    getFTPOK,
+				UpdateFTPFn: updateFTPOK,
+			},
+			wantOutput: "Updated FTP logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestFTPDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteFTPFn: deleteFTPError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteFTPFn: deleteFTPOK},
+			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createFTPOK(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
+	return &fastly.FTP{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createFTPError(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
+	return nil, errTest
+}
+
+func listFTPsOK(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+	return []*fastly.FTP{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Address:           "example.com",
+			Port:              123,
+			Username:          "anonymous",
+			Password:          "foo@example.com",
+			PublicKey:         pgpPublicKey(),
+			Path:              "logs/",
+			Period:            3600,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Address:           "127.0.0.1",
+			Port:              456,
+			Username:          "foo",
+			Password:          "password",
+			PublicKey:         pgpPublicKey(),
+			Path:              "logs/",
+			Period:            86400,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listFTPsError(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+	return nil, errTest
+}
+
+var listFTPsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listFTPsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	FTP 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Address: example.com
+		Port: 123
+		Username: anonymous
+		Password: foo@example.com
+		Public key: `+pgpPublicKey()+`
+		Path: logs/
+		Period: 3600
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+	FTP 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Address: 127.0.0.1
+		Port: 456
+		Username: foo
+		Password: password
+		Public key: `+pgpPublicKey()+`
+		Path: logs/
+		Period: 86400
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+`) + "\n\n"
+
+func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
+	return &fastly.FTP{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Address:           "example.com",
+		Port:              123,
+		Username:          "anonymous",
+		Password:          "foo@example.com",
+		PublicKey:         pgpPublicKey(),
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func getFTPError(i *fastly.GetFTPInput) (*fastly.FTP, error) {
+	return nil, errTest
+}
+
+var describeFTPOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Address: example.com
+Port: 123
+Username: anonymous
+Password: foo@example.com
+Public key: `+pgpPublicKey()+`
+Path: logs/
+Period: 3600
+GZip level: 9
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Timestamp format: %Y-%m-%dT%H:%M:%S.000
+Placement: none
+`) + "\n"
+
+func updateFTPOK(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+	return &fastly.FTP{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Address:           "example.com",
+		Port:              123,
+		Username:          "anonymous",
+		Password:          "foo@example.com",
+		PublicKey:         pgpPublicKey(),
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func updateFTPError(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+	return nil, errTest
+}
+
+func deleteFTPOK(i *fastly.DeleteFTPInput) error {
+	return nil
+}
+
+func deleteFTPError(i *fastly.DeleteFTPInput) error {
+	return errTest
+}
+
+// pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
+func pgpPublicKey() string {
+	return strings.TrimSpace(`-----BEGIN PGP PUBLIC KEY BLOCK-----
+mQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/
+ibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4
+8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p
+lDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn
+dwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB
+89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz
+dCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6
+vFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc
+9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9
+OLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX
+SvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq
+7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx
+kATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG
+M1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe
+u6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L
+4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF
+ftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K
+UEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu
+YrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi
+kiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb
+DAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml
+dYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L
+3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c
+FaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR
+5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR
+wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
+=28dr
+-----END PGP PUBLIC KEY BLOCK-----
+`)
+}

--- a/pkg/logging/ftp/list.go
+++ b/pkg/logging/ftp/list.go
@@ -1,0 +1,80 @@
+package ftp
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list FTP logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListFTPsInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List FTP endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	ftps, err := c.Globals.Client.ListFTPs(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, ftp := range ftps {
+			tw.AddLine(ftp.ServiceID, ftp.Version, ftp.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, ftp := range ftps {
+		fmt.Fprintf(out, "\tFTP %d/%d\n", i+1, len(ftps))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", ftp.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", ftp.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", ftp.Name)
+		fmt.Fprintf(out, "\t\tAddress: %s\n", ftp.Address)
+		fmt.Fprintf(out, "\t\tPort: %d\n", ftp.Port)
+		fmt.Fprintf(out, "\t\tUsername: %s\n", ftp.Username)
+		fmt.Fprintf(out, "\t\tPassword: %s\n", ftp.Password)
+		fmt.Fprintf(out, "\t\tPublic key: %s\n", ftp.PublicKey)
+		fmt.Fprintf(out, "\t\tPath: %s\n", ftp.Path)
+		fmt.Fprintf(out, "\t\tPeriod: %d\n", ftp.Period)
+		fmt.Fprintf(out, "\t\tGZip level: %d\n", ftp.GzipLevel)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", ftp.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", ftp.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", ftp.ResponseCondition)
+		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", ftp.TimestampFormat)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", ftp.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/ftp/root.go
+++ b/pkg/logging/ftp/root.go
@@ -1,0 +1,28 @@
+package ftp
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("ftp", "Manipulate Fastly service version FTP logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -1,0 +1,165 @@
+package ftp
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update FTP logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	Input fastly.GetFTPInput
+
+	NewName common.OptionalString
+
+	Address           common.OptionalString
+	Port              common.OptionalUint
+	Username          common.OptionalString
+	Password          common.OptionalString
+	PublicKey         common.OptionalString
+	Path              common.OptionalString
+	Period            common.OptionalUint
+	GzipLevel         common.OptionalUint8
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	TimestampFormat   common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update an FTP logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.Input.Name)
+
+	c.CmdClause.Flag("new-name", "New name of the FTP logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("address", "An hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
+	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
+	c.CmdClause.Flag("username", "The username for the server (can be anonymous)").Action(c.Username.Set).StringVar(&c.Username.Value)
+	c.CmdClause.Flag("password", "The password for the server (for anonymous use an email address)").Action(c.Password.Set).StringVar(&c.Password.Value)
+	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+	c.CmdClause.Flag("path", "The path to upload log files to. If the path ends in / then it is treated as a directory").Action(c.Path.Set).StringVar(&c.Path.Value)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).Uint8Var(&c.GzipLevel.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	ftp, err := c.Globals.Client.GetFTP(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	input := &fastly.UpdateFTPInput{
+		Service:           ftp.ServiceID,
+		Version:           ftp.Version,
+		Name:              ftp.Name,
+		NewName:           ftp.Name,
+		Address:           ftp.Address,
+		Port:              ftp.Port,
+		Username:          ftp.Username,
+		Password:          ftp.Password,
+		PublicKey:         ftp.PublicKey,
+		Path:              ftp.Path,
+		Period:            ftp.Period,
+		FormatVersion:     ftp.FormatVersion,
+		GzipLevel:         ftp.GzipLevel,
+		Format:            ftp.Format,
+		ResponseCondition: ftp.ResponseCondition,
+		TimestampFormat:   ftp.TimestampFormat,
+		Placement:         ftp.Placement,
+	}
+
+	// Set new values if set by user.
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.Address.Valid {
+		input.Address = c.Address.Value
+	}
+
+	if c.Port.Valid {
+		input.Port = c.Port.Value
+	}
+
+	if c.Username.Valid {
+		input.Username = c.Username.Value
+	}
+
+	if c.Password.Valid {
+		input.Password = c.Password.Value
+	}
+
+	if c.PublicKey.Valid {
+		input.PublicKey = c.PublicKey.Value
+	}
+
+	if c.Path.Valid {
+		input.Path = c.Path.Value
+	}
+
+	if c.Period.Valid {
+		input.Period = c.Period.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.GzipLevel.Valid {
+		input.GzipLevel = c.GzipLevel.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.TimestampFormat.Valid {
+		input.TimestampFormat = c.TimestampFormat.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	ftp, err = c.Globals.Client.UpdateFTP(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated FTP logging endpoint %s (service %s version %d)", ftp.Name, ftp.ServiceID, ftp.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -85,6 +85,12 @@ type API struct {
 	UpdateGCSFn func(*fastly.UpdateGCSInput) (*fastly.GCS, error)
 	DeleteGCSFn func(*fastly.DeleteGCSInput) error
 
+	CreateFTPFn func(*fastly.CreateFTPInput) (*fastly.FTP, error)
+	ListFTPsFn  func(*fastly.ListFTPsInput) ([]*fastly.FTP, error)
+	GetFTPFn    func(*fastly.GetFTPInput) (*fastly.FTP, error)
+	UpdateFTPFn func(*fastly.UpdateFTPInput) (*fastly.FTP, error)
+	DeleteFTPFn func(*fastly.DeleteFTPInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -409,6 +415,31 @@ func (m API) UpdateGCS(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
 // DeleteGCS implements Interface.
 func (m API) DeleteGCS(i *fastly.DeleteGCSInput) error {
 	return m.DeleteGCSFn(i)
+}
+
+// CreateFTP implements Interface.
+func (m API) CreateFTP(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
+	return m.CreateFTPFn(i)
+}
+
+// ListFTPs implements Interface.
+func (m API) ListFTPs(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+	return m.ListFTPsFn(i)
+}
+
+// GetFTP implements Interface.
+func (m API) GetFTP(i *fastly.GetFTPInput) (*fastly.FTP, error) {
+	return m.GetFTPFn(i)
+}
+
+// UpdateFTP implements Interface.
+func (m API) UpdateFTP(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+	return m.UpdateFTPFn(i)
+}
+
+// DeleteFTP implements Interface.
+func (m API) DeleteFTP(i *fastly.DeleteFTPInput) error {
+	return m.DeleteFTPFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_ftp)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/ftp.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
( 
    cd /tmp/cli && \
    git checkout mccurdyc/logging-ftp && \
    make test && \
    rm -rf /tmp/cli \
)
```

## TODOs

- [x] Wait for next go-fastly release to include https://github.com/fastly/go-fastly/pull/165