### PR TITLE
Updates Sumologic to remove extraneous Address field

### DIFF
--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -22,7 +22,6 @@ type UpdateCommand struct {
 
 	// optional
 	NewName           common.OptionalString
-	Address           common.OptionalString
 	URL               common.OptionalString
 	Format            common.OptionalString
 	ResponseCondition common.OptionalString
@@ -75,7 +74,6 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSumologicInput, error) {
 		Version:           sumologic.Version,
 		Name:              sumologic.Name,
 		NewName:           sumologic.Name,
-		Address:           sumologic.Address,
 		URL:               sumologic.URL,
 		Format:            sumologic.Format,
 		ResponseCondition: sumologic.ResponseCondition,
@@ -87,10 +85,6 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSumologicInput, error) {
 	// Set new values if set by user.
 	if c.NewName.Valid {
 		input.NewName = c.NewName.Value
-	}
-
-	if c.Address.Valid {
-		input.Address = c.Address.Value
 	}
 
 	if c.URL.Valid {


### PR DESCRIPTION
I noted [here](https://github.com/fastly/cli/pull/103#discussion_r433282335) that this field is extraneous and is not exposed by the Fastly API ([docs](https://developer.fastly.com/reference/api/logging/sumologic/)), but is however exposed by the [fastly/go-fastly client library](https://github.com/fastly/go-fastly/blob/8c5f5b72363930ec9ba4de2ae53a5f7751a8b68a/fastly/sumologic.go#L16).

I validated that the API code does not expose this field.