### PR TITLE
Adds Elasticsearch logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -154,6 +154,12 @@ type Interface interface {
 	UpdateDigitalOcean(*fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error)
 	DeleteDigitalOcean(*fastly.DeleteDigitalOceanInput) error
 
+	CreateElasticsearch(*fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error)
+	ListElasticsearch(*fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error)
+	GetElasticsearch(*fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error)
+	UpdateElasticsearch(*fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error)
+	DeleteElasticsearch(*fastly.DeleteElasticsearchInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/bigquery"
 	"github.com/fastly/cli/pkg/logging/cloudfiles"
 	"github.com/fastly/cli/pkg/logging/digitalocean"
+	"github.com/fastly/cli/pkg/logging/elasticsearch"
 	"github.com/fastly/cli/pkg/logging/ftp"
 	"github.com/fastly/cli/pkg/logging/gcs"
 	"github.com/fastly/cli/pkg/logging/heroku"
@@ -260,6 +261,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
 	statsRealtime := stats.NewRealtimeCommand(statsRoot.CmdClause, &globals)
 
+	elasticsearchRoot := elasticsearch.NewRootCommand(loggingRoot.CmdClause, &globals)
+	elasticsearchCreate := elasticsearch.NewCreateCommand(elasticsearchRoot.CmdClause, &globals)
+	elasticsearchList := elasticsearch.NewListCommand(elasticsearchRoot.CmdClause, &globals)
+	elasticsearchDescribe := elasticsearch.NewDescribeCommand(elasticsearchRoot.CmdClause, &globals)
+	elasticsearchUpdate := elasticsearch.NewUpdateCommand(elasticsearchRoot.CmdClause, &globals)
+	elasticsearchDelete := elasticsearch.NewDeleteCommand(elasticsearchRoot.CmdClause, &globals)
+
 	commands := []common.Command{
 		configureRoot,
 		whoamiRoot,
@@ -429,6 +437,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		digitaloceanDescribe,
 		digitaloceanUpdate,
 		digitaloceanDelete,
+
+		elasticsearchRoot,
+		elasticsearchCreate,
+		elasticsearchList,
+		elasticsearchDescribe,
+		elasticsearchUpdate,
+		elasticsearchDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2015,6 +2015,141 @@ COMMANDS
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
 
+  logging elasticsearch create --name=NAME --version=VERSION --index=INDEX --url=URL [<flags>]
+    Create an Elasticsearch logging endpoint on a Fastly service version
+
+    -n, --name=NAME                The name of the Elasticsearch logging object.
+                                   Used as a primary key for API access
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+        --index=INDEX              The name of the Elasticsearch index to send
+                                   documents (logs) to. The index must follow
+                                   the Elasticsearch index format rules
+                                   (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html).
+                                   We support strftime
+                                   (http://man7.org/linux/man-pages/man3/strftime.3.html)
+                                   interpolated variables inside braces prefixed
+                                   with a pound symbol. For example, #{%F} will
+                                   interpolate as YYYY-MM-DD with today's date
+        --url=URL                  The URL to stream logs to. Must use HTTPS.
+        --pipeline=PIPELINE        The ID of the Elasticsearch ingest pipeline
+                                   to apply pre-process transformations to
+                                   before indexing. For example my_pipeline_id.
+                                   Learn more about creating a pipeline in the
+                                   Elasticsearch docs
+                                   (https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-client-cert=TLS-CLIENT-CERT
+                                   The client certificate used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-client-key=TLS-CLIENT-KEY
+                                   The client private key used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --format=FORMAT            Apache style log formatting. Your log must
+                                   produce valid JSON that Elasticsearch can
+                                   ingest
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --request-max-entries=REQUEST-MAX-ENTRIES
+                                   Maximum number of logs to append to a batch,
+                                   if non-zero. Defaults to 0 for unbounded
+        --request-max-bytes=REQUEST-MAX-BYTES
+                                   Maximum size of log batch, if non-zero.
+                                   Defaults to 0 for unbounded
+
+  logging elasticsearch list --version=VERSION [<flags>]
+    List Elasticsearch endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging elasticsearch describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about an Elasticsearch logging endpoint on a
+    Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Elasticsearch logging object
+
+  logging elasticsearch update --version=VERSION --name=NAME [<flags>]
+    Update an Elasticsearch logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+    -n, --name=NAME                The name of the Elasticsearch logging object
+        --new-name=NEW-NAME        New name of the Elasticsearch logging object
+        --index=INDEX              The name of the Elasticsearch index to send
+                                   documents (logs) to. The index must follow
+                                   the Elasticsearch index format rules
+                                   (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html).
+                                   We support strftime
+                                   (http://man7.org/linux/man-pages/man3/strftime.3.html)
+                                   interpolated variables inside braces prefixed
+                                   with a pound symbol. For example, #{%F} will
+                                   interpolate as YYYY-MM-DD with today's date
+        --url=URL                  The URL to stream logs to. Must use HTTPS.
+        --pipeline=PIPELINE        The ID of the Elasticsearch ingest pipeline
+                                   to apply pre-process transformations to
+                                   before indexing. For example my_pipeline_id.
+                                   Learn more about creating a pipeline in the
+                                   Elasticsearch docs
+                                   (https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-client-cert=TLS-CLIENT-CERT
+                                   The client certificate used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-client-key=TLS-CLIENT-KEY
+                                   The client private key used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --format=FORMAT            Apache style log formatting. Your log must
+                                   produce valid JSON that Elasticsearch can
+                                   ingest
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --request-max-entries=REQUEST-MAX-ENTRIES
+                                   Maximum number of logs to append to a batch,
+                                   if non-zero. Defaults to 0 for unbounded
+        --request-max-bytes=REQUEST-MAX-BYTES
+                                   Maximum size of log batch, if non-zero.
+                                   Defaults to 0 for unbounded
+
+  logging elasticsearch delete --version=VERSION --name=NAME [<flags>]
+    Delete an Elasticsearch logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Elasticsearch logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/elasticsearch/create.go
+++ b/pkg/logging/elasticsearch/create.go
@@ -1,0 +1,154 @@
+package elasticsearch
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Elasticsearch logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	Index        string
+	URL          string
+
+	// optional
+	Pipeline          common.OptionalString
+	RequestMaxEntries common.OptionalUint
+	RequestMaxBytes   common.OptionalUint
+	User              common.OptionalString
+	Password          common.OptionalString
+	TLSCACert         common.OptionalString
+	TLSClientCert     common.OptionalString
+	TLSClientKey      common.OptionalString
+	TLSHostname       common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Placement         common.OptionalString
+	ResponseCondition common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create an Elasticsearch logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("index", `The name of the Elasticsearch index to send documents (logs) to. The index must follow the Elasticsearch index format rules (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). We support strftime (http://man7.org/linux/man-pages/man3/strftime.3.html) interpolated variables inside braces prefixed with a pound symbol. For example, #{%F} will interpolate as YYYY-MM-DD with today's date`).Required().StringVar(&c.Index)
+	c.CmdClause.Flag("url", "The URL to stream logs to. Must use HTTPS.").Required().StringVar(&c.URL)
+
+	c.CmdClause.Flag("pipeline", "The ID of the Elasticsearch ingest pipeline to apply pre-process transformations to before indexing. For example my_pipeline_id. Learn more about creating a pipeline in the Elasticsearch docs (https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)").Action(c.Password.Set).StringVar(&c.Pipeline.Value)
+	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
+	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)
+	c.CmdClause.Flag("tls-client-key", "The client private key used to make authenticated requests. Must be in PEM format").Action(c.TLSClientKey.Set).StringVar(&c.TLSClientKey.Value)
+	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Elasticsearch can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateElasticsearchInput, error) {
+	var input fastly.CreateElasticsearchInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = fastly.String(c.EndpointName)
+	input.Index = fastly.String(c.Index)
+	input.URL = fastly.String(c.URL)
+
+	if c.Pipeline.Valid {
+		input.Pipeline = fastly.String(c.Pipeline.Value)
+	}
+
+	if c.RequestMaxEntries.Valid {
+		input.RequestMaxEntries = fastly.Uint(c.RequestMaxEntries.Value)
+	}
+
+	if c.RequestMaxBytes.Valid {
+		input.RequestMaxBytes = fastly.Uint(c.RequestMaxBytes.Value)
+	}
+
+	if c.User.Valid {
+		input.User = fastly.String(c.User.Value)
+	}
+
+	if c.Password.Valid {
+		input.Password = fastly.String(c.Password.Value)
+	}
+
+	if c.TLSCACert.Valid {
+		input.TLSCACert = fastly.String(c.TLSCACert.Value)
+	}
+
+	if c.TLSClientCert.Valid {
+		input.TLSClientCert = fastly.String(c.TLSClientCert.Value)
+	}
+
+	if c.TLSClientKey.Valid {
+		input.TLSClientKey = fastly.String(c.TLSClientKey.Value)
+	}
+
+	if c.TLSHostname.Valid {
+		input.TLSHostname = fastly.String(c.TLSHostname.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateElasticsearch(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Elasticsearch logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/elasticsearch/delete.go
+++ b/pkg/logging/elasticsearch/delete.go
@@ -1,0 +1,47 @@
+package elasticsearch
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Elasticsearch logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteElasticsearchInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete an Elasticsearch logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteElasticsearch(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Elasticsearch logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/elasticsearch/describe.go
+++ b/pkg/logging/elasticsearch/describe.go
@@ -1,0 +1,64 @@
+package elasticsearch
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe an Elasticsearch logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetElasticsearchInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about an Elasticsearch logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	elasticsearch, err := c.Globals.Client.GetElasticsearch(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", elasticsearch.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", elasticsearch.Version)
+	fmt.Fprintf(out, "Name: %s\n", elasticsearch.Name)
+	fmt.Fprintf(out, "Index: %s\n", elasticsearch.Index)
+	fmt.Fprintf(out, "URL: %s\n", elasticsearch.URL)
+	fmt.Fprintf(out, "Pipeline: %s\n", elasticsearch.Pipeline)
+	fmt.Fprintf(out, "TLS CA certificate: %s\n", elasticsearch.TLSCACert)
+	fmt.Fprintf(out, "TLS client certificate: %s\n", elasticsearch.TLSClientCert)
+	fmt.Fprintf(out, "TLS client key: %s\n", elasticsearch.TLSClientKey)
+	fmt.Fprintf(out, "TLS hostname: %s\n", elasticsearch.TLSHostname)
+	fmt.Fprintf(out, "User: %s\n", elasticsearch.User)
+	fmt.Fprintf(out, "Password: %s\n", elasticsearch.Password)
+	fmt.Fprintf(out, "Format: %s\n", elasticsearch.Format)
+	fmt.Fprintf(out, "Format version: %d\n", elasticsearch.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", elasticsearch.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", elasticsearch.Placement)
+
+	return nil
+}

--- a/pkg/logging/elasticsearch/doc.go
+++ b/pkg/logging/elasticsearch/doc.go
@@ -1,0 +1,3 @@
+// Package elasticsearch contains commands to inspect and manipulate Fastly service Elasticsearch
+// logging endpoints.
+package elasticsearch

--- a/pkg/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_integration_test.go
@@ -1,0 +1,462 @@
+package elasticsearch_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestElasticsearchCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs"},
+			wantError: "error parsing arguments: required flag --url not provided",
+		},
+		{
+			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			wantError: "error parsing arguments: required flag --index not provided",
+		},
+		{
+			args:       []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
+			api:        mock.API{CreateElasticsearchFn: createElasticsearchOK},
+			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
+			api:       mock.API{CreateElasticsearchFn: createElasticsearchError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestElasticsearchList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			wantOutput: listElasticsearchsShortOutput,
+		},
+		{
+			args:       []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			wantOutput: listElasticsearchsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			wantOutput: listElasticsearchsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "elasticsearch", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			wantOutput: listElasticsearchsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			wantOutput: listElasticsearchsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListElasticsearchFn: listElasticsearchsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestElasticsearchDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetElasticsearchFn: getElasticsearchError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetElasticsearchFn: getElasticsearchOK},
+			wantOutput: describeElasticsearchOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestElasticsearchUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetElasticsearchFn:    getElasticsearchError,
+				UpdateElasticsearchFn: updateElasticsearchOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetElasticsearchFn:    getElasticsearchOK,
+				UpdateElasticsearchFn: updateElasticsearchError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetElasticsearchFn:    getElasticsearchOK,
+				UpdateElasticsearchFn: updateElasticsearchOK,
+			},
+			wantOutput: "Updated Elasticsearch logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestElasticsearchDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteElasticsearchFn: deleteElasticsearchError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteElasticsearchFn: deleteElasticsearchOK},
+			wantOutput: "Deleted Elasticsearch logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createElasticsearchOK(i *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return &fastly.Elasticsearch{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		Index:             "logs",
+		URL:               "example.com",
+		Pipeline:          "logs",
+		User:              "user",
+		Password:          "password",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		FormatVersion:     2,
+	}, nil
+}
+
+func createElasticsearchError(i *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return nil, errTest
+}
+
+func listElasticsearchsOK(i *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
+	return []*fastly.Elasticsearch{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			ResponseCondition: "Prevent default logging",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			Index:             "logs",
+			URL:               "example.com",
+			Pipeline:          "logs",
+			User:              "user",
+			Password:          "password",
+			RequestMaxEntries: 2,
+			RequestMaxBytes:   2,
+			Placement:         "none",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSHostname:       "example.com",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+			FormatVersion:     2,
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Index:             "analytics",
+			URL:               "example.com",
+			Pipeline:          "analytics",
+			User:              "user",
+			Password:          "password",
+			RequestMaxEntries: 2,
+			RequestMaxBytes:   2,
+			Placement:         "none",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSHostname:       "example.com",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+			ResponseCondition: "Prevent default logging",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+		},
+	}, nil
+}
+
+func listElasticsearchsError(i *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
+	return nil, errTest
+}
+
+var listElasticsearchsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listElasticsearchsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Elasticsearch 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Index: logs
+		URL: example.com
+		Pipeline: logs
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS client certificate: -----BEGIN CERTIFICATE-----bar
+		TLS client key: -----BEGIN PRIVATE KEY-----bar
+		TLS hostname: example.com
+		User: user
+		Password: password
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Elasticsearch 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Index: analytics
+		URL: example.com
+		Pipeline: analytics
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS client certificate: -----BEGIN CERTIFICATE-----bar
+		TLS client key: -----BEGIN PRIVATE KEY-----bar
+		TLS hostname: example.com
+		User: user
+		Password: password
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getElasticsearchOK(i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return &fastly.Elasticsearch{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		Index:             "logs",
+		URL:               "example.com",
+		Pipeline:          "logs",
+		User:              "user",
+		Password:          "password",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		FormatVersion:     2,
+	}, nil
+}
+
+func getElasticsearchError(i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return nil, errTest
+}
+
+var describeElasticsearchOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Index: logs
+URL: example.com
+Pipeline: logs
+TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+TLS client certificate: -----BEGIN CERTIFICATE-----bar
+TLS client key: -----BEGIN PRIVATE KEY-----bar
+TLS hostname: example.com
+User: user
+Password: password
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateElasticsearchOK(i *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return &fastly.Elasticsearch{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		Index:             "logs",
+		URL:               "example.com",
+		Pipeline:          "logs",
+		User:              "user",
+		Password:          "password",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		FormatVersion:     2,
+	}, nil
+}
+
+func updateElasticsearchError(i *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return nil, errTest
+}
+
+func deleteElasticsearchOK(i *fastly.DeleteElasticsearchInput) error {
+	return nil
+}
+
+func deleteElasticsearchError(i *fastly.DeleteElasticsearchInput) error {
+	return errTest
+}

--- a/pkg/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_test.go
@@ -1,0 +1,249 @@
+package elasticsearch
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateElasticsearchInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateElasticsearchInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateElasticsearchInput{
+				Service: "123",
+				Version: 2,
+				Name:    fastly.String("log"),
+				Index:   fastly.String("logs"),
+				URL:     fastly.String("example.com"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateElasticsearchInput{
+				Service:           "123",
+				Version:           2,
+				Name:              fastly.String("logs"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				Index:             fastly.String("logs"),
+				URL:               fastly.String("example.com"),
+				Pipeline:          fastly.String("my_pipeline_id"),
+				User:              fastly.String("user"),
+				Password:          fastly.String("password"),
+				RequestMaxEntries: fastly.Uint(2),
+				RequestMaxBytes:   fastly.Uint(2),
+				Placement:         fastly.String("none"),
+				TLSCACert:         fastly.String("-----BEGIN CERTIFICATE-----foo"),
+				TLSHostname:       fastly.String("example.com"),
+				TLSClientCert:     fastly.String("-----BEGIN CERTIFICATE-----bar"),
+				TLSClientKey:      fastly.String("-----BEGIN PRIVATE KEY-----bar"),
+				FormatVersion:     fastly.Uint(2),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateElasticsearchInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateElasticsearchInput
+		wantError string
+	}{
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetElasticsearchFn: getElasticsearchOK},
+			want: &fastly.UpdateElasticsearchInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "log",
+				NewName:           fastly.String("new1"),
+				Index:             fastly.String("new2"),
+				URL:               fastly.String("new3"),
+				Pipeline:          fastly.String("new4"),
+				User:              fastly.String("new5"),
+				Password:          fastly.String("new6"),
+				RequestMaxEntries: fastly.Uint(3),
+				RequestMaxBytes:   fastly.Uint(3),
+				Placement:         fastly.String("new7"),
+				Format:            fastly.String("new8"),
+				FormatVersion:     fastly.Uint(3),
+				ResponseCondition: fastly.String("new9"),
+				TLSCACert:         fastly.String("new10"),
+				TLSClientCert:     fastly.String("new11"),
+				TLSClientKey:      fastly.String("new12"),
+				TLSHostname:       fastly.String("new13"),
+			},
+		},
+		{
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetElasticsearchFn: getElasticsearchOK},
+			want: &fastly.UpdateElasticsearchInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "log",
+				NewName:           fastly.String("log"),
+				Index:             fastly.String("logs"),
+				URL:               fastly.String("example.com"),
+				Pipeline:          fastly.String("my_pipeline_id"),
+				User:              fastly.String("user"),
+				Password:          fastly.String("password"),
+				RequestMaxEntries: fastly.Uint(2),
+				RequestMaxBytes:   fastly.Uint(2),
+				Placement:         fastly.String("none"),
+				TLSCACert:         fastly.String("-----BEGIN CERTIFICATE-----foo"),
+				TLSHostname:       fastly.String("example.com"),
+				TLSClientCert:     fastly.String("-----BEGIN CERTIFICATE-----bar"),
+				TLSClientKey:      fastly.String("-----BEGIN PRIVATE KEY-----bar"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				ResponseCondition: fastly.String("Prevent default logging"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+		Index:        "logs",
+		URL:          "example.com",
+	}
+}
+
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "logs",
+		Version:           2,
+		Index:             "logs",
+		URL:               "example.com",
+		Pipeline:          common.OptionalString{Optional: common.Optional{Valid: true}, Value: "my_pipeline_id"},
+		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		User:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "user"},
+		Password:          common.OptionalString{Optional: common.Optional{Valid: true}, Value: "password"},
+		TLSCACert:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "example.com"},
+		TLSClientCert:     common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		Index:             common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		URL:               common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		Pipeline:          common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		User:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Password:          common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new7"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new8"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
+		TLSCACert:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
+		TLSClientCert:     common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new11"},
+		TLSClientKey:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new12"},
+		TLSHostname:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new13"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getElasticsearchOK(i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return &fastly.Elasticsearch{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		Index:             "logs",
+		URL:               "example.com",
+		Pipeline:          "my_pipeline_id",
+		User:              "user",
+		Password:          "password",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		FormatVersion:     2,
+	}, nil
+}

--- a/pkg/logging/elasticsearch/list.go
+++ b/pkg/logging/elasticsearch/list.go
@@ -1,0 +1,81 @@
+package elasticsearch
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Elasticsearch logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListElasticsearchInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Elasticsearch endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	elasticsearchs, err := c.Globals.Client.ListElasticsearch(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, elasticsearch := range elasticsearchs {
+			tw.AddLine(elasticsearch.ServiceID, elasticsearch.Version, elasticsearch.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, elasticsearch := range elasticsearchs {
+		fmt.Fprintf(out, "\tElasticsearch %d/%d\n", i+1, len(elasticsearchs))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", elasticsearch.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", elasticsearch.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", elasticsearch.Name)
+		fmt.Fprintf(out, "\t\tIndex: %s\n", elasticsearch.Index)
+		fmt.Fprintf(out, "\t\tURL: %s\n", elasticsearch.URL)
+		fmt.Fprintf(out, "\t\tPipeline: %s\n", elasticsearch.Pipeline)
+		fmt.Fprintf(out, "\t\tTLS CA certificate: %s\n", elasticsearch.TLSCACert)
+		fmt.Fprintf(out, "\t\tTLS client certificate: %s\n", elasticsearch.TLSClientCert)
+		fmt.Fprintf(out, "\t\tTLS client key: %s\n", elasticsearch.TLSClientKey)
+		fmt.Fprintf(out, "\t\tTLS hostname: %s\n", elasticsearch.TLSHostname)
+		fmt.Fprintf(out, "\t\tUser: %s\n", elasticsearch.User)
+		fmt.Fprintf(out, "\t\tPassword: %s\n", elasticsearch.Password)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", elasticsearch.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", elasticsearch.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", elasticsearch.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", elasticsearch.Placement)
+
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/elasticsearch/root.go
+++ b/pkg/logging/elasticsearch/root.go
@@ -1,0 +1,28 @@
+package elasticsearch
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("elasticsearch", "Manipulate Fastly service version Elasticsearch logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/elasticsearch/update.go
+++ b/pkg/logging/elasticsearch/update.go
@@ -1,0 +1,191 @@
+package elasticsearch
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Elasticsearch logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	Index             common.OptionalString
+	URL               common.OptionalString
+	Pipeline          common.OptionalString
+	RequestMaxEntries common.OptionalUint
+	RequestMaxBytes   common.OptionalUint
+	User              common.OptionalString
+	Password          common.OptionalString
+	TLSCACert         common.OptionalString
+	TLSClientCert     common.OptionalString
+	TLSClientKey      common.OptionalString
+	TLSHostname       common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Placement         common.OptionalString
+	ResponseCondition common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update an Elasticsearch logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Elasticsearch logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("index", `The name of the Elasticsearch index to send documents (logs) to. The index must follow the Elasticsearch index format rules (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). We support strftime (http://man7.org/linux/man-pages/man3/strftime.3.html) interpolated variables inside braces prefixed with a pound symbol. For example, #{%F} will interpolate as YYYY-MM-DD with today's date`).Action(c.Index.Set).StringVar(&c.Index.Value)
+	c.CmdClause.Flag("url", "The URL to stream logs to. Must use HTTPS.").Action(c.URL.Set).StringVar(&c.URL.Value)
+	c.CmdClause.Flag("pipeline", "The ID of the Elasticsearch ingest pipeline to apply pre-process transformations to before indexing. For example my_pipeline_id. Learn more about creating a pipeline in the Elasticsearch docs (https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)").Action(c.Password.Set).StringVar(&c.Pipeline.Value)
+	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
+	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)
+	c.CmdClause.Flag("tls-client-key", "The client private key used to make authenticated requests. Must be in PEM format").Action(c.TLSClientKey.Set).StringVar(&c.TLSClientKey.Value)
+	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Elasticsearch can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateElasticsearchInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	elasticsearch, err := c.Globals.Client.GetElasticsearch(&fastly.GetElasticsearchInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateElasticsearchInput{
+		Service:           elasticsearch.ServiceID,
+		Version:           elasticsearch.Version,
+		Name:              elasticsearch.Name,
+		NewName:           fastly.String(elasticsearch.Name),
+		ResponseCondition: fastly.String(elasticsearch.ResponseCondition),
+		Format:            fastly.String(elasticsearch.Format),
+		Index:             fastly.String(elasticsearch.Index),
+		URL:               fastly.String(elasticsearch.URL),
+		Pipeline:          fastly.String(elasticsearch.Pipeline),
+		User:              fastly.String(elasticsearch.User),
+		Password:          fastly.String(elasticsearch.Password),
+		RequestMaxEntries: fastly.Uint(elasticsearch.RequestMaxEntries),
+		RequestMaxBytes:   fastly.Uint(elasticsearch.RequestMaxBytes),
+		Placement:         fastly.String(elasticsearch.Placement),
+		TLSCACert:         fastly.String(elasticsearch.TLSCACert),
+		TLSClientCert:     fastly.String(elasticsearch.TLSClientCert),
+		TLSClientKey:      fastly.String(elasticsearch.TLSClientKey),
+		TLSHostname:       fastly.String(elasticsearch.TLSHostname),
+		FormatVersion:     fastly.Uint(elasticsearch.FormatVersion),
+	}
+
+	if c.NewName.Valid {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.Index.Valid {
+		input.Index = fastly.String(c.Index.Value)
+	}
+
+	if c.URL.Valid {
+		input.URL = fastly.String(c.URL.Value)
+	}
+
+	if c.Pipeline.Valid {
+		input.Pipeline = fastly.String(c.Pipeline.Value)
+	}
+
+	if c.RequestMaxEntries.Valid {
+		input.RequestMaxEntries = fastly.Uint(c.RequestMaxEntries.Value)
+	}
+
+	if c.RequestMaxBytes.Valid {
+		input.RequestMaxBytes = fastly.Uint(c.RequestMaxBytes.Value)
+	}
+
+	if c.User.Valid {
+		input.User = fastly.String(c.User.Value)
+	}
+
+	if c.Password.Valid {
+		input.Password = fastly.String(c.Password.Value)
+	}
+
+	if c.TLSCACert.Valid {
+		input.TLSCACert = fastly.String(c.TLSCACert.Value)
+	}
+
+	if c.TLSClientCert.Valid {
+		input.TLSClientCert = fastly.String(c.TLSClientCert.Value)
+	}
+
+	if c.TLSClientKey.Valid {
+		input.TLSClientKey = fastly.String(c.TLSClientKey.Value)
+	}
+
+	if c.TLSHostname.Valid {
+		input.TLSHostname = fastly.String(c.TLSHostname.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	elasticsearch, err := c.Globals.Client.UpdateElasticsearch(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Elasticsearch logging endpoint %s (service %s version %d)", elasticsearch.Name, elasticsearch.ServiceID, elasticsearch.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -145,6 +145,12 @@ type API struct {
 	UpdateDigitalOceanFn func(*fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error)
 	DeleteDigitalOceanFn func(*fastly.DeleteDigitalOceanInput) error
 
+	CreateElasticsearchFn func(*fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error)
+	ListElasticsearchFn   func(*fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error)
+	GetElasticsearchFn    func(*fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error)
+	UpdateElasticsearchFn func(*fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error)
+	DeleteElasticsearchFn func(*fastly.DeleteElasticsearchInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -719,6 +725,31 @@ func (m API) UpdateDigitalOcean(i *fastly.UpdateDigitalOceanInput) (*fastly.Digi
 // DeleteDigitalOcean implements Interface.
 func (m API) DeleteDigitalOcean(i *fastly.DeleteDigitalOceanInput) error {
 	return m.DeleteDigitalOceanFn(i)
+}
+
+// CreateElasticsearch implements Interface.
+func (m API) CreateElasticsearch(i *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return m.CreateElasticsearchFn(i)
+}
+
+// ListElasticsearch implements Interface.
+func (m API) ListElasticsearch(i *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
+	return m.ListElasticsearchFn(i)
+}
+
+// GetElasticsearch implements Interface.
+func (m API) GetElasticsearch(i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return m.GetElasticsearchFn(i)
+}
+
+// UpdateElasticsearch implements Interface.
+func (m API) UpdateElasticsearch(i *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return m.UpdateElasticsearchFn(i)
+}
+
+// DeleteElasticsearch implements Interface.
+func (m API) DeleteElasticsearch(i *fastly.DeleteElasticsearchInput) error {
+	return m.DeleteElasticsearchFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/elasticsearch/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/elasticsearch.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-elasticsearch && \
    make test && \
    rm -rf /tmp/cli \
)
```