### PR TITLE
Real Time Charts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/dustin/go-humanize v1.0.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/fastly/go-fastly v1.11.0
 	github.com/fatih/color v1.7.0
 	github.com/frankban/quicktest v1.5.0 // indirect
+	github.com/gizak/termui/v3 v3.1.0
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-github/v28 v28.1.1
 	github.com/google/jsonapi v0.0.0-20200226002910-c8283f632fb7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:90Ly+6UfUypEF6vvvW5rQIv9opIL8CbmW9FT20LDQoY=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
@@ -36,6 +38,9 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjr
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/frankban/quicktest v1.5.0 h1:Tb4jWdSpdjKzTUicPnY61PZxKbDoGa7ABbrReT3gQVY=
 github.com/frankban/quicktest v1.5.0/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
+github.com/gizak/termui v3.1.0+incompatible h1:N3CFm+j087lanTxPpHOmQs0uS3s5I9TxoAFy6DqPqv8=
+github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
+github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721 h1:KRMr9A3qfbVM7iV/WcLY/rL5LICqwMHLhwRXKu99fXw=
@@ -81,12 +86,15 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC63o=
+github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mholt/archiver v3.1.1+incompatible h1:1dCVxuqs0dJseYEhi5pl7MYPH9zDa1wBi7mF09cbNkU=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/mholt/archiver/v3 v3.3.0 h1:vWjhY8SQp5yzM9P6OJ/eZEkmi3UAbRrxCq48MxjAzig=
 github.com/mholt/archiver/v3 v3.3.0/go.mod h1:YnQtqsp+94Rwd0D/rk5cnLrxusUBUXg+08Ebtr1Mqao=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -94,6 +102,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=
 github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2034,7 +2034,7 @@ COMMANDS
     View realtime stats for a Fastly service
 
     -s, --service-id=SERVICE-ID  Service ID
-        --format=FORMAT          Output format (json)
+        --format=FORMAT          Output format (json, chart)
 
 For help on a specific command, try e.g.
 

--- a/pkg/stats/obj.go
+++ b/pkg/stats/obj.go
@@ -26,6 +26,7 @@ type realtimeResponse struct {
 }
 
 type realtimeResponseData struct {
-	Recorded   float64           `json:"recorded"`
-	Aggregated statsResponseData `json:"aggregated"`
+	Recorded   float64                      `json:"recorded"`
+	Aggregated statsResponseData            `json:"aggregated"`
+	Datacenter map[string]statsResponseData `json:"datacenter"`
 }

--- a/pkg/stats/view.go
+++ b/pkg/stats/view.go
@@ -1,0 +1,297 @@
+package stats
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/fastly/go-fastly/fastly"
+	ui "github.com/gizak/termui/v3"
+	"github.com/gizak/termui/v3/widgets"
+	"github.com/mitchellh/mapstructure"
+)
+
+// Maximum number of time slots to remember (1 sec per spot)
+const MaxSlots = 60
+
+type View struct {
+	Events  <-chan ui.Event
+	Grid    *ui.Grid
+	Service string
+
+	// Header
+	Header *widgets.Paragraph
+
+	// Top Row
+	Hits     *widgets.Paragraph
+	HitTime  *widgets.Paragraph
+	Misses   *widgets.Paragraph
+	HitRatio *widgets.PieChart
+	MissTime *widgets.Paragraph
+	Requests *widgets.Paragraph
+	Errors   *widgets.Paragraph
+
+	// Second Row
+	GlobalLabel *widgets.Paragraph
+	Global      *widgets.BarChart
+	GlobalData  []float64
+
+	// Third Row
+	ReqLabel       *widgets.Paragraph
+	ReqChart       *widgets.StackedBarChart
+	ReqData        [][]float64
+	BandwidthLabel *widgets.Paragraph
+	BandwidthGroup *widgets.SparklineGroup
+	BandwidthChart *widgets.Sparkline
+	BandwidthData  []float64
+
+	// Fourth Row
+	ErrLabel *widgets.Paragraph
+	ErrGroup *widgets.SparklineGroup
+	ErrChart *widgets.Sparkline
+	ErrData  []float64
+	HitLabel *widgets.Paragraph
+	HitGroup *widgets.SparklineGroup
+	HitChart *widgets.Sparkline
+	HitData  []float64
+
+	// Fifth Row
+	IoLabel      *widgets.Paragraph
+	IoGroup      *widgets.SparklineGroup
+	IoChart      *widgets.Sparkline
+	IoData       []float64
+	LoggingLabel *widgets.Paragraph
+	LoggingGroup *widgets.SparklineGroup
+	LoggingChart *widgets.Sparkline
+	LoggingData  []float64
+}
+
+func NewView(service string) (*View, error) {
+	var view = View{}
+	view.Service = service
+
+	if err := ui.Init(); err != nil {
+		return nil, err
+	}
+
+	view.Events = ui.PollEvents()
+	view.Grid = ui.NewGrid()
+
+	view.Header = widgets.NewParagraph()
+	view.Header.Title = "Fastly Real Time Stats"
+
+	// Top Row
+	view.Hits = widgets.NewParagraph()
+	view.Hits.Title = "Hits"
+
+	view.HitTime = widgets.NewParagraph()
+	view.HitTime.Title = "Hit Time"
+
+	view.Misses = widgets.NewParagraph()
+	view.Misses.Title = "Misses"
+
+	view.HitRatio = widgets.NewPieChart()
+	view.HitRatio.Title = "Hit Ratio"
+	view.HitRatio.AngleOffset = -.5 * math.Pi
+	view.HitRatio.LabelFormatter = func(i int, v float64) string {
+		if v > 0.0 {
+			return fmt.Sprintf("%.01f%%", v*100)
+		} else {
+			return ""
+		}
+	}
+
+	view.MissTime = widgets.NewParagraph()
+	view.MissTime.Title = "Miss Time"
+
+	view.Requests = widgets.NewParagraph()
+	view.Requests.Title = "Requests"
+
+	view.Errors = widgets.NewParagraph()
+	view.Errors.Title = "Errors"
+
+	// Second Row
+	view.GlobalLabel = widgets.NewParagraph()
+	view.GlobalLabel.Title = "Global POP Traffic"
+	view.Global = widgets.NewBarChart()
+	view.Global.NumFormatter = func(v float64) string { return "" }
+
+	// Third Row
+	view.ReqLabel = widgets.NewParagraph()
+	view.ReqLabel.Title = "Requests"
+	view.ReqChart = widgets.NewStackedBarChart()
+	view.ReqChart.NumFormatter = func(v float64) string { return "" }
+	// Stacked bar charts are too wide, so only do the last 30 seconds
+	view.ReqData = make([][]float64, MaxSlots/2, MaxSlots/2)
+	for i, _ := range view.ReqData {
+		view.ReqData[i] = make([]float64, 5, 5)
+	}
+
+	view.BandwidthLabel = widgets.NewParagraph()
+	view.BandwidthLabel.Title = "Bandwidth"
+	view.BandwidthLabel.BorderStyle.Fg = ui.ColorMagenta
+	view.BandwidthChart = widgets.NewSparkline()
+	view.BandwidthChart.LineColor = view.BandwidthLabel.BorderStyle.Fg
+	view.BandwidthGroup = widgets.NewSparklineGroup(view.BandwidthChart)
+	view.BandwidthGroup.BorderStyle.Fg = view.BandwidthLabel.BorderStyle.Fg
+	view.BandwidthData = make([]float64, MaxSlots, MaxSlots)
+
+	// Fourth Row
+	view.ErrLabel = widgets.NewParagraph()
+	view.ErrLabel.Title = "Errors"
+	view.ErrLabel.BorderStyle.Fg = ui.ColorRed
+	view.ErrChart = widgets.NewSparkline()
+	view.ErrChart.LineColor = view.ErrLabel.BorderStyle.Fg
+	view.ErrGroup = widgets.NewSparklineGroup(view.ErrChart)
+	view.ErrGroup.BorderStyle.Fg = view.ErrLabel.BorderStyle.Fg
+	view.ErrData = make([]float64, MaxSlots, MaxSlots)
+
+	view.HitLabel = widgets.NewParagraph()
+	view.HitLabel.Title = "Hit Ratio"
+	view.HitLabel.BorderStyle.Fg = ui.ColorGreen
+	view.HitChart = widgets.NewSparkline()
+	view.HitChart.LineColor = view.HitLabel.BorderStyle.Fg
+	view.HitGroup = widgets.NewSparklineGroup(view.HitChart)
+	view.HitGroup.BorderStyle.Fg = view.HitLabel.BorderStyle.Fg
+	view.HitData = make([]float64, MaxSlots, MaxSlots)
+
+	// Fifth Row
+	view.IoLabel = widgets.NewParagraph()
+	view.IoLabel.Title = "Image Optimizer"
+	view.IoLabel.BorderStyle.Fg = ui.ColorYellow
+	view.IoChart = widgets.NewSparkline()
+	view.IoChart.LineColor = view.IoLabel.BorderStyle.Fg
+	view.IoGroup = widgets.NewSparklineGroup(view.IoChart)
+	view.IoGroup.BorderStyle.Fg = view.IoLabel.BorderStyle.Fg
+	view.IoData = make([]float64, MaxSlots, MaxSlots)
+
+	view.LoggingLabel = widgets.NewParagraph()
+	view.LoggingLabel.Title = "Logs Sent"
+	view.LoggingLabel.BorderStyle.Fg = ui.ColorBlue
+	view.LoggingChart = widgets.NewSparkline()
+	view.LoggingChart.LineColor = view.LoggingLabel.BorderStyle.Fg
+	view.LoggingGroup = widgets.NewSparklineGroup(view.LoggingChart)
+	view.LoggingGroup.BorderStyle.Fg = view.LoggingLabel.BorderStyle.Fg
+	view.LoggingData = make([]float64, MaxSlots, MaxSlots)
+
+	return &view, nil
+}
+
+func (v *View) SetLayout() {
+	v.Grid.Set(
+		ui.NewRow(0.05, v.Header),
+		ui.NewRow(0.14,
+			ui.NewCol(1.0/7, v.Hits),
+			ui.NewCol(1.0/7, v.HitTime),
+			ui.NewCol(1.0/7, v.Misses),
+			ui.NewCol(1.0/7, v.HitRatio),
+			ui.NewCol(1.0/7, v.MissTime),
+			ui.NewCol(1.0/7, v.Requests),
+			ui.NewCol(1.0/7, v.Errors),
+		),
+		ui.NewRow(0.15,
+			ui.NewRow(0.2, v.GlobalLabel), ui.NewRow(0.8, v.Global),
+		),
+		ui.NewRow(0.22,
+			ui.NewCol(1.0/2, ui.NewRow(0.2, v.ReqLabel), ui.NewRow(0.8, v.ReqChart)),
+			ui.NewCol(1.0/2, ui.NewRow(0.2, v.BandwidthLabel), ui.NewRow(0.8, v.BandwidthGroup)),
+		),
+		ui.NewRow(0.22,
+			ui.NewCol(1.0/2, ui.NewRow(0.2, v.ErrLabel), ui.NewRow(0.8, v.ErrGroup)),
+			ui.NewCol(1.0/2, ui.NewRow(0.2, v.HitLabel), ui.NewRow(0.8, v.HitGroup)),
+		),
+		ui.NewRow(0.22,
+			ui.NewCol(1.0/2, ui.NewRow(0.2, v.IoLabel), ui.NewRow(0.8, v.IoGroup)),
+			ui.NewCol(1.0/2, ui.NewRow(0.2, v.LoggingLabel), ui.NewRow(0.8, v.LoggingGroup)),
+		),
+	)
+}
+
+func (v *View) Resize() {
+	termWidth, termHeight := ui.TerminalDimensions()
+	v.Grid.SetRect(0, 0, termWidth, termHeight)
+}
+
+func (v *View) Render() {
+	ui.Clear()
+	ui.Render(v.Grid)
+}
+
+func (v *View) UpdateStats(block realtimeResponseData) error {
+	agg := block.Aggregated
+	delete(agg, "miss_histogram")
+
+	var s fastly.Stats
+	if err := mapstructure.Decode(agg, &s); err != nil {
+		return err
+	}
+
+	// Header
+	startTime := time.Unix(int64(block.Recorded), 0).UTC()
+	v.Header.Text = fmt.Sprintf("Stats for %s @ %s", v.Service, startTime)
+
+	// Top Row
+	v.Hits.Text = fmt.Sprintf("%30d\nper second", s.Hits)
+	v.HitTime.Text = fmt.Sprintf("%28.2f\u00b5s\n(avg)", s.HitsTime*1000)
+	v.Misses.Text = fmt.Sprintf("%30d\nper second", s.Miss)
+
+	hitRate := 0.0
+	if s.Hits > 0 {
+		hitRate = float64((s.Hits - s.Miss - s.Errors)) / float64(s.Hits)
+	}
+	v.HitRatio.Data = []float64{hitRate, 1.0 - hitRate}
+
+	v.MissTime.Text = fmt.Sprintf("%28.2f\u00b5s\n(avg)", s.MissTime*1000)
+	v.Requests.Text = fmt.Sprintf("%30d\nper second", s.Requests)
+	v.Errors.Text = fmt.Sprintf("%30d\nper second", s.Errors)
+
+	// Second Row
+	var dcLabels []string
+	var dcReqs []float64
+	for dc, _ := range block.Datacenter {
+		if len(dc) > 3 {
+			continue
+		}
+		dcLabels = append(dcLabels, dc)
+	}
+	sort.Strings(dcLabels)
+	for _, dc := range dcLabels {
+		dcReqs = append(dcReqs, block.Datacenter[dc]["requests"].(float64))
+	}
+
+	v.Global.Labels = dcLabels
+	v.Global.Data = dcReqs
+
+	// Third Row
+	reqNow := []float64{float64(s.Errors), float64(s.Miss), float64(s.Hits), float64(s.Synth), float64(s.Pass)}
+	v.ReqLabel.Text = humanize.SI(float64(s.Requests), "")
+	v.ReqData = append(v.ReqData, reqNow)[1:]
+	v.ReqChart.Data = v.ReqData
+	v.BandwidthLabel.Text = humanize.Bytes(s.ResponseHeaderBytes + s.ResponseBodyBytes)
+	v.BandwidthData = append(v.BandwidthData, float64(s.ResponseHeaderBytes+s.ResponseBodyBytes))[1:]
+	v.BandwidthChart.Data = v.BandwidthData
+
+	// Fourth Row
+	v.ErrLabel.Text = fmt.Sprintf("%30d/second", s.Errors)
+	v.ErrData = append(v.ErrData, float64(s.Errors))[1:]
+	v.ErrChart.Data = v.ErrData
+	v.HitLabel.Text = fmt.Sprintf("%3.1f%%", hitRate*100)
+	v.HitData = append(v.HitData, hitRate)[1:]
+	v.HitChart.Data = v.HitData
+
+	// Fifth Row
+	v.IoLabel.Text = fmt.Sprintf("%30d/second", s.ImageOptimizer)
+	v.IoData = append(v.IoData, float64(s.ImageOptimizer))[1:]
+	v.IoChart.Data = v.IoData
+	v.LoggingLabel.Text = fmt.Sprintf("%30d/second", s.Log)
+	v.LoggingData = append(v.LoggingData, float64(s.Log))[1:]
+	v.LoggingChart.Data = v.LoggingData
+
+	return nil
+}
+
+func (v *View) Close() {
+	ui.Close()
+}

--- a/pkg/stats/view.go
+++ b/pkg/stats/view.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Maximum number of time slots to remember (1 sec per spot)
-const MaxSlots = 60
+const maxSlots = 60
 
 type View struct {
 	Events  <-chan ui.Event
@@ -98,9 +98,8 @@ func NewView(service string) (*View, error) {
 	view.HitRatio.LabelFormatter = func(i int, v float64) string {
 		if v > 0.0 {
 			return fmt.Sprintf("%.01f%%", v*100)
-		} else {
-			return ""
 		}
+		return ""
 	}
 
 	view.MissTime = widgets.NewParagraph()
@@ -124,9 +123,9 @@ func NewView(service string) (*View, error) {
 	view.ReqChart = widgets.NewStackedBarChart()
 	view.ReqChart.NumFormatter = func(v float64) string { return "" }
 	// Stacked bar charts are too wide, so only do the last 30 seconds
-	view.ReqData = make([][]float64, MaxSlots/2, MaxSlots/2)
-	for i, _ := range view.ReqData {
-		view.ReqData[i] = make([]float64, 5, 5)
+	view.ReqData = make([][]float64, maxSlots/2)
+	for i := range view.ReqData {
+		view.ReqData[i] = make([]float64, 5)
 	}
 
 	view.BandwidthLabel = widgets.NewParagraph()
@@ -136,7 +135,7 @@ func NewView(service string) (*View, error) {
 	view.BandwidthChart.LineColor = view.BandwidthLabel.BorderStyle.Fg
 	view.BandwidthGroup = widgets.NewSparklineGroup(view.BandwidthChart)
 	view.BandwidthGroup.BorderStyle.Fg = view.BandwidthLabel.BorderStyle.Fg
-	view.BandwidthData = make([]float64, MaxSlots, MaxSlots)
+	view.BandwidthData = make([]float64, maxSlots)
 
 	// Fourth Row
 	view.ErrLabel = widgets.NewParagraph()
@@ -146,7 +145,7 @@ func NewView(service string) (*View, error) {
 	view.ErrChart.LineColor = view.ErrLabel.BorderStyle.Fg
 	view.ErrGroup = widgets.NewSparklineGroup(view.ErrChart)
 	view.ErrGroup.BorderStyle.Fg = view.ErrLabel.BorderStyle.Fg
-	view.ErrData = make([]float64, MaxSlots, MaxSlots)
+	view.ErrData = make([]float64, maxSlots)
 
 	view.HitLabel = widgets.NewParagraph()
 	view.HitLabel.Title = "Hit Ratio"
@@ -155,7 +154,7 @@ func NewView(service string) (*View, error) {
 	view.HitChart.LineColor = view.HitLabel.BorderStyle.Fg
 	view.HitGroup = widgets.NewSparklineGroup(view.HitChart)
 	view.HitGroup.BorderStyle.Fg = view.HitLabel.BorderStyle.Fg
-	view.HitData = make([]float64, MaxSlots, MaxSlots)
+	view.HitData = make([]float64, maxSlots)
 
 	// Fifth Row
 	view.IoLabel = widgets.NewParagraph()
@@ -165,7 +164,7 @@ func NewView(service string) (*View, error) {
 	view.IoChart.LineColor = view.IoLabel.BorderStyle.Fg
 	view.IoGroup = widgets.NewSparklineGroup(view.IoChart)
 	view.IoGroup.BorderStyle.Fg = view.IoLabel.BorderStyle.Fg
-	view.IoData = make([]float64, MaxSlots, MaxSlots)
+	view.IoData = make([]float64, maxSlots)
 
 	view.LoggingLabel = widgets.NewParagraph()
 	view.LoggingLabel.Title = "Logs Sent"
@@ -174,7 +173,7 @@ func NewView(service string) (*View, error) {
 	view.LoggingChart.LineColor = view.LoggingLabel.BorderStyle.Fg
 	view.LoggingGroup = widgets.NewSparklineGroup(view.LoggingChart)
 	view.LoggingGroup.BorderStyle.Fg = view.LoggingLabel.BorderStyle.Fg
-	view.LoggingData = make([]float64, MaxSlots, MaxSlots)
+	view.LoggingData = make([]float64, maxSlots)
 
 	return &view, nil
 }
@@ -250,7 +249,7 @@ func (v *View) UpdateStats(block realtimeResponseData) error {
 	// Second Row
 	var dcLabels []string
 	var dcReqs []float64
-	for dc, _ := range block.Datacenter {
+	for dc := range block.Datacenter {
 		if len(dc) > 3 {
 			continue
 		}


### PR DESCRIPTION
This builds on the work done on the real time stats display by generating an ASCII realtime dashboard.

It's a port of a standalone experiment I did a while back tied into the CLI framework. Feel free to resize the terminal and hit `q` or `ctrl-c` to quit. 

I figure at worst case it might spark some inspiration in someone and/or someone can critique my Go and I can improve. Best case scenario it's actually useful, even if it's just as a demo.

Potential todos:
- [ ] get some input on the design
- [ ] fix the number of items in the Sparklines so they fill the whole of the box (or find a way to center them)
- [ ] play around with using the Plot type instead of Sparkline for some of the graphs
- [ ] add new "tabs" with WAF and Video and Request Type (IPv6, HTTP 1/2/3 etc etc) dashboards
- [ ] Get more details such as Customer name/id and Service name and put it in the header
- [ ] Fetch a list of Datacenters and use that so to stabilize the per-dc display
- [ ] Figure out some way to do the Miss Histogram
- [ ] Allow switching between Aggregate Data and Per DC (or maybe even Per Region)
- [ ] Maybe experiment with [TermDash](https://github.com/mum4k/termdash) as an alternative charting library
- [ ] Allow configuring of the layout via a config file (à la [GrafTerm](https://github.com/slok/grafterm/blob/master/docs/cfg.md)). Later, if that config was stored in the Fastly API, the dashboard in the UI could also use it.



![stats](https://user-images.githubusercontent.com/38551/82954875-76fb1800-9f62-11ea-8bc8-0c0b6eabab3e.gif)

