### PR TITLE
docs/release: Noting non-determinism of changelog

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     * **Only add labels for relevant changes**
     * `git checkout -b vx.x.x` where `vx.x.x` is your target version tag
     * `CHANGELOG_GITHUB_TOKEN=xxxx SEMVER_TAG=vx.x.x make changelog`
+       * **Known Issue**: We've found that the diffs generated are non-deterministic. Just re-run `make changelog` until you get a diff with just the newest additions. For more details, visit [this link](https://github.com/github-changelog-generator/github-changelog-generator/issues/580#issuecomment-380952266).
     * `git add CHANGELOG.md && git commit -m "vx.x.x`
 1. Send PR for the `CHANGELOG.md`
 1. Once approved and merged, checkout and update the `master` branch:


### PR DESCRIPTION
Seems like the GitHub API is not deterministic and picks up commits differently, so just running the changelog generator until I get the expected.

More conversation here - https://github.com/fastly/cli/pull/119

I'm thinking it may be related to - github-changelog-generator/github-changelog-generator#580