### PR TITLE
logging: fix bugs in tests

### DIFF
--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -184,24 +184,10 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdate() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		Version:           2,
-		EndpointName:      "logs",
-		NewName:           common.OptionalString{Optional: common.Optional{Valid: true}, Value: "logs"},
-		AccessKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "key"},
-		BucketName:        common.OptionalString{Optional: common.Optional{Valid: true}, Value: "bucket"},
-		Path:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "/logs"},
-		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "abc"},
-		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
-		Period:            common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3600},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
-		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
-		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: pgpPublicKey()},
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Version:      2,
+		EndpointName: "logs",
 	}
 }
 
@@ -245,7 +231,7 @@ func getCloudfilesOK(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
 		Path:              "/logs",
 		Region:            "abc",
 		Placement:         "none",
-		Period:            2,
+		Period:            3600,
 		GzipLevel:         2,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,

--- a/pkg/logging/logentries/logentries_test.go
+++ b/pkg/logging/logentries/logentries_test.go
@@ -151,17 +151,10 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "logs",
-		Version:           2,
-		Port:              common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 22},
-		UseTLS:            common.OptionalBool{Optional: common.Optional{Valid: true}, Value: true},
-		Token:             common.OptionalString{Optional: common.Optional{Valid: true}, Value: "tkn"},
-		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "logs",
+		Version:      2,
 	}
 }
 
@@ -193,6 +186,8 @@ func getLogentriesOK(i *fastly.GetLogentriesInput) (*fastly.Logentries, error) {
 		ServiceID:         i.Service,
 		Version:           i.Version,
 		Name:              "logs",
+		Port:              22,
+		UseTLS:            true,
 		Token:             "tkn",
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -193,27 +193,10 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:                         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:                     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:                 "logs",
-		Version:                      2,
-		NewName:                      common.OptionalString{Optional: common.Optional{Valid: true}, Value: "logs"},
-		BucketName:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "bucket"},
-		AccessKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "access"},
-		SecretKey:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "secret"},
-		Domain:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "domain"},
-		Path:                         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "path"},
-		Period:                       common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3600},
-		GzipLevel:                    common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
-		Format:                       common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:                common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
-		MessageType:                  common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
-		ResponseCondition:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
-		TimestampFormat:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		Placement:                    common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
-		Redundancy:                   common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3RedundancyStandard)},
-		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: string(fastly.S3ServerSideEncryptionAES)},
-		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "kmskey"},
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "logs",
+		Version:      2,
 	}
 }
 
@@ -269,6 +252,6 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 		Placement:                    "none",
 		Redundancy:                   fastly.S3RedundancyStandard,
 		ServerSideEncryptionKMSKeyID: "kmskey",
-		ServerSideEncryption:         fastly.S3ServerSideEncryptionKMS,
+		ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
 	}, nil
 }


### PR DESCRIPTION
## Proposed Change(s)

* This change fixes a bug in tests where they were not correctly validating the
scenario of no updates for the following logging endpoints:
  * s3
  * scalyr
  * cloudfiles
  * logentries

## Note(s)

* This was identified in https://github.com/fastly/cli/pull/114.
* Basically, the tests were explicitly setting values and therefore were not exercising [this block of code](https://github.com/fastly/cli/blob/master/pkg/logging/s3/update.go#L93) in the respective logging endpoints, previously-held values are set.

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-fix-tests && \
    make test && \
    rm -rf /tmp/cli \
)
```