### PR TITLE
logging: adds Honeycomb logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -118,6 +118,12 @@ type Interface interface {
 	UpdateLoggly(*fastly.UpdateLogglyInput) (*fastly.Loggly, error)
 	DeleteLoggly(*fastly.DeleteLogglyInput) error
 
+	CreateHoneycomb(*fastly.CreateHoneycombInput) (*fastly.Honeycomb, error)
+	ListHoneycombs(*fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error)
+	GetHoneycomb(*fastly.GetHoneycombInput) (*fastly.Honeycomb, error)
+	UpdateHoneycomb(*fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error)
+	DeleteHoneycomb(*fastly.DeleteHoneycombInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/bigquery"
 	"github.com/fastly/cli/pkg/logging/ftp"
 	"github.com/fastly/cli/pkg/logging/gcs"
+	"github.com/fastly/cli/pkg/logging/honeycomb"
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/loggly"
 	"github.com/fastly/cli/pkg/logging/papertrail"
@@ -207,6 +208,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	logglyUpdate := loggly.NewUpdateCommand(logglyRoot.CmdClause, &globals)
 	logglyDelete := loggly.NewDeleteCommand(logglyRoot.CmdClause, &globals)
 
+	honeycombRoot := honeycomb.NewRootCommand(loggingRoot.CmdClause, &globals)
+	honeycombCreate := honeycomb.NewCreateCommand(honeycombRoot.CmdClause, &globals)
+	honeycombList := honeycomb.NewListCommand(honeycombRoot.CmdClause, &globals)
+	honeycombDescribe := honeycomb.NewDescribeCommand(honeycombRoot.CmdClause, &globals)
+	honeycombUpdate := honeycomb.NewUpdateCommand(honeycombRoot.CmdClause, &globals)
+	honeycombDelete := honeycomb.NewDeleteCommand(honeycombRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -339,6 +347,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		logglyDescribe,
 		logglyUpdate,
 		logglyDelete,
+
+		honeycombRoot,
+		honeycombCreate,
+		honeycombList,
+		honeycombDescribe,
+		honeycombUpdate,
+		honeycombDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1492,6 +1492,75 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Loggly logging object
 
+  logging honeycomb create --name=NAME --version=VERSION --dataset=DATASET --auth-token=AUTH-TOKEN [<flags>]
+    Create a Honeycomb logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Honeycomb logging object. Used
+                                 as a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --dataset=DATASET        The Honeycomb Dataset you want to log to
+        --auth-token=AUTH-TOKEN  The Write Key from the Account page of your
+                                 Honeycomb account
+        --format=FORMAT          Apache style log formatting. Your log must
+                                 produce valid JSON that Honeycomb can ingest
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging honeycomb list --version=VERSION [<flags>]
+    List Honeycomb endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging honeycomb describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Honeycomb logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Honeycomb logging object
+
+  logging honeycomb update --version=VERSION --name=NAME [<flags>]
+    Update a Honeycomb logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Honeycomb logging object
+        --new-name=NEW-NAME      New name of the Honeycomb logging object
+        --format=FORMAT          Apache style log formatting. Your log must
+                                 produce valid JSON that Honeycomb can ingest
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --dataset=DATASET        The Honeycomb Dataset you want to log to
+        --auth-token=AUTH-TOKEN  The Write Key from the Account page of your
+                                 Honeycomb account
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging honeycomb delete --version=VERSION --name=NAME [<flags>]
+    Delete a Honeycomb logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Honeycomb logging object
+
   stats regions
     List stats regions
 
@@ -1517,5 +1586,6 @@ For help on a specific command, try e.g.
 
 	fastly help configure
 	fastly configure --help
+
 
 `) + "\n\n"

--- a/pkg/logging/honeycomb/create.go
+++ b/pkg/logging/honeycomb/create.go
@@ -1,0 +1,103 @@
+package honeycomb
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Honeycomb logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	Token        string
+	Dataset      string
+
+	// optional
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Honeycomb logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Honeycomb logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("dataset", "The Honeycomb Dataset you want to log to").Required().StringVar(&c.Dataset)
+	c.CmdClause.Flag("auth-token", "The Write Key from the Account page of your Honeycomb account").Required().StringVar(&c.Token)
+
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateHoneycombInput, error) {
+	var input fastly.CreateHoneycombInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = fastly.String(c.EndpointName)
+	input.Token = fastly.String(c.Token)
+	input.Dataset = fastly.String(c.Dataset)
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateHoneycomb(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Honeycomb logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/honeycomb/delete.go
+++ b/pkg/logging/honeycomb/delete.go
@@ -1,0 +1,47 @@
+package honeycomb
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Honeycomb logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteHoneycombInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Honeycomb logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteHoneycomb(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Honeycomb logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/honeycomb/describe.go
+++ b/pkg/logging/honeycomb/describe.go
@@ -1,0 +1,57 @@
+package honeycomb
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Honeycomb logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetHoneycombInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Honeycomb logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	honeycomb, err := c.Globals.Client.GetHoneycomb(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", honeycomb.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", honeycomb.Version)
+	fmt.Fprintf(out, "Name: %s\n", honeycomb.Name)
+	fmt.Fprintf(out, "Dataset: %s\n", honeycomb.Dataset)
+	fmt.Fprintf(out, "Token: %s\n", honeycomb.Token)
+	fmt.Fprintf(out, "Format: %s\n", honeycomb.Format)
+	fmt.Fprintf(out, "Format version: %d\n", honeycomb.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", honeycomb.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", honeycomb.Placement)
+
+	return nil
+}

--- a/pkg/logging/honeycomb/doc.go
+++ b/pkg/logging/honeycomb/doc.go
@@ -1,0 +1,3 @@
+// Package honeycomb contains commands to inspect and manipulate Fastly service Honeycomb
+// logging endpoints.
+package honeycomb

--- a/pkg/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/logging/honeycomb/honeycomb_integration_test.go
@@ -1,0 +1,395 @@
+package honeycomb_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestHoneycombCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--dataset", "log"},
+			wantError: "error parsing arguments: required flag --auth-token not provided",
+		},
+		{
+			args:      []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			wantError: "error parsing arguments: required flag --dataset not provided",
+		},
+		{
+			args:       []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
+			api:        mock.API{CreateHoneycombFn: createHoneycombOK},
+			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
+			api:       mock.API{CreateHoneycombFn: createHoneycombError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestHoneycombList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			wantOutput: listHoneycombsShortOutput,
+		},
+		{
+			args:       []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			wantOutput: listHoneycombsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			wantOutput: listHoneycombsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "honeycomb", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			wantOutput: listHoneycombsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "honeycomb", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			wantOutput: listHoneycombsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListHoneycombsFn: listHoneycombsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestHoneycombDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetHoneycombFn: getHoneycombError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetHoneycombFn: getHoneycombOK},
+			wantOutput: describeHoneycombOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestHoneycombUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetHoneycombFn:    getHoneycombError,
+				UpdateHoneycombFn: updateHoneycombOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetHoneycombFn:    getHoneycombOK,
+				UpdateHoneycombFn: updateHoneycombError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetHoneycombFn:    getHoneycombOK,
+				UpdateHoneycombFn: updateHoneycombOK,
+			},
+			wantOutput: "Updated Honeycomb logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestHoneycombDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteHoneycombFn: deleteHoneycombError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteHoneycombFn: deleteHoneycombOK},
+			wantOutput: "Deleted Honeycomb logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createHoneycombOK(i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
+	s := fastly.Honeycomb{
+		ServiceID: i.Service,
+		Version:   i.Version,
+	}
+
+	if i.Name != nil {
+		s.Name = *i.Name
+	}
+
+	return &s, nil
+}
+
+func createHoneycombError(i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
+	return nil, errTest
+}
+
+func listHoneycombsOK(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
+	return []*fastly.Honeycomb{
+		&fastly.Honeycomb{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			Dataset:           "log",
+			Token:             "tkn",
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Dataset:           "log",
+			Token:             "tkn",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listHoneycombsError(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
+	return nil, errTest
+}
+
+var listHoneycombsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listHoneycombsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Honeycomb 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Dataset: log
+		Token: tkn
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Honeycomb 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Dataset: log
+		Token: tkn
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getHoneycombOK(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
+	return &fastly.Honeycomb{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Dataset:           "log",
+		Token:             "tkn",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getHoneycombError(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
+	return nil, errTest
+}
+
+var describeHoneycombOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Dataset: log
+Token: tkn
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateHoneycombOK(i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
+	return &fastly.Honeycomb{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Dataset:           "log",
+		Token:             "tkn",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateHoneycombError(i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
+	return nil, errTest
+}
+
+func deleteHoneycombOK(i *fastly.DeleteHoneycombInput) error {
+	return nil
+}
+
+func deleteHoneycombError(i *fastly.DeleteHoneycombInput) error {
+	return errTest
+}

--- a/pkg/logging/honeycomb/honeycomb_test.go
+++ b/pkg/logging/honeycomb/honeycomb_test.go
@@ -1,0 +1,195 @@
+package honeycomb
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateHoneycombInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateHoneycombInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateHoneycombInput{
+				Service: "123",
+				Version: 2,
+				Name:    fastly.String("log"),
+				Token:   fastly.String("tkn"),
+				Dataset: fastly.String("logs"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateHoneycombInput{
+				Service:           "123",
+				Version:           2,
+				Name:              fastly.String("log"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				Token:             fastly.String("tkn"),
+				Dataset:           fastly.String("logs"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateHoneycombInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateHoneycombInput
+		wantError string
+	}{
+		{
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetHoneycombFn: getHoneycombOK},
+			want: &fastly.UpdateHoneycombInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("logs"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				Token:             fastly.String("tkn"),
+				Dataset:           fastly.String("logs"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetHoneycombFn: getHoneycombOK},
+			want: &fastly.UpdateHoneycombInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("new1"),
+				Format:            fastly.String("new2"),
+				FormatVersion:     fastly.Uint(3),
+				Token:             fastly.String("new3"),
+				Dataset:           fastly.String("new4"),
+				ResponseCondition: fastly.String("new5"),
+				Placement:         fastly.String("new6"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Token:        "tkn",
+		Dataset:      "logs",
+		Version:      2,
+	}
+}
+
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Token:             "tkn",
+		Dataset:           "logs",
+		Version:           2,
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		Token:             common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		Dataset:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getHoneycombOK(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
+	return &fastly.Honeycomb{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Token:             "tkn",
+		Dataset:           "logs",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}

--- a/pkg/logging/honeycomb/list.go
+++ b/pkg/logging/honeycomb/list.go
@@ -1,0 +1,73 @@
+package honeycomb
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Honeycomb logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListHoneycombsInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Honeycomb endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	honeycombs, err := c.Globals.Client.ListHoneycombs(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, honeycomb := range honeycombs {
+			tw.AddLine(honeycomb.ServiceID, honeycomb.Version, honeycomb.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, honeycomb := range honeycombs {
+		fmt.Fprintf(out, "\tHoneycomb %d/%d\n", i+1, len(honeycombs))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", honeycomb.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", honeycomb.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", honeycomb.Name)
+		fmt.Fprintf(out, "\t\tDataset: %s\n", honeycomb.Dataset)
+		fmt.Fprintf(out, "\t\tToken: %s\n", honeycomb.Token)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", honeycomb.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", honeycomb.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", honeycomb.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", honeycomb.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/honeycomb/root.go
+++ b/pkg/logging/honeycomb/root.go
@@ -1,0 +1,28 @@
+package honeycomb
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("honeycomb", "Manipulate Fastly service version Honeycomb logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/honeycomb/update.go
+++ b/pkg/logging/honeycomb/update.go
@@ -1,0 +1,130 @@
+package honeycomb
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Honeycomb logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Dataset           common.OptionalString
+	Token             common.OptionalString
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Honeycomb logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Honeycomb logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("dataset", "The Honeycomb Dataset you want to log to").Action(c.Dataset.Set).StringVar(&c.Dataset.Value)
+	c.CmdClause.Flag("auth-token", "The Write Key from the Account page of your Honeycomb account").Action(c.Token.Set).StringVar(&c.Token.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateHoneycombInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	honeycomb, err := c.Globals.Client.GetHoneycomb(&fastly.GetHoneycombInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateHoneycombInput{
+		Service:           honeycomb.ServiceID,
+		Version:           honeycomb.Version,
+		Name:              honeycomb.Name,
+		NewName:           fastly.String(honeycomb.Name),
+		Format:            fastly.String(honeycomb.Format),
+		FormatVersion:     fastly.Uint(honeycomb.FormatVersion),
+		Token:             fastly.String(honeycomb.Token),
+		Dataset:           fastly.String(honeycomb.Dataset),
+		ResponseCondition: fastly.String(honeycomb.ResponseCondition),
+		Placement:         fastly.String(honeycomb.Placement),
+	}
+
+	if c.NewName.Valid {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.Token.Valid {
+		input.Token = fastly.String(c.Token.Value)
+	}
+
+	if c.Dataset.Valid {
+		input.Dataset = fastly.String(c.Dataset.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	honeycomb, err := c.Globals.Client.UpdateHoneycomb(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Honeycomb logging endpoint %s (service %s version %d)", honeycomb.Name, honeycomb.ServiceID, honeycomb.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -109,6 +109,12 @@ type API struct {
 	UpdateLogglyFn func(*fastly.UpdateLogglyInput) (*fastly.Loggly, error)
 	DeleteLogglyFn func(*fastly.DeleteLogglyInput) error
 
+	CreateHoneycombFn func(*fastly.CreateHoneycombInput) (*fastly.Honeycomb, error)
+	ListHoneycombsFn  func(*fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error)
+	GetHoneycombFn    func(*fastly.GetHoneycombInput) (*fastly.Honeycomb, error)
+	UpdateHoneycombFn func(*fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error)
+	DeleteHoneycombFn func(*fastly.DeleteHoneycombInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -533,6 +539,31 @@ func (m API) UpdateLoggly(i *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
 // DeleteLoggly implements Interface.
 func (m API) DeleteLoggly(i *fastly.DeleteLogglyInput) error {
 	return m.DeleteLogglyFn(i)
+}
+
+// CreateHoneycomb implements Interface.
+func (m API) CreateHoneycomb(i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
+	return m.CreateHoneycombFn(i)
+}
+
+// ListHoneycombs implements Interface.
+func (m API) ListHoneycombs(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
+	return m.ListHoneycombsFn(i)
+}
+
+// GetHoneycomb implements Interface.
+func (m API) GetHoneycomb(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
+	return m.GetHoneycombFn(i)
+}
+
+// UpdateHoneycomb implements Interface.
+func (m API) UpdateHoneycomb(i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
+	return m.UpdateHoneycombFn(i)
+}
+
+// DeleteHoneycomb implements Interface.
+func (m API) DeleteHoneycomb(i *fastly.DeleteHoneycombInput) error {
+	return m.DeleteHoneycombFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_honeycomb)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/honeycomb.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-honeycomb && \
    make test && \
    rm -rf /tmp/cli \
)
```