### PR TITLE
Constrain Version Upgrade Suggestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 SHELL := /bin/bash -o pipefail
 
+# the rationale for using both `git describe` and `git rev-parse` is because
+# when CI builds the application it can be based on a git tag, so this ensures
+# the output is consistent across environments.
 VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
+
 LDFLAGS = -ldflags "\
  -X 'github.com/fastly/cli/pkg/version.AppVersion=${VERSION}' \
  -X 'github.com/fastly/cli/pkg/version.GitRevision=$(shell git rev-parse --short HEAD || echo unknown)' \

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -670,7 +670,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		return errors.RemediationError{Prefix: usage, Inner: fmt.Errorf("command not found")}
 	}
 
-	if versioner != nil && name != "update" && version.PreRelease(version.AppVersion) == false {
+	if versioner != nil && name != "update" && !version.PreRelease(version.AppVersion) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel() // push cancel on the defer stack first...
 		f := update.CheckAsync(ctx, file, configFilePath, version.AppVersion, versioner)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -670,7 +670,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		return errors.RemediationError{Prefix: usage, Inner: fmt.Errorf("command not found")}
 	}
 
-	if versioner != nil && name != "update" && version.AppVersion != version.None {
+	if versioner != nil && name != "update" && version.PreRelease(version.AppVersion) == false {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel() // push cancel on the defer stack first...
 		f := update.CheckAsync(ctx, file, configFilePath, version.AppVersion, versioner)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -670,7 +670,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		return errors.RemediationError{Prefix: usage, Inner: fmt.Errorf("command not found")}
 	}
 
-	if versioner != nil && name != "update" && !version.PreRelease(version.AppVersion) {
+	if versioner != nil && name != "update" && !version.IsPreRelease(version.AppVersion) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel() // push cancel on the defer stack first...
 		f := update.CheckAsync(ctx, file, configFilePath, version.AppVersion, versioner)

--- a/pkg/version/root.go
+++ b/pkg/version/root.go
@@ -70,9 +70,9 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	return nil
 }
 
-// PreRelease determines if the given app version is a pre-release.
+// IsPreRelease determines if the given app version is a pre-release.
 //
 // NOTE: this is indicated by the presence of a hyphen, e.g. v1.0.0-rc.1
-func PreRelease(version string) bool {
-    result strings.Contains(version, "-")
+func IsPreRelease(version string) bool {
+	return strings.Contains(version, "-")
 }

--- a/pkg/version/root.go
+++ b/pkg/version/root.go
@@ -74,11 +74,5 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 //
 // NOTE: this is indicated by the presence of a hyphen, e.g. v1.0.0-rc.1
 func PreRelease(version string) bool {
-	var result bool
-
-	if i := strings.Index(version, "-"); i >= 0 {
-		result = true
-	}
-
-	return result
+    result strings.Contains(version, "-")
 }

--- a/pkg/version/root.go
+++ b/pkg/version/root.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/go-fastly/fastly"
@@ -67,4 +68,17 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Fastly CLI version %s (%s)\n", AppVersion, GitRevision)
 	fmt.Fprintf(out, "Built with %s\n", GoVersion)
 	return nil
+}
+
+// PreRelease determines if the given app version is a pre-release.
+//
+// NOTE: this is indicated by the presence of a hyphen, e.g. v1.0.0-rc.1
+func PreRelease(version string) bool {
+	var result bool
+
+	if i := strings.Index(version, "-"); i >= 0 {
+		result = true
+	}
+
+	return result
 }


### PR DESCRIPTION
**Problem**: when developing locally, `./fastly version` would suggest an upgrade to a pre-release version.
**Solution**: version upgrades should only be for standard semver releases (e.g. `v1.1.1` not `v.1.1.1-rc-1`).
**Notes**: customers should (in theory) only be using an 'official' release and won't expect pre-release.