### PR TITLE
Bump supported Rust toolchain version to 1.46

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.14.x]
-        rust-toolchain: [1.43.0]
+        rust-toolchain: [1.46.0]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -334,7 +334,7 @@ func (r Rust) Build(out io.Writer, verbose bool) error {
 	if err != nil {
 		return fmt.Errorf("error getting current working directory: %w", err)
 	}
-	src := filepath.Join(dir, "target", WasmWasiTarget, "release", "deps", fmt.Sprintf("%s.wasm", binName))
+	src := filepath.Join(dir, "target", WasmWasiTarget, "release", fmt.Sprintf("%s.wasm", binName))
 	dst := filepath.Join(dir, "bin", "main.wasm")
 
 	// Check if bin directory exists and create if not.

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -26,7 +26,7 @@ import (
 const (
 	// RustToolchainVersion is the `rustup` toolchain string for the compiler
 	// that we support
-	RustToolchainVersion = "1.43.0"
+	RustToolchainVersion = "1.46.0"
 	// WasmWasiTarget is the Rust compilation target for Wasi capable Wasm.
 	WasmWasiTarget = "wasm32-wasi"
 )


### PR DESCRIPTION
### TL;DR
Bumps the supported Rust toolchain version for Compute@Edge programs to the stable `1.46.0` version.

### Notes
We intend to move away from fixed versions to a min-max range for more flexibility in the near future. 