### PR TITLE
logging: adds Cloudfiles logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -142,6 +142,12 @@ type Interface interface {
 	UpdateLogshuttle(*fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
 	DeleteLogshuttle(*fastly.DeleteLogshuttleInput) error
 
+	CreateCloudfiles(*fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error)
+	ListCloudfiles(*fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error)
+	GetCloudfiles(*fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error)
+	UpdateCloudfiles(*fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error)
+	DeleteCloudfiles(*fastly.DeleteCloudfilesInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fastly/cli/pkg/healthcheck"
 	"github.com/fastly/cli/pkg/logging"
 	"github.com/fastly/cli/pkg/logging/bigquery"
+	"github.com/fastly/cli/pkg/logging/cloudfiles"
 	"github.com/fastly/cli/pkg/logging/ftp"
 	"github.com/fastly/cli/pkg/logging/gcs"
 	"github.com/fastly/cli/pkg/logging/heroku"
@@ -239,6 +240,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	logshuttleUpdate := logshuttle.NewUpdateCommand(logshuttleRoot.CmdClause, &globals)
 	logshuttleDelete := logshuttle.NewDeleteCommand(logshuttleRoot.CmdClause, &globals)
 
+	cloudfilesRoot := cloudfiles.NewRootCommand(loggingRoot.CmdClause, &globals)
+	cloudfilesCreate := cloudfiles.NewCreateCommand(cloudfilesRoot.CmdClause, &globals)
+	cloudfilesList := cloudfiles.NewListCommand(cloudfilesRoot.CmdClause, &globals)
+	cloudfilesDescribe := cloudfiles.NewDescribeCommand(cloudfilesRoot.CmdClause, &globals)
+	cloudfilesUpdate := cloudfiles.NewUpdateCommand(cloudfilesRoot.CmdClause, &globals)
+	cloudfilesDelete := cloudfiles.NewDeleteCommand(cloudfilesRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -399,6 +407,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		logshuttleDescribe,
 		logshuttleUpdate,
 		logshuttleDelete,
+
+		cloudfilesRoot,
+		cloudfilesCreate,
+		cloudfilesList,
+		cloudfilesDescribe,
+		cloudfilesUpdate,
+		cloudfilesDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1808,6 +1808,108 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Logshuttle logging object
 
+  logging cloudfiles create --name=NAME --version=VERSION --user=USER --access-key=ACCESS-KEY --bucket=BUCKET [<flags>]
+    Create a Cloudfiles logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Cloudfiles logging object. Used
+                                 as a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --user=USER              The username for your Cloudfile account
+        --access-key=ACCESS-KEY  Your Cloudfile account access key
+        --bucket=BUCKET          The name of your Cloudfiles container
+        --path=PATH              The path to upload logs to
+        --region=REGION          The region to stream logs to. One of:
+                                 DFW-Dallas, ORD-Chicago, IAD-Northern Virginia,
+                                 LON-London, SYD-Sydney, HKG-Hong Kong
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+        --period=PERIOD          How frequently log files are finalized so they
+                                 can be available for reading (in seconds,
+                                 default 3600)
+        --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
+                                 dumping logs (default 0, no compression)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --message-type=MESSAGE-TYPE
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
+        --timestamp-format=TIMESTAMP-FORMAT
+                                 strftime specified timestamp formatting
+                                 (default "%Y-%m-%dT%H:%M:%S.000")
+        --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
+                                 encrypt your log files before writing them to
+                                 disk
+
+  logging cloudfiles list --version=VERSION [<flags>]
+    List Cloudfiles endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging cloudfiles describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Cloudfiles logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -d, --name=NAME              The name of the Cloudfiles logging object
+
+  logging cloudfiles update --version=VERSION --name=NAME [<flags>]
+    Update a Cloudfiles logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Cloudfiles logging object
+        --new-name=NEW-NAME      New name of the Cloudfiles logging object
+        --access-key=ACCESS-KEY  Your Cloudfile account access key
+        --bucket=BUCKET          The name of your Cloudfiles container
+        --path=PATH              The path to upload logs to
+        --region=REGION          The region to stream logs to. One of:
+                                 DFW-Dallas, ORD-Chicago, IAD-Northern Virginia,
+                                 LON-London, SYD-Sydney, HKG-Hong Kong
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+        --period=PERIOD          How frequently log files are finalized so they
+                                 can be available for reading (in seconds,
+                                 default 3600)
+        --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
+                                 dumping logs (default 0, no compression)
+        --format=FORMAT          Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --message-type=MESSAGE-TYPE
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
+        --timestamp-format=TIMESTAMP-FORMAT
+                                 strftime specified timestamp formatting
+                                 (default "%Y-%m-%dT%H:%M:%S.000")
+        --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
+                                 encrypt your log files before writing them to
+                                 disk
+
+  logging cloudfiles delete --version=VERSION --name=NAME [<flags>]
+    Delete a Cloudfiles logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Cloudfiles logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -1,0 +1,489 @@
+package cloudfiles_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCloudfilesCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			wantError: "error parsing arguments: required flag --user not provided",
+		},
+		{
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--access-key", "foo"},
+			wantError: "error parsing arguments: required flag --bucket not provided",
+		},
+		{
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log"},
+			wantError: "error parsing arguments: required flag --access-key not provided",
+		},
+		{
+			args:       []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
+			api:        mock.API{CreateCloudfilesFn: createCloudfilesOK},
+			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
+			api:       mock.API{CreateCloudfilesFn: createCloudfilesError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestCloudfilesList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			wantOutput: listCloudfilesShortOutput,
+		},
+		{
+			args:       []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			wantOutput: listCloudfilesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			wantOutput: listCloudfilesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "cloudfiles", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			wantOutput: listCloudfilesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			wantOutput: listCloudfilesVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListCloudfilesFn: listCloudfilesError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestCloudfilesDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetCloudfilesFn: getCloudfilesError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetCloudfilesFn: getCloudfilesOK},
+			wantOutput: describeCloudfilesOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestCloudfilesUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetCloudfilesFn:    getCloudfilesError,
+				UpdateCloudfilesFn: updateCloudfilesOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetCloudfilesFn:    getCloudfilesOK,
+				UpdateCloudfilesFn: updateCloudfilesError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetCloudfilesFn:    getCloudfilesOK,
+				UpdateCloudfilesFn: updateCloudfilesOK,
+			},
+			wantOutput: "Updated Cloudfiles logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestCloudfilesDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteCloudfilesFn: deleteCloudfilesError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteCloudfilesFn: deleteCloudfilesOK},
+			wantOutput: "Deleted Cloudfiles logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createCloudfilesOK(i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	s := fastly.Cloudfiles{
+		ServiceID: i.Service,
+		Version:   i.Version,
+	}
+
+	if i.Name != nil {
+		s.Name = *i.Name
+	}
+
+	return &s, nil
+}
+
+func createCloudfilesError(i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return nil, errTest
+}
+
+func listCloudfilesOK(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
+	return []*fastly.Cloudfiles{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			User:              "username",
+			AccessKey:         "1234",
+			BucketName:        "my-logs",
+			Path:              "logs/",
+			Region:            "ORD",
+			Placement:         "none",
+			Period:            3600,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			MessageType:       "classic",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			PublicKey:         pgpPublicKey(),
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			User:              "username",
+			AccessKey:         "1234",
+			BucketName:        "analytics",
+			Path:              "logs/",
+			Region:            "ORD",
+			Placement:         "none",
+			Period:            86400,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			MessageType:       "classic",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			PublicKey:         pgpPublicKey(),
+		},
+	}, nil
+}
+
+func listCloudfilesError(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
+	return nil, errTest
+}
+
+var listCloudfilesShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listCloudfilesVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Cloudfiles 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		User: username
+		Access key: 1234
+		Bucket: my-logs
+		Path: logs/
+		Region: ORD
+		Placement: none
+		Period: 3600
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Public key: `+pgpPublicKey()+`
+	Cloudfiles 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		User: username
+		Access key: 1234
+		Bucket: analytics
+		Path: logs/
+		Region: ORD
+		Placement: none
+		Period: 86400
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Public key: `+pgpPublicKey()+`
+`) + "\n\n"
+
+func getCloudfilesOK(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return &fastly.Cloudfiles{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		User:              "username",
+		AccessKey:         "1234",
+		BucketName:        "my-logs",
+		Path:              "logs/",
+		Region:            "ORD",
+		Placement:         "none",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		MessageType:       "classic",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		PublicKey:         pgpPublicKey(),
+	}, nil
+}
+
+func getCloudfilesError(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return nil, errTest
+}
+
+var describeCloudfilesOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+User: username
+Access key: 1234
+Bucket: my-logs
+Path: logs/
+Region: ORD
+Placement: none
+Period: 3600
+GZip level: 9
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Message type: classic
+Timestamp format: %Y-%m-%dT%H:%M:%S.000
+Public key: `+pgpPublicKey()+`
+`) + "\n"
+
+func updateCloudfilesOK(i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return &fastly.Cloudfiles{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		User:              "username",
+		AccessKey:         "1234",
+		BucketName:        "my-logs",
+		Path:              "logs/",
+		Region:            "ORD",
+		Placement:         "none",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		MessageType:       "classic",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		PublicKey:         pgpPublicKey(),
+	}, nil
+}
+
+func updateCloudfilesError(i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return nil, errTest
+}
+
+func deleteCloudfilesOK(i *fastly.DeleteCloudfilesInput) error {
+	return nil
+}
+
+func deleteCloudfilesError(i *fastly.DeleteCloudfilesInput) error {
+	return errTest
+}
+
+// pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
+func pgpPublicKey() string {
+	return strings.TrimSpace(`-----BEGIN PGP PUBLIC KEY BLOCK-----
+mQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/
+ibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4
+8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p
+lDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn
+dwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB
+89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz
+dCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6
+vFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc
+9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9
+OLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX
+SvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq
+7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx
+kATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG
+M1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe
+u6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L
+4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF
+ftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K
+UEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu
+YrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi
+kiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb
+DAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml
+dYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L
+3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c
+FaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR
+5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR
+wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
+=28dr
+-----END PGP PUBLIC KEY BLOCK-----
+`)
+}

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -1,0 +1,291 @@
+package cloudfiles
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateCloudfilesInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateCloudfilesInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateCloudfilesInput{
+				Service:    "123",
+				Version:    2,
+				Name:       fastly.String("log"),
+				User:       fastly.String("user"),
+				AccessKey:  fastly.String("key"),
+				BucketName: fastly.String("bucket"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateCloudfilesInput{
+				Service:           "123",
+				Version:           2,
+				Name:              fastly.String("log"),
+				User:              fastly.String("user"),
+				AccessKey:         fastly.String("key"),
+				BucketName:        fastly.String("bucket"),
+				Path:              fastly.String("/logs"),
+				Region:            fastly.String("abc"),
+				Placement:         fastly.String("none"),
+				Period:            fastly.Uint(3600),
+				GzipLevel:         fastly.Uint(2),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				MessageType:       fastly.String("classic"),
+				TimestampFormat:   fastly.String("%Y-%m-%dT%H:%M:%S.000"),
+				PublicKey:         fastly.String(pgpPublicKey()),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateCloudfilesInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateCloudfilesInput
+		wantError string
+	}{
+		{
+			name: "no update",
+			cmd:  updateCommandNoUpdate(),
+			api:  mock.API{GetCloudfilesFn: getCloudfilesOK},
+			want: &fastly.UpdateCloudfilesInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("logs"),
+				AccessKey:         fastly.String("key"),
+				BucketName:        fastly.String("bucket"),
+				Path:              fastly.String("/logs"),
+				Region:            fastly.String("abc"),
+				Placement:         fastly.String("none"),
+				Period:            fastly.Uint(3600),
+				GzipLevel:         fastly.Uint(2),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				MessageType:       fastly.String("classic"),
+				TimestampFormat:   fastly.String("%Y-%m-%dT%H:%M:%S.000"),
+				PublicKey:         fastly.String(pgpPublicKey()),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetCloudfilesFn: getCloudfilesOK},
+			want: &fastly.UpdateCloudfilesInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("new1"),
+				AccessKey:         fastly.String("new2"),
+				BucketName:        fastly.String("new3"),
+				Path:              fastly.String("new4"),
+				Region:            fastly.String("new5"),
+				Placement:         fastly.String("new6"),
+				Period:            fastly.Uint(3601),
+				GzipLevel:         fastly.Uint(3),
+				Format:            fastly.String("new7"),
+				FormatVersion:     fastly.Uint(3),
+				ResponseCondition: fastly.String("new8"),
+				MessageType:       fastly.String("new9"),
+				TimestampFormat:   fastly.String("new10"),
+				PublicKey:         fastly.String("new11"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+		User:         "user",
+		AccessKey:    "key",
+		BucketName:   "bucket",
+	}
+}
+
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		User:              "user",
+		AccessKey:         "key",
+		BucketName:        "bucket",
+		Path:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "/logs"},
+		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "abc"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		Period:            common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3600},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
+		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		PublicKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: pgpPublicKey()},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdate() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Version:           2,
+		EndpointName:      "logs",
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "logs"},
+		AccessKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "key"},
+		BucketName:        common.OptionalString{Optional: common.Optional{Valid: true}, Value: "bucket"},
+		Path:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "/logs"},
+		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "abc"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		Period:            common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3600},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
+		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		PublicKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: pgpPublicKey()},
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Version:           2,
+		EndpointName:      "log",
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		AccessKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		BucketName:        common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		Path:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+		Period:            common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3601},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new7"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new8"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
+		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
+		PublicKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new11"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getCloudfilesOK(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return &fastly.Cloudfiles{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		User:              "user",
+		AccessKey:         "key",
+		BucketName:        "bucket",
+		Path:              "/logs",
+		Region:            "abc",
+		Placement:         "none",
+		Period:            2,
+		GzipLevel:         2,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		MessageType:       "classic",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		PublicKey:         pgpPublicKey(),
+	}, nil
+}
+
+// pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
+func pgpPublicKey() string {
+	return strings.TrimSpace(`-----BEGIN PGP PUBLIC KEY BLOCK-----
+mQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/
+ibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4
+8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p
+lDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn
+dwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB
+89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz
+dCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6
+vFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc
+9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9
+OLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX
+SvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq
+7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx
+kATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG
+M1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe
+u6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L
+4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF
+ftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K
+UEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu
+YrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi
+kiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb
+DAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml
+dYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L
+3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c
+FaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR
+5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR
+wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
+=28dr
+-----END PGP PUBLIC KEY BLOCK-----
+`)
+}

--- a/pkg/logging/cloudfiles/create.go
+++ b/pkg/logging/cloudfiles/create.go
@@ -1,0 +1,149 @@
+package cloudfiles
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Cloudfiles logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Token        string
+	Version      int
+	User         string
+	AccessKey    string
+	BucketName   string
+
+	// optional
+	Path              common.OptionalString
+	Region            common.OptionalString
+	PublicKey         common.OptionalString
+	Period            common.OptionalUint
+	GzipLevel         common.OptionalUint
+	MessageType       common.OptionalString
+	TimestampFormat   common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Cloudfiles logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("user", "The username for your Cloudfile account").Required().StringVar(&c.User)
+	c.CmdClause.Flag("access-key", "Your Cloudfile account access key").Required().StringVar(&c.AccessKey)
+	c.CmdClause.Flag("bucket", "The name of your Cloudfiles container").Required().StringVar(&c.BucketName)
+
+	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
+	c.CmdClause.Flag("region", "The region to stream logs to. One of: DFW-Dallas, ORD-Chicago, IAD-Northern Virginia, LON-London, SYD-Sydney, HKG-Hong Kong").Action(c.Region.Set).StringVar(&c.Region.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).UintVar(&c.GzipLevel.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateCloudfilesInput, error) {
+	var input fastly.CreateCloudfilesInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = fastly.String(c.EndpointName)
+	input.User = fastly.String(c.User)
+	input.AccessKey = fastly.String(c.AccessKey)
+	input.BucketName = fastly.String(c.BucketName)
+
+	if c.Path.Valid {
+		input.Path = fastly.String(c.Path.Value)
+	}
+
+	if c.Region.Valid {
+		input.Region = fastly.String(c.Region.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	if c.Period.Valid {
+		input.Period = fastly.Uint(c.Period.Value)
+	}
+
+	if c.GzipLevel.Valid {
+		input.GzipLevel = fastly.Uint(c.GzipLevel.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = fastly.String(c.MessageType.Value)
+	}
+
+	if c.TimestampFormat.Valid {
+		input.TimestampFormat = fastly.String(c.TimestampFormat.Value)
+	}
+
+	if c.PublicKey.Valid {
+		input.PublicKey = fastly.String(c.PublicKey.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateCloudfiles(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Cloudfiles logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/cloudfiles/delete.go
+++ b/pkg/logging/cloudfiles/delete.go
@@ -1,0 +1,47 @@
+package cloudfiles
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Cloudfiles logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteCloudfilesInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Cloudfiles logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteCloudfiles(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Cloudfiles logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/cloudfiles/describe.go
+++ b/pkg/logging/cloudfiles/describe.go
@@ -1,0 +1,65 @@
+package cloudfiles
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Cloudfiles logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetCloudfilesInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Cloudfiles logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('d').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	cloudfiles, err := c.Globals.Client.GetCloudfiles(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", cloudfiles.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", cloudfiles.Version)
+	fmt.Fprintf(out, "Name: %s\n", cloudfiles.Name)
+	fmt.Fprintf(out, "User: %s\n", cloudfiles.User)
+	fmt.Fprintf(out, "Access key: %s\n", cloudfiles.AccessKey)
+	fmt.Fprintf(out, "Bucket: %s\n", cloudfiles.BucketName)
+	fmt.Fprintf(out, "Path: %s\n", cloudfiles.Path)
+	fmt.Fprintf(out, "Region: %s\n", cloudfiles.Region)
+	fmt.Fprintf(out, "Placement: %s\n", cloudfiles.Placement)
+	fmt.Fprintf(out, "Period: %d\n", cloudfiles.Period)
+	fmt.Fprintf(out, "GZip level: %d\n", cloudfiles.GzipLevel)
+	fmt.Fprintf(out, "Format: %s\n", cloudfiles.Format)
+	fmt.Fprintf(out, "Format version: %d\n", cloudfiles.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", cloudfiles.ResponseCondition)
+	fmt.Fprintf(out, "Message type: %s\n", cloudfiles.MessageType)
+	fmt.Fprintf(out, "Timestamp format: %s\n", cloudfiles.TimestampFormat)
+	fmt.Fprintf(out, "Public key: %s\n", cloudfiles.PublicKey)
+
+	return nil
+}

--- a/pkg/logging/cloudfiles/doc.go
+++ b/pkg/logging/cloudfiles/doc.go
@@ -1,0 +1,3 @@
+// Package cloudfiles contains commands to inspect and manipulate Fastly service Cloudfiles
+// logging endpoints.
+package cloudfiles

--- a/pkg/logging/cloudfiles/list.go
+++ b/pkg/logging/cloudfiles/list.go
@@ -1,0 +1,81 @@
+package cloudfiles
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Cloudfiles logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListCloudfilesInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Cloudfiles endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	cloudfiles, err := c.Globals.Client.ListCloudfiles(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, cloudfile := range cloudfiles {
+			tw.AddLine(cloudfile.ServiceID, cloudfile.Version, cloudfile.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, cloudfile := range cloudfiles {
+		fmt.Fprintf(out, "\tCloudfiles %d/%d\n", i+1, len(cloudfiles))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", cloudfile.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", cloudfile.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", cloudfile.Name)
+		fmt.Fprintf(out, "\t\tUser: %s\n", cloudfile.User)
+		fmt.Fprintf(out, "\t\tAccess key: %s\n", cloudfile.AccessKey)
+		fmt.Fprintf(out, "\t\tBucket: %s\n", cloudfile.BucketName)
+		fmt.Fprintf(out, "\t\tPath: %s\n", cloudfile.Path)
+		fmt.Fprintf(out, "\t\tRegion: %s\n", cloudfile.Region)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", cloudfile.Placement)
+		fmt.Fprintf(out, "\t\tPeriod: %d\n", cloudfile.Period)
+		fmt.Fprintf(out, "\t\tGZip level: %d\n", cloudfile.GzipLevel)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", cloudfile.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", cloudfile.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", cloudfile.ResponseCondition)
+		fmt.Fprintf(out, "\t\tMessage type: %s\n", cloudfile.MessageType)
+		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", cloudfile.TimestampFormat)
+		fmt.Fprintf(out, "\t\tPublic key: %s\n", cloudfile.PublicKey)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/cloudfiles/root.go
+++ b/pkg/logging/cloudfiles/root.go
@@ -1,0 +1,28 @@
+package cloudfiles
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("cloudfiles", "Manipulate Fastly service version Cloudfiles logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -1,0 +1,180 @@
+package cloudfiles
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Cloudfiles logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	AccessKey         common.OptionalString
+	BucketName        common.OptionalString
+	Path              common.OptionalString
+	Region            common.OptionalString
+	Placement         common.OptionalString
+	Period            common.OptionalUint
+	GzipLevel         common.OptionalUint
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	MessageType       common.OptionalString
+	TimestampFormat   common.OptionalString
+	PublicKey         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Cloudfiles logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Cloudfiles logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("access-key", "Your Cloudfile account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)
+	c.CmdClause.Flag("bucket", "The name of your Cloudfiles container").Action(c.BucketName.Set).StringVar(&c.BucketName.Value)
+	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
+	c.CmdClause.Flag("region", "The region to stream logs to. One of: DFW-Dallas, ORD-Chicago, IAD-Northern Virginia, LON-London, SYD-Sydney, HKG-Hong Kong").Action(c.Region.Set).StringVar(&c.Region.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).UintVar(&c.GzipLevel.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateCloudfilesInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	cloudfiles, err := c.Globals.Client.GetCloudfiles(&fastly.GetCloudfilesInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateCloudfilesInput{
+		Service:           cloudfiles.ServiceID,
+		Version:           cloudfiles.Version,
+		Name:              cloudfiles.Name,
+		NewName:           fastly.String(cloudfiles.Name),
+		AccessKey:         fastly.String(cloudfiles.AccessKey),
+		BucketName:        fastly.String(cloudfiles.BucketName),
+		Path:              fastly.String(cloudfiles.Path),
+		Region:            fastly.String(cloudfiles.Region),
+		Placement:         fastly.String(cloudfiles.Placement),
+		Period:            fastly.Uint(cloudfiles.Period),
+		GzipLevel:         fastly.Uint(cloudfiles.GzipLevel),
+		Format:            fastly.String(cloudfiles.Format),
+		FormatVersion:     fastly.Uint(cloudfiles.FormatVersion),
+		ResponseCondition: fastly.String(cloudfiles.ResponseCondition),
+		MessageType:       fastly.String(cloudfiles.MessageType),
+		TimestampFormat:   fastly.String(cloudfiles.TimestampFormat),
+		PublicKey:         fastly.String(cloudfiles.PublicKey),
+	}
+
+	// Set new values if set by user.
+	if c.NewName.Valid {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.AccessKey.Valid {
+		input.AccessKey = fastly.String(c.AccessKey.Value)
+	}
+
+	if c.BucketName.Valid {
+		input.BucketName = fastly.String(c.BucketName.Value)
+	}
+
+	if c.Path.Valid {
+		input.Path = fastly.String(c.Path.Value)
+	}
+
+	if c.Region.Valid {
+		input.Region = fastly.String(c.Region.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	if c.Period.Valid {
+		input.Period = fastly.Uint(c.Period.Value)
+	}
+
+	if c.GzipLevel.Valid {
+		input.GzipLevel = fastly.Uint(c.GzipLevel.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = fastly.String(c.MessageType.Value)
+	}
+
+	if c.TimestampFormat.Valid {
+		input.TimestampFormat = fastly.String(c.TimestampFormat.Value)
+	}
+
+	if c.PublicKey.Valid {
+		input.PublicKey = fastly.String(c.PublicKey.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	cloudfiles, err := c.Globals.Client.UpdateCloudfiles(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Cloudfiles logging endpoint %s (service %s version %d)", cloudfiles.Name, cloudfiles.ServiceID, cloudfiles.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -133,6 +133,12 @@ type API struct {
 	UpdateLogshuttleFn func(*fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
 	DeleteLogshuttleFn func(*fastly.DeleteLogshuttleInput) error
 
+	CreateCloudfilesFn func(*fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error)
+	ListCloudfilesFn   func(*fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error)
+	GetCloudfilesFn    func(*fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error)
+	UpdateCloudfilesFn func(*fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error)
+	DeleteCloudfilesFn func(*fastly.DeleteCloudfilesInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -657,6 +663,31 @@ func (m API) UpdateLogshuttle(i *fastly.UpdateLogshuttleInput) (*fastly.Logshutt
 // DeleteLogshuttle implements Interface.
 func (m API) DeleteLogshuttle(i *fastly.DeleteLogshuttleInput) error {
 	return m.DeleteLogshuttleFn(i)
+}
+
+// CreateCloudfiles implements Interface.
+func (m API) CreateCloudfiles(i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return m.CreateCloudfilesFn(i)
+}
+
+// ListCloudfiles implements Interface.
+func (m API) ListCloudfiles(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
+	return m.ListCloudfilesFn(i)
+}
+
+// GetCloudfiles implements Interface.
+func (m API) GetCloudfiles(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return m.GetCloudfilesFn(i)
+}
+
+// UpdateCloudfiles implements Interface.
+func (m API) UpdateCloudfiles(i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return m.UpdateCloudfilesFn(i)
+}
+
+// DeleteCloudfiles implements Interface.
+func (m API) DeleteCloudfiles(i *fastly.DeleteCloudfilesInput) error {
+	return m.DeleteCloudfilesFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://docs.fastly.com/api/logging#api-section-logging_cloudfiles)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/cloudfiles.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-cloudfiles && \
    make test && \
    rm -rf /tmp/cli \
)
```