### PR TITLE
Compare package hashsum during deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
-	github.com/fastly/go-fastly v1.15.0
+	github.com/fastly/go-fastly v1.16.0
 	github.com/fatih/color v1.7.0
 	github.com/frankban/quicktest v1.5.0 // indirect
 	github.com/google/go-cmp v0.3.1
@@ -22,7 +22,7 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mholt/archiver/v3 v3.3.0
 	github.com/mitchellh/go-wordwrap v1.0.0
-	github.com/mitchellh/mapstructure v1.1.2
+	github.com/mitchellh/mapstructure v1.3.2
 	github.com/nicksnyder/go-i18n v1.10.1 // indirect
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
 	github.com/segmentio/textio v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:9
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
-github.com/fastly/go-fastly v1.15.0 h1:t7f0ZnQy0rKYN8FCql4wHkfZNHajxDs1hT/phazOpp8=
-github.com/fastly/go-fastly v1.15.0/go.mod h1:jILbTQnU/K/7XHQNzQWd1O7hbXIcp6dKrxfRWqU6xfk=
+github.com/fastly/go-fastly v1.16.0 h1:RMHvkzZ52J60+jSPK+6BLodIsx4OBlaoB18XmL7C0+Y=
+github.com/fastly/go-fastly v1.16.0/go.mod h1:jILbTQnU/K/7XHQNzQWd1O7hbXIcp6dKrxfRWqU6xfk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
@@ -92,8 +92,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
-github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYGN7GeoRg=
+github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=
 github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -52,6 +52,7 @@ type Interface interface {
 	UpdateHealthCheck(*fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
 	DeleteHealthCheck(*fastly.DeleteHealthCheckInput) error
 
+	GetPackage(*fastly.GetPackageInput) (*fastly.Package, error)
 	UpdatePackage(*fastly.UpdatePackageInput) (*fastly.Package, error)
 
 	CreateBigQuery(*fastly.CreateBigQueryInput) (*fastly.BigQuery, error)

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -52,6 +52,8 @@ type Interface interface {
 	UpdateHealthCheck(*fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
 	DeleteHealthCheck(*fastly.DeleteHealthCheckInput) error
 
+	UpdatePackage(*fastly.UpdatePackageInput) (*fastly.Package, error)
+
 	CreateBigQuery(*fastly.CreateBigQueryInput) (*fastly.BigQuery, error)
 	ListBigQueries(*fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error)
 	GetBigQuery(*fastly.GetBigQueryInput) (*fastly.BigQuery, error)

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -1,23 +1,16 @@
 package compute
 
 import (
-	"bytes"
 	"fmt"
 	"io"
-	"mime/multipart"
-	"net/http"
-	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/cli/pkg/version"
 	"github.com/fastly/go-fastly/fastly"
 	"github.com/kennygrant/sanitize"
 )
@@ -25,7 +18,6 @@ import (
 // DeployCommand deploys an artifact previously produced by build.
 type DeployCommand struct {
 	common.Base
-	client   api.HTTPClient
 	manifest manifest.Data
 	path     string
 	version  int
@@ -35,7 +27,6 @@ type DeployCommand struct {
 func NewDeployCommand(parent common.Registerer, client api.HTTPClient, globals *config.Data) *DeployCommand {
 	var c DeployCommand
 	c.Globals = globals
-	c.client = client
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("deploy", "Deploy a package to a Fastly Compute@Edge service")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
@@ -112,14 +103,13 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 
 	progress.Step("Uploading package...")
-	token, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-	endpoint, _ := c.Globals.Endpoint()
-	client := NewClient(c.client, endpoint, token)
-	if err := client.UpdatePackage(serviceID, c.version, c.path); err != nil {
-		return err
+	_, err = c.Globals.Client.UpdatePackage(&fastly.UpdatePackageInput{
+		Service:     serviceID,
+		Version:     c.version,
+		PackagePath: c.path,
+	})
+	if err != nil {
+		return fmt.Errorf("error uploading package: %w", err)
 	}
 
 	progress.Step("Activating version...")
@@ -155,76 +145,6 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 
 	text.Success(out, "Deployed package (service %s, version %v)", serviceID, c.version)
-	return nil
-}
-
-// Client wraps a HTTP client with an endpoint and token to make API requests.
-type Client struct {
-	client api.HTTPClient
-
-	endpoint string
-	token    string
-}
-
-// NewClient constructs a new Client.
-func NewClient(client api.HTTPClient, endpoint, token string) *Client {
-	return &Client{
-		client,
-		endpoint,
-		token,
-	}
-}
-
-// UpdatePackage is an HTTP API client method to update a package on a given
-// service version. It reads the package from a given path and encodes it as
-// multi-part form data in the request with associated content-type.
-// TODO(ph): This should eventually be replaced by the equivilent method in
-// the go-fastly client.
-func (c *Client) UpdatePackage(serviceID string, v int, path string) error {
-	file, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return fmt.Errorf("error reading package: %w", err)
-	}
-	defer file.Close() // #nosec G307
-
-	var body bytes.Buffer
-	w := multipart.NewWriter(&body)
-	part, err := w.CreateFormFile("package", filepath.Base(path))
-	if err != nil {
-		return fmt.Errorf("error creating multipart form: %w", err)
-	}
-
-	_, err = io.Copy(part, file)
-	if err != nil {
-		return fmt.Errorf("error copying package to multipart form: %w", err)
-	}
-
-	err = w.Close()
-	if err != nil {
-		return fmt.Errorf("error closing multipart form: %w", err)
-	}
-
-	fullurl := fmt.Sprintf("%s/service/%s/version/%d/package", strings.TrimSuffix(c.endpoint, "/"), serviceID, v)
-	req, err := http.NewRequest("PUT", fullurl, &body)
-	if err != nil {
-		return fmt.Errorf("error constructing API request: %w", err)
-	}
-
-	req.Header.Set("Fastly-Key", c.token)
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", w.FormDataContentType())
-	req.Header.Set("User-Agent", version.UserAgent)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("error executing API request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error from API: %s", resp.Status)
-	}
-
 	return nil
 }
 

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -43,6 +43,7 @@ type API struct {
 	UpdateHealthCheckFn func(*fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
 	DeleteHealthCheckFn func(*fastly.DeleteHealthCheckInput) error
 
+	GetPackageFn    func(*fastly.GetPackageInput) (*fastly.Package, error)
 	UpdatePackageFn func(*fastly.UpdatePackageInput) (*fastly.Package, error)
 
 	CreateBigQueryFn func(*fastly.CreateBigQueryInput) (*fastly.BigQuery, error)
@@ -338,6 +339,11 @@ func (m API) UpdateHealthCheck(i *fastly.UpdateHealthCheckInput) (*fastly.Health
 // DeleteHealthCheck implements Interface.
 func (m API) DeleteHealthCheck(i *fastly.DeleteHealthCheckInput) error {
 	return m.DeleteHealthCheckFn(i)
+}
+
+// GetPackage implements Interface.
+func (m API) GetPackage(i *fastly.GetPackageInput) (*fastly.Package, error) {
+	return m.GetPackageFn(i)
 }
 
 // UpdatePackage implements Interface.

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -43,6 +43,8 @@ type API struct {
 	UpdateHealthCheckFn func(*fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
 	DeleteHealthCheckFn func(*fastly.DeleteHealthCheckInput) error
 
+	UpdatePackageFn func(*fastly.UpdatePackageInput) (*fastly.Package, error)
+
 	CreateBigQueryFn func(*fastly.CreateBigQueryInput) (*fastly.BigQuery, error)
 	ListBigQueriesFn func(*fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error)
 	GetBigQueryFn    func(*fastly.GetBigQueryInput) (*fastly.BigQuery, error)
@@ -336,6 +338,11 @@ func (m API) UpdateHealthCheck(i *fastly.UpdateHealthCheckInput) (*fastly.Health
 // DeleteHealthCheck implements Interface.
 func (m API) DeleteHealthCheck(i *fastly.DeleteHealthCheckInput) error {
 	return m.DeleteHealthCheckFn(i)
+}
+
+// UpdatePackage implements Interface.
+func (m API) UpdatePackage(i *fastly.UpdatePackageInput) (*fastly.Package, error) {
+	return m.UpdatePackageFn(i)
 }
 
 // CreateBigQuery implements Interface.


### PR DESCRIPTION
### TL;DR
Refactors `fastly compute deploy` to use `gofastly.UpdatePackage()` methods now that we have upstreamed the API endpoints to `go-fastly` API client. Also adds new functionality to prevent a deploy if the package hashsum matches the package that already exists on the service.