### PR TITLE
Fixes copy-paste error in Loggly tests

### DIFF
--- a/pkg/logging/loggly/loggly_test.go
+++ b/pkg/logging/loggly/loggly_test.go
@@ -58,7 +58,7 @@ func TestCreateLogglyInput(t *testing.T) {
 	}
 }
 
-func TestUpdateSFTPInput(t *testing.T) {
+func TestUpdateLogglyInput(t *testing.T) {
 	for _, testcase := range []struct {
 		name      string
 		cmd       *UpdateCommand


### PR DESCRIPTION
## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-loggly-fix-copy-paste && \
    make test && \
    rm -rf /tmp/cli \
)
```