### PR TITLE
Adds MessageType field to GCS Updates

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1187,6 +1187,9 @@ COMMANDS
         --timestamp-format=TIMESTAMP-FORMAT
                                  strftime specified timestamp formatting
                                  (default "%Y-%m-%dT%H:%M:%S.000")
+        --message-type=MESSAGE-TYPE
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -46,6 +46,7 @@ func TestCreateGCSInput(t *testing.T) {
 				FormatVersion:     2,
 				GzipLevel:         2,
 				Format:            `%h %l %u %t "%r" %>s %b`,
+				MessageType:       "classic",
 				ResponseCondition: "Prevent default logging",
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				Placement:         "none",
@@ -93,6 +94,7 @@ func TestUpdateGCSInput(t *testing.T) {
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				ResponseCondition: "Prevent default logging",
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+				MessageType:       "classic",
 				Placement:         "none",
 			},
 		},
@@ -116,6 +118,7 @@ func TestUpdateGCSInput(t *testing.T) {
 				ResponseCondition: "new7",
 				TimestampFormat:   "new8",
 				Placement:         "new9",
+				MessageType:       "new10",
 			},
 		},
 		{
@@ -160,6 +163,7 @@ func createCommandAll() *CreateCommand {
 		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
 		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
 	}
@@ -198,6 +202,7 @@ func updateCommandAll() *UpdateCommand {
 		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new7"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new8"},
 		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
 	}
 }
 
@@ -220,6 +225,7 @@ func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
 		GzipLevel:         2,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
+		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -32,9 +32,8 @@ type UpdateCommand struct {
 	Format            common.OptionalString
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
+	MessageType       common.OptionalString
 	Placement         common.OptionalString
-
-	// TODO (@mccurdyc): Add supported MessageType field once exposed for Updates (already exists for Creates).
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -60,6 +59,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 
 	return &c
@@ -94,6 +94,7 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateGCSInput, error) {
 		FormatVersion:     gcs.FormatVersion,
 		GzipLevel:         gcs.GzipLevel,
 		Format:            gcs.Format,
+		MessageType:       gcs.MessageType,
 		ResponseCondition: gcs.ResponseCondition,
 		TimestampFormat:   gcs.TimestampFormat,
 		Placement:         gcs.Placement,
@@ -142,6 +143,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateGCSInput, error) {
 
 	if c.TimestampFormat.Valid {
 		input.TimestampFormat = c.TimestampFormat.Value
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = c.MessageType.Value
 	}
 
 	if c.Placement.Valid {


### PR DESCRIPTION
## Proposed Change(s)

* Add MessageType field to GCS Updates.

## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/gcs/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/fe7cd620035a0ab3980f93d9180df0db7c4f93c4/fastly/gcs.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/gcs-messagetype && \
    make test && \
    rm -rf /tmp/cli \
)
```