### PR TITLE
fix release changelog tagging

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if ! command -v github_changelog_generator > /dev/null; then
+	echo "No github_changelog_generator in \$PATH, install via 'gem install github_changelog_generator'."
+	exit 1
+fi
+
+if [ -z "$CHANGELOG_GITHUB_TOKEN" ]; then
+	printf "\nWARNING: No \$CHANGELOG_GITHUB_TOKEN in environment, set one to avoid hitting rate limit.\n\n"
+fi
+
+if [ -z "$SEMVER_TAG" ]; then
+	echo "You must set \$SEMVER_TAG to your desired release semver version."
+	exit 1
+fi
+
+github_changelog_generator -u fastly -p cli \
+	--future-release $SEMVER_TAG \
+	--no-pr-wo-labels \
+	--no-author \
+	--enhancement-label "**Enhancements:**" \
+	--bugs-label "**Bug fixes:**" \
+	--release-url "https://github.com/fastly/cli/releases/tag/%s" \
+	--exclude-labels documentation \
+	--exclude-tags-regex "v.*-.*"

--- a/scripts/release-changelog.sh
+++ b/scripts/release-changelog.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+prev_tag="$(source scripts/tags.sh; previous_tag)"
+
+if ! command -v github_changelog_generator > /dev/null; then
+	echo "No github_changelog_generator in \$PATH, install via 'gem install github_changelog_generator'."
+	exit 1
+fi
+
+if [ -z "$CHANGELOG_GITHUB_TOKEN" ]; then
+	printf "\nWARNING: No \$CHANGELOG_GITHUB_TOKEN in environment, set one to avoid hitting rate limit.\n\n"
+fi
+
+if [ -z "$SEMVER_TAG" ]; then
+	echo "You must set \$SEMVER_TAG to your desired release semver version."
+	exit 1
+fi
+
+github_changelog_generator -u fastly -p cli \
+  --no-pr-wo-labels \
+  --no-author \
+  --no-issues \
+  --enhancement-label "**Enhancements:**" \
+  --bugs-label "**Bug fixes:**" \
+  --release-url "https://github.com/fastly/cli/releases/tag/%s" \
+  --exclude-labels documentation \
+  --output RELEASE_CHANGELOG.md \
+  --since-tag $prev_tag

--- a/scripts/tags.sh
+++ b/scripts/tags.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# credit: https://github.com/cli/cli/blob/trunk/script/changelog
+
+function previous_tag() {
+  current_tag="$(git describe --tags HEAD^ --abbrev=0)"
+  start_ref="HEAD"
+
+  # Find the previous release on the same branch, skipping prereleases if the
+  # current tag is a full release
+  previous_tag=""
+  while [[ -z $previous_tag || ( $previous_tag == *-* && $current_tag != *-* ) ]]; do
+    previous_tag="$(git describe --tags "$start_ref"^ --abbrev=0)"
+    start_ref="$previous_tag"
+  done
+  echo $previous_tag
+}


### PR DESCRIPTION
## Problem Description

* If you look at all https://github.com/fastly/cli/releases `>v0.8.0`, they all
include the changelog from all previous releases since `v0.8.0`.

* I am on a linux machine ([similar to our CI/CD machine which is ubuntu](https://github.com/fastly/cli/blob/master/.github/workflows/tag_release.yml#L8))
and when I run the command used to determine `PREVIOUS_SEMVER_TAG` [here](https://github.com/fastly/cli/blob/master/Makefile#L4),
I get `v0.8.0` as the previous version, which is wrong.

```bash
$ git tag | sort -r --version-sort
v0.12.0
v0.11.0
v0.10.0
v0.9.0
v0.8.0
v0.7.1
v0.7.0
v0.6.0
v0.5.0-rc1
v0.5.0
v0.4.1
v0.4.0
v0.3.0
v0.2.0
v0.1.0
```

```bash
$ git tag | sort -r --version-sort | egrep '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$$' | head -n2 | tail -n1
v0.8.0
```

## Proposed Change(s)

* Update the way that we determine the previous semver tag so that we can generate
a changelog only including items since the last release ([for pages similar to this](https://github.com/fastly/cli/releases/tag/v0.12.0)).

* Use a similar approach as [`github.com/cli/cli`](https://github.com/cli/cli/blob/trunk/script/changelog).

## Validation

```
$ git clone git@github.com:mccurdyc/cli.git /tmp/cli
(
    cd /tmp/cli
    git fetch
    git checkout mccurdyc/fix-release-changelog
    echo $(source /tmp/cli/scripts/tags.sh; previous_tag)
)
rm -rf /tmp/cli
# printed: v0.12.0
```

* :crossed_fingers: and hope build machine also works???
    * Can you ssh into GitHub Action machines?

---

## System Info

```
$ uname -a
Linux arch 5.6.15-arch1-1 #1 SMP PREEMPT Wed, 27 May 2020 23:42:26 +0000 x86_64 GNU/Linux
```

```
$ egrep -V
grep (GNU grep) 3.4
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Mike Haertel and others; see
<https://git.sv.gnu.org/cgit/grep.git/tree/AUTHORS>.
```