### PR TITLE
Fallback to a file copy during update if the file rename fails

### DIFF
--- a/pkg/update/root.go
+++ b/pkg/update/root.go
@@ -68,8 +68,10 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	if err := os.Rename(latestPath, currentPath); err != nil {
-		progress.Fail()
-		return fmt.Errorf("error moving latest binary in place: %w", err)
+		if err := common.CopyFile(latestPath, currentPath); err != nil {
+			progress.Fail()
+			return fmt.Errorf("error moving latest binary in place: %w", err)
+		}
 	}
 
 	progress.Done()


### PR DESCRIPTION
### TL;DR
Fallback to a file copy if `os.Rename()` fails during `fastly update`. Normally caused if the destination isn't on the same filesystem as the temporary download directory. 

Copy of #49 