### PR TITLE
Update Syslog to use new Create/Update pattern

### DIFF
--- a/pkg/logging/syslog/syslog_integration_test.go
+++ b/pkg/logging/syslog/syslog_integration_test.go
@@ -1,0 +1,449 @@
+package syslog_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestSyslogCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --address not provided",
+		},
+		{
+			args:       []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
+			api:        mock.API{CreateSyslogFn: createSyslogOK},
+			wantOutput: "Created Syslog logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
+			api:       mock.API{CreateSyslogFn: createSyslogError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSyslogList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			wantOutput: listSyslogsShortOutput,
+		},
+		{
+			args:       []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			wantOutput: listSyslogsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			wantOutput: listSyslogsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "syslog", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			wantOutput: listSyslogsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "syslog", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			wantOutput: listSyslogsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListSyslogsFn: listSyslogsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSyslogDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetSyslogFn: getSyslogError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetSyslogFn: getSyslogOK},
+			wantOutput: describeSyslogOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSyslogUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSyslogFn:    getSyslogError,
+				UpdateSyslogFn: updateSyslogOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSyslogFn:    getSyslogOK,
+				UpdateSyslogFn: updateSyslogError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSyslogFn:    getSyslogOK,
+				UpdateSyslogFn: updateSyslogOK,
+			},
+			wantOutput: "Updated Syslog logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSyslogDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteSyslogFn: deleteSyslogError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteSyslogFn: deleteSyslogOK},
+			wantOutput: "Deleted Syslog logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createSyslogOK(i *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
+	return &fastly.Syslog{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createSyslogError(i *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
+	return nil, errTest
+}
+
+func listSyslogsOK(i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
+	return []*fastly.Syslog{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Address:           "127.0.0.1",
+			Hostname:          "",
+			Port:              514,
+			UseTLS:            false,
+			IPV4:              "127.0.0.1",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+			TLSHostname:       "example.com",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+			Token:             "tkn",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Address:           "example.com",
+			Hostname:          "example.com",
+			Port:              789,
+			UseTLS:            true,
+			IPV4:              "",
+			TLSCACert:         "-----BEGIN CERTIFICATE-----baz",
+			TLSHostname:       "example.com",
+			TLSClientCert:     "-----BEGIN CERTIFICATE-----qux",
+			TLSClientKey:      "-----BEGIN PRIVATE KEY-----qux",
+			Token:             "tkn",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listSyslogsError(i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
+	return nil, errTest
+}
+
+var listSyslogsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listSyslogsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Syslog 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Address: 127.0.0.1
+		Hostname: 
+		Port: 514
+		Use TLS: false
+		IPV4: 127.0.0.1
+		TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+		TLS hostname: example.com
+		TLS client certificate: -----BEGIN CERTIFICATE-----bar
+		TLS client key: -----BEGIN PRIVATE KEY-----bar
+		Token: tkn
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Message type: classic
+		Response condition: Prevent default logging
+		Placement: none
+	Syslog 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Address: example.com
+		Hostname: example.com
+		Port: 789
+		Use TLS: true
+		IPV4: 
+		TLS CA certificate: -----BEGIN CERTIFICATE-----baz
+		TLS hostname: example.com
+		TLS client certificate: -----BEGIN CERTIFICATE-----qux
+		TLS client key: -----BEGIN PRIVATE KEY-----qux
+		Token: tkn
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Message type: classic
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getSyslogOK(i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
+	return &fastly.Syslog{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Address:           "example.com",
+		Hostname:          "example.com",
+		Port:              514,
+		UseTLS:            true,
+		IPV4:              "",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		Token:             "tkn",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getSyslogError(i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
+	return nil, errTest
+}
+
+var describeSyslogOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Address: example.com
+Hostname: example.com
+Port: 514
+Use TLS: true
+IPV4: 
+TLS CA certificate: -----BEGIN CERTIFICATE-----foo
+TLS hostname: example.com
+TLS client certificate: -----BEGIN CERTIFICATE-----bar
+TLS client key: -----BEGIN PRIVATE KEY-----bar
+Token: tkn
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Message type: classic
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateSyslogOK(i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
+	return &fastly.Syslog{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Address:           "example.com",
+		Hostname:          "example.com",
+		Port:              514,
+		UseTLS:            true,
+		IPV4:              "",
+		TLSCACert:         "-----BEGIN CERTIFICATE-----foo",
+		TLSHostname:       "example.com",
+		TLSClientCert:     "-----BEGIN CERTIFICATE-----bar",
+		TLSClientKey:      "-----BEGIN PRIVATE KEY-----bar",
+		Token:             "tkn",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateSyslogError(i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
+	return nil, errTest
+}
+
+func deleteSyslogOK(i *fastly.DeleteSyslogInput) error {
+	return nil
+}
+
+func deleteSyslogError(i *fastly.DeleteSyslogInput) error {
+	return errTest
+}

--- a/pkg/logging/syslog/update.go
+++ b/pkg/logging/syslog/update.go
@@ -16,8 +16,11 @@ type UpdateCommand struct {
 	common.Base
 	manifest manifest.Data
 
-	Input fastly.GetSyslogInput
+	// required
+	EndpointName string
+	Version      int
 
+	// optional
 	NewName           common.OptionalString
 	Address           common.OptionalString
 	Port              common.OptionalUint
@@ -43,8 +46,8 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause = parent.Command("update", "Update a Syslog logging endpoint on a Fastly service version")
 
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.EndpointName)
 
 	c.CmdClause.Flag("new-name", "New name of the Syslog logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
@@ -64,20 +67,23 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	return &c
 }
 
-// Exec invokes the application logic for the command.
-func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateSyslogInput, error) {
 	serviceID, source := c.manifest.ServiceID()
 	if source == manifest.SourceUndefined {
-		return errors.ErrNoServiceID
+		return nil, errors.ErrNoServiceID
 	}
-	c.Input.Service = serviceID
 
-	syslog, err := c.Globals.Client.GetSyslog(&c.Input)
+	syslog, err := c.Globals.Client.GetSyslog(&fastly.GetSyslogInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	input := &fastly.UpdateSyslogInput{
+	input := fastly.UpdateSyslogInput{
 		Service:           syslog.ServiceID,
 		Version:           syslog.Version,
 		Name:              syslog.Name,
@@ -98,10 +104,6 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	// Set new values if set by user.
-	if c.NewName.Valid {
-		input.NewName = c.NewName.Value
-	}
-
 	if c.NewName.Valid {
 		input.NewName = c.NewName.Value
 	}
@@ -158,7 +160,17 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		input.Placement = c.Placement.Value
 	}
 
-	syslog, err = c.Globals.Client.UpdateSyslog(input)
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	syslog, err := c.Globals.Client.UpdateSyslog(input)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed Change(s)

* Uses a factory pattern for Creates and Updates.
* Adds test for non-exported API in `_test.go` file.
* Moves exported API test to `_integration_test.go` file.

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-test-syslog && \
    make test && \
    rm -rf /tmp/cli \
)
```

## Notes

 * The missing `Hostname` and `IPV4` fields are because the `Address` field can be used instead.