### PR TITLE
Adds Kafka logging endpoint support

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -178,6 +178,12 @@ type Interface interface {
 	UpdateHTTPS(*fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
 	DeleteHTTPS(*fastly.DeleteHTTPSInput) error
 
+	CreateKafka(*fastly.CreateKafkaInput) (*fastly.Kafka, error)
+	ListKafkas(*fastly.ListKafkasInput) ([]*fastly.Kafka, error)
+	GetKafka(*fastly.GetKafkaInput) (*fastly.Kafka, error)
+	UpdateKafka(*fastly.UpdateKafkaInput) (*fastly.Kafka, error)
+	DeleteKafka(*fastly.DeleteKafkaInput) error
+
 	GetUser(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegions() (*fastly.RegionsResponse, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/heroku"
 	"github.com/fastly/cli/pkg/logging/honeycomb"
 	"github.com/fastly/cli/pkg/logging/https"
+	"github.com/fastly/cli/pkg/logging/kafka"
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/loggly"
 	"github.com/fastly/cli/pkg/logging/logshuttle"
@@ -292,6 +293,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
 	statsRealtime := stats.NewRealtimeCommand(statsRoot.CmdClause, &globals)
 
+	kafkaRoot := kafka.NewRootCommand(loggingRoot.CmdClause, &globals)
+	kafkaCreate := kafka.NewCreateCommand(kafkaRoot.CmdClause, &globals)
+	kafkaList := kafka.NewListCommand(kafkaRoot.CmdClause, &globals)
+	kafkaDescribe := kafka.NewDescribeCommand(kafkaRoot.CmdClause, &globals)
+	kafkaUpdate := kafka.NewUpdateCommand(kafkaRoot.CmdClause, &globals)
+	kafkaDelete := kafka.NewDeleteCommand(kafkaRoot.CmdClause, &globals)
+
 	commands := []common.Command{
 		configureRoot,
 		whoamiRoot,
@@ -489,6 +497,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		httpsDescribe,
 		httpsUpdate,
 		httpsDelete,
+
+		kafkaRoot,
+		kafkaCreate,
+		kafkaList,
+		kafkaDescribe,
+		kafkaUpdate,
+		kafkaDelete,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2475,6 +2475,125 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the HTTPS logging object
 
+  logging kafka create --name=NAME --version=VERSION --topic=TOPIC --brokers=BROKERS [<flags>]
+    Create a Kafka logging endpoint on a Fastly service version
+
+    -n, --name=NAME                The name of the Kafka logging object. Used as
+                                   a primary key for API access
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+        --topic=TOPIC              The Kafka topic to send logs to
+        --brokers=BROKERS          A comma-separated list of IP addresses or
+                                   hostnames of Kafka brokers
+        --compression-codec=COMPRESSION-CODEC
+                                   The codec used for compression of your logs.
+                                   One of: gzip, snappy, lz4
+        --required-acks=REQUIRED-ACKS
+                                   The Number of acknowledgements a leader must
+                                   receive before a write is considered
+                                   successful. One of: 1 (default) One server
+                                   needs to respond. 0 No servers need to
+                                   respond. -1 Wait for all in-sync replicas to
+                                   respond
+        --use-tls                  Whether to use TLS for secure logging. Can be
+                                   either true or false
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-client-cert=TLS-CLIENT-CERT
+                                   The client certificate used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-client-key=TLS-CLIENT-KEY
+                                   The client private key used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --format=FORMAT            Apache style log formatting. Your log must
+                                   produce valid JSON that Kafka can ingest
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+
+  logging kafka list --version=VERSION [<flags>]
+    List Kafka endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging kafka describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Kafka logging endpoint on a Fastly service
+    version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Kafka logging object
+
+  logging kafka update --version=VERSION --name=NAME [<flags>]
+    Update a Kafka logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+    -n, --name=NAME                The name of the Kafka logging object
+        --new-name=NEW-NAME        New name of the Kafka logging object
+        --topic=TOPIC              The Kafka topic to send logs to
+        --brokers=BROKERS          A comma-separated list of IP addresses or
+                                   hostnames of Kafka brokers
+        --compression-codec=COMPRESSION-CODEC
+                                   The codec used for compression of your logs.
+                                   One of: gzip, snappy, lz4
+        --required-acks=REQUIRED-ACKS
+                                   The Number of acknowledgements a leader must
+                                   receive before a write is considered
+                                   successful. One of: 1 (default) One server
+                                   needs to respond. 0 No servers need to
+                                   respond. -1 Wait for all in-sync replicas to
+                                   respond
+        --use-tls                  Whether to use TLS for secure logging. Can be
+                                   either true or false
+        --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
+                                   server with. Must be in PEM format
+        --tls-client-cert=TLS-CLIENT-CERT
+                                   The client certificate used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-client-key=TLS-CLIENT-KEY
+                                   The client private key used to make
+                                   authenticated requests. Must be in PEM format
+        --tls-hostname=TLS-HOSTNAME
+                                   The hostname used to verify the server's
+                                   certificate. It can either be the Common Name
+                                   or a Subject Alternative Name (SAN)
+        --format=FORMAT            Apache style log formatting. Your log must
+                                   produce valid JSON that Kafka can ingest
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+
+  logging kafka delete --version=VERSION --name=NAME [<flags>]
+    Delete a Kafka logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Kafka logging object
+
   stats regions
     List stats regions
 

--- a/pkg/logging/kafka/create.go
+++ b/pkg/logging/kafka/create.go
@@ -1,0 +1,144 @@
+package kafka
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Kafka logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	Topic        string
+	Brokers      string
+
+	// optional
+	UseTLS            common.OptionalBool
+	CompressionCodec  common.OptionalString
+	RequiredACKs      common.OptionalString
+	TLSCACert         common.OptionalString
+	TLSClientCert     common.OptionalString
+	TLSClientKey      common.OptionalString
+	TLSHostname       common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Placement         common.OptionalString
+	ResponseCondition common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create a Kafka logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Kafka logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("topic", "The Kafka topic to send logs to").Required().StringVar(&c.Topic)
+	c.CmdClause.Flag("brokers", "A comma-separated list of IP addresses or hostnames of Kafka brokers").Required().StringVar(&c.Brokers)
+
+	c.CmdClause.Flag("compression-codec", "The codec used for compression of your logs. One of: gzip, snappy, lz4").Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
+	c.CmdClause.Flag("required-acks", "The Number of acknowledgements a leader must receive before a write is considered successful. One of: 1 (default) One server needs to respond. 0	No servers need to respond. -1	Wait for all in-sync replicas to respond").Action(c.RequiredACKs.Set).StringVar(&c.RequiredACKs.Value)
+	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)
+	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
+	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)
+	c.CmdClause.Flag("tls-client-key", "The client private key used to make authenticated requests. Must be in PEM format").Action(c.TLSClientKey.Set).StringVar(&c.TLSClientKey.Value)
+	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Kafka can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateKafkaInput, error) {
+	var input fastly.CreateKafkaInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = fastly.String(c.EndpointName)
+	input.Topic = fastly.String(c.Topic)
+	input.Brokers = fastly.String(c.Brokers)
+
+	if c.CompressionCodec.Valid {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
+	}
+
+	if c.RequiredACKs.Valid {
+		input.RequiredACKs = fastly.String(c.RequiredACKs.Value)
+	}
+
+	if c.UseTLS.Valid {
+		input.UseTLS = fastly.CBool(c.UseTLS.Value)
+	}
+
+	if c.TLSCACert.Valid {
+		input.TLSCACert = fastly.String(c.TLSCACert.Value)
+	}
+
+	if c.TLSClientCert.Valid {
+		input.TLSClientCert = fastly.String(c.TLSClientCert.Value)
+	}
+
+	if c.TLSClientKey.Valid {
+		input.TLSClientKey = fastly.String(c.TLSClientKey.Value)
+	}
+
+	if c.TLSHostname.Valid {
+		input.TLSHostname = fastly.String(c.TLSHostname.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateKafka(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Kafka logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.Version)
+	return nil
+}

--- a/pkg/logging/kafka/delete.go
+++ b/pkg/logging/kafka/delete.go
@@ -1,0 +1,47 @@
+package kafka
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Kafka logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteKafkaInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Kafka logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	if err := c.Globals.Client.DeleteKafka(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Kafka logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.Service, c.Input.Version)
+	return nil
+}

--- a/pkg/logging/kafka/describe.go
+++ b/pkg/logging/kafka/describe.go
@@ -1,0 +1,64 @@
+package kafka
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe a Kafka logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetKafkaInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Kafka logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	kafka, err := c.Globals.Client.GetKafka(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", kafka.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", kafka.Version)
+	fmt.Fprintf(out, "Name: %s\n", kafka.Name)
+	fmt.Fprintf(out, "Topic: %s\n", kafka.Topic)
+	fmt.Fprintf(out, "Brokers: %s\n", kafka.Brokers)
+	fmt.Fprintf(out, "Required acks: %s\n", kafka.RequiredACKs)
+	fmt.Fprintf(out, "Compression codec: %s\n", kafka.CompressionCodec)
+	fmt.Fprintf(out, "Use TLS: %t\n", kafka.UseTLS)
+	fmt.Fprintf(out, "TLS CA certificate: %s\n", kafka.TLSCACert)
+	fmt.Fprintf(out, "TLS client certificate: %s\n", kafka.TLSClientCert)
+	fmt.Fprintf(out, "TLS client key: %s\n", kafka.TLSClientKey)
+	fmt.Fprintf(out, "TLS hostname: %s\n", kafka.TLSHostname)
+	fmt.Fprintf(out, "Format: %s\n", kafka.Format)
+	fmt.Fprintf(out, "Format version: %d\n", kafka.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", kafka.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", kafka.Placement)
+
+	return nil
+}

--- a/pkg/logging/kafka/doc.go
+++ b/pkg/logging/kafka/doc.go
@@ -1,0 +1,3 @@
+// Package kafka contains commands to inspect and manipulate Fastly service Kafka
+// logging endpoints.
+package kafka

--- a/pkg/logging/kafka/kafka_integration_test.go
+++ b/pkg/logging/kafka/kafka_integration_test.go
@@ -1,0 +1,452 @@
+package kafka_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestKafkaCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
+			wantError: "error parsing arguments: required flag --topic not provided",
+		},
+		{
+			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs"},
+			wantError: "error parsing arguments: required flag --brokers not provided",
+		},
+		{
+			args:       []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2"},
+			api:        mock.API{CreateKafkaFn: createKafkaOK},
+			wantOutput: "Created Kafka logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2"},
+			api:       mock.API{CreateKafkaFn: createKafkaError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestKafkaList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListKafkasFn: listKafkasOK},
+			wantOutput: listKafkasShortOutput,
+		},
+		{
+			args:       []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListKafkasFn: listKafkasOK},
+			wantOutput: listKafkasVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListKafkasFn: listKafkasOK},
+			wantOutput: listKafkasVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "kafka", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListKafkasFn: listKafkasOK},
+			wantOutput: listKafkasVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "kafka", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListKafkasFn: listKafkasOK},
+			wantOutput: listKafkasVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListKafkasFn: listKafkasError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestKafkaDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetKafkaFn: getKafkaError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetKafkaFn: getKafkaOK},
+			wantOutput: describeKafkaOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestKafkaUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetKafkaFn:    getKafkaError,
+				UpdateKafkaFn: updateKafkaOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetKafkaFn:    getKafkaOK,
+				UpdateKafkaFn: updateKafkaError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetKafkaFn:    getKafkaOK,
+				UpdateKafkaFn: updateKafkaOK,
+			},
+			wantOutput: "Updated Kafka logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestKafkaDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteKafkaFn: deleteKafkaError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteKafkaFn: deleteKafkaOK},
+			wantOutput: "Deleted Kafka logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createKafkaOK(i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
+	return &fastly.Kafka{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		Topic:             "logs",
+		Brokers:           "127.0.0.1,127.0.0.2",
+		RequiredACKs:      "-1",
+		CompressionCodec:  "zippy",
+		UseTLS:            true,
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "127.0.0.1,127.0.0.2",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		FormatVersion:     2,
+	}, nil
+}
+
+func createKafkaError(i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
+	return nil, errTest
+}
+
+func listKafkasOK(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
+	return []*fastly.Kafka{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			ResponseCondition: "Prevent default logging",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			Topic:             "logs",
+			Brokers:           "127.0.0.1,127.0.0.2",
+			RequiredACKs:      "-1",
+			CompressionCodec:  "zippy",
+			UseTLS:            true,
+			Placement:         "none",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSHostname:       "127.0.0.1,127.0.0.2",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+			FormatVersion:     2,
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Topic:             "analytics",
+			Brokers:           "127.0.0.1,127.0.0.2",
+			RequiredACKs:      "-1",
+			CompressionCodec:  "zippy",
+			UseTLS:            true,
+			Placement:         "none",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSHostname:       "127.0.0.1,127.0.0.2",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+			ResponseCondition: "Prevent default logging",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+		},
+	}, nil
+}
+
+func listKafkasError(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
+	return nil, errTest
+}
+
+var listKafkasShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listKafkasVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Kafka 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Topic: logs
+		Brokers: 127.0.0.1,127.0.0.2
+		Required acks: -1
+		Compression codec: zippy
+		Use TLS: true
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS client certificate: -----BEGIN CERTIFICATE-----bar
+		TLS client key: -----BEGIN PRIVATE KEY-----bar
+		TLS hostname: 127.0.0.1,127.0.0.2
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Kafka 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Topic: analytics
+		Brokers: 127.0.0.1,127.0.0.2
+		Required acks: -1
+		Compression codec: zippy
+		Use TLS: true
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS client certificate: -----BEGIN CERTIFICATE-----bar
+		TLS client key: -----BEGIN PRIVATE KEY-----bar
+		TLS hostname: 127.0.0.1,127.0.0.2
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getKafkaOK(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+	return &fastly.Kafka{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Brokers:           "127.0.0.1,127.0.0.2",
+		Topic:             "logs",
+		RequiredACKs:      "-1",
+		UseTLS:            true,
+		CompressionCodec:  "zippy",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "127.0.0.1,127.0.0.2",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+	}, nil
+}
+
+func getKafkaError(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+	return nil, errTest
+}
+
+var describeKafkaOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: log
+Topic: logs
+Brokers: 127.0.0.1,127.0.0.2
+Required acks: -1
+Compression codec: zippy
+Use TLS: true
+TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+TLS client certificate: -----BEGIN CERTIFICATE-----bar
+TLS client key: -----BEGIN PRIVATE KEY-----bar
+TLS hostname: 127.0.0.1,127.0.0.2
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateKafkaOK(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
+	return &fastly.Kafka{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		ResponseCondition: "Prevent default logging",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		Topic:             "logs",
+		Brokers:           "127.0.0.1,127.0.0.2",
+		RequiredACKs:      "-1",
+		CompressionCodec:  "zippy",
+		UseTLS:            true,
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "127.0.0.1,127.0.0.2",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		FormatVersion:     2,
+	}, nil
+}
+
+func updateKafkaError(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
+	return nil, errTest
+}
+
+func deleteKafkaOK(i *fastly.DeleteKafkaInput) error {
+	return nil
+}
+
+func deleteKafkaError(i *fastly.DeleteKafkaInput) error {
+	return errTest
+}

--- a/pkg/logging/kafka/kafka_test.go
+++ b/pkg/logging/kafka/kafka_test.go
@@ -1,0 +1,237 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestCreateKafkaInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateKafkaInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateKafkaInput{
+				Service: "123",
+				Version: 2,
+				Name:    fastly.String("log"),
+				Topic:   fastly.String("logs"),
+				Brokers: fastly.String("127.0.0.1,127.0.0.2"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateKafkaInput{
+				Service:           "123",
+				Version:           2,
+				Name:              fastly.String("logs"),
+				Brokers:           fastly.String("127.0.0.1,127.0.0.2"),
+				Topic:             fastly.String("logs"),
+				RequiredACKs:      fastly.String("-1"),
+				UseTLS:            fastly.CBool(true),
+				CompressionCodec:  fastly.String("zippy"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+				TLSCACert:         fastly.String("-----BEGIN CERTIFICATE-----foo"),
+				TLSHostname:       fastly.String("example.com"),
+				TLSClientCert:     fastly.String("-----BEGIN CERTIFICATE-----bar"),
+				TLSClientKey:      fastly.String("-----BEGIN PRIVATE KEY-----bar"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateKafkaInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateKafkaInput
+		wantError string
+	}{
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetKafkaFn: getKafkaOK},
+			want: &fastly.UpdateKafkaInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "log",
+				NewName:           fastly.String("new1"),
+				Topic:             fastly.String("new2"),
+				Brokers:           fastly.String("new3"),
+				RequiredACKs:      fastly.String("new4"),
+				UseTLS:            fastly.CBool(false),
+				CompressionCodec:  fastly.String("new5"),
+				Placement:         fastly.String("new6"),
+				Format:            fastly.String("new7"),
+				FormatVersion:     fastly.Uint(3),
+				ResponseCondition: fastly.String("new8"),
+				TLSCACert:         fastly.String("new9"),
+				TLSClientCert:     fastly.String("new10"),
+				TLSClientKey:      fastly.String("new11"),
+				TLSHostname:       fastly.String("new12"),
+			},
+		},
+		{
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetKafkaFn: getKafkaOK},
+			want: &fastly.UpdateKafkaInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "log",
+				NewName:           fastly.String("log"),
+				Brokers:           fastly.String("127.0.0.1,127.0.0.2"),
+				Topic:             fastly.String("logs"),
+				RequiredACKs:      fastly.String("-1"),
+				UseTLS:            fastly.CBool(true),
+				CompressionCodec:  fastly.String("zippy"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+				TLSCACert:         fastly.String("-----BEGIN CERTIFICATE-----foo"),
+				TLSHostname:       fastly.String("example.com"),
+				TLSClientCert:     fastly.String("-----BEGIN CERTIFICATE-----bar"),
+				TLSClientKey:      fastly.String("-----BEGIN PRIVATE KEY-----bar"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+		Topic:        "logs",
+		Brokers:      "127.0.0.1,127.0.0.2",
+	}
+}
+
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "logs",
+		Version:           2,
+		Topic:             "logs",
+		Brokers:           "127.0.0.1,127.0.0.2",
+		UseTLS:            common.OptionalBool{Optional: common.Optional{Valid: true}, Value: true},
+		RequiredACKs:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-1"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{Valid: true}, Value: "zippy"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		TLSCACert:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "example.com"},
+		TLSClientCert:     common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		Topic:             common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		Brokers:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		UseTLS:            common.OptionalBool{Optional: common.Optional{Valid: true}, Value: false},
+		RequiredACKs:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new7"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new8"},
+		TLSCACert:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
+		TLSClientCert:     common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
+		TLSClientKey:      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new11"},
+		TLSHostname:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new12"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getKafkaOK(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+	return &fastly.Kafka{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Brokers:           "127.0.0.1,127.0.0.2",
+		Topic:             "logs",
+		RequiredACKs:      "-1",
+		UseTLS:            true,
+		CompressionCodec:  "zippy",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+	}, nil
+}

--- a/pkg/logging/kafka/list.go
+++ b/pkg/logging/kafka/list.go
@@ -1,0 +1,80 @@
+package kafka
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// ListCommand calls the Fastly API to list Kafka logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListKafkasInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Kafka endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.Service = serviceID
+
+	kafkas, err := c.Globals.Client.ListKafkas(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, kafka := range kafkas {
+			tw.AddLine(kafka.ServiceID, kafka.Version, kafka.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.Service)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.Version)
+	for i, kafka := range kafkas {
+		fmt.Fprintf(out, "\tKafka %d/%d\n", i+1, len(kafkas))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", kafka.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", kafka.Version)
+		fmt.Fprintf(out, "\t\tName: %s\n", kafka.Name)
+		fmt.Fprintf(out, "\t\tTopic: %s\n", kafka.Topic)
+		fmt.Fprintf(out, "\t\tBrokers: %s\n", kafka.Brokers)
+		fmt.Fprintf(out, "\t\tRequired acks: %s\n", kafka.RequiredACKs)
+		fmt.Fprintf(out, "\t\tCompression codec: %s\n", kafka.CompressionCodec)
+		fmt.Fprintf(out, "\t\tUse TLS: %t\n", kafka.UseTLS)
+		fmt.Fprintf(out, "\t\tTLS CA certificate: %s\n", kafka.TLSCACert)
+		fmt.Fprintf(out, "\t\tTLS client certificate: %s\n", kafka.TLSClientCert)
+		fmt.Fprintf(out, "\t\tTLS client key: %s\n", kafka.TLSClientKey)
+		fmt.Fprintf(out, "\t\tTLS hostname: %s\n", kafka.TLSHostname)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", kafka.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", kafka.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", kafka.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", kafka.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/kafka/root.go
+++ b/pkg/logging/kafka/root.go
@@ -1,0 +1,28 @@
+package kafka
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("kafka", "Manipulate Fastly service version Kafka logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/kafka/update.go
+++ b/pkg/logging/kafka/update.go
@@ -1,0 +1,180 @@
+package kafka
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Kafka logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	Index             common.OptionalString
+	Topic             common.OptionalString
+	Brokers           common.OptionalString
+	UseTLS            common.OptionalBool
+	CompressionCodec  common.OptionalString
+	RequiredACKs      common.OptionalString
+	TLSCACert         common.OptionalString
+	TLSClientCert     common.OptionalString
+	TLSClientKey      common.OptionalString
+	TLSHostname       common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	Placement         common.OptionalString
+	ResponseCondition common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Kafka logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Kafka logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("topic", "The Kafka topic to send logs to").Action(c.Topic.Set).StringVar(&c.Topic.Value)
+	c.CmdClause.Flag("brokers", "A comma-separated list of IP addresses or hostnames of Kafka brokers").Action(c.Brokers.Set).StringVar(&c.Brokers.Value)
+	c.CmdClause.Flag("compression-codec", "The codec used for compression of your logs. One of: gzip, snappy, lz4").Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
+	c.CmdClause.Flag("required-acks", "The Number of acknowledgements a leader must receive before a write is considered successful. One of: 1 (default) One server needs to respond. 0	No servers need to respond. -1	Wait for all in-sync replicas to respond").Action(c.RequiredACKs.Set).StringVar(&c.RequiredACKs.Value)
+	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)
+	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
+	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)
+	c.CmdClause.Flag("tls-client-key", "The client private key used to make authenticated requests. Must be in PEM format").Action(c.TLSClientKey.Set).StringVar(&c.TLSClientKey.Value)
+	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Kafka can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateKafkaInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	kafka, err := c.Globals.Client.GetKafka(&fastly.GetKafkaInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateKafkaInput{
+		Service:           kafka.ServiceID,
+		Version:           kafka.Version,
+		Name:              kafka.Name,
+		NewName:           fastly.String(kafka.Name),
+		Brokers:           fastly.String(kafka.Brokers),
+		Topic:             fastly.String(kafka.Topic),
+		RequiredACKs:      fastly.String(kafka.RequiredACKs),
+		UseTLS:            fastly.CBool(kafka.UseTLS),
+		CompressionCodec:  fastly.String(kafka.CompressionCodec),
+		Format:            fastly.String(kafka.Format),
+		FormatVersion:     fastly.Uint(kafka.FormatVersion),
+		ResponseCondition: fastly.String(kafka.ResponseCondition),
+		Placement:         fastly.String(kafka.Placement),
+		TLSCACert:         fastly.String(kafka.TLSCACert),
+		TLSHostname:       fastly.String(kafka.TLSHostname),
+		TLSClientCert:     fastly.String(kafka.TLSClientCert),
+		TLSClientKey:      fastly.String(kafka.TLSClientKey),
+	}
+
+	if c.NewName.Valid {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.Topic.Valid {
+		input.Topic = fastly.String(c.Topic.Value)
+	}
+
+	if c.Brokers.Valid {
+		input.Brokers = fastly.String(c.Brokers.Value)
+	}
+
+	if c.CompressionCodec.Valid {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
+	}
+
+	if c.RequiredACKs.Valid {
+		input.RequiredACKs = fastly.String(c.RequiredACKs.Value)
+	}
+
+	if c.UseTLS.Valid {
+		input.UseTLS = fastly.CBool(c.UseTLS.Value)
+	}
+
+	if c.TLSCACert.Valid {
+		input.TLSCACert = fastly.String(c.TLSCACert.Value)
+	}
+
+	if c.TLSClientCert.Valid {
+		input.TLSClientCert = fastly.String(c.TLSClientCert.Value)
+	}
+
+	if c.TLSClientKey.Valid {
+		input.TLSClientKey = fastly.String(c.TLSClientKey.Value)
+	}
+
+	if c.TLSHostname.Valid {
+		input.TLSHostname = fastly.String(c.TLSHostname.Value)
+	}
+
+	if c.Format.Valid {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.Valid {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	kafka, err := c.Globals.Client.UpdateKafka(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Kafka logging endpoint %s (service %s version %d)", kafka.Name, kafka.ServiceID, kafka.Version)
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -169,6 +169,12 @@ type API struct {
 	UpdateHTTPSFn func(*fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
 	DeleteHTTPSFn func(*fastly.DeleteHTTPSInput) error
 
+	CreateKafkaFn func(*fastly.CreateKafkaInput) (*fastly.Kafka, error)
+	ListKafkasFn  func(*fastly.ListKafkasInput) ([]*fastly.Kafka, error)
+	GetKafkaFn    func(*fastly.GetKafkaInput) (*fastly.Kafka, error)
+	UpdateKafkaFn func(*fastly.UpdateKafkaInput) (*fastly.Kafka, error)
+	DeleteKafkaFn func(*fastly.DeleteKafkaInput) error
+
 	GetUserFn func(*fastly.GetUserInput) (*fastly.User, error)
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
@@ -843,6 +849,31 @@ func (m API) UpdateHTTPS(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
 // DeleteHTTPS implements Interface.
 func (m API) DeleteHTTPS(i *fastly.DeleteHTTPSInput) error {
 	return m.DeleteHTTPSFn(i)
+}
+
+// CreateKafka implements Interface.
+func (m API) CreateKafka(i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
+	return m.CreateKafkaFn(i)
+}
+
+// ListKafkas implements Interface.
+func (m API) ListKafkas(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
+	return m.ListKafkasFn(i)
+}
+
+// GetKafka implements Interface.
+func (m API) GetKafka(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+	return m.GetKafkaFn(i)
+}
+
+// UpdateKafka implements Interface.
+func (m API) UpdateKafka(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
+	return m.UpdateKafkaFn(i)
+}
+
+// DeleteKafka implements Interface.
+func (m API) DeleteKafka(i *fastly.DeleteKafkaInput) error {
+	return m.DeleteKafkaFn(i)
 }
 
 // GetUser implements Interface.


### PR DESCRIPTION
## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/kafka/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/c2c2c62210800daab641161412fbe210004aac0a/fastly/kafka.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-kafka && \
    make test && \
    rm -rf /tmp/cli \
)
```