### PR TITLE
Refactor fastly crate verification to only enforce fastly-sys version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/testutil"

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -2,12 +2,18 @@ package compute
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/blang/semver"
+	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/go-fastly/fastly"
@@ -314,6 +320,130 @@ func TestGetIdealPackage(t *testing.T) {
 	}
 }
 
+func TestGetLatestCrateVersion(t *testing.T) {
+	for _, testcase := range []struct {
+		name        string
+		inputClient api.HTTPClient
+		wantVersion *semver.Version
+		wantError   string
+	}{
+		{
+			name:        "http error",
+			inputClient: &errorClient{errTest},
+			wantError:   "fixture error",
+		},
+		{
+			name:        "no valid versions",
+			inputClient: &versionClient{[]string{}},
+			wantError:   "no valid crate versions found",
+		},
+		{
+			name:        "unsorted",
+			inputClient: &versionClient{[]string{"0.5.23", "0.1.0", "1.2.3", "0.7.3"}},
+			wantVersion: semver.MustParse("1.2.3"),
+		},
+		{
+			name:        "reverse chronological",
+			inputClient: &versionClient{[]string{"1.2.3", "0.8.3", "0.3.2"}},
+			wantVersion: semver.MustParse("1.2.3"),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			v, err := getLatestCrateVersion(testcase.inputClient, "fastly")
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			if err == nil && !v.Equal(testcase.wantVersion) {
+				t.Errorf("wanted version %s, got %s", testcase.wantVersion, v)
+			}
+		})
+	}
+}
+
+func TestGetCrateVersionFromMetadata(t *testing.T) {
+	for _, testcase := range []struct {
+		name        string
+		inputLock   CargoMetadata
+		inputCrate  string
+		wantVersion *semver.Version
+		wantError   string
+	}{
+		{
+			name:       "crate not found",
+			inputLock:  CargoMetadata{},
+			inputCrate: "fastly",
+			wantError:  "fastly crate not found",
+		},
+		{
+			name: "parsing error",
+			inputLock: CargoMetadata{
+				Package: []CargoPackage{
+					{
+						Name:    "foo",
+						Version: "1.2.3",
+					},
+					{
+						Name:    "fastly",
+						Version: "dgsfdfg",
+					},
+				},
+			},
+			inputCrate: "fastly",
+			wantError:  "error parsing cargo metadata",
+		},
+		{
+			name: "success",
+			inputLock: CargoMetadata{
+				Package: []CargoPackage{
+					{
+						Name:    "foo",
+						Version: "1.2.3",
+					},
+					{
+						Name:    "fastly-sys",
+						Version: "0.3.0",
+					},
+					{
+						Name:    "fastly",
+						Version: "3.0.0",
+					},
+				},
+			},
+			inputCrate:  "fastly",
+			wantVersion: semver.MustParse("3.0.0"),
+		},
+		{
+			name: "success nested",
+			inputLock: CargoMetadata{
+				Package: []CargoPackage{
+					{
+						Name:    "foo",
+						Version: "1.2.3",
+					},
+					{
+						Name:    "fastly",
+						Version: "3.0.0",
+						Dependencies: []CargoPackage{
+							{
+								Name:    "fastly-sys",
+								Version: "0.3.0",
+							},
+						},
+					},
+				},
+			},
+			inputCrate:  "fastly-sys",
+			wantVersion: semver.MustParse("0.3.0"),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			v, err := getCrateVersionFromMetadata(testcase.inputLock, testcase.inputCrate)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			if err == nil && !v.Equal(testcase.wantVersion) {
+				t.Errorf("wanted version %s, got %s", testcase.wantVersion, v)
+			}
+		})
+	}
+}
+
 func makeBuildEnvironment(t *testing.T, fastlyIgnoreContent string) (rootdir string) {
 	t.Helper()
 
@@ -352,4 +482,33 @@ func makeBuildEnvironment(t *testing.T, fastlyIgnoreContent string) (rootdir str
 	}
 
 	return rootdir
+}
+
+var errTest = errors.New("fixture error")
+
+type errorClient struct {
+	err error
+}
+
+func (c errorClient) Do(*http.Request) (*http.Response, error) {
+	return nil, c.err
+}
+
+type versionClient struct {
+	versions []string
+}
+
+func (v versionClient) Do(*http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+
+	var versions []string
+	for _, vv := range v.versions {
+		versions = append(versions, fmt.Sprintf(`{"num":"%s"}`, vv))
+	}
+
+	_, err := rec.Write([]byte(fmt.Sprintf(`{"versions":[%s]}`, strings.Join(versions, ","))))
+	if err != nil {
+		return nil, err
+	}
+	return rec.Result(), nil
 }

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -236,7 +236,7 @@ func (r Rust) Verify(out io.Writer) error {
 	if fastlyVersion.LessThan(latestFastly) {
 		text.Break(out)
 		text.Info(out, fmt.Sprintf(
-			"a newer version of the fastly crate is avaiable, edit %s with:\n\n\t %s\n\nAnd then run the following command:\n\n\t$ %s\n",
+			"an optional upgrade for the fastly crate is available, edit %s with:\n\n\t %s\n\nAnd then run the following command:\n\n\t$ %s\n",
 			text.Bold("Cargo.toml"),
 			text.Bold(fmt.Sprintf(`fastly = "^%s"`, latestFastly)),
 			text.Bold("cargo update -p fastly"),

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -208,7 +208,7 @@ func (r Rust) Verify(out io.Writer) error {
 
 	// Create a semver contraint to be within the latest minor range or above.
 	// TODO(phamann): Update this to major when fastly-sys hits 1.x.x.
-	fastlySysConstraint, err := semver.NewConstraint(fmt.Sprintf("~%d.%d.0", latestFastlySys.Major(), latestFastlySys.Major()))
+	fastlySysConstraint, err := semver.NewConstraint(fmt.Sprintf("~%d.%d.0", latestFastlySys.Major(), latestFastlySys.Minor()))
 	if err != nil {
 		return fmt.Errorf("error parsing latest crate version: %w", err)
 	}

--- a/pkg/text/text.go
+++ b/pkg/text/text.go
@@ -145,6 +145,12 @@ func Warning(w io.Writer, format string, args ...interface{}) {
 	fmt.Fprintf(w, "\n"+BoldYellow("WARNING: ")+format, args...)
 }
 
+// Info is a wrapper for fmt.Fprintf with a bold "INFO: " prefix.
+func Info(w io.Writer, format string, args ...interface{}) {
+	format = strings.TrimRight(format, "\r\n") + "\n"
+	fmt.Fprintf(w, "\n"+Bold("INFO: ")+format, args...)
+}
+
 // Success is a wrapper for fmt.Fprintf with a bold green "SUCCESS: " prefix.
 func Success(w io.Writer, format string, args ...interface{}) {
 	format = strings.TrimRight(format, "\r\n") + "\n"


### PR DESCRIPTION
### TL;DR
Refactors the crate verification introduced in #67 to only fail the build if a user has an out of range `fastly-sys` transient dependency and not an out of range `fastly` crate. This should reduce the frequency in which a user sees this message.

### Why?
Now that the ABI work has been abstracted out of the `fastly` crate to `fastly-sys`, we can refactor the CLI verification so that in only blocks builds when there is a semver-incompatible new version of the `fastly-sys` crate available. Which will be updated less frequently than the `fastly` crate itself. 

The simplest remediation to offer in this case is to recommend an upgrade to the latest fastly crate, since users are unlikely to be depending on fastly-sys directly. We could get fancy about the suggested remediations in case we decide to backport dependency upgrades to older major versions of the fastly crate, but let's stick to the simpler remediation for now.

We decided to have keep the version check for new versions of the `fastly` crate, but only emit an info message rather than blocking the build when a new one is available.