### PR TITLE
Adds MessageType field to SFTP

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1681,6 +1681,9 @@ COMMANDS
                                  (default) or 1
         --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
                                  dumping logs (default 0, no compression)
+        --message-type=MESSAGE-TYPE
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
         --response-condition=RESPONSE-CONDITION
                                  The name of an existing condition in the
                                  configured endpoint, or leave blank to always
@@ -1739,6 +1742,9 @@ COMMANDS
                                  The version of the custom logging format used
                                  for the configured endpoint. Can be either 2
                                  (default) or 1
+        --message-type=MESSAGE-TYPE
+                                 How the message should be formatted. One of:
+                                 classic (default), loggly, logplex or blank
         --gzip-level=GZIP-LEVEL  What level of GZIP encoding to have when
                                  dumping logs (default 0, no compression)
         --response-condition=RESPONSE-CONDITION

--- a/pkg/logging/sftp/create.go
+++ b/pkg/logging/sftp/create.go
@@ -33,6 +33,7 @@ type CreateCommand struct {
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	GzipLevel         common.OptionalUint
+	MessageType       common.OptionalString
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
@@ -63,6 +64,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).UintVar(&c.GzipLevel.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
@@ -120,6 +122,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateSFTPInput, error) {
 
 	if c.GzipLevel.Valid {
 		input.GzipLevel = fastly.Uint(c.GzipLevel.Value)
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = fastly.String(c.MessageType.Value)
 	}
 
 	if c.ResponseCondition.Valid {

--- a/pkg/logging/sftp/describe.go
+++ b/pkg/logging/sftp/describe.go
@@ -58,6 +58,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "GZip level: %d\n", sftp.GzipLevel)
 	fmt.Fprintf(out, "Format: %s\n", sftp.Format)
 	fmt.Fprintf(out, "Format version: %d\n", sftp.FormatVersion)
+	fmt.Fprintf(out, "Message type: %s\n", sftp.MessageType)
 	fmt.Fprintf(out, "Response condition: %s\n", sftp.ResponseCondition)
 	fmt.Fprintf(out, "Timestamp format: %s\n", sftp.TimestampFormat)
 	fmt.Fprintf(out, "Placement: %s\n", sftp.Placement)

--- a/pkg/logging/sftp/list.go
+++ b/pkg/logging/sftp/list.go
@@ -72,6 +72,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tGZip level: %d\n", sftp.GzipLevel)
 		fmt.Fprintf(out, "\t\tFormat: %s\n", sftp.Format)
 		fmt.Fprintf(out, "\t\tFormat version: %d\n", sftp.FormatVersion)
+		fmt.Fprintf(out, "\t\tMessage type: %s\n", sftp.MessageType)
 		fmt.Fprintf(out, "\t\tResponse condition: %s\n", sftp.ResponseCondition)
 		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", sftp.TimestampFormat)
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", sftp.Placement)

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -296,6 +296,7 @@ func listSFTPsOK(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 			GzipLevel:         2,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
+			MessageType:       "classic",
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
@@ -315,6 +316,7 @@ func listSFTPsOK(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 			Period:            3600,
 			GzipLevel:         3,
 			Format:            `%h %l %u %t "%r" %>s %b`,
+			MessageType:       "classic",
 			FormatVersion:     2,
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
@@ -354,6 +356,7 @@ Version: 1
 		GZip level: 2
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
+		Message type: classic
 		Response condition: Prevent default logging
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
@@ -373,6 +376,7 @@ Version: 1
 		GZip level: 3
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
+		Message type: classic
 		Response condition: Prevent default logging
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
@@ -395,6 +399,7 @@ func getSFTPOK(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 		GzipLevel:         2,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
+		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
@@ -421,6 +426,7 @@ Period: 3600
 GZip level: 2
 Format: %h %l %u %t "%r" %>s %b
 Format version: 2
+Message type: classic
 Response condition: Prevent default logging
 Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
@@ -443,6 +449,7 @@ func updateSFTPOK(i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
 		GzipLevel:         3,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
+		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",

--- a/pkg/logging/sftp/sftp_test.go
+++ b/pkg/logging/sftp/sftp_test.go
@@ -52,6 +52,7 @@ func TestCreateSFTPInput(t *testing.T) {
 				GzipLevel:         fastly.Uint(2),
 				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
 				ResponseCondition: fastly.String("Prevent default logging"),
+				MessageType:       fastly.String("classic"),
 				TimestampFormat:   fastly.String("%Y-%m-%dT%H:%M:%S.000"),
 				Placement:         fastly.String("none"),
 			},
@@ -103,6 +104,7 @@ func TestUpdateSFTPInput(t *testing.T) {
 				ResponseCondition: fastly.String("new10"),
 				TimestampFormat:   fastly.String("new11"),
 				Placement:         fastly.String("new12"),
+				MessageType:       fastly.String("new13"),
 			},
 		},
 		{
@@ -127,6 +129,7 @@ func TestUpdateSFTPInput(t *testing.T) {
 				GzipLevel:         fastly.Uint(2),
 				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
 				ResponseCondition: fastly.String("Prevent default logging"),
+				MessageType:       fastly.String("classic"),
 				TimestampFormat:   fastly.String("%Y-%m-%dT%H:%M:%S.000"),
 				Placement:         fastly.String("none"),
 			},
@@ -176,6 +179,7 @@ func createCommandAll() *CreateCommand {
 		Format:            common.OptionalString{Optional: common.Optional{Valid: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
 		GzipLevel:         common.OptionalUint{Optional: common.Optional{Valid: true}, Value: 2},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "classic"},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "Prevent default logging"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
 		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "none"},
@@ -219,6 +223,7 @@ func updateCommandAll() *UpdateCommand {
 		ResponseCondition: common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new10"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new11"},
 		Placement:         common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new12"},
+		MessageType:       common.OptionalString{Optional: common.Optional{Valid: true}, Value: "new13"},
 	}
 }
 
@@ -245,6 +250,7 @@ func getSFTPOK(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		GzipLevel:         2,
+		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",

--- a/pkg/logging/sftp/update.go
+++ b/pkg/logging/sftp/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 	FormatVersion     common.OptionalUint
 	GzipLevel         common.OptionalUint
 	Format            common.OptionalString
+	MessageType       common.OptionalString
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
@@ -63,6 +64,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).UintVar(&c.GzipLevel.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
@@ -104,6 +106,7 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSFTPInput, error) {
 		Format:            fastly.String(sftp.Format),
 		FormatVersion:     fastly.Uint(sftp.FormatVersion),
 		GzipLevel:         fastly.Uint(uint(sftp.GzipLevel)), // TODO (v2): consistent type.
+		MessageType:       fastly.String(sftp.MessageType),
 		ResponseCondition: fastly.String(sftp.ResponseCondition),
 		TimestampFormat:   fastly.String(sftp.TimestampFormat),
 		Placement:         fastly.String(sftp.Placement),
@@ -159,6 +162,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSFTPInput, error) {
 
 	if c.GzipLevel.Valid {
 		input.GzipLevel = fastly.Uint(c.GzipLevel.Value)
+	}
+
+	if c.MessageType.Valid {
+		input.MessageType = fastly.String(c.MessageType.Value)
 	}
 
 	if c.ResponseCondition.Valid {


### PR DESCRIPTION
## Proposed Change(s)

* Add MessageType field to all Scalyr CRUD operations.

## Relevant (Referenced) Link(s)

* [Fastly API Docs](https://developer.fastly.com/reference/api/logging/sftp/)
* [fastly/go-fastly](https://github.com/fastly/go-fastly/blob/fe7cd620035a0ab3980f93d9180df0db7c4f93c4/fastly/sftp.go)

## Validation

```
$ make test
```

```
git clone git@github.com:mccurdyc/cli.git /tmp/cli && \
(
    cd /tmp/cli && \
    git checkout mccurdyc/logging-sftp-messagetype && \
    make test && \
    rm -rf /tmp/cli \
)
```