### PR TITLE
Update Sumologic to use new Create/Update pattern

### DIFF
--- a/pkg/logging/sumologic/create.go
+++ b/pkg/logging/sumologic/create.go
@@ -15,7 +15,18 @@ import (
 type CreateCommand struct {
 	common.Base
 	manifest manifest.Data
-	Input    fastly.CreateSumologicInput
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	URL          string
+
+	// optional
+	Format            common.OptionalString
+	FormatVersion     common.OptionalInt
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+	MessageType       common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -25,29 +36,66 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Sumologic logging endpoint on a Fastly service version").Alias("add")
 
-	c.CmdClause.Flag("name", "The name of the Sumologic logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the Sumologic logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
 
-	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.Input.URL)
-	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
-	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").IntVar(&c.Input.FormatVersion)
-	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
-	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").StringVar(&c.Input.MessageType)
-	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").StringVar(&c.Input.Placement)
+	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.URL)
+
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).IntVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 
 	return &c
 }
 
-// Exec invokes the application logic for the command.
-func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateSumologicInput, error) {
+	var input fastly.CreateSumologicInput
+
 	serviceID, source := c.manifest.ServiceID()
 	if source == manifest.SourceUndefined {
-		return errors.ErrNoServiceID
+		return nil, errors.ErrNoServiceID
 	}
-	c.Input.Service = serviceID
 
-	d, err := c.Globals.Client.CreateSumologic(&c.Input)
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = c.EndpointName
+	input.URL = c.URL
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = c.MessageType.Value
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateSumologic(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/logging/sumologic/sumologic_integration_test.go
@@ -1,0 +1,386 @@
+package sumologic_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestSumologicCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			wantError: "error parsing arguments: required flag --url not provided",
+		},
+		{
+			args:       []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:        mock.API{CreateSumologicFn: createSumologicOK},
+			wantOutput: "Created Sumologic logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api:       mock.API{CreateSumologicFn: createSumologicError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSumologicList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsShortOutput,
+		},
+		{
+			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "sumologic", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "sumologic", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			wantOutput: listSumologicsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListSumologicsFn: listSumologicsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSumologicDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetSumologicFn: getSumologicError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetSumologicFn: getSumologicOK},
+			wantOutput: describeSumologicOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestSumologicUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSumologicFn:    getSumologicError,
+				UpdateSumologicFn: updateSumologicOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSumologicFn:    getSumologicOK,
+				UpdateSumologicFn: updateSumologicError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetSumologicFn:    getSumologicOK,
+				UpdateSumologicFn: updateSumologicOK,
+			},
+			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestSumologicDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteSumologicFn: deleteSumologicError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteSumologicFn: deleteSumologicOK},
+			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createSumologicOK(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+	return &fastly.Sumologic{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createSumologicError(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+func listSumologicsOK(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+	return []*fastly.Sumologic{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			URL:               "example.com",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			URL:               "bar.com",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			ResponseCondition: "Prevent default logging",
+			MessageType:       "classic",
+			FormatVersion:     2,
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listSumologicsError(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+var listSumologicsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listSumologicsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Sumologic 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		URL: example.com
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Placement: none
+	Sumologic 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		URL: bar.com
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Placement: none
+`) + "\n\n"
+
+func getSumologicOK(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+	return &fastly.Sumologic{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		URL:               "example.com",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getSumologicError(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+var describeSumologicOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+URL: example.com
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Message type: classic
+Placement: none
+`) + "\n"
+
+func updateSumologicOK(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+	return &fastly.Sumologic{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		URL:               "example.com",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateSumologicError(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+	return nil, errTest
+}
+
+func deleteSumologicOK(i *fastly.DeleteSumologicInput) error {
+	return nil
+}
+
+func deleteSumologicError(i *fastly.DeleteSumologicInput) error {
+	return errTest
+}

--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -16,10 +16,12 @@ type UpdateCommand struct {
 	common.Base
 	manifest manifest.Data
 
-	Input fastly.GetSumologicInput
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
 
-	NewName common.OptionalString
-
+	// optional
+	NewName           common.OptionalString
 	Address           common.OptionalString
 	URL               common.OptionalString
 	Format            common.OptionalString
@@ -38,8 +40,8 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause = parent.Command("update", "Update a Sumologic logging endpoint on a Fastly service version")
 
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
-	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.EndpointName)
 
 	c.CmdClause.Flag("new-name", "New name of the Sumologic logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("url", "The URL to POST to").Action(c.URL.Set).StringVar(&c.URL.Value)
@@ -52,20 +54,23 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	return &c
 }
 
-// Exec invokes the application logic for the command.
-func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateSumologicInput, error) {
 	serviceID, source := c.manifest.ServiceID()
 	if source == manifest.SourceUndefined {
-		return errors.ErrNoServiceID
+		return nil, errors.ErrNoServiceID
 	}
-	c.Input.Service = serviceID
 
-	sumologic, err := c.Globals.Client.GetSumologic(&c.Input)
+	sumologic, err := c.Globals.Client.GetSumologic(&fastly.GetSumologicInput{
+		Service: serviceID,
+		Name:    c.EndpointName,
+		Version: c.Version,
+	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	input := &fastly.UpdateSumologicInput{
+	input := fastly.UpdateSumologicInput{
 		Service:           sumologic.ServiceID,
 		Version:           sumologic.Version,
 		Name:              sumologic.Name,
@@ -112,7 +117,16 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		input.Placement = c.Placement.Value
 	}
 
-	sumologic, err = c.Globals.Client.UpdateSumologic(input)
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+	sumologic, err := c.Globals.Client.UpdateSumologic(input)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed Change(s)

* Uses a factory pattern for Creates and Updates.
* Adds test for non-exported API in `_test.go` file.
* Moves exported API test to `_integration_test.go` file.

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-test-sumologic && \
    make test && \
    rm -rf /tmp/cli \
)
```