### PR TITLE
Update S3 to use new Create/Update pattern

### DIFF
--- a/pkg/logging/s3/create.go
+++ b/pkg/logging/s3/create.go
@@ -15,10 +15,28 @@ import (
 type CreateCommand struct {
 	common.Base
 	manifest manifest.Data
-	Input    fastly.CreateS3Input
 
-	redundancy           string
-	serverSideEncryption string
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	BucketName   string
+	AccessKey    string
+	SecretKey    string
+
+	// optional
+	Domain                       common.OptionalString
+	Path                         common.OptionalString
+	Period                       common.OptionalUint
+	GzipLevel                    common.OptionalUint
+	Format                       common.OptionalString
+	FormatVersion                common.OptionalUint
+	MessageType                  common.OptionalString
+	ResponseCondition            common.OptionalString
+	TimestampFormat              common.OptionalString
+	Placement                    common.OptionalString
+	Redundancy                   common.OptionalString
+	ServerSideEncryption         common.OptionalString
+	ServerSideEncryptionKMSKeyID common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -28,53 +46,119 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Amazon S3 logging endpoint on a Fastly service version").Alias("add")
 
-	c.CmdClause.Flag("name", "The name of the S3 logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the S3 logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
 
-	c.CmdClause.Flag("bucket", "Your S3 bucket name").Required().StringVar(&c.Input.BucketName)
-	c.CmdClause.Flag("access-key", "Your S3 account access key").Required().StringVar(&c.Input.AccessKey)
-	c.CmdClause.Flag("secret-key", "Your S3 account secret key").Required().StringVar(&c.Input.SecretKey)
+	c.CmdClause.Flag("bucket", "Your S3 bucket name").Required().StringVar(&c.BucketName)
+	c.CmdClause.Flag("access-key", "Your S3 account access key").Required().StringVar(&c.AccessKey)
+	c.CmdClause.Flag("secret-key", "Your S3 account secret key").Required().StringVar(&c.SecretKey)
 
-	c.CmdClause.Flag("domain", "The domain of the S3 endpoint").StringVar(&c.Input.Domain)
-	c.CmdClause.Flag("path", "The path to upload logs to").StringVar(&c.Input.Path)
-	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").UintVar(&c.Input.Period)
-	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").UintVar(&c.Input.GzipLevel)
-	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
-	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").UintVar(&c.Input.FormatVersion)
-	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").StringVar(&c.Input.MessageType)
-	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
-	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).StringVar(&c.Input.TimestampFormat)
-	c.CmdClause.Flag("redundancy", "The S3 redundancy level. Can be either standard or reduced_redundancy").EnumVar(&c.redundancy, string(fastly.S3RedundancyStandard), string(fastly.S3RedundancyReduced))
-	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").StringVar(&c.Input.Placement)
-	c.CmdClause.Flag("server-side-encryption", "Set to enable S3 Server Side Encryption. Can be either AES256 or aws:kms").EnumVar(&c.serverSideEncryption, string(fastly.S3ServerSideEncryptionAES), string(fastly.S3ServerSideEncryptionKMS))
-	c.CmdClause.Flag("server-side-encryption-kms-key-id", "Server-side KMS Key ID. Must be set if server-side-encryption is set to aws:kms").StringVar(&c.Input.ServerSideEncryptionKMSKeyID)
+	c.CmdClause.Flag("domain", "The domain of the S3 endpoint").Action(c.Domain.Set).StringVar(&c.Domain.Value)
+	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).UintVar(&c.GzipLevel.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("redundancy", "The S3 redundancy level. Can be either standard or reduced_redundancy").Action(c.Redundancy.Set).EnumVar(&c.Redundancy.Value, string(fastly.S3RedundancyStandard), string(fastly.S3RedundancyReduced))
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("server-side-encryption", "Set to enable S3 Server Side Encryption. Can be either AES256 or aws:kms").Action(c.ServerSideEncryption.Set).EnumVar(&c.ServerSideEncryption.Value, string(fastly.S3ServerSideEncryptionAES), string(fastly.S3ServerSideEncryptionKMS))
+	c.CmdClause.Flag("server-side-encryption-kms-key-id", "Server-side KMS Key ID. Must be set if server-side-encryption is set to aws:kms").Action(c.ServerSideEncryptionKMSKeyID.Set).StringVar(&c.ServerSideEncryptionKMSKeyID.Value)
 	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateS3Input, error) {
+	var input fastly.CreateS3Input
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = c.EndpointName
+	input.BucketName = c.BucketName
+	input.AccessKey = c.AccessKey
+	input.SecretKey = c.SecretKey
+
+	if c.Domain.Valid {
+		input.Domain = c.Domain.Value
+	}
+
+	if c.Path.Valid {
+		input.Path = c.Path.Value
+	}
+
+	if c.Period.Valid {
+		input.Period = c.Period.Value
+	}
+
+	if c.GzipLevel.Valid {
+		input.GzipLevel = c.GzipLevel.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = c.MessageType.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.TimestampFormat.Valid {
+		input.TimestampFormat = c.TimestampFormat.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	if c.ServerSideEncryptionKMSKeyID.Valid {
+		input.ServerSideEncryptionKMSKeyID = c.ServerSideEncryptionKMSKeyID.Value
+	}
+
+	if c.Redundancy.Valid {
+		switch c.Redundancy.Value {
+		case string(fastly.S3RedundancyStandard):
+			input.Redundancy = fastly.S3RedundancyStandard
+		case string(fastly.S3RedundancyReduced):
+			input.Redundancy = fastly.S3RedundancyReduced
+		}
+	}
+
+	if c.ServerSideEncryption.Valid {
+		switch c.ServerSideEncryption.Value {
+		case string(fastly.S3ServerSideEncryptionAES):
+			input.ServerSideEncryption = fastly.S3ServerSideEncryptionAES
+		case string(fastly.S3ServerSideEncryptionKMS):
+			input.ServerSideEncryption = fastly.S3ServerSideEncryptionKMS
+		}
+	}
+
+	return &input, nil
 }
 
 // Exec invokes the application logic for the command.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	serviceID, source := c.manifest.ServiceID()
-	if source == manifest.SourceUndefined {
-		return errors.ErrNoServiceID
-	}
-	c.Input.Service = serviceID
-
-	switch c.redundancy {
-	case string(fastly.S3RedundancyStandard):
-		c.Input.Redundancy = fastly.S3RedundancyStandard
-	case string(fastly.S3RedundancyReduced):
-		c.Input.Redundancy = fastly.S3RedundancyReduced
+	input, err := c.createInput()
+	if err != nil {
+		return err
 	}
 
-	switch c.serverSideEncryption {
-	case string(fastly.S3ServerSideEncryptionAES):
-		c.Input.ServerSideEncryption = fastly.S3ServerSideEncryptionAES
-	case string(fastly.S3ServerSideEncryptionKMS):
-		c.Input.ServerSideEncryption = fastly.S3ServerSideEncryptionKMS
-	}
-
-	d, err := c.Globals.Client.CreateS3(&c.Input)
+	d, err := c.Globals.Client.CreateS3(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -1,0 +1,453 @@
+package s3_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestS3Create(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			wantError: "error parsing arguments: required flag --secret-key not provided",
+		},
+		{
+			args:       []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
+			api:        mock.API{CreateS3Fn: createS3OK},
+			wantOutput: "Created S3 logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
+			api:       mock.API{CreateS3Fn: createS3Error},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestS3List(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListS3sFn: listS3sOK},
+			wantOutput: listS3sShortOutput,
+		},
+		{
+			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListS3sFn: listS3sOK},
+			wantOutput: listS3sVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListS3sFn: listS3sOK},
+			wantOutput: listS3sVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "s3", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListS3sFn: listS3sOK},
+			wantOutput: listS3sVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "s3", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListS3sFn: listS3sOK},
+			wantOutput: listS3sVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListS3sFn: listS3sError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestS3Describe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetS3Fn: getS3Error},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetS3Fn: getS3OK},
+			wantOutput: describeS3Output,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestS3Update(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetS3Fn:    getS3Error,
+				UpdateS3Fn: updateS3OK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetS3Fn:    getS3OK,
+				UpdateS3Fn: updateS3Error,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetS3Fn:    getS3OK,
+				UpdateS3Fn: updateS3OK,
+			},
+			wantOutput: "Updated S3 logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestS3Delete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteS3Fn: deleteS3Error},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteS3Fn: deleteS3OK},
+			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createS3OK(i *fastly.CreateS3Input) (*fastly.S3, error) {
+	return &fastly.S3{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createS3Error(i *fastly.CreateS3Input) (*fastly.S3, error) {
+	return nil, errTest
+}
+
+func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
+	return []*fastly.S3{
+		&fastly.S3{
+			ServiceID:                    i.Service,
+			Version:                      i.Version,
+			Name:                         "logs",
+			BucketName:                   "my-logs",
+			AccessKey:                    "1234",
+			SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+			Domain:                       "https://s3.us-east-1.amazonaws.com",
+			Path:                         "logs/",
+			Period:                       3600,
+			GzipLevel:                    9,
+			Format:                       `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:                2,
+			MessageType:                  "classic",
+			ResponseCondition:            "Prevent default logging",
+			TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
+			Redundancy:                   "standard",
+			Placement:                    "none",
+			ServerSideEncryption:         "aws:kms",
+			ServerSideEncryptionKMSKeyID: "1234",
+		},
+		&fastly.S3{
+			ServiceID:                    i.Service,
+			Version:                      i.Version,
+			Name:                         "analytics",
+			BucketName:                   "analytics",
+			AccessKey:                    "1234",
+			SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+			Domain:                       "https://s3.us-east-2.amazonaws.com",
+			Path:                         "logs/",
+			Period:                       86400,
+			GzipLevel:                    9,
+			Format:                       `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:                2,
+			MessageType:                  "classic",
+			ResponseCondition:            "Prevent default logging",
+			TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
+			Redundancy:                   "standard",
+			Placement:                    "none",
+			ServerSideEncryption:         "aws:kms",
+			ServerSideEncryptionKMSKeyID: "1234",
+		},
+	}, nil
+}
+
+func listS3sError(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
+	return nil, errTest
+}
+
+var listS3sShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listS3sVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	S3 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Bucket: my-logs
+		Access key: 1234
+		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
+		Path: logs/
+		Period: 3600
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+		Redundancy: standard
+		Server-side encryption: aws:kms
+		Server-side encryption KMS key ID: aws:kms
+	S3 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Bucket: analytics
+		Access key: 1234
+		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
+		Path: logs/
+		Period: 86400
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+		Redundancy: standard
+		Server-side encryption: aws:kms
+		Server-side encryption KMS key ID: aws:kms
+`) + "\n\n"
+
+func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
+	return &fastly.S3{
+		ServiceID:                    i.Service,
+		Version:                      i.Version,
+		Name:                         "logs",
+		BucketName:                   "my-logs",
+		AccessKey:                    "1234",
+		SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+		Domain:                       "https://s3.us-east-1.amazonaws.com",
+		Path:                         "logs/",
+		Period:                       3600,
+		GzipLevel:                    9,
+		Format:                       `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:                2,
+		MessageType:                  "classic",
+		ResponseCondition:            "Prevent default logging",
+		TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
+		Redundancy:                   "standard",
+		Placement:                    "none",
+		ServerSideEncryption:         "aws:kms",
+		ServerSideEncryptionKMSKeyID: "1234",
+	}, nil
+}
+
+func getS3Error(i *fastly.GetS3Input) (*fastly.S3, error) {
+	return nil, errTest
+}
+
+var describeS3Output = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Bucket: my-logs
+Access key: 1234
+Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
+Path: logs/
+Period: 3600
+GZip level: 9
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Message type: classic
+Timestamp format: %Y-%m-%dT%H:%M:%S.000
+Placement: none
+Redundancy: standard
+Server-side encryption: aws:kms
+Server-side encryption KMS key ID: aws:kms
+`) + "\n"
+
+func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
+	return &fastly.S3{
+		ServiceID:                    i.Service,
+		Version:                      i.Version,
+		Name:                         "log",
+		BucketName:                   "my-logs",
+		AccessKey:                    "1234",
+		SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+		Domain:                       "https://s3.us-east-1.amazonaws.com",
+		Path:                         "logs/",
+		Period:                       3600,
+		GzipLevel:                    9,
+		Format:                       `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:                2,
+		MessageType:                  "classic",
+		ResponseCondition:            "Prevent default logging",
+		TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
+		Redundancy:                   "standard",
+		Placement:                    "none",
+		ServerSideEncryption:         "aws:kms",
+		ServerSideEncryptionKMSKeyID: "1234",
+	}, nil
+}
+
+func updateS3Error(i *fastly.UpdateS3Input) (*fastly.S3, error) {
+	return nil, errTest
+}
+
+func deleteS3OK(i *fastly.DeleteS3Input) error {
+	return nil
+}
+
+func deleteS3Error(i *fastly.DeleteS3Input) error {
+	return errTest
+}

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -1,453 +1,274 @@
-package s3_test
+package s3
 
 import (
-	"bytes"
-	"errors"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/cli/pkg/update"
 	"github.com/fastly/go-fastly/fastly"
 )
 
-func TestS3Create(t *testing.T) {
+func TestCreateS3Input(t *testing.T) {
 	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateS3Input
+		wantError string
 	}{
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
-			wantError: "error parsing arguments: required flag --secret-key not provided",
-		},
-		{
-			args:       []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
-			api:        mock.API{CreateS3Fn: createS3OK},
-			wantOutput: "Created S3 logging endpoint log (service 123 version 1)",
-		},
-		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
-			api:       mock.API{CreateS3Fn: createS3Error},
-			wantError: errTest.Error(),
-		},
-	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
-			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
-		})
-	}
-}
-
-func TestS3List(t *testing.T) {
-	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
-	}{
-		{
-			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListS3sFn: listS3sOK},
-			wantOutput: listS3sShortOutput,
-		},
-		{
-			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListS3sFn: listS3sOK},
-			wantOutput: listS3sVerboseOutput,
-		},
-		{
-			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListS3sFn: listS3sOK},
-			wantOutput: listS3sVerboseOutput,
-		},
-		{
-			args:       []string{"logging", "s3", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListS3sFn: listS3sOK},
-			wantOutput: listS3sVerboseOutput,
-		},
-		{
-			args:       []string{"logging", "-v", "s3", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListS3sFn: listS3sOK},
-			wantOutput: listS3sVerboseOutput,
-		},
-		{
-			args:      []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListS3sFn: listS3sError},
-			wantError: errTest.Error(),
-		},
-	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
-			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertString(t, testcase.wantOutput, out.String())
-		})
-	}
-}
-
-func TestS3Describe(t *testing.T) {
-	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
-	}{
-		{
-			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1"},
-			wantError: "error parsing arguments: required flag --name not provided",
-		},
-		{
-			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetS3Fn: getS3Error},
-			wantError: errTest.Error(),
-		},
-		{
-			args:       []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetS3Fn: getS3OK},
-			wantOutput: describeS3Output,
-		},
-	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
-			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertString(t, testcase.wantOutput, out.String())
-		})
-	}
-}
-
-func TestS3Update(t *testing.T) {
-	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
-	}{
-		{
-			args:      []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
-			wantError: "error parsing arguments: required flag --name not provided",
-		},
-		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api: mock.API{
-				GetS3Fn:    getS3Error,
-				UpdateS3Fn: updateS3OK,
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateS3Input{
+				Service:    "123",
+				Version:    2,
+				Name:       "log",
+				BucketName: "bucket",
+				AccessKey:  "access",
+				SecretKey:  "secret",
 			},
-			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api: mock.API{
-				GetS3Fn:    getS3OK,
-				UpdateS3Fn: updateS3Error,
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateS3Input{
+				Service:                      "123",
+				Version:                      2,
+				Name:                         "logs",
+				BucketName:                   "bucket",
+				Domain:                       "domain",
+				AccessKey:                    "access",
+				SecretKey:                    "secret",
+				Path:                         "path",
+				Period:                       3600,
+				GzipLevel:                    2,
+				Format:                       `%h %l %u %t "%r" %>s %b`,
+				MessageType:                  "classic",
+				FormatVersion:                2,
+				ResponseCondition:            "Prevent default logging",
+				TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
+				Redundancy:                   fastly.S3RedundancyStandard,
+				Placement:                    "none",
+				ServerSideEncryptionKMSKeyID: "kmskey",
+				ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
 			},
-			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api: mock.API{
-				GetS3Fn:    getS3OK,
-				UpdateS3Fn: updateS3OK,
-			},
-			wantOutput: "Updated S3 logging endpoint log (service 123 version 1)",
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
 		},
 	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
 			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+			testutil.AssertEqual(t, testcase.want, have)
 		})
 	}
 }
 
-func TestS3Delete(t *testing.T) {
+func TestUpdateS3Input(t *testing.T) {
 	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateS3Input
+		wantError string
 	}{
 		{
-			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1"},
-			wantError: "error parsing arguments: required flag --name not provided",
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetS3Fn: getS3OK},
+			want: &fastly.UpdateS3Input{
+				Service:                      "123",
+				Version:                      2,
+				Name:                         "logs",
+				NewName:                      "logs",
+				BucketName:                   "bucket",
+				AccessKey:                    "access",
+				SecretKey:                    "secret",
+				Domain:                       "domain",
+				Path:                         "path",
+				Period:                       3600,
+				GzipLevel:                    2,
+				Format:                       `%h %l %u %t "%r" %>s %b`,
+				FormatVersion:                2,
+				MessageType:                  "classic",
+				ResponseCondition:            "Prevent default logging",
+				TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
+				Placement:                    "none",
+				Redundancy:                   fastly.S3RedundancyStandard,
+				ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
+				ServerSideEncryptionKMSKeyID: "kmskey",
+			},
 		},
 		{
-			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteS3Fn: deleteS3Error},
-			wantError: errTest.Error(),
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetS3Fn: getS3OK},
+			want: &fastly.UpdateS3Input{
+				Service:                      "123",
+				Version:                      2,
+				Name:                         "logs",
+				NewName:                      "new1",
+				BucketName:                   "new2",
+				AccessKey:                    "new3",
+				SecretKey:                    "new4",
+				Domain:                       "new5",
+				Path:                         "new6",
+				Period:                       3601,
+				GzipLevel:                    3,
+				Format:                       "new7",
+				FormatVersion:                3,
+				MessageType:                  "new8",
+				ResponseCondition:            "new9",
+				TimestampFormat:              "new10",
+				Placement:                    "new11",
+				Redundancy:                   fastly.S3RedundancyReduced,
+				ServerSideEncryption:         fastly.S3ServerSideEncryptionKMS,
+				ServerSideEncryptionKMSKeyID: "new12",
+			},
 		},
 		{
-			args:       []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteS3Fn: deleteS3OK},
-			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 1)",
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
 		},
 	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
 			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+			testutil.AssertEqual(t, testcase.want, have)
 		})
 	}
 }
 
-var errTest = errors.New("fixture error")
-
-func createS3OK(i *fastly.CreateS3Input) (*fastly.S3, error) {
-	return &fastly.S3{
-		ServiceID: i.Service,
-		Version:   i.Version,
-		Name:      i.Name,
-	}, nil
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+		BucketName:   "bucket",
+		AccessKey:    "access",
+		SecretKey:    "secret",
+	}
 }
 
-func createS3Error(i *fastly.CreateS3Input) (*fastly.S3, error) {
-	return nil, errTest
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:                     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:                 "logs",
+		Version:                      2,
+		BucketName:                   "bucket",
+		AccessKey:                    "access",
+		SecretKey:                    "secret",
+		Domain:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "domain"},
+		Path:                         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "path"},
+		Period:                       common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3600},
+		GzipLevel:                    common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		Format:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:                common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		MessageType:                  common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
+		ResponseCondition:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		TimestampFormat:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		Placement:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		Redundancy:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3RedundancyStandard)},
+		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3ServerSideEncryptionAES)},
+		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "kmskey"},
+	}
 }
 
-func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
-	return []*fastly.S3{
-		&fastly.S3{
-			ServiceID:                    i.Service,
-			Version:                      i.Version,
-			Name:                         "logs",
-			BucketName:                   "my-logs",
-			AccessKey:                    "1234",
-			SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
-			Domain:                       "https://s3.us-east-1.amazonaws.com",
-			Path:                         "logs/",
-			Period:                       3600,
-			GzipLevel:                    9,
-			Format:                       `%h %l %u %t "%r" %>s %b`,
-			FormatVersion:                2,
-			MessageType:                  "classic",
-			ResponseCondition:            "Prevent default logging",
-			TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
-			Redundancy:                   "standard",
-			Placement:                    "none",
-			ServerSideEncryption:         "aws:kms",
-			ServerSideEncryptionKMSKeyID: "1234",
-		},
-		&fastly.S3{
-			ServiceID:                    i.Service,
-			Version:                      i.Version,
-			Name:                         "analytics",
-			BucketName:                   "analytics",
-			AccessKey:                    "1234",
-			SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
-			Domain:                       "https://s3.us-east-2.amazonaws.com",
-			Path:                         "logs/",
-			Period:                       86400,
-			GzipLevel:                    9,
-			Format:                       `%h %l %u %t "%r" %>s %b`,
-			FormatVersion:                2,
-			MessageType:                  "classic",
-			ResponseCondition:            "Prevent default logging",
-			TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
-			Redundancy:                   "standard",
-			Placement:                    "none",
-			ServerSideEncryption:         "aws:kms",
-			ServerSideEncryptionKMSKeyID: "1234",
-		},
-	}, nil
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
 }
 
-func listS3sError(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
-	return nil, errTest
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:                         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:                     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:                 "logs",
+		Version:                      2,
+		NewName:                      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "logs"},
+		BucketName:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "bucket"},
+		AccessKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "access"},
+		SecretKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "secret"},
+		Domain:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "domain"},
+		Path:                         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "path"},
+		Period:                       common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3600},
+		GzipLevel:                    common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		Format:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:                common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		MessageType:                  common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
+		ResponseCondition:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		TimestampFormat:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		Placement:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		Redundancy:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3RedundancyStandard)},
+		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3ServerSideEncryptionAES)},
+		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "kmskey"},
+	}
 }
 
-var listS3sShortOutput = strings.TrimSpace(`
-SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
-`) + "\n"
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:                         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:                     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:                 "logs",
+		Version:                      2,
+		NewName:                      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		BucketName:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		AccessKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		SecretKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		Domain:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Path:                         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+		Period:                       common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3601},
+		GzipLevel:                    common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		Format:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new7"},
+		FormatVersion:                common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		MessageType:                  common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new8"},
+		ResponseCondition:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
+		TimestampFormat:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
+		Placement:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new11"},
+		Redundancy:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3RedundancyReduced)},
+		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3ServerSideEncryptionKMS)},
+		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new12"},
+	}
+}
 
-var listS3sVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
-Fastly API endpoint: https://api.fastly.com
-Service ID: 123
-Version: 1
-	S3 1/2
-		Service ID: 123
-		Version: 1
-		Name: logs
-		Bucket: my-logs
-		Access key: 1234
-		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
-		Path: logs/
-		Period: 3600
-		GZip level: 9
-		Format: %h %l %u %t "%r" %>s %b
-		Format version: 2
-		Response condition: Prevent default logging
-		Message type: classic
-		Timestamp format: %Y-%m-%dT%H:%M:%S.000
-		Placement: none
-		Redundancy: standard
-		Server-side encryption: aws:kms
-		Server-side encryption KMS key ID: aws:kms
-	S3 2/2
-		Service ID: 123
-		Version: 1
-		Name: analytics
-		Bucket: analytics
-		Access key: 1234
-		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
-		Path: logs/
-		Period: 86400
-		GZip level: 9
-		Format: %h %l %u %t "%r" %>s %b
-		Format version: 2
-		Response condition: Prevent default logging
-		Message type: classic
-		Timestamp format: %Y-%m-%dT%H:%M:%S.000
-		Placement: none
-		Redundancy: standard
-		Server-side encryption: aws:kms
-		Server-side encryption KMS key ID: aws:kms
-`) + "\n\n"
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
 
 func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 	return &fastly.S3{
 		ServiceID:                    i.Service,
 		Version:                      i.Version,
 		Name:                         "logs",
-		BucketName:                   "my-logs",
-		AccessKey:                    "1234",
-		SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
-		Domain:                       "https://s3.us-east-1.amazonaws.com",
-		Path:                         "logs/",
+		BucketName:                   "bucket",
+		Domain:                       "domain",
+		AccessKey:                    "access",
+		SecretKey:                    "secret",
+		Path:                         "path",
 		Period:                       3600,
-		GzipLevel:                    9,
+		GzipLevel:                    2,
 		Format:                       `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:                2,
-		MessageType:                  "classic",
 		ResponseCondition:            "Prevent default logging",
-		TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
-		Redundancy:                   "standard",
-		Placement:                    "none",
-		ServerSideEncryption:         "aws:kms",
-		ServerSideEncryptionKMSKeyID: "1234",
-	}, nil
-}
-
-func getS3Error(i *fastly.GetS3Input) (*fastly.S3, error) {
-	return nil, errTest
-}
-
-var describeS3Output = strings.TrimSpace(`
-Service ID: 123
-Version: 1
-Name: logs
-Bucket: my-logs
-Access key: 1234
-Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
-Path: logs/
-Period: 3600
-GZip level: 9
-Format: %h %l %u %t "%r" %>s %b
-Format version: 2
-Response condition: Prevent default logging
-Message type: classic
-Timestamp format: %Y-%m-%dT%H:%M:%S.000
-Placement: none
-Redundancy: standard
-Server-side encryption: aws:kms
-Server-side encryption KMS key ID: aws:kms
-`) + "\n"
-
-func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
-	return &fastly.S3{
-		ServiceID:                    i.Service,
-		Version:                      i.Version,
-		Name:                         "log",
-		BucketName:                   "my-logs",
-		AccessKey:                    "1234",
-		SecretKey:                    "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
-		Domain:                       "https://s3.us-east-1.amazonaws.com",
-		Path:                         "logs/",
-		Period:                       3600,
-		GzipLevel:                    9,
-		Format:                       `%h %l %u %t "%r" %>s %b`,
-		FormatVersion:                2,
 		MessageType:                  "classic",
-		ResponseCondition:            "Prevent default logging",
 		TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
-		Redundancy:                   "standard",
 		Placement:                    "none",
-		ServerSideEncryption:         "aws:kms",
-		ServerSideEncryptionKMSKeyID: "1234",
+		Redundancy:                   fastly.S3RedundancyStandard,
+		ServerSideEncryptionKMSKeyID: "kmskey",
+		ServerSideEncryption:         fastly.S3ServerSideEncryptionKMS,
 	}, nil
-}
-
-func updateS3Error(i *fastly.UpdateS3Input) (*fastly.S3, error) {
-	return nil, errTest
-}
-
-func deleteS3OK(i *fastly.DeleteS3Input) error {
-	return nil
-}
-
-func deleteS3Error(i *fastly.DeleteS3Input) error {
-	return errTest
 }


### PR DESCRIPTION
## Proposed Change(s)

* Uses a factory pattern for Creates and Updates.
* Adds test for non-exported API in `_test.go` file.
* Moves exported API test to `_integration_test.go` file.

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-test-s3 && \
    make test && \
    rm -rf /tmp/cli \
)
```