### PR TITLE
Adds HTTPS logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -172,6 +172,12 @@ type Interface interface {
 	UpdateDatadog(*fastly.UpdateDatadogInput) (*fastly.Datadog, error)
 	DeleteDatadog(*fastly.DeleteDatadogInput) error
 
+	CreateHTTPS(*fastly.CreateHTTPSInput) (*fastly.HTTPS, error)
+	ListHTTPS(*fastly.ListHTTPSInput) ([]*fastly.HTTPS, error)
+	GetHTTPS(*fastly.GetHTTPSInput) (*fastly.HTTPS, error)
+	UpdateHTTPS(*fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
+	DeleteHTTPS(*fastly.DeleteHTTPSInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/gcs"
 	"github.com/fastly/cli/pkg/logging/heroku"
 	"github.com/fastly/cli/pkg/logging/honeycomb"
+	"github.com/fastly/cli/pkg/logging/https"
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/loggly"
 	"github.com/fastly/cli/pkg/logging/logshuttle"
@@ -279,6 +280,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	datadogUpdate := datadog.NewUpdateCommand(datadogRoot.CmdClause, &globals)
 	datadogDelete := datadog.NewDeleteCommand(datadogRoot.CmdClause, &globals)
 
+	httpsRoot := https.NewRootCommand(loggingRoot.CmdClause, &globals)
+	httpsCreate := https.NewCreateCommand(httpsRoot.CmdClause, &globals)
+	httpsList := https.NewListCommand(httpsRoot.CmdClause, &globals)
+	httpsDescribe := https.NewDescribeCommand(httpsRoot.CmdClause, &globals)
+	httpsUpdate := https.NewUpdateCommand(httpsRoot.CmdClause, &globals)
+	httpsDelete := https.NewDeleteCommand(httpsRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -474,6 +482,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		datadogDescribe,
 		datadogUpdate,
 		datadogDelete,
+
+		httpsRoot,
+		httpsCreate,
+		httpsList,
+		httpsDescribe,
+		httpsUpdate,
+		httpsDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2334,6 +2334,147 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Datadog logging object
 
+  logging https create --name=NAME --version=VERSION --url=URL [<flags>]
+    Create an HTTPS logging endpoint on a Fastly service version
+
+    -n, --name=NAME                The name of the HTTPS logging object. Used as
+                                   a primary key for API access
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+        --url=URL                  URL that log data will be sent to. Must use
+                                   the https protocol
+        --content-type=CONTENT-TYPE
+                                   Content type of the header sent with the
+                                   request
+        --header-name=HEADER-NAME  Name of the custom header sent with the
+                                   request
+        --header-value=HEADER-VALUE
+                                   Value of the custom header sent with the
+                                   request
+        --method=METHOD            HTTP method used for request. Can be POST or
+                                   PUT. Defaults to POST if not specified
+        --json-format=JSON-FORMAT  Enforces valid JSON formatting for log
+                                   entries. Can be disabled 0, array of json
+                                   (wraps JSON log batches in an array) 1, or
+                                   newline delimited json (places each JSON log
+                                   entry onto a new line in a batch) 2
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-client-cert=TLS-CLIENT-CERT
+                                   The client certificate used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-client-key=TLS-CLIENT-KEY
+                                   The client private key used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --message-type=MESSAGE-TYPE
+                                   How the message should be formatted. One of:
+                                   classic (default), loggly, logplex or blank
+        --format=FORMAT            Apache style log formatting. Your log must
+                                   produce valid JSON that HTTPS can ingest
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --request-max-entries=REQUEST-MAX-ENTRIES
+                                   Maximum number of logs to append to a batch,
+                                   if non-zero. Defaults to 0 for unbounded
+        --request-max-bytes=REQUEST-MAX-BYTES
+                                   Maximum size of log batch, if non-zero.
+                                   Defaults to 0 for unbounded
+
+  logging https list --version=VERSION [<flags>]
+    List HTTPS endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging https describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about an HTTPS logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the HTTPS logging object
+
+  logging https update --version=VERSION --name=NAME [<flags>]
+    Update an HTTPS logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+    -n, --name=NAME                The name of the HTTPS logging object
+        --new-name=NEW-NAME        New name of the HTTPS logging object
+        --url=URL                  URL that log data will be sent to. Must use
+                                   the https protocol
+        --content-type=CONTENT-TYPE
+                                   Content type of the header sent with the
+                                   request
+        --header-name=HEADER-NAME  Name of the custom header sent with the
+                                   request
+        --header-value=HEADER-VALUE
+                                   Value of the custom header sent with the
+                                   request
+        --method=METHOD            HTTP method used for request. Can be POST or
+                                   PUT. Defaults to POST if not specified
+        --json-format=JSON-FORMAT  Enforces valid JSON formatting for log
+                                   entries. Can be disabled 0, array of json
+                                   (wraps JSON log batches in an array) 1, or
+                                   newline delimited json (places each JSON log
+                                   entry onto a new line in a batch) 2
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-client-cert=TLS-CLIENT-CERT
+                                   The client certificate used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-client-key=TLS-CLIENT-KEY
+                                   The client private key used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --message-type=MESSAGE-TYPE
+                                   How the message should be formatted. One of:
+                                   classic (default), loggly, logplex or blank
+        --format=FORMAT            Apache style log formatting. Your log must
+                                   produce valid JSON that HTTPS can ingest
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --request-max-entries=REQUEST-MAX-ENTRIES
+                                   Maximum number of logs to append to a batch,
+                                   if non-zero. Defaults to 0 for unbounded
+        --request-max-bytes=REQUEST-MAX-BYTES
+                                   Maximum size of log batch, if non-zero.
+                                   Defaults to 0 for unbounded
+
+  logging https delete --version=VERSION --name=NAME [<flags>]
+    Delete an HTTPS logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the HTTPS logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/https/create.go
+++ b/pkg/logging/https/create.go
@@ -1,0 +1,171 @@
+package https
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create HTTPS logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	URL          string
+
+	// optional
+	RequestMaxEntries common.OptionalUint
+	RequestMaxBytes   common.OptionalUint
+	TLSCACert         common.OptionalString
+	TLSClientCert     common.OptionalString
+	TLSClientKey      common.OptionalString
+	TLSHostname       common.OptionalString
+	MessageType       common.OptionalString
+	ContentType       common.OptionalString
+	HeaderName        common.OptionalString
+	HeaderValue       common.OptionalString
+	Method            common.OptionalString
+	JSONFormat        common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Placement         common.OptionalString
+	ResponseCondition common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create an HTTPS logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the HTTPS logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("url", "URL that log data will be sent to. Must use the https protocol").Required().StringVar(&c.URL)
+
+	c.CmdClause.Flag("content-type", "Content type of the header sent with the request").Action(c.ContentType.Set).StringVar(&c.ContentType.Value)
+	c.CmdClause.Flag("header-name", "Name of the custom header sent with the request").Action(c.HeaderName.Set).StringVar(&c.HeaderName.Value)
+	c.CmdClause.Flag("header-value", "Value of the custom header sent with the request").Action(c.HeaderValue.Set).StringVar(&c.HeaderValue.Value)
+	c.CmdClause.Flag("method", "HTTP method used for request. Can be POST or PUT. Defaults to POST if not specified").Action(c.Method.Set).StringVar(&c.Method.Value)
+	c.CmdClause.Flag("json-format", "Enforces valid JSON formatting for log entries. Can be disabled 0, array of json (wraps JSON log batches in an array) 1, or newline delimited json (places each JSON log entry onto a new line in a batch) 2").Action(c.JSONFormat.Set).StringVar(&c.JSONFormat.Value)
+	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
+	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)
+	c.CmdClause.Flag("tls-client-key", "The client private key used to make authenticated requests. Must be in PEM format").Action(c.TLSClientKey.Set).StringVar(&c.TLSClientKey.Value)
+	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that HTTPS can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateHTTPSInput, error) {
+	var input fastly.CreateHTTPSInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = c.EndpointName
+	input.URL = c.URL
+
+	if c.ContentType.Valid {
+		input.ContentType = c.ContentType.Value
+	}
+
+	if c.HeaderName.Valid {
+		input.HeaderName = c.HeaderName.Value
+	}
+
+	if c.HeaderValue.Valid {
+		input.HeaderValue = c.HeaderValue.Value
+	}
+
+	if c.Method.Valid {
+		input.Method = c.Method.Value
+	}
+
+	if c.JSONFormat.Valid {
+		input.JSONFormat = c.JSONFormat.Value
+	}
+
+	if c.RequestMaxEntries.Valid {
+		input.RequestMaxEntries = c.RequestMaxEntries.Value
+	}
+
+	if c.RequestMaxBytes.Valid {
+		input.RequestMaxBytes = c.RequestMaxBytes.Value
+	}
+
+	if c.TLSCACert.Valid {
+		input.TLSCACert = c.TLSCACert.Value
+	}
+
+	if c.TLSClientCert.Valid {
+		input.TLSClientCert = c.TLSClientCert.Value
+	}
+
+	if c.TLSClientKey.Valid {
+		input.TLSClientKey = c.TLSClientKey.Value
+	}
+
+	if c.TLSHostname.Valid {
+		input.TLSHostname = c.TLSHostname.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = c.MessageType.Value
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateHTTPS(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created HTTPS logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/https/delete.go
+++ b/pkg/logging/https/delete.go
@@ -1,0 +1,47 @@
+package https
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete HTTPS logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteHTTPSInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete an HTTPS logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteHTTPS(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted HTTPS logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/https/describe.go
+++ b/pkg/logging/https/describe.go
@@ -1,0 +1,68 @@
+package https
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe an HTTPS logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetHTTPSInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about an HTTPS logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	https, err := c.Globals.Client.GetHTTPS(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", https.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", https.Version)
+	fmt.Fprintf(out, "Name: %s\n", https.Name)
+	fmt.Fprintf(out, "URL: %s\n", https.URL)
+	fmt.Fprintf(out, "Content type: %s\n", https.ContentType)
+	fmt.Fprintf(out, "Header name: %s\n", https.HeaderName)
+	fmt.Fprintf(out, "Header value: %s\n", https.HeaderValue)
+	fmt.Fprintf(out, "Method: %s\n", https.Method)
+	fmt.Fprintf(out, "JSON format: %s\n", https.JSONFormat)
+	fmt.Fprintf(out, "TLS CA certificate: %s\n", https.TLSCACert)
+	fmt.Fprintf(out, "TLS client certificate: %s\n", https.TLSClientCert)
+	fmt.Fprintf(out, "TLS client key: %s\n", https.TLSClientKey)
+	fmt.Fprintf(out, "TLS hostname: %s\n", https.TLSHostname)
+	fmt.Fprintf(out, "Request max entries: %d\n", https.RequestMaxEntries)
+	fmt.Fprintf(out, "Request max bytes: %d\n", https.RequestMaxBytes)
+	fmt.Fprintf(out, "Message type: %s\n", https.MessageType)
+	fmt.Fprintf(out, "Format: %s\n", https.Format)
+	fmt.Fprintf(out, "Format version: %d\n", https.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", https.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", https.Placement)
+
+	return nil
+}

--- a/pkg/logging/https/doc.go
+++ b/pkg/logging/https/doc.go
@@ -1,0 +1,3 @@
+// Package https contains commands to inspect and manipulate Fastly service HTTPS
+// logging endpoints.
+package https

--- a/pkg/logging/https/https_integration_test.go
+++ b/pkg/logging/https/https_integration_test.go
@@ -1,0 +1,480 @@
+package https_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestHTTPSCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --url not provided",
+		},
+		{
+			args:       []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:        mock.API{CreateHTTPSFn: createHTTPSOK},
+			wantOutput: "Created HTTPS logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:       mock.API{CreateHTTPSFn: createHTTPSError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestHTTPSList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			wantOutput: listHTTPSsShortOutput,
+		},
+		{
+			args:       []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			wantOutput: listHTTPSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			wantOutput: listHTTPSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "https", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			wantOutput: listHTTPSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "https", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			wantOutput: listHTTPSsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListHTTPSFn: listHTTPSsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestHTTPSDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "https", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetHTTPSFn: getHTTPSError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetHTTPSFn: getHTTPSOK},
+			wantOutput: describeHTTPSOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestHTTPSUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetHTTPSFn:    getHTTPSError,
+				UpdateHTTPSFn: updateHTTPSOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetHTTPSFn:    getHTTPSOK,
+				UpdateHTTPSFn: updateHTTPSError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetHTTPSFn:    getHTTPSOK,
+				UpdateHTTPSFn: updateHTTPSOK,
+			},
+			wantOutput: "Updated HTTPS logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestHTTPSDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "https", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteHTTPSFn: deleteHTTPSError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteHTTPSFn: deleteHTTPSOK},
+			wantOutput: "Deleted HTTPS logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createHTTPSOK(i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
+	return &fastly.HTTPS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		URL:               "example.com",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		ContentType:       "application/json",
+		HeaderName:        "name",
+		HeaderValue:       "value",
+		Method:            "GET",
+		JSONFormat:        "1",
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		TLSHostname:       "example.com",
+		MessageType:       "classic",
+		FormatVersion:     2,
+	}, nil
+}
+
+func createHTTPSError(i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
+	return nil, errTest
+}
+
+func listHTTPSsOK(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
+	return []*fastly.HTTPS{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			ResponseCondition: "Prevent default logging",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			URL:               "example.com",
+			RequestMaxEntries: 2,
+			RequestMaxBytes:   2,
+			ContentType:       "application/json",
+			HeaderName:        "name",
+			HeaderValue:       "value",
+			Method:            "GET",
+			JSONFormat:        "1",
+			Placement:         "none",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+			TLSHostname:       "example.com",
+			MessageType:       "classic",
+			FormatVersion:     2,
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			ResponseCondition: "Prevent default logging",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			URL:               "analytics.example.com",
+			RequestMaxEntries: 2,
+			RequestMaxBytes:   2,
+			ContentType:       "application/json",
+			HeaderName:        "name",
+			HeaderValue:       "value",
+			Method:            "GET",
+			JSONFormat:        "1",
+			Placement:         "none",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+			TLSHostname:       "example.com",
+			MessageType:       "classic",
+			FormatVersion:     2,
+		},
+	}, nil
+}
+
+func listHTTPSsError(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
+	return nil, errTest
+}
+
+var listHTTPSsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listHTTPSsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	HTTPS 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		URL: example.com
+		Content type: application/json
+		Header name: name
+		Header value: value
+		Method: GET
+		JSON format: 1
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS client certificate: -----BEGIN CERTIFICATE-----bar
+		TLS client key: -----BEGIN PRIVATE KEY-----bar
+		TLS hostname: example.com
+		Request max entries: 2
+		Request max bytes: 2
+		Message type: classic
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	HTTPS 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		URL: analytics.example.com
+		Content type: application/json
+		Header name: name
+		Header value: value
+		Method: GET
+		JSON format: 1
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS client certificate: -----BEGIN CERTIFICATE-----bar
+		TLS client key: -----BEGIN PRIVATE KEY-----bar
+		TLS hostname: example.com
+		Request max entries: 2
+		Request max bytes: 2
+		Message type: classic
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getHTTPSOK(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
+	return &fastly.HTTPS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		URL:               "example.com",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		ContentType:       "application/json",
+		HeaderName:        "name",
+		HeaderValue:       "value",
+		Method:            "GET",
+		JSONFormat:        "1",
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		TLSHostname:       "example.com",
+		MessageType:       "classic",
+		FormatVersion:     2,
+	}, nil
+}
+
+func getHTTPSError(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
+	return nil, errTest
+}
+
+var describeHTTPSOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: log
+URL: example.com
+Content type: application/json
+Header name: name
+Header value: value
+Method: GET
+JSON format: 1
+TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+TLS client certificate: -----BEGIN CERTIFICATE-----bar
+TLS client key: -----BEGIN PRIVATE KEY-----bar
+TLS hostname: example.com
+Request max entries: 2
+Request max bytes: 2
+Message type: classic
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateHTTPSOK(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
+	return &fastly.HTTPS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		URL:               "example.com",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		ContentType:       "application/json",
+		HeaderName:        "name",
+		HeaderValue:       "value",
+		Method:            "GET",
+		JSONFormat:        "1",
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		TLSHostname:       "example.com",
+		MessageType:       "classic",
+		FormatVersion:     2,
+	}, nil
+}
+
+func updateHTTPSError(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
+	return nil, errTest
+}
+
+func deleteHTTPSOK(i *fastly.DeleteHTTPSInput) error {
+	return nil
+}
+
+func deleteHTTPSError(i *fastly.DeleteHTTPSInput) error {
+	return errTest
+}

--- a/pkg/logging/https/https_test.go
+++ b/pkg/logging/https/https_test.go
@@ -1,0 +1,259 @@
+package https
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateHTTPSInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateHTTPSInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateHTTPSInput{
+				Service: "123",
+				Version: 2,
+				Name:    "log",
+				URL:     "example.com",
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateHTTPSInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				ResponseCondition: "Prevent default logging",
+				Format:            `%h %l %u %t "%r" %>s %b`,
+				URL:               "example.com",
+				RequestMaxEntries: 2,
+				RequestMaxBytes:   2,
+				ContentType:       "application/json",
+				HeaderName:        "name",
+				HeaderValue:       "value",
+				Method:            "GET",
+				JSONFormat:        "1",
+				Placement:         "none",
+				TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+				TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+				TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+				TLSHostname:       "example.com",
+				MessageType:       "classic",
+				FormatVersion:     2,
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateHTTPSInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateHTTPSInput
+		wantError string
+	}{
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetHTTPSFn: getHTTPSOK},
+			want: &fastly.UpdateHTTPSInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "log",
+				NewName:           "new1",
+				ResponseCondition: "new2",
+				Format:            "new3",
+				URL:               "new4",
+				RequestMaxEntries: 3,
+				RequestMaxBytes:   3,
+				ContentType:       "new5",
+				HeaderName:        "new6",
+				HeaderValue:       "new7",
+				Method:            "new8",
+				JSONFormat:        "new9",
+				Placement:         "new10",
+				TLSCACert:         "new11",
+				TLSClientCert:     "new12",
+				TLSClientKey:      "new13",
+				TLSHostname:       "new14",
+				MessageType:       "new15",
+				FormatVersion:     3,
+			},
+		},
+		{
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetHTTPSFn: getHTTPSOK},
+			want: &fastly.UpdateHTTPSInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "log",
+				NewName:           "log",
+				ResponseCondition: "Prevent default logging",
+				Format:            `%h %l %u %t "%r" %>s %b`,
+				URL:               "example.com",
+				RequestMaxEntries: 2,
+				RequestMaxBytes:   2,
+				ContentType:       "application/json",
+				HeaderName:        "name",
+				HeaderValue:       "value",
+				Method:            "GET",
+				JSONFormat:        "1",
+				Placement:         "none",
+				TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+				TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+				TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+				TLSHostname:       "example.com",
+				MessageType:       "classic",
+				FormatVersion:     2,
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+		URL:          "example.com",
+	}
+}
+
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "logs",
+		Version:           2,
+		URL:               "example.com",
+		ContentType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "application/json"},
+		HeaderName:        common.OptionalString{Optional: common.Optional{Valid: true}, Value: "name"},
+		HeaderValue:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "value"},
+		Method:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "GET"},
+		JSONFormat:        common.OptionalString{Optional: common.Optional{Valid: true}, Value: "1"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
+		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		TLSCACert:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "example.com"},
+		TLSClientCert:     common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "logs",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		URL:               common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		ContentType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		HeaderName:        common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+		HeaderValue:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new7"},
+		Method:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new8"},
+		JSONFormat:        common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
+		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		TLSCACert:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new11"},
+		TLSClientCert:     common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new12"},
+		TLSClientKey:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new13"},
+		TLSHostname:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new14"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new15"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getHTTPSOK(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
+	return &fastly.HTTPS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		URL:               "example.com",
+		RequestMaxEntries: 2,
+		RequestMaxBytes:   2,
+		ContentType:       "application/json",
+		HeaderName:        "name",
+		HeaderValue:       "value",
+		Method:            "GET",
+		JSONFormat:        "1",
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		TLSHostname:       "example.com",
+		MessageType:       "classic",
+		FormatVersion:     2,
+	}, nil
+}

--- a/pkg/logging/https/list.go
+++ b/pkg/logging/https/list.go
@@ -1,0 +1,84 @@
+package https
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list HTTPS logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListHTTPSInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List HTTPS endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	httpss, err := c.Globals.Client.ListHTTPS(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, https := range httpss {
+			tw.AddLine(https.ServiceID, https.Version, https.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, https := range httpss {
+		fmt.Fprintf(out, "\tHTTPS %d/%d\n", i+1, len(httpss))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", https.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", https.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", https.Name)
+		fmt.Fprintf(out, "\t\tURL: %s\n", https.URL)
+		fmt.Fprintf(out, "\t\tContent type: %s\n", https.ContentType)
+		fmt.Fprintf(out, "\t\tHeader name: %s\n", https.HeaderName)
+		fmt.Fprintf(out, "\t\tHeader value: %s\n", https.HeaderValue)
+		fmt.Fprintf(out, "\t\tMethod: %s\n", https.Method)
+		fmt.Fprintf(out, "\t\tJSON format: %s\n", https.JSONFormat)
+		fmt.Fprintf(out, "\t\tTLS CA certificate: %s\n", https.TLSCACert)
+		fmt.Fprintf(out, "\t\tTLS client certificate: %s\n", https.TLSClientCert)
+		fmt.Fprintf(out, "\t\tTLS client key: %s\n", https.TLSClientKey)
+		fmt.Fprintf(out, "\t\tTLS hostname: %s\n", https.TLSHostname)
+		fmt.Fprintf(out, "\t\tRequest max entries: %d\n", https.RequestMaxEntries)
+		fmt.Fprintf(out, "\t\tRequest max bytes: %d\n", https.RequestMaxBytes)
+		fmt.Fprintf(out, "\t\tMessage type: %s\n", https.MessageType)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", https.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", https.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", https.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", https.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/https/root.go
+++ b/pkg/logging/https/root.go
@@ -1,0 +1,28 @@
+package https
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("https", "Manipulate Fastly service version HTTPS logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/https/update.go
+++ b/pkg/logging/https/update.go
@@ -1,0 +1,207 @@
+package https
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update HTTPS logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	URL               common.OptionalString
+	RequestMaxEntries common.OptionalUint
+	RequestMaxBytes   common.OptionalUint
+	TLSCACert         common.OptionalString
+	TLSClientCert     common.OptionalString
+	TLSClientKey      common.OptionalString
+	TLSHostname       common.OptionalString
+	MessageType       common.OptionalString
+	ContentType       common.OptionalString
+	HeaderName        common.OptionalString
+	HeaderValue       common.OptionalString
+	Method            common.OptionalString
+	JSONFormat        common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Placement         common.OptionalString
+	ResponseCondition common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update an HTTPS logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the HTTPS logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("url", "URL that log data will be sent to. Must use the https protocol").Action(c.URL.Set).StringVar(&c.URL.Value)
+	c.CmdClause.Flag("content-type", "Content type of the header sent with the request").Action(c.ContentType.Set).StringVar(&c.ContentType.Value)
+	c.CmdClause.Flag("header-name", "Name of the custom header sent with the request").Action(c.HeaderName.Set).StringVar(&c.HeaderName.Value)
+	c.CmdClause.Flag("header-value", "Value of the custom header sent with the request").Action(c.HeaderValue.Set).StringVar(&c.HeaderValue.Value)
+	c.CmdClause.Flag("method", "HTTP method used for request. Can be POST or PUT. Defaults to POST if not specified").Action(c.Method.Set).StringVar(&c.Method.Value)
+	c.CmdClause.Flag("json-format", "Enforces valid JSON formatting for log entries. Can be disabled 0, array of json (wraps JSON log batches in an array) 1, or newline delimited json (places each JSON log entry onto a new line in a batch) 2").Action(c.JSONFormat.Set).StringVar(&c.JSONFormat.Value)
+	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
+	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)
+	c.CmdClause.Flag("tls-client-key", "The client private key used to make authenticated requests. Must be in PEM format").Action(c.TLSClientKey.Set).StringVar(&c.TLSClientKey.Value)
+	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that HTTPS can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateHTTPSInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	https, err := c.Globals.Client.GetHTTPS(&fastly.GetHTTPSInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateHTTPSInput{
+		Service:           https.ServiceID,
+		Version:           https.Version,
+		Name:              https.Name,
+		NewName:           https.Name,
+		ResponseCondition: https.ResponseCondition,
+		Format:            https.Format,
+		URL:               https.URL,
+		RequestMaxEntries: https.RequestMaxEntries,
+		RequestMaxBytes:   https.RequestMaxBytes,
+		ContentType:       https.ContentType,
+		HeaderName:        https.HeaderName,
+		HeaderValue:       https.HeaderValue,
+		Method:            https.Method,
+		JSONFormat:        https.JSONFormat,
+		Placement:         https.Placement,
+		TLSCACert:         https.TLSCACert,
+		TLSClientCert:     https.TLSClientCert,
+		TLSClientKey:      https.TLSClientKey,
+		TLSHostname:       https.TLSHostname,
+		MessageType:       https.MessageType,
+		FormatVersion:     https.FormatVersion,
+	}
+
+	if c.NewName.Valid {
+		input.NewName = c.NewName.Value
+	}
+
+	if c.URL.Valid {
+		input.URL = c.URL.Value
+	}
+
+	if c.ContentType.Valid {
+		input.ContentType = c.ContentType.Value
+	}
+
+	if c.JSONFormat.Valid {
+		input.JSONFormat = c.JSONFormat.Value
+	}
+
+	if c.HeaderName.Valid {
+		input.HeaderName = c.HeaderName.Value
+	}
+
+	if c.HeaderValue.Valid {
+		input.HeaderValue = c.HeaderValue.Value
+	}
+
+	if c.Method.Valid {
+		input.Method = c.Method.Value
+	}
+
+	if c.RequestMaxEntries.Valid {
+		input.RequestMaxEntries = c.RequestMaxEntries.Value
+	}
+
+	if c.RequestMaxBytes.Valid {
+		input.RequestMaxBytes = c.RequestMaxBytes.Value
+	}
+
+	if c.TLSCACert.Valid {
+		input.TLSCACert = c.TLSCACert.Value
+	}
+
+	if c.TLSClientCert.Valid {
+		input.TLSClientCert = c.TLSClientCert.Value
+	}
+
+	if c.TLSClientKey.Valid {
+		input.TLSClientKey = c.TLSClientKey.Value
+	}
+
+	if c.TLSHostname.Valid {
+		input.TLSHostname = c.TLSHostname.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = c.MessageType.Value
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	https, err := c.Globals.Client.UpdateHTTPS(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated HTTPS logging endpoint %s (service %s version %d)", https.Name, https.ServiceID, https.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -163,6 +163,12 @@ type API struct {
 	UpdateDatadogFn func(*fastly.UpdateDatadogInput) (*fastly.Datadog, error)
 	DeleteDatadogFn func(*fastly.DeleteDatadogInput) error
 
+	CreateHTTPSFn func(*fastly.CreateHTTPSInput) (*fastly.HTTPS, error)
+	ListHTTPSFn   func(*fastly.ListHTTPSInput) ([]*fastly.HTTPS, error)
+	GetHTTPSFn    func(*fastly.GetHTTPSInput) (*fastly.HTTPS, error)
+	UpdateHTTPSFn func(*fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
+	DeleteHTTPSFn func(*fastly.DeleteHTTPSInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -812,6 +818,31 @@ func (m API) UpdateDatadog(i *fastly.UpdateDatadogInput) (*fastly.Datadog, error
 // DeleteDatadog implements Interface.
 func (m API) DeleteDatadog(i *fastly.DeleteDatadogInput) error {
 	return m.DeleteDatadogFn(i)
+}
+
+// CreateHTTPS implements Interface.
+func (m API) CreateHTTPS(i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
+	return m.CreateHTTPSFn(i)
+}
+
+// ListHTTPS implements Interface.
+func (m API) ListHTTPS(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
+	return m.ListHTTPSFn(i)
+}
+
+// GetHTTPS implements Interface.
+func (m API) GetHTTPS(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
+	return m.GetHTTPSFn(i)
+}
+
+// UpdateHTTPS implements Interface.
+func (m API) UpdateHTTPS(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
+	return m.UpdateHTTPSFn(i)
+}
+
+// DeleteHTTPS implements Interface.
+func (m API) DeleteHTTPS(i *fastly.DeleteHTTPSInput) error {
+	return m.DeleteHTTPSFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/https/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/https.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-https && \
    make test && \
    rm -rf /tmp/cli \
)
```

## Notes

* Assumes that https://github.com/fastly/cli/pull/90 gets merged first.