### PR TITLE
Update FTP to use new Create/Update pattern

### DIFF
--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -15,7 +15,24 @@ import (
 type CreateCommand struct {
 	common.Base
 	manifest manifest.Data
-	Input    fastly.CreateFTPInput
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	Address      string
+	Username     string
+	Password     string
+
+	// optional
+	Port              common.OptionalUint
+	Path              common.OptionalString
+	Period            common.OptionalUint
+	GzipLevel         common.OptionalUint8
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	TimestampFormat   common.OptionalString
+	Placement         common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -25,35 +42,90 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an FTP logging endpoint on a Fastly service version").Alias("add")
 
-	c.CmdClause.Flag("name", "The name of the FTP logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the FTP logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
 
-	c.CmdClause.Flag("address", "An hostname or IPv4 address").Required().StringVar(&c.Input.Address)
-	c.CmdClause.Flag("user", "The username for the server (can be anonymous)").Required().StringVar(&c.Input.Username)
-	c.CmdClause.Flag("password", "The password for the server (for anonymous use an email address)").Required().StringVar(&c.Input.Password)
+	c.CmdClause.Flag("address", "An hostname or IPv4 address").Required().StringVar(&c.Address)
+	c.CmdClause.Flag("user", "The username for the server (can be anonymous)").Required().StringVar(&c.Username)
+	c.CmdClause.Flag("password", "The password for the server (for anonymous use an email address)").Required().StringVar(&c.Password)
 
-	c.CmdClause.Flag("port", "The port number").UintVar(&c.Input.Port)
-	c.CmdClause.Flag("path", "The path to upload log files to. If the path ends in / then it is treated as a directory").StringVar(&c.Input.Path)
-	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").UintVar(&c.Input.Period)
-	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Uint8Var(&c.Input.GzipLevel)
-	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
-	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").UintVar(&c.Input.FormatVersion)
-	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
-	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).StringVar(&c.Input.TimestampFormat)
-	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").StringVar(&c.Input.Placement)
+	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
+	c.CmdClause.Flag("path", "The path to upload log files to. If the path ends in / then it is treated as a directory").Action(c.Path.Set).StringVar(&c.Path.Value)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).Uint8Var(&c.GzipLevel.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 
 	return &c
 }
 
-// Exec invokes the application logic for the command.
-func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateFTPInput, error) {
+	var input fastly.CreateFTPInput
+
 	serviceID, source := c.manifest.ServiceID()
 	if source == manifest.SourceUndefined {
-		return errors.ErrNoServiceID
+		return nil, errors.ErrNoServiceID
 	}
-	c.Input.Service = serviceID
-	d, err := c.Globals.Client.CreateFTP(&c.Input)
+
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = c.EndpointName
+	input.Address = c.Address
+	input.Username = c.Username
+	input.Password = c.Password
+
+	if c.Port.Valid {
+		input.Port = c.Port.Value
+	}
+
+	if c.Path.Valid {
+		input.Path = c.Path.Value
+	}
+
+	if c.Period.Valid {
+		input.Period = c.Period.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.GzipLevel.Valid {
+		input.GzipLevel = c.GzipLevel.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.TimestampFormat.Valid {
+		input.TimestampFormat = c.TimestampFormat.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateFTP(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -1,0 +1,477 @@
+package ftp_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestFTPCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
+			wantError: "error parsing arguments: required flag --address not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
+			wantError: "error parsing arguments: required flag --user not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
+			wantError: "error parsing arguments: required flag --password not provided",
+		},
+		{
+			args:       []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
+			api:        mock.API{CreateFTPFn: createFTPOK},
+			wantOutput: "Created FTP logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
+			api:       mock.API{CreateFTPFn: createFTPError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestFTPList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsShortOutput,
+		},
+		{
+			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListFTPsFn: listFTPsOK},
+			wantOutput: listFTPsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListFTPsFn: listFTPsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestFTPDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetFTPFn: getFTPError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetFTPFn: getFTPOK},
+			wantOutput: describeFTPOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestFTPUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetFTPFn:    getFTPError,
+				UpdateFTPFn: updateFTPOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetFTPFn:    getFTPOK,
+				UpdateFTPFn: updateFTPError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetFTPFn:    getFTPOK,
+				UpdateFTPFn: updateFTPOK,
+			},
+			wantOutput: "Updated FTP logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestFTPDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteFTPFn: deleteFTPError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteFTPFn: deleteFTPOK},
+			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createFTPOK(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
+	return &fastly.FTP{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createFTPError(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
+	return nil, errTest
+}
+
+func listFTPsOK(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+	return []*fastly.FTP{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Address:           "example.com",
+			Port:              123,
+			Username:          "anonymous",
+			Password:          "foo@example.com",
+			PublicKey:         pgpPublicKey(),
+			Path:              "logs/",
+			Period:            3600,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Address:           "127.0.0.1",
+			Port:              456,
+			Username:          "foo",
+			Password:          "password",
+			PublicKey:         pgpPublicKey(),
+			Path:              "logs/",
+			Period:            86400,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listFTPsError(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+	return nil, errTest
+}
+
+var listFTPsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listFTPsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	FTP 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Address: example.com
+		Port: 123
+		Username: anonymous
+		Password: foo@example.com
+		Public key: `+pgpPublicKey()+`
+		Path: logs/
+		Period: 3600
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+	FTP 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Address: 127.0.0.1
+		Port: 456
+		Username: foo
+		Password: password
+		Public key: `+pgpPublicKey()+`
+		Path: logs/
+		Period: 86400
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+`) + "\n\n"
+
+func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
+	return &fastly.FTP{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Address:           "example.com",
+		Port:              123,
+		Username:          "anonymous",
+		Password:          "foo@example.com",
+		PublicKey:         pgpPublicKey(),
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func getFTPError(i *fastly.GetFTPInput) (*fastly.FTP, error) {
+	return nil, errTest
+}
+
+var describeFTPOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Address: example.com
+Port: 123
+Username: anonymous
+Password: foo@example.com
+Public key: `+pgpPublicKey()+`
+Path: logs/
+Period: 3600
+GZip level: 9
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Timestamp format: %Y-%m-%dT%H:%M:%S.000
+Placement: none
+`) + "\n"
+
+func updateFTPOK(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+	return &fastly.FTP{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Address:           "example.com",
+		Port:              123,
+		Username:          "anonymous",
+		Password:          "foo@example.com",
+		PublicKey:         pgpPublicKey(),
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func updateFTPError(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+	return nil, errTest
+}
+
+func deleteFTPOK(i *fastly.DeleteFTPInput) error {
+	return nil
+}
+
+func deleteFTPError(i *fastly.DeleteFTPInput) error {
+	return errTest
+}
+
+// pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
+func pgpPublicKey() string {
+	return strings.TrimSpace(`-----BEGIN PGP PUBLIC KEY BLOCK-----
+mQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/
+ibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4
+8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p
+lDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn
+dwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB
+89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz
+dCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6
+vFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc
+9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9
+OLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX
+SvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq
+7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx
+kATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG
+M1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe
+u6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L
+4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF
+ftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K
+UEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu
+YrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi
+kiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb
+DAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml
+dYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L
+3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c
+FaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR
+5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR
+wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
+=28dr
+-----END PGP PUBLIC KEY BLOCK-----
+`)
+}

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -1,369 +1,216 @@
-package ftp_test
+package ftp
 
 import (
-	"bytes"
-	"errors"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/cli/pkg/update"
 	"github.com/fastly/go-fastly/fastly"
 )
 
-func TestFTPCreate(t *testing.T) {
+func TestCreateFTPInput(t *testing.T) {
 	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateFTPInput
+		wantError string
 	}{
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
-			wantError: "error parsing arguments: required flag --address not provided",
-		},
-		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
-			wantError: "error parsing arguments: required flag --user not provided",
-		},
-		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
-			wantError: "error parsing arguments: required flag --password not provided",
-		},
-		{
-			args:       []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
-			api:        mock.API{CreateFTPFn: createFTPOK},
-			wantOutput: "Created FTP logging endpoint log (service 123 version 1)",
-		},
-		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
-			api:       mock.API{CreateFTPFn: createFTPError},
-			wantError: errTest.Error(),
-		},
-	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
-			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
-		})
-	}
-}
-
-func TestFTPList(t *testing.T) {
-	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
-	}{
-		{
-			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
-			wantOutput: listFTPsShortOutput,
-		},
-		{
-			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
-			wantOutput: listFTPsVerboseOutput,
-		},
-		{
-			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
-			wantOutput: listFTPsVerboseOutput,
-		},
-		{
-			args:       []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
-			wantOutput: listFTPsVerboseOutput,
-		},
-		{
-			args:       []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
-			wantOutput: listFTPsVerboseOutput,
-		},
-		{
-			args:      []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListFTPsFn: listFTPsError},
-			wantError: errTest.Error(),
-		},
-	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
-			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertString(t, testcase.wantOutput, out.String())
-		})
-	}
-}
-
-func TestFTPDescribe(t *testing.T) {
-	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
-	}{
-		{
-			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1"},
-			wantError: "error parsing arguments: required flag --name not provided",
-		},
-		{
-			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetFTPFn: getFTPError},
-			wantError: errTest.Error(),
-		},
-		{
-			args:       []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetFTPFn: getFTPOK},
-			wantOutput: describeFTPOutput,
-		},
-	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
-			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertString(t, testcase.wantOutput, out.String())
-		})
-	}
-}
-
-func TestFTPUpdate(t *testing.T) {
-	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
-	}{
-		{
-			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
-			wantError: "error parsing arguments: required flag --name not provided",
-		},
-		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api: mock.API{
-				GetFTPFn:    getFTPError,
-				UpdateFTPFn: updateFTPOK,
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateFTPInput{
+				Service:  "123",
+				Version:  2,
+				Name:     "log",
+				Address:  "example.com",
+				Username: "user",
+				Password: "password",
 			},
-			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api: mock.API{
-				GetFTPFn:    getFTPOK,
-				UpdateFTPFn: updateFTPError,
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateFTPInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "log",
+				Address:           "example.com",
+				Port:              22,
+				Username:          "user",
+				Password:          "password",
+				Path:              "/logs",
+				Period:            3600,
+				FormatVersion:     2,
+				GzipLevel:         2,
+				Format:            `%h %l %u %t "%r" %>s %b`,
+				ResponseCondition: "Prevent default logging",
+				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+				Placement:         "none",
 			},
-			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api: mock.API{
-				GetFTPFn:    getFTPOK,
-				UpdateFTPFn: updateFTPOK,
-			},
-			wantOutput: "Updated FTP logging endpoint log (service 123 version 1)",
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
 		},
 	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
 			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+			testutil.AssertEqual(t, testcase.want, have)
 		})
 	}
 }
 
-func TestFTPDelete(t *testing.T) {
+func TestUpdateFTPInput(t *testing.T) {
 	for _, testcase := range []struct {
-		args       []string
-		api        mock.API
-		wantError  string
-		wantOutput string
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateFTPInput
+		wantError string
 	}{
 		{
-			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1"},
-			wantError: "error parsing arguments: required flag --name not provided",
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetFTPFn: getFTPOK},
+			want: &fastly.UpdateFTPInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           "logs",
+				Address:           "example.com",
+				Port:              22,
+				Username:          "user",
+				Password:          "password",
+				Path:              "/logs",
+				Period:            3600,
+				FormatVersion:     2,
+				GzipLevel:         2,
+				Format:            `%h %l %u %t "%r" %>s %b`,
+				ResponseCondition: "Prevent default logging",
+				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+				Placement:         "none",
+			},
 		},
 		{
-			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteFTPFn: deleteFTPError},
-			wantError: errTest.Error(),
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetFTPFn: getFTPOK},
+			want: &fastly.UpdateFTPInput{
+				Service:           "123",
+				Version:           2,
+				Name:              "logs",
+				NewName:           "new1",
+				Address:           "new2",
+				Port:              23,
+				Username:          "new3",
+				Password:          "new4",
+				Path:              "new5",
+				Period:            3601,
+				FormatVersion:     3,
+				GzipLevel:         3,
+				Format:            "new6",
+				ResponseCondition: "new7",
+				TimestampFormat:   "new8",
+				Placement:         "new9",
+			},
 		},
 		{
-			args:       []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteFTPFn: deleteFTPOK},
-			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 1)",
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
 		},
 	} {
-		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
-			var (
-				args                           = testcase.args
-				env                            = config.Environment{}
-				file                           = config.File{}
-				appConfigFile                  = "/dev/null"
-				clientFactory                  = mock.APIClient(testcase.api)
-				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
-				in            io.Reader        = nil
-				out           bytes.Buffer
-			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
 			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+			testutil.AssertEqual(t, testcase.want, have)
 		})
 	}
 }
 
-var errTest = errors.New("fixture error")
-
-func createFTPOK(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
-	return &fastly.FTP{
-		ServiceID: i.Service,
-		Version:   i.Version,
-		Name:      i.Name,
-	}, nil
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Address:      "example.com",
+		Username:     "user",
+		Password:     "password",
+		Version:      2,
+	}
 }
 
-func createFTPError(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
-	return nil, errTest
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		Address:           "example.com",
+		Username:          "user",
+		Password:          "password",
+		Port:              common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 22},
+		Path:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "/logs"},
+		Period:            common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3600},
+		GzipLevel:         common.OptionalUint8{Optional: common.Optional{Valid: true}, Value: 2},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+	}
 }
 
-func listFTPsOK(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
-	return []*fastly.FTP{
-		{
-			ServiceID:         i.Service,
-			Version:           i.Version,
-			Name:              "logs",
-			Address:           "example.com",
-			Port:              123,
-			Username:          "anonymous",
-			Password:          "foo@example.com",
-			PublicKey:         pgpPublicKey(),
-			Path:              "logs/",
-			Period:            3600,
-			GzipLevel:         9,
-			Format:            `%h %l %u %t "%r" %>s %b`,
-			FormatVersion:     2,
-			ResponseCondition: "Prevent default logging",
-			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-			Placement:         "none",
-		},
-		{
-			ServiceID:         i.Service,
-			Version:           i.Version,
-			Name:              "analytics",
-			Address:           "127.0.0.1",
-			Port:              456,
-			Username:          "foo",
-			Password:          "password",
-			PublicKey:         pgpPublicKey(),
-			Path:              "logs/",
-			Period:            86400,
-			GzipLevel:         9,
-			Format:            `%h %l %u %t "%r" %>s %b`,
-			FormatVersion:     2,
-			ResponseCondition: "Prevent default logging",
-			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-			Placement:         "none",
-		},
-	}, nil
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
 }
 
-func listFTPsError(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
-	return nil, errTest
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+	}
 }
 
-var listFTPsShortOutput = strings.TrimSpace(`
-SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
-`) + "\n"
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "log",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new1"},
+		Address:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new2"},
+		Port:              common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 23},
+		Username:          common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new3"},
+		Password:          common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
+		Path:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Period:            common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3601},
+		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
+		GzipLevel:         common.OptionalUint8{Optional: common.Optional{Valid: true}, Value: 3},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new7"},
+		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new8"},
+		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
+	}
+}
 
-var listFTPsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
-Fastly API endpoint: https://api.fastly.com
-Service ID: 123
-Version: 1
-	FTP 1/2
-		Service ID: 123
-		Version: 1
-		Name: logs
-		Address: example.com
-		Port: 123
-		Username: anonymous
-		Password: foo@example.com
-		Public key: `+pgpPublicKey()+`
-		Path: logs/
-		Period: 3600
-		GZip level: 9
-		Format: %h %l %u %t "%r" %>s %b
-		Format version: 2
-		Response condition: Prevent default logging
-		Timestamp format: %Y-%m-%dT%H:%M:%S.000
-		Placement: none
-	FTP 2/2
-		Service ID: 123
-		Version: 1
-		Name: analytics
-		Address: 127.0.0.1
-		Port: 456
-		Username: foo
-		Password: password
-		Public key: `+pgpPublicKey()+`
-		Path: logs/
-		Period: 86400
-		GZip level: 9
-		Format: %h %l %u %t "%r" %>s %b
-		Format version: 2
-		Response condition: Prevent default logging
-		Timestamp format: %Y-%m-%dT%H:%M:%S.000
-		Placement: none
-`) + "\n\n"
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
 
 func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
 	return &fastly.FTP{
@@ -371,107 +218,16 @@ func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
 		Version:           i.Version,
 		Name:              "logs",
 		Address:           "example.com",
-		Port:              123,
-		Username:          "anonymous",
-		Password:          "foo@example.com",
-		PublicKey:         pgpPublicKey(),
-		Path:              "logs/",
+		Port:              22,
+		Username:          "user",
+		Password:          "password",
+		Path:              "/logs",
 		Period:            3600,
-		GzipLevel:         9,
+		GzipLevel:         2,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
 	}, nil
-}
-
-func getFTPError(i *fastly.GetFTPInput) (*fastly.FTP, error) {
-	return nil, errTest
-}
-
-var describeFTPOutput = strings.TrimSpace(`
-Service ID: 123
-Version: 1
-Name: logs
-Address: example.com
-Port: 123
-Username: anonymous
-Password: foo@example.com
-Public key: `+pgpPublicKey()+`
-Path: logs/
-Period: 3600
-GZip level: 9
-Format: %h %l %u %t "%r" %>s %b
-Format version: 2
-Response condition: Prevent default logging
-Timestamp format: %Y-%m-%dT%H:%M:%S.000
-Placement: none
-`) + "\n"
-
-func updateFTPOK(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
-	return &fastly.FTP{
-		ServiceID:         i.Service,
-		Version:           i.Version,
-		Name:              "log",
-		Address:           "example.com",
-		Port:              123,
-		Username:          "anonymous",
-		Password:          "foo@example.com",
-		PublicKey:         pgpPublicKey(),
-		Path:              "logs/",
-		Period:            3600,
-		GzipLevel:         9,
-		Format:            `%h %l %u %t "%r" %>s %b`,
-		FormatVersion:     2,
-		ResponseCondition: "Prevent default logging",
-		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		Placement:         "none",
-	}, nil
-}
-
-func updateFTPError(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
-	return nil, errTest
-}
-
-func deleteFTPOK(i *fastly.DeleteFTPInput) error {
-	return nil
-}
-
-func deleteFTPError(i *fastly.DeleteFTPInput) error {
-	return errTest
-}
-
-// pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
-func pgpPublicKey() string {
-	return strings.TrimSpace(`-----BEGIN PGP PUBLIC KEY BLOCK-----
-mQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/
-ibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4
-8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p
-lDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn
-dwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB
-89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz
-dCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6
-vFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc
-9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9
-OLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX
-SvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq
-7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx
-kATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG
-M1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe
-u6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L
-4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF
-ftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K
-UEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu
-YrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi
-kiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb
-DAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml
-dYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L
-3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c
-FaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR
-5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR
-wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
-=28dr
------END PGP PUBLIC KEY BLOCK-----
-`)
 }

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -16,10 +16,12 @@ type UpdateCommand struct {
 	common.Base
 	manifest manifest.Data
 
-	Input fastly.GetFTPInput
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
 
-	NewName common.OptionalString
-
+	// optional
+	NewName           common.OptionalString
 	Address           common.OptionalString
 	Port              common.OptionalUint
 	Username          common.OptionalString
@@ -44,8 +46,8 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause = parent.Command("update", "Update an FTP logging endpoint on a Fastly service version")
 
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.EndpointName)
 
 	c.CmdClause.Flag("new-name", "New name of the FTP logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "An hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
@@ -65,29 +67,32 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	return &c
 }
 
-// Exec invokes the application logic for the command.
-func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateFTPInput, error) {
 	serviceID, source := c.manifest.ServiceID()
 	if source == manifest.SourceUndefined {
-		return errors.ErrNoServiceID
+		return nil, errors.ErrNoServiceID
 	}
-	c.Input.Service = serviceID
 
-	ftp, err := c.Globals.Client.GetFTP(&c.Input)
+	ftp, err := c.Globals.Client.GetFTP(&fastly.GetFTPInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	input := &fastly.UpdateFTPInput{
+	input := fastly.UpdateFTPInput{
 		Service:           ftp.ServiceID,
 		Version:           ftp.Version,
 		Name:              ftp.Name,
 		NewName:           ftp.Name,
 		Address:           ftp.Address,
 		Port:              ftp.Port,
+		PublicKey:         ftp.PublicKey,
 		Username:          ftp.Username,
 		Password:          ftp.Password,
-		PublicKey:         ftp.PublicKey,
 		Path:              ftp.Path,
 		Period:            ftp.Period,
 		FormatVersion:     ftp.FormatVersion,
@@ -155,7 +160,17 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		input.Placement = c.Placement.Value
 	}
 
-	ftp, err = c.Globals.Client.UpdateFTP(input)
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	ftp, err := c.Globals.Client.UpdateFTP(input)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed Change(s)

* Uses a factory pattern for Creates and Updates.
* Adds test for non-exported API in `_test.go` file.
* Moves exported API test to `_integration_test.go` file.

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-test-ftp && \
    make test && \
    rm -rf /tmp/cli \
)
```