### PR TITLE
Adds PublicKey field to S3

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -678,6 +678,9 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
+                                 encrypt your log files before writing them to
+                                 disk
         --server-side-encryption=SERVER-SIDE-ENCRYPTION
                                  Set to enable S3 Server Side Encryption. Can be
                                  either AES256 or aws:kms
@@ -736,6 +739,9 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
+                                 encrypt your log files before writing them to
+                                 disk
         --server-side-encryption=SERVER-SIDE-ENCRYPTION
                                  Set to enable S3 Server Side Encryption. Can be
                                  either AES256 or aws:kms

--- a/pkg/logging/s3/create.go
+++ b/pkg/logging/s3/create.go
@@ -35,6 +35,7 @@ type CreateCommand struct {
 	TimestampFormat              common.OptionalString
 	Placement                    common.OptionalString
 	Redundancy                   common.OptionalString
+	PublicKey                    common.OptionalString
 	ServerSideEncryption         common.OptionalString
 	ServerSideEncryptionKMSKeyID common.OptionalString
 }
@@ -65,8 +66,10 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("redundancy", "The S3 redundancy level. Can be either standard or reduced_redundancy").Action(c.Redundancy.Set).EnumVar(&c.Redundancy.Value, string(fastly.S3RedundancyStandard), string(fastly.S3RedundancyReduced))
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("server-side-encryption", "Set to enable S3 Server Side Encryption. Can be either AES256 or aws:kms").Action(c.ServerSideEncryption.Set).EnumVar(&c.ServerSideEncryption.Value, string(fastly.S3ServerSideEncryptionAES), string(fastly.S3ServerSideEncryptionKMS))
 	c.CmdClause.Flag("server-side-encryption-kms-key-id", "Server-side KMS Key ID. Must be set if server-side-encryption is set to aws:kms").Action(c.ServerSideEncryptionKMSKeyID.Set).StringVar(&c.ServerSideEncryptionKMSKeyID.Value)
+
 	return &c
 }
 
@@ -124,6 +127,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateS3Input, error) {
 
 	if c.Placement.Valid {
 		input.Placement = c.Placement.Value
+	}
+
+	if c.PublicKey.Valid {
+		input.PublicKey = c.PublicKey.Value
 	}
 
 	if c.ServerSideEncryptionKMSKeyID.Valid {

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -58,6 +58,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Message type: %s\n", s3.MessageType)
 	fmt.Fprintf(out, "Timestamp format: %s\n", s3.TimestampFormat)
 	fmt.Fprintf(out, "Placement: %s\n", s3.Placement)
+	fmt.Fprintf(out, "Public key: %s\n", s3.PublicKey)
 	fmt.Fprintf(out, "Redundancy: %s\n", s3.Redundancy)
 	fmt.Fprintf(out, "Server-side encryption: %s\n", s3.ServerSideEncryption)
 	fmt.Fprintf(out, "Server-side encryption KMS key ID: %s\n", s3.ServerSideEncryption)

--- a/pkg/logging/s3/list.go
+++ b/pkg/logging/s3/list.go
@@ -72,6 +72,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tMessage type: %s\n", s3.MessageType)
 		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", s3.TimestampFormat)
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", s3.Placement)
+		fmt.Fprintf(out, "\t\tPublic key: %s\n", s3.PublicKey)
 		fmt.Fprintf(out, "\t\tRedundancy: %s\n", s3.Redundancy)
 		fmt.Fprintf(out, "\t\tServer-side encryption: %s\n", s3.ServerSideEncryption)
 		fmt.Fprintf(out, "\t\tServer-side encryption KMS key ID: %s\n", s3.ServerSideEncryption)

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -267,7 +267,7 @@ func createS3Error(i *fastly.CreateS3Input) (*fastly.S3, error) {
 
 func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 	return []*fastly.S3{
-		&fastly.S3{
+		{
 			ServiceID:                    i.Service,
 			Version:                      i.Version,
 			Name:                         "logs",
@@ -285,10 +285,11 @@ func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 			TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
 			Redundancy:                   "standard",
 			Placement:                    "none",
+			PublicKey:                    pgpPublicKey(),
 			ServerSideEncryption:         "aws:kms",
 			ServerSideEncryptionKMSKeyID: "1234",
 		},
-		&fastly.S3{
+		{
 			ServiceID:                    i.Service,
 			Version:                      i.Version,
 			Name:                         "analytics",
@@ -306,6 +307,7 @@ func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 			TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
 			Redundancy:                   "standard",
 			Placement:                    "none",
+			PublicKey:                    pgpPublicKey(),
 			ServerSideEncryption:         "aws:kms",
 			ServerSideEncryptionKMSKeyID: "1234",
 		},
@@ -343,6 +345,7 @@ Version: 1
 		Message type: classic
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Public key: `+pgpPublicKey()+`
 		Redundancy: standard
 		Server-side encryption: aws:kms
 		Server-side encryption KMS key ID: aws:kms
@@ -362,6 +365,7 @@ Version: 1
 		Message type: classic
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Public key: `+pgpPublicKey()+`
 		Redundancy: standard
 		Server-side encryption: aws:kms
 		Server-side encryption KMS key ID: aws:kms
@@ -386,6 +390,7 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 		TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
 		Redundancy:                   "standard",
 		Placement:                    "none",
+		PublicKey:                    pgpPublicKey(),
 		ServerSideEncryption:         "aws:kms",
 		ServerSideEncryptionKMSKeyID: "1234",
 	}, nil
@@ -411,6 +416,7 @@ Response condition: Prevent default logging
 Message type: classic
 Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
+Public key: `+pgpPublicKey()+`
 Redundancy: standard
 Server-side encryption: aws:kms
 Server-side encryption KMS key ID: aws:kms
@@ -435,6 +441,7 @@ func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
 		TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
 		Redundancy:                   "standard",
 		Placement:                    "none",
+		PublicKey:                    pgpPublicKey(),
 		ServerSideEncryption:         "aws:kms",
 		ServerSideEncryptionKMSKeyID: "1234",
 	}, nil
@@ -450,4 +457,38 @@ func deleteS3OK(i *fastly.DeleteS3Input) error {
 
 func deleteS3Error(i *fastly.DeleteS3Input) error {
 	return errTest
+}
+
+// pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
+func pgpPublicKey() string {
+	return strings.TrimSpace(`-----BEGIN PGP PUBLIC KEY BLOCK-----
+mQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/
+ibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4
+8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p
+lDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn
+dwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB
+89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz
+dCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6
+vFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc
+9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9
+OLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX
+SvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq
+7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx
+kATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG
+M1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe
+u6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L
+4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF
+ftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K
+UEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu
+YrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi
+kiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb
+DAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml
+dYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L
+3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c
+FaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR
+5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR
+wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
+=28dr
+-----END PGP PUBLIC KEY BLOCK-----
+`)
 }

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -52,6 +53,7 @@ func TestCreateS3Input(t *testing.T) {
 				TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
 				Redundancy:                   fastly.S3RedundancyStandard,
 				Placement:                    "none",
+				PublicKey:                    pgpPublicKey(),
 				ServerSideEncryptionKMSKeyID: "kmskey",
 				ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
 			},
@@ -101,6 +103,7 @@ func TestUpdateS3Input(t *testing.T) {
 				ResponseCondition:            "Prevent default logging",
 				TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
 				Placement:                    "none",
+				PublicKey:                    pgpPublicKey(),
 				Redundancy:                   fastly.S3RedundancyStandard,
 				ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
 				ServerSideEncryptionKMSKeyID: "kmskey",
@@ -131,6 +134,7 @@ func TestUpdateS3Input(t *testing.T) {
 				Redundancy:                   fastly.S3RedundancyReduced,
 				ServerSideEncryption:         fastly.S3ServerSideEncryptionKMS,
 				ServerSideEncryptionKMSKeyID: "new12",
+				PublicKey:                    "new13",
 			},
 		},
 		{
@@ -179,6 +183,7 @@ func createCommandAll() *CreateCommand {
 		ResponseCondition:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
 		TimestampFormat:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
 		Placement:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		PublicKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: pgpPublicKey()},
 		Redundancy:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3RedundancyStandard)},
 		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3ServerSideEncryptionAES)},
 		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "kmskey"},
@@ -223,6 +228,7 @@ func updateCommandAll() *UpdateCommand {
 		Redundancy:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3RedundancyReduced)},
 		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3ServerSideEncryptionKMS)},
 		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new12"},
+		PublicKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new13"},
 	}
 }
 
@@ -250,8 +256,43 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 		MessageType:                  "classic",
 		TimestampFormat:              "%Y-%m-%dT%H:%M:%S.000",
 		Placement:                    "none",
+		PublicKey:                    pgpPublicKey(),
 		Redundancy:                   fastly.S3RedundancyStandard,
 		ServerSideEncryptionKMSKeyID: "kmskey",
 		ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
 	}, nil
+}
+
+// pgpPublicKey returns a PEM encoded PGP public key suitable for testing.
+func pgpPublicKey() string {
+	return strings.TrimSpace(`-----BEGIN PGP PUBLIC KEY BLOCK-----
+mQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/
+ibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4
+8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p
+lDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn
+dwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB
+89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz
+dCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6
+vFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc
+9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9
+OLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX
+SvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq
+7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx
+kATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG
+M1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe
+u6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L
+4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF
+ftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K
+UEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu
+YrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi
+kiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb
+DAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml
+dYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L
+3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c
+FaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR
+5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR
+wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
+=28dr
+-----END PGP PUBLIC KEY BLOCK-----
+`)
 }

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 	ResponseCondition            common.OptionalString
 	TimestampFormat              common.OptionalString
 	Placement                    common.OptionalString
+	PublicKey                    common.OptionalString
 	Redundancy                   common.OptionalString
 	ServerSideEncryption         common.OptionalString
 	ServerSideEncryptionKMSKeyID common.OptionalString
@@ -68,6 +69,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("redundancy", "The S3 redundancy level. Can be either standard or reduced_redundancy").Action(c.Redundancy.Set).EnumVar(&c.Redundancy.Value, string(fastly.S3RedundancyStandard), string(fastly.S3RedundancyReduced))
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("server-side-encryption", "Set to enable S3 Server Side Encryption. Can be either AES256 or aws:kms").Action(c.ServerSideEncryption.Set).EnumVar(&c.ServerSideEncryption.Value, string(fastly.S3ServerSideEncryptionAES), string(fastly.S3ServerSideEncryptionKMS))
 	c.CmdClause.Flag("server-side-encryption-kms-key-id", "Server-side KMS Key ID. Must be set if server-side-encryption is set to aws:kms").Action(c.ServerSideEncryptionKMSKeyID.Set).StringVar(&c.ServerSideEncryptionKMSKeyID.Value)
 
@@ -167,6 +169,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateS3Input, error) {
 
 	if c.Placement.Valid {
 		input.Placement = c.Placement.Value
+	}
+
+	if c.PublicKey.Valid {
+		input.PublicKey = c.PublicKey.Value
 	}
 
 	if c.ServerSideEncryptionKMSKeyID.Valid {

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -111,6 +111,7 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateS3Input, error) {
 		TimestampFormat:              s3.TimestampFormat,
 		Redundancy:                   s3.Redundancy,
 		Placement:                    s3.Placement,
+		PublicKey:                    s3.PublicKey,
 		ServerSideEncryption:         s3.ServerSideEncryption,
 		ServerSideEncryptionKMSKeyID: s3.ServerSideEncryptionKMSKeyID,
 	}


### PR DESCRIPTION
## Proposed Change(s)

* Add PublicKey field to all S3 CRUD operations.

## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/s3/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/fe7cd620035a0ab3980f93d9180df0db7c4f93c4/fastly/s3.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-s3-publickey && \
    make test && \
    rm -rf /tmp/cli \
)
```