### PR TITLE
Update GCS to use new Create/Update pattern

### DIFF
--- a/pkg/logging/gcs/create.go
+++ b/pkg/logging/gcs/create.go
@@ -15,7 +15,24 @@ import (
 type CreateCommand struct {
 	common.Base
 	manifest manifest.Data
-	Input    fastly.CreateGCSInput
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	Bucket       string
+	User         string
+	SecretKey    string
+
+	// optional
+	Path              common.OptionalString
+	Period            common.OptionalUint
+	GzipLevel         common.OptionalUint8
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	MessageType       common.OptionalString
+	ResponseCondition common.OptionalString
+	TimestampFormat   common.OptionalString
+	Placement         common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -25,36 +42,90 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a GCS logging endpoint on a Fastly service version").Alias("add")
 
-	c.CmdClause.Flag("name", "The name of the GCS logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "The name of the GCS logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.Version)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
 
-	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Required().StringVar(&c.Input.User)
-	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Required().StringVar(&c.Input.Bucket)
-	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Required().StringVar(&c.Input.SecretKey)
+	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Required().StringVar(&c.User)
+	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Required().StringVar(&c.Bucket)
+	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Required().StringVar(&c.SecretKey)
 
-	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").UintVar(&c.Input.Period)
-	c.CmdClause.Flag("path", "The path to upload logs to (default '/')").StringVar(&c.Input.Path)
-	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Uint8Var(&c.Input.GzipLevel)
-	c.CmdClause.Flag("format", "Apache style log formatting").StringVar(&c.Input.Format)
-	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").UintVar(&c.Input.FormatVersion)
-	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").StringVar(&c.Input.MessageType)
-	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").StringVar(&c.Input.ResponseCondition)
-	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).StringVar(&c.Input.TimestampFormat)
-	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").StringVar(&c.Input.Placement)
+	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
+	c.CmdClause.Flag("path", "The path to upload logs to (default '/')").Action(c.Path.Set).StringVar(&c.Path.Value)
+	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).Uint8Var(&c.GzipLevel.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 
 	return &c
 }
 
-// Exec invokes the application logic for the command.
-func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateGCSInput, error) {
+	var input fastly.CreateGCSInput
+
 	serviceID, source := c.manifest.ServiceID()
 	if source == manifest.SourceUndefined {
-		return errors.ErrNoServiceID
+		return nil, errors.ErrNoServiceID
 	}
-	c.Input.Service = serviceID
 
-	d, err := c.Globals.Client.CreateGCS(&c.Input)
+	input.Service = serviceID
+	input.Version = c.Version
+	input.Name = c.EndpointName
+	input.Bucket = c.Bucket
+	input.User = c.User
+	input.SecretKey = c.SecretKey
+
+	if c.Path.Valid {
+		input.Path = c.Path.Value
+	}
+
+	if c.Period.Valid {
+		input.Period = c.Period.Value
+	}
+
+	if c.Format.Valid {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.Valid {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.GzipLevel.Valid {
+		input.GzipLevel = c.GzipLevel.Value
+	}
+
+	if c.ResponseCondition.Valid {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.TimestampFormat.Valid {
+		input.TimestampFormat = c.TimestampFormat.Value
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = c.MessageType.Value
+	}
+
+	if c.Placement.Valid {
+		input.Placement = c.Placement.Value
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateGCS(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -1,0 +1,436 @@
+package gcs_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+func TestGCSCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
+			wantError: "error parsing arguments: required flag --bucket not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
+			wantError: "error parsing arguments: required flag --user not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
+			wantError: "error parsing arguments: required flag --secret-key not provided",
+		},
+		{
+			args:       []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			api:        mock.API{CreateGCSFn: createGCSOK},
+			wantOutput: "Created GCS logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			api:       mock.API{CreateGCSFn: createGCSError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestGCSList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsShortOutput,
+		},
+		{
+			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "gcs", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "gcs", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListGCSsFn: listGCSsOK},
+			wantOutput: listGCSsVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListGCSsFn: listGCSsError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestGCSDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetGCSFn: getGCSError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetGCSFn: getGCSOK},
+			wantOutput: describeGCSOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestGCSUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetGCSFn:    getGCSError,
+				UpdateGCSFn: updateGCSOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetGCSFn:    getGCSOK,
+				UpdateGCSFn: updateGCSError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetGCSFn:    getGCSOK,
+				UpdateGCSFn: updateGCSOK,
+			},
+			wantOutput: "Updated GCS logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestGCSDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteGCSFn: deleteGCSError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteGCSFn: deleteGCSOK},
+			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createGCSOK(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
+	return &fastly.GCS{
+		ServiceID: i.Service,
+		Version:   i.Version,
+		Name:      i.Name,
+	}, nil
+}
+
+func createGCSError(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
+	return nil, errTest
+}
+
+func listGCSsOK(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+	return []*fastly.GCS{
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "logs",
+			Bucket:            "my-logs",
+			User:              "foo@example.com",
+			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+			Path:              "logs/",
+			Period:            3600,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.Service,
+			Version:           i.Version,
+			Name:              "analytics",
+			Bucket:            "analytics",
+			User:              "foo@example.com",
+			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+			Path:              "logs/",
+			Period:            86400,
+			GzipLevel:         9,
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			MessageType:       "classic",
+			ResponseCondition: "Prevent default logging",
+			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listGCSsError(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+	return nil, errTest
+}
+
+var listGCSsShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listGCSsVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	GCS 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Bucket: my-logs
+		User: foo@example.com
+		Secret key: -----BEGIN RSA PRIVATE KEY-----foo
+		Path: logs/
+		Period: 3600
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+	GCS 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Bucket: analytics
+		User: foo@example.com
+		Secret key: -----BEGIN RSA PRIVATE KEY-----foo
+		Path: logs/
+		Period: 86400
+		GZip level: 9
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Message type: classic
+		Timestamp format: %Y-%m-%dT%H:%M:%S.000
+		Placement: none
+`) + "\n\n"
+
+func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
+	return &fastly.GCS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "logs",
+		Bucket:            "my-logs",
+		User:              "foo@example.com",
+		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		MessageType:       "classic",
+		ResponseCondition: "Prevent default logging",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func getGCSError(i *fastly.GetGCSInput) (*fastly.GCS, error) {
+	return nil, errTest
+}
+
+var describeGCSOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Bucket: my-logs
+User: foo@example.com
+Secret key: -----BEGIN RSA PRIVATE KEY-----foo
+Path: logs/
+Period: 3600
+GZip level: 9
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Message type: classic
+Timestamp format: %Y-%m-%dT%H:%M:%S.000
+Placement: none
+`) + "\n"
+
+func updateGCSOK(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+	return &fastly.GCS{
+		ServiceID:         i.Service,
+		Version:           i.Version,
+		Name:              "log",
+		Bucket:            "logs",
+		User:              "foo@example.com",
+		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
+		Path:              "logs/",
+		Period:            3600,
+		GzipLevel:         9,
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		MessageType:       "classic",
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		Placement:         "none",
+	}, nil
+}
+
+func updateGCSError(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+	return nil, errTest
+}
+
+func deleteGCSOK(i *fastly.DeleteGCSInput) error {
+	return nil
+}
+
+func deleteGCSError(i *fastly.DeleteGCSInput) error {
+	return errTest
+}

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -33,6 +33,8 @@ type UpdateCommand struct {
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
+
+	// TODO (@mccurdyc): Add supported MessageType field once exposed for Updates (already exists for Creates).
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.


### PR DESCRIPTION
## Proposed Change(s)

* Uses a factory pattern for Creates and Updates.
* Adds test for non-exported API in `_test.go` file.
* Moves exported API test to `_integration_test.go` file.

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-test-gcs && \
    make test && \
    rm -rf /tmp/cli \
)
```