### PR TITLE
logging: adds Scalyr logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -106,6 +106,12 @@ type Interface interface {
 	UpdateSplunk(*fastly.UpdateSplunkInput) (*fastly.Splunk, error)
 	DeleteSplunk(*fastly.DeleteSplunkInput) error
 
+	CreateScalyr(*fastly.CreateScalyrInput) (*fastly.Scalyr, error)
+	ListScalyrs(*fastly.ListScalyrsInput) ([]*fastly.Scalyr, error)
+	GetScalyr(*fastly.GetScalyrInput) (*fastly.Scalyr, error)
+	UpdateScalyr(*fastly.UpdateScalyrInput) (*fastly.Scalyr, error)
+	DeleteScalyr(*fastly.DeleteScalyrInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/papertrail"
 	"github.com/fastly/cli/pkg/logging/s3"
+	"github.com/fastly/cli/pkg/logging/scalyr"
 	"github.com/fastly/cli/pkg/logging/splunk"
 	"github.com/fastly/cli/pkg/logging/sumologic"
 	"github.com/fastly/cli/pkg/logging/syslog"
@@ -191,6 +192,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	splunkUpdate := splunk.NewUpdateCommand(splunkRoot.CmdClause, &globals)
 	splunkDelete := splunk.NewDeleteCommand(splunkRoot.CmdClause, &globals)
 
+	scalyrRoot := scalyr.NewRootCommand(loggingRoot.CmdClause, &globals)
+	scalyrCreate := scalyr.NewCreateCommand(scalyrRoot.CmdClause, &globals)
+	scalyrList := scalyr.NewListCommand(scalyrRoot.CmdClause, &globals)
+	scalyrDescribe := scalyr.NewDescribeCommand(scalyrRoot.CmdClause, &globals)
+	scalyrUpdate := scalyr.NewUpdateCommand(scalyrRoot.CmdClause, &globals)
+	scalyrDelete := scalyr.NewDeleteCommand(scalyrRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -309,6 +317,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		splunkDescribe,
 		splunkUpdate,
 		splunkDelete,
+
+		scalyrRoot,
+		scalyrCreate,
+		scalyrList,
+		scalyrDescribe,
+		scalyrUpdate,
+		scalyrDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1362,6 +1362,71 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Splunk logging object
 
+  logging scalyr create --name=NAME --version=VERSION --auth-token=AUTH-TOKEN [<flags>]
+    Create a Scalyr logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Scalyr logging object. Used as
+                                 a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --auth-token=AUTH-TOKEN  The token to use for authentication
+                                 (https://www.scalyr.com/keys)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging scalyr list --version=VERSION [<flags>]
+    List Scalyr endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging scalyr describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Scalyr logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Scalyr logging object
+
+  logging scalyr update --version=VERSION --name=NAME [<flags>]
+    Update a Scalyr logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Scalyr logging object
+        --new-name=NEW-NAME      New name of the Scalyr logging object
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --auth-token=AUTH-TOKEN  The token to use for authentication
+                                 (https://www.scalyr.com/keys)
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging scalyr delete --version=VERSION --name=NAME [<flags>]
+    Delete a Scalyr logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Scalyr logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/scalyr/create.go
+++ b/pkg/logging/scalyr/create.go
@@ -1,0 +1,100 @@
+package scalyr
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Scalyr logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Token        string
+	Version      int
+
+	// optional
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Scalyr logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Scalyr logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.scalyr.com/keys)").Required().StringVar(&c.Token)
+
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateScalyrInput, error) {
+	var input fastly.CreateScalyrInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = fastly.String(c.EndpointName)
+	input.Token = fastly.String(c.Token)
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateScalyr(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Scalyr logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/scalyr/delete.go
+++ b/pkg/logging/scalyr/delete.go
@@ -1,0 +1,47 @@
+package scalyr
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Scalyr logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteScalyrInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Scalyr logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteScalyr(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Scalyr logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -1,0 +1,56 @@
+package scalyr
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Scalyr logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetScalyrInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Scalyr logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	scalyr, err := c.Globals.Client.GetScalyr(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", scalyr.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", scalyr.Version)
+	fmt.Fprintf(out, "Name: %s\n", scalyr.Name)
+	fmt.Fprintf(out, "Token: %s\n", scalyr.Token)
+	fmt.Fprintf(out, "Format: %s\n", scalyr.Format)
+	fmt.Fprintf(out, "Format version: %d\n", scalyr.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", scalyr.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", scalyr.Placement)
+
+	return nil
+}

--- a/pkg/logging/scalyr/doc.go
+++ b/pkg/logging/scalyr/doc.go
@@ -1,0 +1,3 @@
+// Package scalyr contains commands to inspect and manipulate Fastly service Scalyr
+// logging endpoints.
+package scalyr

--- a/pkg/logging/scalyr/list.go
+++ b/pkg/logging/scalyr/list.go
@@ -1,0 +1,72 @@
+package scalyr
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Scalyr logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListScalyrsInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Scalyr endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	scalyrs, err := c.Globals.Client.ListScalyrs(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, scalyr := range scalyrs {
+			tw.AddLine(scalyr.ServiceID, scalyr.Version, scalyr.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, scalyr := range scalyrs {
+		fmt.Fprintf(out, "\tScalyr %d/%d\n", i+1, len(scalyrs))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", scalyr.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", scalyr.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", scalyr.Name)
+		fmt.Fprintf(out, "\t\tToken: %s\n", scalyr.Token)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", scalyr.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", scalyr.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", scalyr.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", scalyr.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/scalyr/root.go
+++ b/pkg/logging/scalyr/root.go
@@ -1,0 +1,28 @@
+package scalyr
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("scalyr", "Manipulate Fastly service version Scalyr logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -1,0 +1,415 @@
+package scalyr_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	fsterrs "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestScalyrCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--auth-token", "abc"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --auth-token not provided",
+		},
+		{
+			args:      []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "1", "--auth-token", "abc"},
+			wantError: fsterrs.ErrNoServiceID.Error(),
+		},
+		{
+			args:       []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			api:        mock.API{CreateScalyrFn: createScalyrOK},
+			wantOutput: "Created Scalyr logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			api:       mock.API{CreateScalyrFn: createScalyrError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestScalyrList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			wantOutput: listScalyrsShortOutput,
+		},
+		{
+			args:       []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			wantOutput: listScalyrsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			wantOutput: listScalyrsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "scalyr", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			wantOutput: listScalyrsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "scalyr", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			wantOutput: listScalyrsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListScalyrsFn: listScalyrsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestScalyrDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetScalyrFn: getScalyrError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetScalyrFn: getScalyrOK},
+			wantOutput: describeScalyrOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestScalyrUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetScalyrFn:    getScalyrError,
+				UpdateScalyrFn: updateScalyrOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetScalyrFn:    getScalyrOK,
+				UpdateScalyrFn: updateScalyrError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetScalyrFn:    getScalyrOK,
+				UpdateScalyrFn: updateScalyrOK,
+			},
+			wantOutput: "Updated Scalyr logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestScalyrDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteScalyrFn: deleteScalyrError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteScalyrFn: deleteScalyrOK},
+			wantOutput: "Deleted Scalyr logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createScalyrOK(i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
+	s := fastly.Scalyr{
+		ServiceID: i.Service,
+		Version:   i.Version,
+	}
+
+	// Avoids null pointer dereference for test cases with missing required params.
+	// If omitted, tests are guaranteed to panic.
+	if i.Name != nil {
+		s.Name = *i.Name
+	}
+
+	if i.Token != nil {
+		s.Token = *i.Token
+	}
+
+	if i.Format != nil {
+		s.Format = *i.Format
+	}
+
+	if i.FormatVersion != nil {
+		s.FormatVersion = *i.FormatVersion
+	}
+
+	if i.ResponseCondition != nil {
+		s.ResponseCondition = *i.ResponseCondition
+	}
+
+	if i.Placement != nil {
+		s.Placement = *i.Placement
+	}
+
+	return &s, nil
+}
+
+func createScalyrError(i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
+	return nil, errTest
+}
+
+func listScalyrsOK(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
+	return []*fastly.Scalyr{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Token:             "abc",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Token:             "abc",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listScalyrsError(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
+	return nil, errTest
+}
+
+var listScalyrsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listScalyrsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Scalyr 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Token: abc
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Scalyr 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Token: abc
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getScalyrOK(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
+	return &fastly.Scalyr{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Token:             "abc",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getScalyrError(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
+	return nil, errTest
+}
+
+var describeScalyrOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Token: abc
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateScalyrOK(i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
+	return &fastly.Scalyr{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Token:             "abc",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateScalyrError(i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
+	return nil, errTest
+}
+
+func deleteScalyrOK(i *fastly.DeleteScalyrInput) error {
+	return nil
+}
+
+func deleteScalyrError(i *fastly.DeleteScalyrInput) error {
+	return errTest
+}

--- a/pkg/logging/scalyr/scalyr_test.go
+++ b/pkg/logging/scalyr/scalyr_test.go
@@ -1,0 +1,147 @@
+package scalyr
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateCreateInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateScalyrInput
+		wantError string
+	}{
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandOK(),
+			want: &fastly.CreateScalyrInput{
+				Service:           "123",
+				Version:           2,
+				Name:              fastly.String("log"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				Token:             fastly.String("tkn"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateCreateInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateScalyrInput
+		wantError string
+	}{
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandOK(),
+			api:  mock.API{GetScalyrFn: getScalyrOK},
+			want: &fastly.UpdateScalyrInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("new-log"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				Token:             fastly.String("tkn"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandOK() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Token:             "tkn",
+		Version:           2,
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandOK()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandOK() *UpdateCommand {
+	return &UpdateCommand{
+		Base: common.Base{Globals: &config.Data{Client: nil}},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName:      "log",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new-log"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		Token:             common.OptionalString{Optional: common.Optional{Valid: true}, Value: "tkn"},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandOK()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getScalyrOK(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
+	return &fastly.Scalyr{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Token:             "tkn",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}

--- a/pkg/logging/scalyr/update.go
+++ b/pkg/logging/scalyr/update.go
@@ -1,0 +1,123 @@
+package scalyr
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Scalyr logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Token             common.OptionalString
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Scalyr logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Scalyr logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.scalyr.com/keys)").Action(c.Token.Set).StringVar(&c.Token.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateScalyrInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	scalyr, err := c.Globals.Client.GetScalyr(&fastly.GetScalyrInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateScalyrInput{
+		Service:           scalyr.ServiceID,
+		Version:           scalyr.Version,
+		Name:              scalyr.Name,
+		NewName:           fastly.String(scalyr.Name),
+		Format:            fastly.String(scalyr.Format),
+		FormatVersion:     fastly.Uint(scalyr.FormatVersion),
+		Token:             fastly.String(scalyr.Token),
+		ResponseCondition: fastly.String(scalyr.ResponseCondition),
+		Placement:         fastly.String(scalyr.Placement),
+	}
+
+	if c.NewName.Valid {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.Token.Valid {
+		input.Token = fastly.String(c.Token.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	scalyr, err := c.Globals.Client.UpdateScalyr(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Scalyr logging endpoint %s (service %s version %d)", scalyr.Name, scalyr.ServiceID, scalyr.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -97,6 +97,12 @@ type API struct {
 	UpdateSplunkFn func(*fastly.UpdateSplunkInput) (*fastly.Splunk, error)
 	DeleteSplunkFn func(*fastly.DeleteSplunkInput) error
 
+	CreateScalyrFn func(*fastly.CreateScalyrInput) (*fastly.Scalyr, error)
+	ListScalyrsFn  func(*fastly.ListScalyrsInput) ([]*fastly.Scalyr, error)
+	GetScalyrFn    func(*fastly.GetScalyrInput) (*fastly.Scalyr, error)
+	UpdateScalyrFn func(*fastly.UpdateScalyrInput) (*fastly.Scalyr, error)
+	DeleteScalyrFn func(*fastly.DeleteScalyrInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -471,6 +477,31 @@ func (m API) UpdateSplunk(i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
 // DeleteSplunk implements Interface.
 func (m API) DeleteSplunk(i *fastly.DeleteSplunkInput) error {
 	return m.DeleteSplunkFn(i)
+}
+
+// CreateScalyr implements Interface.
+func (m API) CreateScalyr(i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
+	return m.CreateScalyrFn(i)
+}
+
+// ListScalyrs implements Interface.
+func (m API) ListScalyrs(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
+	return m.ListScalyrsFn(i)
+}
+
+// GetScalyr implements Interface.
+func (m API) GetScalyr(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
+	return m.GetScalyrFn(i)
+}
+
+// UpdateScalyr implements Interface.
+func (m API) UpdateScalyr(i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
+	return m.UpdateScalyrFn(i)
+}
+
+// DeleteScalyr implements Interface.
+func (m API) DeleteScalyr(i *fastly.DeleteScalyrInput) error {
+	return m.DeleteScalyrFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_scalyr)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/scalyr.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-scalyr && \
    make test && \
    rm -rf /tmp/cli \
)
```