### PR TITLE
Update S3 & BigQuery root docs to be consistent

### DIFF
--- a/pkg/logging/bigquery/root.go
+++ b/pkg/logging/bigquery/root.go
@@ -18,7 +18,7 @@ type RootCommand struct {
 func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
-	c.CmdClause = parent.Command("bigquery", "Manipulate Fastly service version BigQuery logging endpoints.")
+	c.CmdClause = parent.Command("bigquery", "Manipulate Fastly service version BigQuery logging endpoints")
 	return &c
 }
 

--- a/pkg/logging/s3/root.go
+++ b/pkg/logging/s3/root.go
@@ -18,7 +18,7 @@ type RootCommand struct {
 func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
-	c.CmdClause = parent.Command("s3", "Manipulate Fastly service version S3 logging endpoints.")
+	c.CmdClause = parent.Command("s3", "Manipulate Fastly service version S3 logging endpoints")
 	return &c
 }
 


### PR DESCRIPTION
## Proposed Change(s)

Update S3 and BigQuery root command docs to be consistent with all other logging
endpoints and docs in general, by removing trailing '.' (period).

## Validation

```bash
make test
```