### PR TITLE
Update Goreleaser CI action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - master
-name: Test
+name: Scan
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -29,9 +29,9 @@ jobs:
       env:
         CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v1
+      uses: goreleaser/goreleaser-action@108bc4d
       with:
-        version: 'v0.131.1'
+        version: 'v0.135.0'
         args: release --rm-dist --release-notes=RELEASE_CHANGELOG.md
       env:
         GOVERSION: ${{ env.GOVERSION }}


### PR DESCRIPTION
### TL;DR
- Pins the goreleaser-action version to a commit hash, per our security guidelines
- Updates goreleaser version to 0.135.0
- Renames scan workflow (copy/paste error in #61)