### PR TITLE
Adds User field to Cloudfiles Updates

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1894,6 +1894,7 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Cloudfiles logging object
         --new-name=NEW-NAME      New name of the Cloudfiles logging object
+        --user=USER              The username for your Cloudfile account
         --access-key=ACCESS-KEY  Your Cloudfile account access key
         --bucket=BUCKET          The name of your Cloudfiles container
         --path=PATH              The path to upload logs to

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -87,6 +87,7 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 				Version:           2,
 				Name:              "logs",
 				NewName:           fastly.String("logs"),
+				User:              fastly.String("user"),
 				AccessKey:         fastly.String("key"),
 				BucketName:        fastly.String("bucket"),
 				Path:              fastly.String("/logs"),
@@ -124,6 +125,7 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 				MessageType:       fastly.String("new9"),
 				TimestampFormat:   fastly.String("new10"),
 				PublicKey:         fastly.String("new11"),
+				User:              fastly.String("new12"),
 			},
 		},
 		{
@@ -211,6 +213,7 @@ func updateCommandAll() *UpdateCommand {
 		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new9"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new11"},
+		User:              common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new12"},
 	}
 }
 

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -22,6 +22,7 @@ type UpdateCommand struct {
 
 	// optional
 	NewName           common.OptionalString
+	User              common.OptionalString
 	AccessKey         common.OptionalString
 	BucketName        common.OptionalString
 	Path              common.OptionalString
@@ -50,6 +51,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.EndpointName)
 
 	c.CmdClause.Flag("new-name", "New name of the Cloudfiles logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("user", "The username for your Cloudfile account").Action(c.User.Set).StringVar(&c.User.Value)
 	c.CmdClause.Flag("access-key", "Your Cloudfile account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)
 	c.CmdClause.Flag("bucket", "The name of your Cloudfiles container").Action(c.BucketName.Set).StringVar(&c.BucketName.Value)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
@@ -88,6 +90,7 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateCloudfilesInput, error) {
 		Version:           cloudfiles.Version,
 		Name:              cloudfiles.Name,
 		NewName:           fastly.String(cloudfiles.Name),
+		User:              fastly.String(cloudfiles.User),
 		AccessKey:         fastly.String(cloudfiles.AccessKey),
 		BucketName:        fastly.String(cloudfiles.BucketName),
 		Path:              fastly.String(cloudfiles.Path),
@@ -106,6 +109,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateCloudfilesInput, error) {
 	// Set new values if set by user.
 	if c.NewName.Valid {
 		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.User.Valid {
+		input.User = fastly.String(c.User.Value)
 	}
 
 	if c.AccessKey.Valid {


### PR DESCRIPTION
## Proposed Change(s)

* Add User field to Cloudfiles Updates.

## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/cloudfiles/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/fe7cd620035a0ab3980f93d9180df0db7c4f93c4/fastly/cloudfiles.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-cloudfiles-user-update && \
    make test && \
    rm -rf /tmp/cli \
)
```