### PR TITLE
Describe subcommand consistent --name short flag -d -> -n

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -315,7 +315,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              Name of domain
+    -n, --name=NAME              Name of domain
 
   domain update --version=VERSION --name=NAME [<flags>]
     Update a domain on a Fastly service version
@@ -586,7 +586,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the BigQuery logging object
+    -n, --name=NAME              The name of the BigQuery logging object
 
   logging bigquery update --version=VERSION --name=NAME [<flags>]
     Update a BigQuery logging endpoint on a Fastly service version
@@ -688,7 +688,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the S3 logging object
+    -n, --name=NAME              The name of the S3 logging object
 
   logging s3 update --version=VERSION --name=NAME [<flags>]
     Update a S3 logging endpoint on a Fastly service version
@@ -794,7 +794,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Syslog logging object
+    -n, --name=NAME              The name of the Syslog logging object
 
   logging syslog update --version=VERSION --name=NAME [<flags>]
     Update a Syslog logging endpoint on a Fastly service version
@@ -886,7 +886,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Logentries logging object
+    -n, --name=NAME              The name of the Logentries logging object
 
   logging logentries update --version=VERSION --name=NAME [<flags>]
     Update a Logentries logging endpoint on a Fastly service version
@@ -964,7 +964,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Papertrail logging object
+    -n, --name=NAME              The name of the Papertrail logging object
 
   logging papertrail update --version=VERSION --name=NAME [<flags>]
     Update a Papertrail logging endpoint on a Fastly service version
@@ -1041,7 +1041,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Sumologic logging object
+    -n, --name=NAME              The name of the Sumologic logging object
 
   logging sumologic update --version=VERSION --name=NAME [<flags>]
     Update a Sumologic logging endpoint on a Fastly service version
@@ -1134,7 +1134,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the GCS logging object
+    -n, --name=NAME              The name of the GCS logging object
 
   logging gcs update --version=VERSION --name=NAME [<flags>]
     Update a GCS logging endpoint on a Fastly service version
@@ -1230,7 +1230,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the FTP logging object
+    -n, --name=NAME              The name of the FTP logging object
 
   logging ftp update --version=VERSION --name=NAME [<flags>]
     Update an FTP logging endpoint on a Fastly service version
@@ -1323,7 +1323,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Splunk logging object
+    -n, --name=NAME              The name of the Splunk logging object
 
   logging splunk update --version=VERSION --name=NAME [<flags>]
     Update a Splunk logging endpoint on a Fastly service version
@@ -1396,7 +1396,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Scalyr logging object
+    -n, --name=NAME              The name of the Scalyr logging object
 
   logging scalyr update --version=VERSION --name=NAME [<flags>]
     Update a Scalyr logging endpoint on a Fastly service version
@@ -1461,7 +1461,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Loggly logging object
+    -n, --name=NAME              The name of the Loggly logging object
 
   logging loggly update --version=VERSION --name=NAME [<flags>]
     Update a Loggly logging endpoint on a Fastly service version
@@ -1528,7 +1528,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Honeycomb logging object
+    -n, --name=NAME              The name of the Honeycomb logging object
 
   logging honeycomb update --version=VERSION --name=NAME [<flags>]
     Update a Honeycomb logging endpoint on a Fastly service version
@@ -1596,7 +1596,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Heroku logging object
+    -n, --name=NAME              The name of the Heroku logging object
 
   logging heroku update --version=VERSION --name=NAME [<flags>]
     Update a Heroku logging endpoint on a Fastly service version
@@ -1686,7 +1686,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the SFTP logging object
+    -n, --name=NAME              The name of the SFTP logging object
 
   logging sftp update --version=VERSION --name=NAME [<flags>]
     Update an SFTP logging endpoint on a Fastly service version
@@ -1776,7 +1776,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Logshuttle logging object
+    -n, --name=NAME              The name of the Logshuttle logging object
 
   logging logshuttle update --version=VERSION --name=NAME [<flags>]
     Update a Logshuttle logging endpoint on a Fastly service version
@@ -1861,7 +1861,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the Cloudfiles logging object
+    -n, --name=NAME              The name of the Cloudfiles logging object
 
   logging cloudfiles update --version=VERSION --name=NAME [<flags>]
     Update a Cloudfiles logging endpoint on a Fastly service version
@@ -1962,7 +1962,7 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
-    -d, --name=NAME              The name of the DigitalOcean Spaces logging
+    -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
 
   logging digitalocean update --version=VERSION --name=NAME [<flags>]

--- a/pkg/domain/describe.go
+++ b/pkg/domain/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a domain on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "Name of domain").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "Name of domain").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/bigquery/describe.go
+++ b/pkg/logging/bigquery/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a BigQuery logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the BigQuery logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the BigQuery logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/cloudfiles/describe.go
+++ b/pkg/logging/cloudfiles/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Cloudfiles logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/digitalocean/describe.go
+++ b/pkg/logging/digitalocean/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about an FTP logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a GCS logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/heroku/describe.go
+++ b/pkg/logging/heroku/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Heroku logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Heroku logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Heroku logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/honeycomb/describe.go
+++ b/pkg/logging/honeycomb/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Honeycomb logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/logentries/describe.go
+++ b/pkg/logging/logentries/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logentries logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/loggly/describe.go
+++ b/pkg/logging/loggly/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Loggly logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Loggly logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Loggly logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/logshuttle/describe.go
+++ b/pkg/logging/logshuttle/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logshuttle logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/papertrail/describe.go
+++ b/pkg/logging/papertrail/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Papertrail logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a S3 logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the S3 logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the S3 logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Scalyr logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/sftp/describe.go
+++ b/pkg/logging/sftp/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about an SFTP logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the SFTP logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the SFTP logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/splunk/describe.go
+++ b/pkg/logging/splunk/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Splunk logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/sumologic/describe.go
+++ b/pkg/logging/sumologic/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Sumologic logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/logging/syslog/describe.go
+++ b/pkg/logging/syslog/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Syslog logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('d').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 


### PR DESCRIPTION
## Proposed Change(s)

* Consistently use of `-n` as the short flag for `--name` (previously was `-d` that got copy-pasted ubiquitously).

```shell
$ find . -type f -name "describe.go" -exec sed -i "s/\"name\", \(.*\).Short('d')/\"name\", \1.Short('n')/g" {} \;`
```

## Validation

* `make test`