### PR TITLE
Adds Region field to Scalyr

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1389,6 +1389,8 @@ COMMANDS
         --version=VERSION        Number of service version
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://www.scalyr.com/keys)
+        --region=REGION          The region that log data will be sent to. One
+                                 of US or EU. Defaults to US if undefined
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
                                  The version of the custom logging format used
@@ -1430,6 +1432,8 @@ COMMANDS
                                  (default) or 1
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://www.scalyr.com/keys)
+        --region=REGION          The region that log data will be sent to. One
+                                 of US or EU. Defaults to US if undefined
         --response-condition=RESPONSE-CONDITION
                                  The name of an existing condition in the
                                  configured endpoint, or leave blank to always

--- a/pkg/logging/scalyr/create.go
+++ b/pkg/logging/scalyr/create.go
@@ -22,6 +22,7 @@ type CreateCommand struct {
 	Version      int
 
 	// optional
+	Region            common.OptionalString
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	ResponseCondition common.OptionalString
@@ -42,6 +43,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.scalyr.com/keys)").Required().StringVar(&c.Token)
 
+	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
@@ -63,6 +65,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateScalyrInput, error) {
 	input.Version = c.Version
 	input.Name = fastly.String(c.EndpointName)
 	input.Token = fastly.String(c.Token)
+
+	if c.Region.Valid {
+		input.Region = fastly.String(c.Region.Value)
+	}
 
 	if c.Format.Valid {
 		input.Format = fastly.String(c.Format.Value)

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -47,6 +47,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Version: %d\n", scalyr.Version)
 	fmt.Fprintf(out, "Name: %s\n", scalyr.Name)
 	fmt.Fprintf(out, "Token: %s\n", scalyr.Token)
+	fmt.Fprintf(out, "Region: %s\n", scalyr.Region)
 	fmt.Fprintf(out, "Format: %s\n", scalyr.Format)
 	fmt.Fprintf(out, "Format version: %d\n", scalyr.FormatVersion)
 	fmt.Fprintf(out, "Response condition: %s\n", scalyr.ResponseCondition)

--- a/pkg/logging/scalyr/list.go
+++ b/pkg/logging/scalyr/list.go
@@ -61,6 +61,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tVersion: %d\n", scalyr.Version)
 		fmt.Fprintf(out, "\t\tName: %s\n", scalyr.Name)
 		fmt.Fprintf(out, "\t\tToken: %s\n", scalyr.Token)
+		fmt.Fprintf(out, "\t\tRegion: %s\n", scalyr.Region)
 		fmt.Fprintf(out, "\t\tFormat: %s\n", scalyr.Format)
 		fmt.Fprintf(out, "\t\tFormat version: %d\n", scalyr.FormatVersion)
 		fmt.Fprintf(out, "\t\tResponse condition: %s\n", scalyr.ResponseCondition)

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -308,6 +308,7 @@ func listScalyrsOK(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
 			Version:           i.Version,
 			Name:              "logs",
 			Token:             "abc",
+			Region:            "US",
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			ResponseCondition: "Prevent default logging",
@@ -318,6 +319,7 @@ func listScalyrsOK(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
 			Version:           i.Version,
 			Name:              "analytics",
 			Token:             "abc",
+			Region:            "US",
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			ResponseCondition: "Prevent default logging",
@@ -346,6 +348,7 @@ Version: 1
 		Version: 1
 		Name: logs
 		Token: abc
+		Region: US
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -355,6 +358,7 @@ Version: 1
 		Version: 1
 		Name: analytics
 		Token: abc
+		Region: US
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -367,6 +371,7 @@ func getScalyrOK(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
 		Version:           i.Version,
 		Name:              "logs",
 		Token:             "abc",
+		Region:            "US",
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
@@ -383,6 +388,7 @@ Service ID: 123
 Version: 1
 Name: logs
 Token: abc
+Region: US
 Format: %h %l %u %t "%r" %>s %b
 Format version: 2
 Response condition: Prevent default logging
@@ -395,6 +401,7 @@ func updateScalyrOK(i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
 		Version:           i.Version,
 		Name:              "log",
 		Token:             "abc",
+		Region:            "EU",
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",

--- a/pkg/logging/scalyr/scalyr_test.go
+++ b/pkg/logging/scalyr/scalyr_test.go
@@ -37,6 +37,7 @@ func TestCreateScalyrInput(t *testing.T) {
 				Version:           2,
 				Name:              fastly.String("log"),
 				Token:             fastly.String("tkn"),
+				Region:            fastly.String("US"),
 				FormatVersion:     fastly.Uint(2),
 				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
 				ResponseCondition: fastly.String("Prevent default logging"),
@@ -76,6 +77,7 @@ func TestUpdateScalyrInput(t *testing.T) {
 				Name:              "logs",
 				NewName:           fastly.String("logs"),
 				Token:             fastly.String("tkn"),
+				Region:            fastly.String("US"),
 				FormatVersion:     fastly.Uint(2),
 				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
 				ResponseCondition: fastly.String("Prevent default logging"),
@@ -96,6 +98,7 @@ func TestUpdateScalyrInput(t *testing.T) {
 				Format:            fastly.String("new3"),
 				ResponseCondition: fastly.String("new4"),
 				Placement:         fastly.String("new5"),
+				Region:            fastly.String("new6"),
 			},
 		},
 		{
@@ -130,6 +133,7 @@ func createCommandAll() *CreateCommand {
 		EndpointName:      "log",
 		Version:           2,
 		Token:             "tkn",
+		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "US"},
 		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
@@ -164,6 +168,7 @@ func updateCommandAll() *UpdateCommand {
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 3},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new4"},
 		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new5"},
+		Region:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new6"},
 	}
 }
 
@@ -181,6 +186,7 @@ func getScalyrOK(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		Token:             "tkn",
+		Region:            "US",
 		ResponseCondition: "Prevent default logging",
 		Placement:         "none",
 	}, nil

--- a/pkg/logging/scalyr/update.go
+++ b/pkg/logging/scalyr/update.go
@@ -25,6 +25,7 @@ type UpdateCommand struct {
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	Token             common.OptionalString
+	Region            common.OptionalString
 	ResponseCondition common.OptionalString
 	Placement         common.OptionalString
 }
@@ -45,6 +46,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.scalyr.com/keys)").Action(c.Token.Set).StringVar(&c.Token.Value)
+	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 
@@ -75,6 +77,7 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateScalyrInput, error) {
 		Format:            fastly.String(scalyr.Format),
 		FormatVersion:     fastly.Uint(scalyr.FormatVersion),
 		Token:             fastly.String(scalyr.Token),
+		Region:            fastly.String(scalyr.Region),
 		ResponseCondition: fastly.String(scalyr.ResponseCondition),
 		Placement:         fastly.String(scalyr.Placement),
 	}
@@ -93,6 +96,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateScalyrInput, error) {
 
 	if c.Token.Valid {
 		input.Token = fastly.String(c.Token.Value)
+	}
+
+	if c.Region.Valid {
+		input.Region = fastly.String(c.Region.Value)
 	}
 
 	if c.ResponseCondition.Valid {


### PR DESCRIPTION
## Proposed Change(s)

* Add Region field to all Scalyr CRUD operations.

## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/scalyr/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/fe7cd620035a0ab3980f93d9180df0db7c4f93c4/fastly/scalyr.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-scalyr-region && \
    make test && \
    rm -rf /tmp/cli \
)
```