### PR TITLE
Adds Datadog logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -166,6 +166,12 @@ type Interface interface {
 	UpdateBlobStorage(*fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error)
 	DeleteBlobStorage(*fastly.DeleteBlobStorageInput) error
 
+	CreateDatadog(*fastly.CreateDatadogInput) (*fastly.Datadog, error)
+	ListDatadog(*fastly.ListDatadogInput) ([]*fastly.Datadog, error)
+	GetDatadog(*fastly.GetDatadogInput) (*fastly.Datadog, error)
+	UpdateDatadog(*fastly.UpdateDatadogInput) (*fastly.Datadog, error)
+	DeleteDatadog(*fastly.DeleteDatadogInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/azureblob"
 	"github.com/fastly/cli/pkg/logging/bigquery"
 	"github.com/fastly/cli/pkg/logging/cloudfiles"
+	"github.com/fastly/cli/pkg/logging/datadog"
 	"github.com/fastly/cli/pkg/logging/digitalocean"
 	"github.com/fastly/cli/pkg/logging/elasticsearch"
 	"github.com/fastly/cli/pkg/logging/ftp"
@@ -271,6 +272,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	azureblobUpdate := azureblob.NewUpdateCommand(azureblobRoot.CmdClause, &globals)
 	azureblobDelete := azureblob.NewDeleteCommand(azureblobRoot.CmdClause, &globals)
 
+	datadogRoot := datadog.NewRootCommand(loggingRoot.CmdClause, &globals)
+	datadogCreate := datadog.NewCreateCommand(datadogRoot.CmdClause, &globals)
+	datadogList := datadog.NewListCommand(datadogRoot.CmdClause, &globals)
+	datadogDescribe := datadog.NewDescribeCommand(datadogRoot.CmdClause, &globals)
+	datadogUpdate := datadog.NewUpdateCommand(datadogRoot.CmdClause, &globals)
+	datadogDelete := datadog.NewDeleteCommand(datadogRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -459,6 +467,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		azureblobDescribe,
 		azureblobUpdate,
 		azureblobDelete,
+
+		datadogRoot,
+		datadogCreate,
+		datadogList,
+		datadogDescribe,
+		datadogUpdate,
+		datadogDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2263,6 +2263,77 @@ COMMANDS
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object
 
+  logging datadog create --name=NAME --version=VERSION --auth-token=AUTH-TOKEN [<flags>]
+    Create a Datadog logging endpoint on a Fastly service version
+
+    -n, --name=NAME              The name of the Datadog logging object. Used as
+                                 a primary key for API access
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+        --auth-token=AUTH-TOKEN  The API key from your Datadog account
+        --region=REGION          The region that log data will be sent to. One
+                                 of US or EU. Defaults to US if undefined
+        --format=FORMAT          Apache style log formatting. For details on the
+                                 default value refer to the documentation
+                                 (https://developer.fastly.com/reference/api/logging/datadog/)
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging datadog list --version=VERSION [<flags>]
+    List Datadog endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging datadog describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Datadog logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Datadog logging object
+
+  logging datadog update --version=VERSION --name=NAME [<flags>]
+    Update a Datadog logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Datadog logging object
+        --new-name=NEW-NAME      New name of the Datadog logging object
+        --auth-token=AUTH-TOKEN  The API key from your Datadog account
+        --region=REGION          The region that log data will be sent to. One
+                                 of US or EU. Defaults to US if undefined
+        --format=FORMAT          Apache style log formatting. For details on the
+                                 default value refer to the documentation
+                                 (https://developer.fastly.com/reference/api/logging/datadog/)
+        --format-version=FORMAT-VERSION
+                                 The version of the custom logging format used
+                                 for the configured endpoint. Can be either 2
+                                 (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                 The name of an existing condition in the
+                                 configured endpoint, or leave blank to always
+                                 execute
+        --placement=PLACEMENT    Where in the generated VCL the logging call
+                                 should be placed, overriding any format_version
+                                 default. Can be none or waf_debug
+
+  logging datadog delete --version=VERSION --name=NAME [<flags>]
+    Delete a Datadog logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Datadog logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/datadog/create.go
+++ b/pkg/logging/datadog/create.go
@@ -1,0 +1,106 @@
+package datadog
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Datadog logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Token        string
+	Version      int
+
+	// optional
+	Region            common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Datadog logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Datadog logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("auth-token", "The API key from your Datadog account").Required().StringVar(&c.Token)
+
+	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. For details on the default value refer to the documentation (https://developer.fastly.com/reference/api/logging/datadog/)").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateDatadogInput, error) {
+	var input fastly.CreateDatadogInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = fastly.String(c.EndpointName)
+	input.Token = fastly.String(c.Token)
+
+	if c.Region.Valid {
+		input.Region = fastly.String(c.Region.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateDatadog(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Datadog logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/datadog/datadog_integration_test.go
+++ b/pkg/logging/datadog/datadog_integration_test.go
@@ -1,0 +1,390 @@
+package datadog_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestDatadogCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --auth-token not provided",
+		},
+		{
+			args:       []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			api:        mock.API{CreateDatadogFn: createDatadogOK},
+			wantOutput: "Created Datadog logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			api:       mock.API{CreateDatadogFn: createDatadogError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestDatadogList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			wantOutput: listDatadogsShortOutput,
+		},
+		{
+			args:       []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			wantOutput: listDatadogsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			wantOutput: listDatadogsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "datadog", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			wantOutput: listDatadogsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "datadog", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			wantOutput: listDatadogsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListDatadogFn: listDatadogsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestDatadogDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetDatadogFn: getDatadogError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetDatadogFn: getDatadogOK},
+			wantOutput: describeDatadogOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestDatadogUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetDatadogFn:    getDatadogError,
+				UpdateDatadogFn: updateDatadogOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetDatadogFn:    getDatadogOK,
+				UpdateDatadogFn: updateDatadogError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetDatadogFn:    getDatadogOK,
+				UpdateDatadogFn: updateDatadogOK,
+			},
+			wantOutput: "Updated Datadog logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestDatadogDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteDatadogFn: deleteDatadogError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteDatadogFn: deleteDatadogOK},
+			wantOutput: "Deleted Datadog logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createDatadogOK(i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
+	s := fastly.Datadog{
+		ServiceID: i.Service,
+		Version:   i.Version,
+	}
+
+	if i.Name != nil {
+		s.Name = *i.Name
+	}
+
+	return &s, nil
+}
+
+func createDatadogError(i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
+	return nil, errTest
+}
+
+func listDatadogsOK(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
+	return []*fastly.Datadog{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Token:             "abc",
+			Region:            "US",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Token:             "abc",
+			Region:            "US",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listDatadogsError(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
+	return nil, errTest
+}
+
+var listDatadogsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listDatadogsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Datadog 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Token: abc
+		Region: US
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Datadog 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Token: abc
+		Region: US
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getDatadogOK(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
+	return &fastly.Datadog{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Token:             "abc",
+		Region:            "US",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getDatadogError(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
+	return nil, errTest
+}
+
+var describeDatadogOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Token: abc
+Region: US
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateDatadogOK(i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
+	return &fastly.Datadog{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Token:             "abc",
+		Region:            "US",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+	}, nil
+}
+
+func updateDatadogError(i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
+	return nil, errTest
+}
+
+func deleteDatadogOK(i *fastly.DeleteDatadogInput) error {
+	return nil
+}
+
+func deleteDatadogError(i *fastly.DeleteDatadogInput) error {
+	return errTest
+}

--- a/pkg/logging/datadog/datadog_test.go
+++ b/pkg/logging/datadog/datadog_test.go
@@ -1,0 +1,193 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateDatadogInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateDatadogInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateDatadogInput{
+				Service: "123",
+				Version: 2,
+				Name:    fastly.String("log"),
+				Token:   fastly.String("tkn"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandOK(),
+			want: &fastly.CreateDatadogInput{
+				Service:           "123",
+				Version:           2,
+				Name:              fastly.String("log"),
+				Region:            fastly.String("US"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				Token:             fastly.String("tkn"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateDatadogInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateDatadogInput
+		wantError string
+	}{
+		{
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetDatadogFn: getDatadogOK},
+			want: &fastly.UpdateDatadogInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("logs"),
+				Region:            fastly.String("US"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				Token:             fastly.String("tkn"),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetDatadogFn: getDatadogOK},
+			want: &fastly.UpdateDatadogInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           fastly.String("new1"),
+				Region:            fastly.String("new2"),
+				Format:            fastly.String("new3"),
+				FormatVersion:     fastly.Uint(3),
+				Token:             fastly.String("new4"),
+				ResponseCondition: fastly.String("new5"),
+				Placement:         fastly.String("new6"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandOK() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Token:             "tkn",
+		Version:           2,
+		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "US"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Token:        "tkn",
+		Version:      2,
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandOK()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "logs",
+		Version:      2,
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		Token:             common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getDatadogOK(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
+	return &fastly.Datadog{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Token:             "tkn",
+		Region:            "US",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}

--- a/pkg/logging/datadog/delete.go
+++ b/pkg/logging/datadog/delete.go
@@ -1,0 +1,47 @@
+package datadog
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Datadog logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteDatadogInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Datadog logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteDatadog(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Datadog logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/datadog/describe.go
+++ b/pkg/logging/datadog/describe.go
@@ -1,0 +1,57 @@
+package datadog
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Datadog logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetDatadogInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Datadog logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	datadog, err := c.Globals.Client.GetDatadog(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", datadog.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", datadog.Version)
+	fmt.Fprintf(out, "Name: %s\n", datadog.Name)
+	fmt.Fprintf(out, "Token: %s\n", datadog.Token)
+	fmt.Fprintf(out, "Region: %s\n", datadog.Region)
+	fmt.Fprintf(out, "Format: %s\n", datadog.Format)
+	fmt.Fprintf(out, "Format version: %d\n", datadog.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", datadog.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", datadog.Placement)
+
+	return nil
+}

--- a/pkg/logging/datadog/doc.go
+++ b/pkg/logging/datadog/doc.go
@@ -1,0 +1,3 @@
+// Package datadog contains commands to inspect and manipulate Fastly service Datadog
+// logging endpoints.
+package datadog

--- a/pkg/logging/datadog/list.go
+++ b/pkg/logging/datadog/list.go
@@ -1,0 +1,73 @@
+package datadog
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Datadog logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListDatadogInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Datadog endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	datadogs, err := c.Globals.Client.ListDatadog(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, datadog := range datadogs {
+			tw.AddLine(datadog.ServiceID, datadog.Version, datadog.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, datadog := range datadogs {
+		fmt.Fprintf(out, "\tDatadog %d/%d\n", i+1, len(datadogs))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", datadog.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", datadog.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", datadog.Name)
+		fmt.Fprintf(out, "\t\tToken: %s\n", datadog.Token)
+		fmt.Fprintf(out, "\t\tRegion: %s\n", datadog.Region)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", datadog.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", datadog.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", datadog.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", datadog.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/datadog/root.go
+++ b/pkg/logging/datadog/root.go
@@ -1,0 +1,28 @@
+package datadog
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("datadog", "Manipulate Fastly service version Datadog logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/datadog/update.go
+++ b/pkg/logging/datadog/update.go
@@ -1,0 +1,130 @@
+package datadog
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Datadog logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	Token             common.OptionalString
+	Region            common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Datadog logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Datadog logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("auth-token", "The API key from your Datadog account").Action(c.Token.Set).StringVar(&c.Token.Value)
+	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. For details on the default value refer to the documentation (https://developer.fastly.com/reference/api/logging/datadog/)").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateDatadogInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	datadog, err := c.Globals.Client.GetDatadog(&fastly.GetDatadogInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateDatadogInput{
+		Service:           datadog.ServiceID,
+		Version:           datadog.Version,
+		Name:              datadog.Name,
+		NewName:           fastly.String(datadog.Name),
+		Token:             fastly.String(datadog.Token),
+		Region:            fastly.String(datadog.Region),
+		Format:            fastly.String(datadog.Format),
+		FormatVersion:     fastly.Uint(datadog.FormatVersion),
+		ResponseCondition: fastly.String(datadog.ResponseCondition),
+		Placement:         fastly.String(datadog.Placement),
+	}
+
+	if c.NewName.Valid {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.Token.Valid {
+		input.Token = fastly.String(c.Token.Value)
+	}
+
+	if c.Region.Valid {
+		input.Region = fastly.String(c.Region.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	datadog, err := c.Globals.Client.UpdateDatadog(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Datadog logging endpoint %s (service %s version %d)", datadog.Name, datadog.ServiceID, datadog.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -157,6 +157,12 @@ type API struct {
 	UpdateBlobStorageFn func(*fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error)
 	DeleteBlobStorageFn func(*fastly.DeleteBlobStorageInput) error
 
+	CreateDatadogFn func(*fastly.CreateDatadogInput) (*fastly.Datadog, error)
+	ListDatadogFn   func(*fastly.ListDatadogInput) ([]*fastly.Datadog, error)
+	GetDatadogFn    func(*fastly.GetDatadogInput) (*fastly.Datadog, error)
+	UpdateDatadogFn func(*fastly.UpdateDatadogInput) (*fastly.Datadog, error)
+	DeleteDatadogFn func(*fastly.DeleteDatadogInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -781,6 +787,31 @@ func (m API) UpdateBlobStorage(i *fastly.UpdateBlobStorageInput) (*fastly.BlobSt
 // DeleteBlobStorage implements Interface.
 func (m API) DeleteBlobStorage(i *fastly.DeleteBlobStorageInput) error {
 	return m.DeleteBlobStorageFn(i)
+}
+
+// CreateDatadog implements Interface.
+func (m API) CreateDatadog(i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
+	return m.CreateDatadogFn(i)
+}
+
+// ListDatadog implements Interface.
+func (m API) ListDatadog(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
+	return m.ListDatadogFn(i)
+}
+
+// GetDatadog implements Interface.
+func (m API) GetDatadog(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
+	return m.GetDatadogFn(i)
+}
+
+// UpdateDatadog implements Interface.
+func (m API) UpdateDatadog(i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
+	return m.UpdateDatadogFn(i)
+}
+
+// DeleteDatadog implements Interface.
+func (m API) DeleteDatadog(i *fastly.DeleteDatadogInput) error {
+	return m.DeleteDatadogFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/datadog/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/datadog.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-datadog && \
    make test && \
    rm -rf /tmp/cli \
)
```