### PR TITLE
mock: remove dependency on app package

### DIFF
--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -2,12 +2,11 @@ package mock
 
 import (
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/app"
 )
 
 // APIClient takes a mock.API and returns an app.ClientFactory that uses that
 // mock, ignoring the token and endpoint. It should only be used for tests.
-func APIClient(a API) app.APIClientFactory {
+func APIClient(a API) func(string, string) (api.Interface, error) {
 	return func(token, endpoint string) (api.Interface, error) {
 		return a, nil
 	}


### PR DESCRIPTION
Removes dependency on `app` package which improved convenience, but limited its use.

See https://github.com/fastly/cli/pull/73/files#diff-aa80104cc7a38c091d22ef0cab9d4853R55

Previously, this introduced a cyclical dependency and made it impossible to test the package without significant changes.