### PR TITLE
logging: adds Splunk endpoint

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -100,6 +100,12 @@ type Interface interface {
 	UpdateFTP(*fastly.UpdateFTPInput) (*fastly.FTP, error)
 	DeleteFTP(*fastly.DeleteFTPInput) error
 
+	CreateSplunk(*fastly.CreateSplunkInput) (*fastly.Splunk, error)
+	ListSplunks(*fastly.ListSplunksInput) ([]*fastly.Splunk, error)
+	GetSplunk(*fastly.GetSplunkInput) (*fastly.Splunk, error)
+	UpdateSplunk(*fastly.UpdateSplunkInput) (*fastly.Splunk, error)
+	DeleteSplunk(*fastly.DeleteSplunkInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/papertrail"
 	"github.com/fastly/cli/pkg/logging/s3"
+	"github.com/fastly/cli/pkg/logging/splunk"
 	"github.com/fastly/cli/pkg/logging/sumologic"
 	"github.com/fastly/cli/pkg/logging/syslog"
 	"github.com/fastly/cli/pkg/service"
@@ -183,6 +184,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	ftpUpdate := ftp.NewUpdateCommand(ftpRoot.CmdClause, &globals)
 	ftpDelete := ftp.NewDeleteCommand(ftpRoot.CmdClause, &globals)
 
+	splunkRoot := splunk.NewRootCommand(loggingRoot.CmdClause, &globals)
+	splunkCreate := splunk.NewCreateCommand(splunkRoot.CmdClause, &globals)
+	splunkList := splunk.NewListCommand(splunkRoot.CmdClause, &globals)
+	splunkDescribe := splunk.NewDescribeCommand(splunkRoot.CmdClause, &globals)
+	splunkUpdate := splunk.NewUpdateCommand(splunkRoot.CmdClause, &globals)
+	splunkDelete := splunk.NewDeleteCommand(splunkRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -294,6 +302,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		ftpDescribe,
 		ftpUpdate,
 		ftpDelete,
+
+		splunkRoot,
+		splunkCreate,
+		splunkList,
+		splunkDescribe,
+		splunkUpdate,
+		splunkDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1281,6 +1281,87 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the FTP logging object
 
+  logging splunk create --name=NAME --version=VERSION --url=URL [<flags>]
+    Create a Splunk logging endpoint on a Fastly service version
+
+    -n, --name=NAME                The name of the Splunk logging object. Used
+                                   as a primary key for API access
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+        --url=URL                  The URL to POST to
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --format=FORMAT            Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+        --auth-token=AUTH-TOKEN    A Splunk token for use in posting logs over
+                                   HTTP to your collector
+
+  logging splunk list --version=VERSION [<flags>]
+    List Splunk endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging splunk describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Splunk logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Splunk logging object
+
+  logging splunk update --version=VERSION --name=NAME [<flags>]
+    Update a Splunk logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+    -n, --name=NAME                The name of the Splunk logging object
+        --new-name=NEW-NAME        New name of the Splunk logging object
+        --url=URL                  The URL to POST to.
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --format=FORMAT            Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug. This field is not required and has
+                                   no default value
+        --auth-token=AUTH-TOKEN
+
+  logging splunk delete --version=VERSION --name=NAME [<flags>]
+    Delete a Splunk logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Splunk logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/splunk/create.go
+++ b/pkg/logging/splunk/create.go
@@ -1,0 +1,60 @@
+package splunk
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Splunk logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.CreateSplunkInput
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Splunk logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Splunk logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+
+	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.Input.URL)
+
+	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").StringVar(&c.Input.TLSCACert)
+	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").StringVar(&c.Input.TLSHostname)
+	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").UintVar(&c.Input.FormatVersion)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").StringVar(&c.Input.Placement)
+	c.CmdClause.Flag("auth-token", "A Splunk token for use in posting logs over HTTP to your collector").StringVar(&c.Input.Token)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	d, err := c.Globals.Client.CreateSplunk(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Splunk logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/splunk/delete.go
+++ b/pkg/logging/splunk/delete.go
@@ -1,0 +1,47 @@
+package splunk
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Splunk logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteSplunkInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Splunk logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteSplunk(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Splunk logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/splunk/describe.go
+++ b/pkg/logging/splunk/describe.go
@@ -1,0 +1,59 @@
+package splunk
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Splunk logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetSplunkInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Splunk logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	splunk, err := c.Globals.Client.GetSplunk(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", splunk.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", splunk.Version)
+	fmt.Fprintf(out, "Name: %s\n", splunk.Name)
+	fmt.Fprintf(out, "URL: %s\n", splunk.URL)
+	fmt.Fprintf(out, "Token: %s\n", splunk.Token)
+	fmt.Fprintf(out, "TLS CA certificate: %s\n", splunk.TLSCACert)
+	fmt.Fprintf(out, "TLS hostname: %s\n", splunk.TLSHostname)
+	fmt.Fprintf(out, "Format: %s\n", splunk.Format)
+	fmt.Fprintf(out, "Format version: %d\n", splunk.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", splunk.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", splunk.Placement)
+
+	return nil
+}

--- a/pkg/logging/splunk/doc.go
+++ b/pkg/logging/splunk/doc.go
@@ -1,0 +1,3 @@
+// Package splunk contains commands to inspect and manipulate Fastly service Splunk
+// logging endpoints.
+package splunk

--- a/pkg/logging/splunk/list.go
+++ b/pkg/logging/splunk/list.go
@@ -1,0 +1,75 @@
+package splunk
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Splunk logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListSplunksInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Splunk endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	splunks, err := c.Globals.Client.ListSplunks(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, splunk := range splunks {
+			tw.AddLine(splunk.ServiceID, splunk.Version, splunk.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, splunk := range splunks {
+		fmt.Fprintf(out, "\tSplunk %d/%d\n", i+1, len(splunks))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", splunk.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", splunk.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", splunk.Name)
+		fmt.Fprintf(out, "\t\tURL: %s\n", splunk.URL)
+		fmt.Fprintf(out, "\t\tToken: %s\n", splunk.Token)
+		fmt.Fprintf(out, "\t\tTLS CA certificate: %s\n", splunk.TLSCACert)
+		fmt.Fprintf(out, "\t\tTLS hostname: %s\n", splunk.TLSHostname)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", splunk.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", splunk.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", splunk.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", splunk.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/splunk/root.go
+++ b/pkg/logging/splunk/root.go
@@ -1,0 +1,28 @@
+package splunk
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("splunk", "Manipulate Fastly service version Splunk logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/splunk/splunk_test.go
+++ b/pkg/logging/splunk/splunk_test.go
@@ -1,0 +1,400 @@
+package splunk_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestSplunkCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --url not provided",
+		},
+		{
+			args:       []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:        mock.API{CreateSplunkFn: createSplunkOK},
+			wantOutput: "Created Splunk logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:       mock.API{CreateSplunkFn: createSplunkError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSplunkList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSplunksFn: listSplunksOK},
+			wantOutput: listSplunksShortOutput,
+		},
+		{
+			args:       []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListSplunksFn: listSplunksOK},
+			wantOutput: listSplunksVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListSplunksFn: listSplunksOK},
+			wantOutput: listSplunksVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "splunk", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSplunksFn: listSplunksOK},
+			wantOutput: listSplunksVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "splunk", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSplunksFn: listSplunksOK},
+			wantOutput: listSplunksVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListSplunksFn: listSplunksError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSplunkDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetSplunkFn: getSplunkError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetSplunkFn: getSplunkOK},
+			wantOutput: describeSplunkOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSplunkUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSplunkFn:    getSplunkError,
+				UpdateSplunkFn: updateSplunkOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSplunkFn:    getSplunkOK,
+				UpdateSplunkFn: updateSplunkError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSplunkFn:    getSplunkOK,
+				UpdateSplunkFn: updateSplunkOK,
+			},
+			wantOutput: "Updated Splunk logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSplunkDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteSplunkFn: deleteSplunkError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteSplunkFn: deleteSplunkOK},
+			wantOutput: "Deleted Splunk logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createSplunkOK(i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
+	return &fastly.Splunk{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createSplunkError(i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
+	return nil, errTest
+}
+
+func listSplunksOK(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
+	return []*fastly.Splunk{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			URL:               "example.com",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+			Token:             "tkn",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSHostname:       "example.com",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			URL:               "127.0.0.1",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+			Token:             "tkn1",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSHostname:       "example.com",
+		},
+	}, nil
+}
+
+func listSplunksError(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
+	return nil, errTest
+}
+
+var listSplunksShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listSplunksVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Splunk 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		URL: example.com
+		Token: tkn
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS hostname: example.com
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Splunk 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		URL: 127.0.0.1
+		Token: tkn1
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS hostname: example.com
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getSplunkOK(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
+	return &fastly.Splunk{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		URL:               "example.com",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+		Token:             "tkn",
+	}, nil
+}
+
+func getSplunkError(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
+	return nil, errTest
+}
+
+var describeSplunkOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+URL: example.com
+Token: tkn
+TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+TLS hostname: example.com
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateSplunkOK(i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
+	return &fastly.Splunk{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		URL:               "example.com",
+		Token:             "tkn",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateSplunkError(i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
+	return nil, errTest
+}
+
+func deleteSplunkOK(i *fastly.DeleteSplunkInput) error {
+	return nil
+}
+
+func deleteSplunkError(i *fastly.DeleteSplunkInput) error {
+	return errTest
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -91,6 +91,12 @@ type API struct {
 	UpdateFTPFn func(*fastly.UpdateFTPInput) (*fastly.FTP, error)
 	DeleteFTPFn func(*fastly.DeleteFTPInput) error
 
+	CreateSplunkFn func(*fastly.CreateSplunkInput) (*fastly.Splunk, error)
+	ListSplunksFn  func(*fastly.ListSplunksInput) ([]*fastly.Splunk, error)
+	GetSplunkFn    func(*fastly.GetSplunkInput) (*fastly.Splunk, error)
+	UpdateSplunkFn func(*fastly.UpdateSplunkInput) (*fastly.Splunk, error)
+	DeleteSplunkFn func(*fastly.DeleteSplunkInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -440,6 +446,31 @@ func (m API) UpdateFTP(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
 // DeleteFTP implements Interface.
 func (m API) DeleteFTP(i *fastly.DeleteFTPInput) error {
 	return m.DeleteFTPFn(i)
+}
+
+// CreateSplunk implements Interface.
+func (m API) CreateSplunk(i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
+	return m.CreateSplunkFn(i)
+}
+
+// ListSplunks implements Interface.
+func (m API) ListSplunks(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
+	return m.ListSplunksFn(i)
+}
+
+// GetSplunk implements Interface.
+func (m API) GetSplunk(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
+	return m.GetSplunkFn(i)
+}
+
+// UpdateSplunk implements Interface.
+func (m API) UpdateSplunk(i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
+	return m.UpdateSplunkFn(i)
+}
+
+// DeleteSplunk implements Interface.
+func (m API) DeleteSplunk(i *fastly.DeleteSplunkInput) error {
+	return m.DeleteSplunkFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_splunk)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/88b210b97743b0bfece81dc3dbbd7e3254e22d97/fastly/splunk.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
( 
    cd /tmp/cli && \
    git checkout mccurdyc/logging-splunk && \
    make test && \
    rm -rf /tmp/cli \
)
```

## TODOs

- [x] I didn't realize until later that we should update `fastly/go-fastly` to pull
in the recent changes to add the TLS-related fields for Splunk configuration.
     * PR to upgrade fastly/go-fastly version to v1.10.0 - https://github.com/fastly/cli/pull/65