### PR TITLE
Fix bug where name was not added to the manifest

### DIFF
--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -273,6 +273,19 @@ func TestInit(t *testing.T) {
 				"Updating package manifest...",
 			},
 		},
+		{
+			name:       "with default name inferred from directory",
+			args:       []string{"compute", "init"},
+			configFile: config.File{Token: "123"},
+			api: mock.API{
+				GetTokenSelfFn:  tokenOK,
+				GetUserFn:       getUserOk,
+				CreateServiceFn: createServiceOK,
+				CreateDomainFn:  createDomainOK,
+				CreateBackendFn: createBackendOK,
+			},
+			manifestIncludes: `name = "fastly-build`,
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			// We're going to chdir to an init environment,

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -151,12 +151,13 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	c.path = abspath
 
 	if name == "" {
-		name = filepath.Base(c.path)
-		fmt.Fprintf(progress, "--name not specified, using %s\n\n", name)
-
-		name, err = text.Input(out, fmt.Sprintf("Name: [%s] ", name), in)
+		defaultName := filepath.Base(c.path)
+		name, err = text.Input(out, fmt.Sprintf("Name: [%s] ", defaultName), in)
 		if err != nil {
 			return fmt.Errorf("error reading input: %w", err)
+		}
+		if name == "" {
+			name = defaultName
 		}
 	}
 


### PR DESCRIPTION
Use the default name if the user press enter at the name prompt.