### PR TITLE
Allow compute services to be initialised from an existing service ID

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -258,7 +258,8 @@ COMMANDS
   compute init [<flags>]
     Initialize a new Compute@Edge package locally
 
-    -s, --service-id=SERVICE-ID    Existing service ID to initialize from
+    -s, --service-id=SERVICE-ID    Existing service ID to use. By default, this
+                                   command creates a new service
     -n, --name=NAME                Name of package, defaulting to directory name
                                    of the --path destination
     -d, --description=DESCRIPTION  Description of the package

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -258,6 +258,7 @@ COMMANDS
   compute init [<flags>]
     Initialize a new Compute@Edge package locally
 
+    -s, --service-id=SERVICE-ID    Existing service ID to initialize from
     -n, --name=NAME                Name of package, defaulting to directory name
                                    of the --path destination
     -d, --description=DESCRIPTION  Description of the package

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -122,6 +122,24 @@ func TestInit(t *testing.T) {
 			manifestIncludes: `name = "test"`,
 		},
 		{
+			name:       "with service",
+			args:       []string{"compute", "init", "-s", "test"},
+			configFile: config.File{Token: "123"},
+			api: mock.API{
+				GetTokenSelfFn:  tokenOK,
+				GetUserFn:       getUserOk,
+				GetServiceFn:    getServiceOK,
+				CreateDomainFn:  createDomainOK,
+				CreateBackendFn: createBackendOK,
+			},
+			wantOutput: []string{
+				"Initializing...",
+				"Fetching package template...",
+				"Updating package manifest...",
+			},
+			manifestIncludes: `name = "test"`,
+		},
+		{
 			name:       "with description",
 			args:       []string{"compute", "init", "--description", "test"},
 			configFile: config.File{Token: "123"},
@@ -1195,6 +1213,13 @@ func createServiceOK(i *fastly.CreateServiceInput) (*fastly.Service, error) {
 		ID:   "12345",
 		Name: i.Name,
 		Type: i.Type,
+	}, nil
+}
+
+func getServiceOK(i *fastly.GetServiceInput) (*fastly.Service, error) {
+	return &fastly.Service{
+		ID:   "12345",
+		Name: "test",
 	}, nil
 }
 

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -129,6 +129,8 @@ func TestInit(t *testing.T) {
 				GetTokenSelfFn:  tokenOK,
 				GetUserFn:       getUserOk,
 				GetServiceFn:    getServiceOK,
+				ListVersionsFn:  listVersionsActiveOk,
+				CloneVersionFn:  cloneVersionOk,
 				CreateDomainFn:  createDomainOK,
 				CreateBackendFn: createBackendOK,
 			},
@@ -939,84 +941,6 @@ func TestUploadPackage(t *testing.T) {
 
 			err = testcase.client.UpdatePackage(testcase.serviceID, testcase.version, testcase.path)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
-		})
-	}
-}
-
-func TestGetIdealPackage(t *testing.T) {
-	for _, testcase := range []struct {
-		name          string
-		inputVersions []*fastly.Version
-		wantVersion   int
-	}{
-		{
-			name: "active",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "active not latest",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "active and locked",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")}},
-			wantVersion: 2,
-		},
-		{
-			name: "locked",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "locked not latest",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "no active or locked",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 3,
-		},
-		{
-			name: "not sorted",
-			inputVersions: []*fastly.Version{
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 4, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z")},
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-			},
-			wantVersion: 4,
-		},
-	} {
-		t.Run(testcase.name, func(t *testing.T) {
-			v, err := compute.GetLatestIdealVersion(testcase.inputVersions)
-			testutil.AssertNoError(t, err)
-			if v.Number != testcase.wantVersion {
-				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
-			}
 		})
 	}
 }

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/fastly"
 	"github.com/mholt/archiver/v3"
 )
 
@@ -231,6 +232,84 @@ func TestGetNonIgnoredFiles(t *testing.T) {
 			output, err := getNonIgnoredFiles(testcase.path, testcase.ignoredFiles)
 			testutil.AssertNoError(t, err)
 			testutil.AssertEqual(t, testcase.wantFiles, output)
+		})
+	}
+}
+
+func TestGetIdealPackage(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+	}{
+		{
+			name: "active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "active not latest",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "active and locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")}},
+			wantVersion: 2,
+		},
+		{
+			name: "locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "locked not latest",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "no active or locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+			},
+			wantVersion: 3,
+		},
+		{
+			name: "not sorted",
+			inputVersions: []*fastly.Version{
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 4, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z")},
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+			},
+			wantVersion: 4,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			v, err := getLatestIdealVersion(testcase.inputVersions)
+			testutil.AssertNoError(t, err)
+			if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
 		})
 	}
 }

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -92,7 +92,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			return fmt.Errorf("error listing service versions: %w", err)
 		}
 
-		version, err := GetLatestIdealVersion(versions)
+		version, err := getLatestIdealVersion(versions)
 		if err != nil {
 			return fmt.Errorf("error finding latest service version")
 		}
@@ -228,11 +228,11 @@ func (c *Client) UpdatePackage(serviceID string, v int, path string) error {
 	return nil
 }
 
-// GetLatestIdealVersion gets the most ideal service version using the following logic:
+// getLatestIdealVersion gets the most ideal service version using the following logic:
 // - Find the active version and return
 // - If no active version, find the latest locked version and return
 // - Otherwise return the latest version
-func GetLatestIdealVersion(versions []*fastly.Version) (*fastly.Version, error) {
+func getLatestIdealVersion(versions []*fastly.Version) (*fastly.Version, error) {
 	sort.Slice(versions, func(i, j int) bool {
 		return versions[i].UpdatedAt.Before(*versions[j].UpdatedAt)
 	})

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -68,7 +68,7 @@ func NewInitCommand(parent common.Registerer, globals *config.Data) *InitCommand
 	var c InitCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("init", "Initialize a new Compute@Edge package locally")
-	c.CmdClause.Flag("service-id", "Existing service ID to initialize from").Short('s').StringVar(&c.serviceID)
+	c.CmdClause.Flag("service-id", "Existing service ID to use. By default, this command creates a new service").Short('s').StringVar(&c.serviceID)
 	c.CmdClause.Flag("name", "Name of package, defaulting to directory name of the --path destination").Short('n').StringVar(&c.name)
 	c.CmdClause.Flag("description", "Description of the package").Short('d').StringVar(&c.description)
 	c.CmdClause.Flag("author", "Author of the package").Short('a').StringVar(&c.author)


### PR DESCRIPTION
### TL;DR
Refactors  `compute init` to accept a `--service-id` flag which will be used instead of provisioning a new service. This is an important feature request to bridge the UX flow between the UI -> CLI, i.e. this allows a user to first create a service via the UI and then move to the CLI to initialise the package. 