### PR TITLE
Update the default Rust template to fastly-0.5.0

### DIFF
--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -47,7 +47,7 @@ var (
 			{
 				Name:   "Default",
 				Path:   "https://github.com/fastly/fastly-template-rust-default.git",
-				Branch: "0.4.0",
+				Branch: "0.5.0",
 			},
 		},
 	}

--- a/pkg/compute/testdata/build/Cargo.lock
+++ b/pkg/compute/testdata/build/Cargo.lock
@@ -47,20 +47,20 @@ dependencies = [
 name = "edge-compute-default-rust-template"
 version = "0.1.0"
 dependencies = [
- "fastly 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fastly"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fastly-macros 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-shared 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-shared 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-sys 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -91,10 +91,10 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fastly-shared 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-shared 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -309,10 +309,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)" = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
-"checksum fastly 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "238ebcba2d40d5a60c5830e50a0d0e2afb58983254372ec9f403affa40e59b76"
+"checksum fastly 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3e9d2a7ef97cb0d4619458538228ff22f527df4e8c97ba69b7a9a7375efa726"
 "checksum fastly-macros 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b9984ad9326e0e677e00ab5a996942ad6eacc9b085877bc078bad9b3119fd808"
-"checksum fastly-shared 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "533b3809fad597f3c6e602b7b69d1bb0ca9028a06725b1a1eabc85742c7fa780"
-"checksum fastly-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "70249b5ad5aba30047e6f75d20c5634cca0972b686170bb13533b20c52a01b2b"
+"checksum fastly-shared 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c0589ab13a2e0a54eba06e4b281b6611d10eb26fc9ab2fc59d266a6f03506f2"
+"checksum fastly-sys 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8bb88322ba43fe939b3b18fc3e8b1387a0df67fb55c3cade44b1c4c6321589"
 "checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 "checksum generator 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
 "checksum http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"


### PR DESCRIPTION
## 🦀 update the default rust template to fastly-0.5.0

### Changes Made

This updates the branch used to clone the default Rust template to
a branch that includes the `fastly-0.5.0` crate.

That branch, which can be found
here<sup>[1](https://github.com/fastly/fastly-template-rust-default/tree/0.5.0)</sup>
includes most importantly our PR's fastly-template-rust-default/pull/19, and
fastly-template-rust-default/pull/20.

### Changes NOT Made

The previous commit which updated the default version to `0.4.0`,
e505d08, included changes to our
`pkg/compute/testdata/build/Cargo.toml` file. This was already
changed in d25ef1a, and has been left out of this commit.
