### PR TITLE
logging: adds Logshuttle logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -136,6 +136,12 @@ type Interface interface {
 	UpdateSFTP(*fastly.UpdateSFTPInput) (*fastly.SFTP, error)
 	DeleteSFTP(*fastly.DeleteSFTPInput) error
 
+	CreateLogshuttle(*fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error)
+	ListLogshuttles(*fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error)
+	GetLogshuttle(*fastly.GetLogshuttleInput) (*fastly.Logshuttle, error)
+	UpdateLogshuttle(*fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
+	DeleteLogshuttle(*fastly.DeleteLogshuttleInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/honeycomb"
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/loggly"
+	"github.com/fastly/cli/pkg/logging/logshuttle"
 	"github.com/fastly/cli/pkg/logging/papertrail"
 	"github.com/fastly/cli/pkg/logging/s3"
 	"github.com/fastly/cli/pkg/logging/scalyr"
@@ -231,6 +232,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	sftpUpdate := sftp.NewUpdateCommand(sftpRoot.CmdClause, &globals)
 	sftpDelete := sftp.NewDeleteCommand(sftpRoot.CmdClause, &globals)
 
+	logshuttleRoot := logshuttle.NewRootCommand(loggingRoot.CmdClause, &globals)
+	logshuttleCreate := logshuttle.NewCreateCommand(logshuttleRoot.CmdClause, &globals)
+	logshuttleList := logshuttle.NewListCommand(logshuttleRoot.CmdClause, &globals)
+	logshuttleDescribe := logshuttle.NewDescribeCommand(logshuttleRoot.CmdClause, &globals)
+	logshuttleUpdate := logshuttle.NewUpdateCommand(logshuttleRoot.CmdClause, &globals)
+	logshuttleDelete := logshuttle.NewDeleteCommand(logshuttleRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -384,6 +392,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		sftpDescribe,
 		sftpUpdate,
 		sftpDelete,
+
+		logshuttleRoot,
+		logshuttleCreate,
+		logshuttleList,
+		logshuttleDescribe,
+		logshuttleUpdate,
+		logshuttleDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1741,6 +1741,73 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the SFTP logging object
 
+  logging logshuttle create --name=NAME --version=VERSION --url=URL --auth-token=AUTH-TOKEN [<flags>]
+    Create a Logshuttle logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Logshuttle logging object. Used
+                                 as a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --url=URL                Your Log Shuttle endpoint url
+        --auth-token=AUTH-TOKEN  The data authentication token associated with
+                                 this endpoint
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging logshuttle list --version=VERSION [<flags>]
+    List Logshuttle endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging logshuttle describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Logshuttle logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Logshuttle logging object
+
+  logging logshuttle update --version=VERSION --name=NAME [<flags>]
+    Update a Logshuttle logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Logshuttle logging object
+        --new-name=NEW-NAME      New name of the Logshuttle logging object
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --url=URL                Your Log Shuttle endpoint url
+        --auth-token=AUTH-TOKEN  The data authentication token associated with
+                                 this endpoint
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging logshuttle delete --version=VERSION --name=NAME [<flags>]
+    Delete a Logshuttle logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Logshuttle logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/logshuttle/create.go
+++ b/pkg/logging/logshuttle/create.go
@@ -1,0 +1,103 @@
+package logshuttle
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Logshuttle logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	Token        string
+	URL          string
+
+	// optional
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Logshuttle logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Logshuttle logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("url", "Your Log Shuttle endpoint url").Required().StringVar(&c.URL)
+	c.CmdClause.Flag("auth-token", "The data authentication token associated with this endpoint").Required().StringVar(&c.Token)
+
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateLogshuttleInput, error) {
+	var input fastly.CreateLogshuttleInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = fastly.String(c.EndpointName)
+	input.Token = fastly.String(c.Token)
+	input.URL = fastly.String(c.URL)
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateLogshuttle(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Logshuttle logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/logshuttle/delete.go
+++ b/pkg/logging/logshuttle/delete.go
@@ -1,0 +1,47 @@
+package logshuttle
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Logshuttle logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteLogshuttleInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Logshuttle logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteLogshuttle(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Logshuttle logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/logshuttle/describe.go
+++ b/pkg/logging/logshuttle/describe.go
@@ -1,0 +1,57 @@
+package logshuttle
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Logshuttle logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetLogshuttleInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Logshuttle logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	logshuttle, err := c.Globals.Client.GetLogshuttle(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", logshuttle.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", logshuttle.Version)
+	fmt.Fprintf(out, "Name: %s\n", logshuttle.Name)
+	fmt.Fprintf(out, "URL: %s\n", logshuttle.URL)
+	fmt.Fprintf(out, "Token: %s\n", logshuttle.Token)
+	fmt.Fprintf(out, "Format: %s\n", logshuttle.Format)
+	fmt.Fprintf(out, "Format version: %d\n", logshuttle.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", logshuttle.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", logshuttle.Placement)
+
+	return nil
+}

--- a/pkg/logging/logshuttle/doc.go
+++ b/pkg/logging/logshuttle/doc.go
@@ -1,0 +1,3 @@
+// Package logshuttle contains commands to inspect and manipulate Fastly service Logshuttle
+// logging endpoints.
+package logshuttle

--- a/pkg/logging/logshuttle/list.go
+++ b/pkg/logging/logshuttle/list.go
@@ -1,0 +1,73 @@
+package logshuttle
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Logshuttle logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListLogshuttlesInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Logshuttle endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	logshuttles, err := c.Globals.Client.ListLogshuttles(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, logshuttle := range logshuttles {
+			tw.AddLine(logshuttle.ServiceID, logshuttle.Version, logshuttle.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, logshuttle := range logshuttles {
+		fmt.Fprintf(out, "\tLogshuttle %d/%d\n", i+1, len(logshuttles))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", logshuttle.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", logshuttle.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", logshuttle.Name)
+		fmt.Fprintf(out, "\t\tURL: %s\n", logshuttle.URL)
+		fmt.Fprintf(out, "\t\tToken: %s\n", logshuttle.Token)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", logshuttle.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", logshuttle.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", logshuttle.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", logshuttle.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/logging/logshuttle/logshuttle_integration_test.go
@@ -1,0 +1,395 @@
+package logshuttle_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestLogshuttleCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			wantError: "error parsing arguments: required flag --url not provided",
+		},
+		{
+			args:      []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			wantError: "error parsing arguments: required flag --auth-token not provided",
+		},
+		{
+			args:       []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
+			api:        mock.API{CreateLogshuttleFn: createLogshuttleOK},
+			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
+			api:       mock.API{CreateLogshuttleFn: createLogshuttleError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestLogshuttleList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			wantOutput: listLogshuttlesShortOutput,
+		},
+		{
+			args:       []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			wantOutput: listLogshuttlesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			wantOutput: listLogshuttlesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "logshuttle", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			wantOutput: listLogshuttlesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "logshuttle", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			wantOutput: listLogshuttlesVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListLogshuttlesFn: listLogshuttlesError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestLogshuttleDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetLogshuttleFn: getLogshuttleError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetLogshuttleFn: getLogshuttleOK},
+			wantOutput: describeLogshuttleOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestLogshuttleUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetLogshuttleFn:    getLogshuttleError,
+				UpdateLogshuttleFn: updateLogshuttleOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetLogshuttleFn:    getLogshuttleOK,
+				UpdateLogshuttleFn: updateLogshuttleError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetLogshuttleFn:    getLogshuttleOK,
+				UpdateLogshuttleFn: updateLogshuttleOK,
+			},
+			wantOutput: "Updated Logshuttle logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestLogshuttleDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteLogshuttleFn: deleteLogshuttleError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteLogshuttleFn: deleteLogshuttleOK},
+			wantOutput: "Deleted Logshuttle logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createLogshuttleOK(i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
+	s := fastly.Logshuttle{
+		ServiceID: i.Service,
+		Version:   i.Version,
+	}
+
+	if i.Name != nil {
+		s.Name = *i.Name
+	}
+
+	return &s, nil
+}
+
+func createLogshuttleError(i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
+	return nil, errTest
+}
+
+func listLogshuttlesOK(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
+	return []*fastly.Logshuttle{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			URL:               "example.com",
+			Token:             "abc",
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			URL:               "example.com",
+			Token:             "abc",
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listLogshuttlesError(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
+	return nil, errTest
+}
+
+var listLogshuttlesShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listLogshuttlesVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Logshuttle 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		URL: example.com
+		Token: abc
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Logshuttle 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		URL: example.com
+		Token: abc
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getLogshuttleOK(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
+	return &fastly.Logshuttle{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		URL:               "example.com",
+		Token:             "abc",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getLogshuttleError(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
+	return nil, errTest
+}
+
+var describeLogshuttleOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+URL: example.com
+Token: abc
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateLogshuttleOK(i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
+	return &fastly.Logshuttle{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		URL:               "example.com",
+		Token:             "abc",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateLogshuttleError(i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
+	return nil, errTest
+}
+
+func deleteLogshuttleOK(i *fastly.DeleteLogshuttleInput) error {
+	return nil
+}
+
+func deleteLogshuttleError(i *fastly.DeleteLogshuttleInput) error {
+	return errTest
+}

--- a/pkg/logging/logshuttle/logshuttle_test.go
+++ b/pkg/logging/logshuttle/logshuttle_test.go
@@ -1,0 +1,195 @@
+package logshuttle
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateLogshuttleInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateLogshuttleInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateLogshuttleInput{
+				Service: "123",
+				Version: 2,
+				Name:    fastly.String("log"),
+				Token:   fastly.String("tkn"),
+				URL:     fastly.String("example.com"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateLogshuttleInput{
+				Service:           "123",
+				Version:           2,
+				Name:              fastly.String("log"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				URL:               fastly.String("example.com"),
+				Token:             fastly.String("tkn"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateLogshuttleInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateLogshuttleInput
+		wantError string
+	}{
+		{
+			name: "no update",
+			cmd:  updateCommandNoUpdate(),
+			api:  mock.API{GetLogshuttleFn: getLogshuttleOK},
+			want: &fastly.UpdateLogshuttleInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("logs"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				Token:             fastly.String("tkn"),
+				URL:               fastly.String("example.com"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetLogshuttleFn: getLogshuttleOK},
+			want: &fastly.UpdateLogshuttleInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("new1"),
+				Format:            fastly.String("new2"),
+				FormatVersion:     fastly.Uint(3),
+				Token:             fastly.String("new3"),
+				URL:               fastly.String("new4"),
+				ResponseCondition: fastly.String("new5"),
+				Placement:         fastly.String("new6"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Token:        "tkn",
+		URL:          "example.com",
+		Version:      2,
+	}
+}
+
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Token:             "tkn",
+		URL:               "example.com",
+		Version:           2,
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdate() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		Token:             common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		URL:               common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getLogshuttleOK(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
+	return &fastly.Logshuttle{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		URL:               "example.com",
+		Token:             "tkn",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}

--- a/pkg/logging/logshuttle/root.go
+++ b/pkg/logging/logshuttle/root.go
@@ -1,0 +1,28 @@
+package logshuttle
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("logshuttle", "Manipulate Fastly service version Logshuttle logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/logshuttle/update.go
+++ b/pkg/logging/logshuttle/update.go
@@ -1,0 +1,132 @@
+package logshuttle
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Logshuttle logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Token             common.OptionalString
+	URL               common.OptionalString
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Logshuttle logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Logshuttle logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("url", "Your Log Shuttle endpoint url").Action(c.URL.Set).StringVar(&c.URL.Value)
+	c.CmdClause.Flag("auth-token", "The data authentication token associated with this endpoint").Action(c.Token.Set).StringVar(&c.Token.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateLogshuttleInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	logshuttle, err := c.Globals.Client.GetLogshuttle(&fastly.GetLogshuttleInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateLogshuttleInput{
+		Service:           logshuttle.ServiceID,
+		Version:           logshuttle.Version,
+		Name:              logshuttle.Name,
+		NewName:           fastly.String(logshuttle.Name),
+		Format:            fastly.String(logshuttle.Format),
+		FormatVersion:     fastly.Uint(logshuttle.FormatVersion),
+		URL:               fastly.String(logshuttle.URL),
+		Token:             fastly.String(logshuttle.Token),
+		ResponseCondition: fastly.String(logshuttle.ResponseCondition),
+		Placement:         fastly.String(logshuttle.Placement),
+	}
+
+	// Set new values if set by user.
+	if c.NewName.Valid {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.URL.Valid {
+		input.URL = fastly.String(c.URL.Value)
+	}
+
+	if c.Token.Valid {
+		input.Token = fastly.String(c.Token.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	logshuttle, err := c.Globals.Client.UpdateLogshuttle(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Logshuttle logging endpoint %s (service %s version %d)", logshuttle.Name, logshuttle.ServiceID, logshuttle.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -127,6 +127,12 @@ type API struct {
 	UpdateSFTPFn func(*fastly.UpdateSFTPInput) (*fastly.SFTP, error)
 	DeleteSFTPFn func(*fastly.DeleteSFTPInput) error
 
+	CreateLogshuttleFn func(*fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error)
+	ListLogshuttlesFn  func(*fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error)
+	GetLogshuttleFn    func(*fastly.GetLogshuttleInput) (*fastly.Logshuttle, error)
+	UpdateLogshuttleFn func(*fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
+	DeleteLogshuttleFn func(*fastly.DeleteLogshuttleInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -626,6 +632,31 @@ func (m API) UpdateSFTP(i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
 // DeleteSFTP implements Interface.
 func (m API) DeleteSFTP(i *fastly.DeleteSFTPInput) error {
 	return m.DeleteSFTPFn(i)
+}
+
+// CreateLogshuttle implements Interface.
+func (m API) CreateLogshuttle(i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
+	return m.CreateLogshuttleFn(i)
+}
+
+// ListLogshuttles implements Interface.
+func (m API) ListLogshuttles(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
+	return m.ListLogshuttlesFn(i)
+}
+
+// GetLogshuttle implements Interface.
+func (m API) GetLogshuttle(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
+	return m.GetLogshuttleFn(i)
+}
+
+// UpdateLogshuttle implements Interface.
+func (m API) UpdateLogshuttle(i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
+	return m.UpdateLogshuttleFn(i)
+}
+
+// DeleteLogshuttle implements Interface.
+func (m API) DeleteLogshuttle(i *fastly.DeleteLogshuttleInput) error {
+	return m.DeleteLogshuttleFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_logshuttle)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/logshuttle.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-logshuttle && \
    make test && \
    rm -rf /tmp/cli \
)
```