### PR TITLE
Add support for Kinesis logging endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
-	github.com/fastly/go-fastly/v2 v2.0.0
+	github.com/fastly/go-fastly/v2 v2.1.0
 	github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible
 	github.com/fatih/color v1.7.0
 	github.com/frankban/quicktest v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:9
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
-github.com/fastly/go-fastly/v2 v2.0.0 h1:dCPOEbTXy8ic5CGj6YibPNvRYG01y15H7kHTlC4d57k=
-github.com/fastly/go-fastly/v2 v2.0.0/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
+github.com/fastly/go-fastly/v2 v2.1.0 h1:VQWCFiUZyCcknyxyhiQwU0MjLYzeK4g1mLo/US2r/P0=
+github.com/fastly/go-fastly/v2 v2.1.0/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -87,6 +87,12 @@ type Interface interface {
 	UpdateS3(*fastly.UpdateS3Input) (*fastly.S3, error)
 	DeleteS3(*fastly.DeleteS3Input) error
 
+	CreateKinesis(*fastly.CreateKinesisInput) (*fastly.Kinesis, error)
+	ListKineses(*fastly.ListKinesesInput) ([]*fastly.Kinesis, error)
+	GetKinesis(*fastly.GetKinesisInput) (*fastly.Kinesis, error)
+	UpdateKinesis(*fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
+	DeleteKinesis(*fastly.DeleteKinesisInput) error
+
 	CreateSyslog(*fastly.CreateSyslogInput) (*fastly.Syslog, error)
 	ListSyslogs(*fastly.ListSyslogsInput) ([]*fastly.Syslog, error)
 	GetSyslog(*fastly.GetSyslogInput) (*fastly.Syslog, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -35,6 +35,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/honeycomb"
 	"github.com/fastly/cli/pkg/logging/https"
 	"github.com/fastly/cli/pkg/logging/kafka"
+	"github.com/fastly/cli/pkg/logging/kinesis"
 	"github.com/fastly/cli/pkg/logging/logentries"
 	"github.com/fastly/cli/pkg/logging/loggly"
 	"github.com/fastly/cli/pkg/logging/logshuttle"
@@ -188,6 +189,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	s3Describe := s3.NewDescribeCommand(s3Root.CmdClause, &globals)
 	s3Update := s3.NewUpdateCommand(s3Root.CmdClause, &globals)
 	s3Delete := s3.NewDeleteCommand(s3Root.CmdClause, &globals)
+
+	kinesisRoot := kinesis.NewRootCommand(loggingRoot.CmdClause, &globals)
+	kinesisCreate := kinesis.NewCreateCommand(kinesisRoot.CmdClause, &globals)
+	kinesisList := kinesis.NewListCommand(kinesisRoot.CmdClause, &globals)
+	kinesisDescribe := kinesis.NewDescribeCommand(kinesisRoot.CmdClause, &globals)
+	kinesisUpdate := kinesis.NewUpdateCommand(kinesisRoot.CmdClause, &globals)
+	kinesisDelete := kinesis.NewDeleteCommand(kinesisRoot.CmdClause, &globals)
 
 	syslogRoot := syslog.NewRootCommand(loggingRoot.CmdClause, &globals)
 	syslogCreate := syslog.NewCreateCommand(syslogRoot.CmdClause, &globals)
@@ -428,6 +436,13 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		s3Describe,
 		s3Update,
 		s3Delete,
+
+		kinesisRoot,
+		kinesisCreate,
+		kinesisList,
+		kinesisDescribe,
+		kinesisUpdate,
+		kinesisDelete,
 
 		syslogRoot,
 		syslogCreate,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -859,12 +859,11 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the S3 logging object
 
-  logging kinesis create --name=NAME --service-id=SERVICE-ID --version=VERSION --stream-name=STREAM-NAME --access-key=ACCESS-KEY --secret-key=SECRET-KEY --region=REGION [<flags>]
+  logging kinesis create --name=NAME --version=VERSION --stream-name=STREAM-NAME --access-key=ACCESS-KEY --secret-key=SECRET-KEY --region=REGION [<flags>]
     Create an Amazon Kinesis logging endpoint on a Fastly service version
 
     -n, --name=NAME                The name of the Kinesis logging object. Used
                                    as a primary key for API access
-    -s, --service-id=SERVICE-ID    Service ID
         --version=VERSION          Number of service version
         --stream-name=STREAM-NAME  The Amazon Kinesis stream to send logs to
         --access-key=ACCESS-KEY    The access key associated with the target
@@ -873,6 +872,7 @@ COMMANDS
                                    Amazon Kinesis stream
         --region=REGION            The AWS region where the Kinesis stream
                                    exists
+    -s, --service-id=SERVICE-ID    Service ID
         --format=FORMAT            Apache style log formatting
         --format-version=FORMAT-VERSION
                                    The version of the custom logging format used
@@ -901,12 +901,12 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Kinesis logging object
 
-  logging kinesis update --service-id=SERVICE-ID --version=VERSION --name=NAME [<flags>]
+  logging kinesis update --version=VERSION --name=NAME [<flags>]
     Update a Kinesis logging endpoint on a Fastly service version
 
-    -s, --service-id=SERVICE-ID    Service ID
         --version=VERSION          Number of service version
     -n, --name=NAME                The name of the Kinesis logging object
+    -s, --service-id=SERVICE-ID    Service ID
         --new-name=NEW-NAME        New name of the Kinesis logging object
         --stream-name=STREAM-NAME  Your Kinesis stream name
         --access-key=ACCESS-KEY    Your Kinesis account access key
@@ -927,12 +927,12 @@ COMMANDS
                                    format_version default. Can be none or
                                    waf_debug
 
-  logging kinesis delete --service-id=SERVICE-ID --version=VERSION --name=NAME
+  logging kinesis delete --version=VERSION --name=NAME [<flags>]
     Delete a Kinesis logging endpoint on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the Kinesis logging object
+    -s, --service-id=SERVICE-ID  Service ID
 
   logging syslog create --name=NAME --version=VERSION --address=ADDRESS [<flags>]
     Create a Syslog logging endpoint on a Fastly service version

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -859,6 +859,81 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the S3 logging object
 
+  logging kinesis create --name=NAME --service-id=SERVICE-ID --version=VERSION --stream-name=STREAM-NAME --access-key=ACCESS-KEY --secret-key=SECRET-KEY --region=REGION [<flags>]
+    Create an Amazon Kinesis logging endpoint on a Fastly service version
+
+    -n, --name=NAME                The name of the Kinesis logging object. Used
+                                   as a primary key for API access
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+        --stream-name=STREAM-NAME  The Amazon Kinesis stream to send logs to
+        --access-key=ACCESS-KEY    The access key associated with the target
+                                   Amazon Kinesis stream
+        --secret-key=SECRET-KEY    The secret key associated with the target
+                                   Amazon Kinesis stream
+        --region=REGION            The AWS region where the Kinesis stream
+                                   exists
+        --format=FORMAT            Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+
+  logging kinesis list --version=VERSION [<flags>]
+    List Kinesis endpoints on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+
+  logging kinesis describe --version=VERSION --name=NAME [<flags>]
+    Show detailed information about a Kinesis logging endpoint on a Fastly
+    service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Kinesis logging object
+
+  logging kinesis update --service-id=SERVICE-ID --version=VERSION --name=NAME [<flags>]
+    Update a Kinesis logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID    Service ID
+        --version=VERSION          Number of service version
+    -n, --name=NAME                The name of the Kinesis logging object
+        --new-name=NEW-NAME        New name of the Kinesis logging object
+        --stream-name=STREAM-NAME  Your Kinesis stream name
+        --access-key=ACCESS-KEY    Your Kinesis account access key
+        --secret-key=SECRET-KEY    Your Kinesis account secret key
+        --region=REGION            The AWS region where the Kinesis stream
+                                   exists
+        --format=FORMAT            Apache style log formatting
+        --format-version=FORMAT-VERSION
+                                   The version of the custom logging format used
+                                   for the configured endpoint. Can be either 2
+                                   (default) or 1
+        --response-condition=RESPONSE-CONDITION
+                                   The name of an existing condition in the
+                                   configured endpoint, or leave blank to always
+                                   execute
+        --placement=PLACEMENT      Where in the generated VCL the logging call
+                                   should be placed, overriding any
+                                   format_version default. Can be none or
+                                   waf_debug
+
+  logging kinesis delete --service-id=SERVICE-ID --version=VERSION --name=NAME
+    Delete a Kinesis logging endpoint on a Fastly service version
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of service version
+    -n, --name=NAME              The name of the Kinesis logging object
+
   logging syslog create --name=NAME --version=VERSION --address=ADDRESS [<flags>]
     Create a Syslog logging endpoint on a Fastly service version
 

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -17,7 +17,7 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shaddow common.Base method Name().
+	EndpointName string // Can't shadow common.Base method Name().
 	Version      int
 	StreamName   string
 	AccessKey    string

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -40,7 +40,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 
 	// required
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Required().Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
 	c.CmdClause.Flag("stream-name", "The Amazon Kinesis stream to send logs to").Required().StringVar(&c.StreamName)
 	c.CmdClause.Flag("access-key", "The access key associated with the target Amazon Kinesis stream").Required().StringVar(&c.AccessKey)
@@ -48,6 +47,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("region", "The AWS region where the Kinesis stream exists").Required().StringVar(&c.Region)
 
 	// optional
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/go-fastly/v2/fastly"
 )
 
-// CreateCommand calls the Fastly API to create Amazon Kinesis logging endpoints.
+// CreateCommand calls the Fastly API to create an Amazon Kinesis logging endpoint.
 type CreateCommand struct {
 	common.Base
 	manifest manifest.Data
@@ -38,15 +38,16 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Amazon Kinesis logging endpoint on a Fastly service version").Alias("add")
 
+	// required
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("service-id", "Service ID").Required().Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
-
 	c.CmdClause.Flag("stream-name", "The Amazon Kinesis stream to send logs to").Required().StringVar(&c.StreamName)
 	c.CmdClause.Flag("access-key", "The access key associated with the target Amazon Kinesis stream").Required().StringVar(&c.AccessKey)
 	c.CmdClause.Flag("secret-key", "The secret key associated with the target Amazon Kinesis stream").Required().StringVar(&c.SecretKey)
-
 	c.CmdClause.Flag("region", "The AWS region where the Kinesis stream exists").Required().StringVar(&c.Region)
+
+	// optional
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -1,0 +1,108 @@
+package kinesis
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v2/fastly"
+)
+
+// CreateCommand calls the Fastly API to create Amazon Kinesis logging endpoints.
+type CreateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+	StreamName   string
+	AccessKey    string
+	SecretKey    string
+	Region       string
+
+	// optional
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("create", "Create an Amazon Kinesis logging endpoint on a Fastly service version").Alias("add")
+
+	c.CmdClause.Flag("name", "The name of the Kinesis logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+
+	c.CmdClause.Flag("stream-name", "The Amazon Kinesis stream to send logs to").Required().StringVar(&c.StreamName)
+	c.CmdClause.Flag("access-key", "The access key associated with the target Amazon Kinesis stream").Required().StringVar(&c.AccessKey)
+	c.CmdClause.Flag("secret-key", "The secret key associated with the target Amazon Kinesis stream").Required().StringVar(&c.SecretKey)
+
+	c.CmdClause.Flag("region", "The AWS region where the Kinesis stream exists").Required().StringVar(&c.Region)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) createInput() (*fastly.CreateKinesisInput, error) {
+	var input fastly.CreateKinesisInput
+
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	input.ServiceID = serviceID
+	input.ServiceVersion = c.Version
+	input.Name = c.EndpointName
+	input.StreamName = c.StreamName
+	input.AccessKey = c.AccessKey
+	input.SecretKey = c.SecretKey
+	input.Region = c.Region
+
+	if c.Format.WasSet {
+		input.Format = c.Format.Value
+	}
+
+	if c.FormatVersion.WasSet {
+		input.FormatVersion = c.FormatVersion.Value
+	}
+
+	if c.ResponseCondition.WasSet {
+		input.ResponseCondition = c.ResponseCondition.Value
+	}
+
+	if c.Placement.WasSet {
+		input.Placement = c.Placement.Value
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	d, err := c.Globals.Client.CreateKinesis(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created Kinesis logging endpoint %s (service %s version %d)", d.Name, d.ServiceID, d.ServiceVersion)
+	return nil
+}

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -24,7 +24,7 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.Globals = globals
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Kinesis logging endpoint on a Fastly service version").Alias("remove")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("service-id", "Service ID").Required().Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -24,9 +24,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.Globals = globals
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Kinesis logging endpoint on a Fastly service version").Alias("remove")
-	c.CmdClause.Flag("service-id", "Service ID").Required().Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+
 	return &c
 }
 

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/go-fastly/v2/fastly"
 )
 
-// DeleteCommand calls the Fastly API to delete Amazon Kinesis logging endpoints.
+// DeleteCommand calls the Fastly API to delete an Amazon Kinesis logging endpoint.
 type DeleteCommand struct {
 	common.Base
 	manifest manifest.Data

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -1,0 +1,47 @@
+package kinesis
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v2/fastly"
+)
+
+// DeleteCommand calls the Fastly API to delete Amazon Kinesis logging endpoints.
+type DeleteCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.DeleteKinesisInput
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("delete", "Delete a Kinesis logging endpoint on a Fastly service version").Alias("remove")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.ServiceID = serviceID
+
+	if err := c.Globals.Client.DeleteKinesis(&c.Input); err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted Kinesis logging endpoint %s (service %s version %d)", c.Input.Name, c.Input.ServiceID, c.Input.ServiceVersion)
+	return nil
+}

--- a/pkg/logging/kinesis/describe.go
+++ b/pkg/logging/kinesis/describe.go
@@ -1,0 +1,59 @@
+package kinesis
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/v2/fastly"
+)
+
+// DescribeCommand calls the Fastly API to describe an Amazon Kinesis logging endpoint.
+type DescribeCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.GetKinesisInput
+}
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("describe", "Show detailed information about a Kinesis logging endpoint on a Fastly service version").Alias("get")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.Input.Name)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.ServiceID = serviceID
+
+	kinesis, err := c.Globals.Client.GetKinesis(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", kinesis.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", kinesis.ServiceVersion)
+	fmt.Fprintf(out, "Name: %s\n", kinesis.Name)
+	fmt.Fprintf(out, "Stream name: %s\n", kinesis.StreamName)
+	fmt.Fprintf(out, "Region: %s\n", kinesis.Region)
+	fmt.Fprintf(out, "Access key: %s\n", kinesis.AccessKey)
+	fmt.Fprintf(out, "Secret key: %s\n", kinesis.SecretKey)
+	fmt.Fprintf(out, "Format: %s\n", kinesis.Format)
+	fmt.Fprintf(out, "Format version: %d\n", kinesis.FormatVersion)
+	fmt.Fprintf(out, "Response condition: %s\n", kinesis.ResponseCondition)
+	fmt.Fprintf(out, "Placement: %s\n", kinesis.Placement)
+
+	return nil
+}

--- a/pkg/logging/kinesis/doc.go
+++ b/pkg/logging/kinesis/doc.go
@@ -1,0 +1,3 @@
+// Package kinesis contains commands to inspect and manipulate Fastly service Kinesis
+// logging endpoints.
+package kinesis

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -1,0 +1,400 @@
+package kinesis_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/v2/fastly"
+)
+
+func TestKinesisCreate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--region", "us-east-1"},
+			wantError: "error parsing arguments: required flag --secret-key not provided",
+		},
+		{
+			args:       []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
+			api:        mock.API{CreateKinesisFn: createKinesisOK},
+			wantOutput: "Created Kinesis logging endpoint log (service 123 version 1)",
+		},
+		{
+			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
+			api:       mock.API{CreateKinesisFn: createKinesisError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestKinesisList(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListKinesesFn: listKinesesOK},
+			wantOutput: listKinesesShortOutput,
+		},
+		{
+			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api:        mock.API{ListKinesesFn: listKinesesOK},
+			wantOutput: listKinesesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "-v"},
+			api:        mock.API{ListKinesesFn: listKinesesOK},
+			wantOutput: listKinesesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "kinesis", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListKinesesFn: listKinesesOK},
+			wantOutput: listKinesesVerboseOutput,
+		},
+		{
+			args:       []string{"logging", "-v", "kinesis", "list", "--service-id", "123", "--version", "1"},
+			api:        mock.API{ListKinesesFn: listKinesesOK},
+			wantOutput: listKinesesVerboseOutput,
+		},
+		{
+			args:      []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
+			api:       mock.API{ListKinesesFn: listKinesesError},
+			wantError: errTest.Error(),
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestKinesisDescribe(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{GetKinesisFn: getKinesisError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{GetKinesisFn: getKinesisOK},
+			wantOutput: describeKinesisOutput,
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertString(t, testcase.wantOutput, out.String())
+		})
+	}
+}
+
+func TestKinesisUpdate(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1"},
+			api: mock.API{
+				GetKinesisFn:    getKinesisError,
+				UpdateKinesisFn: updateKinesisOK,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				GetKinesisFn:    getKinesisOK,
+				UpdateKinesisFn: updateKinesisError,
+			},
+			wantError: errTest.Error(),
+		},
+		{
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1"},
+			api: mock.API{
+				GetKinesisFn:    getKinesisOK,
+				UpdateKinesisFn: updateKinesisOK,
+			},
+			wantOutput: "Updated Kinesis logging endpoint log (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+func TestKinesisDelete(t *testing.T) {
+	for _, testcase := range []struct {
+		args       []string
+		api        mock.API
+		wantError  string
+		wantOutput string
+	}{
+		{
+			args:      []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1"},
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			args:      []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:       mock.API{DeleteKinesisFn: deleteKinesisError},
+			wantError: errTest.Error(),
+		},
+		{
+			args:       []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api:        mock.API{DeleteKinesisFn: deleteKinesisOK},
+			wantOutput: "Deleted Kinesis logging endpoint logs (service 123 version 1)",
+		},
+	} {
+		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = config.File{}
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = http.DefaultClient
+				versioner     update.Versioner = nil
+				in            io.Reader        = nil
+				out           bytes.Buffer
+			)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
+		})
+	}
+}
+
+var errTest = errors.New("fixture error")
+
+func createKinesisOK(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
+	return &fastly.Kinesis{
+		ServiceID:      i.ServiceID,
+		ServiceVersion: i.ServiceVersion,
+		Name:           i.Name,
+	}, nil
+}
+
+func createKinesisError(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
+	return nil, errTest
+}
+
+func listKinesesOK(i *fastly.ListKinesesInput) ([]*fastly.Kinesis, error) {
+	return []*fastly.Kinesis{
+		{
+			ServiceID:         i.ServiceID,
+			ServiceVersion:    i.ServiceVersion,
+			Name:              "logs",
+			StreamName:        "my-logs",
+			AccessKey:         "1234",
+			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+			Region:            "us-east-1",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+		{
+			ServiceID:         i.ServiceID,
+			ServiceVersion:    i.ServiceVersion,
+			Name:              "analytics",
+			StreamName:        "analytics",
+			AccessKey:         "1234",
+			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+			Region:            "us-east-1",
+			Format:            `%h %l %u %t "%r" %>s %b`,
+			FormatVersion:     2,
+			ResponseCondition: "Prevent default logging",
+			Placement:         "none",
+		},
+	}, nil
+}
+
+func listKinesesError(i *fastly.ListKinesesInput) ([]*fastly.Kinesis, error) {
+	return nil, errTest
+}
+
+var listKinesesShortOutput = strings.TrimSpace(`
+SERVICE  VERSION  NAME
+123      1        logs
+123      1        analytics
+`) + "\n"
+
+var listKinesesVerboseOutput = strings.TrimSpace(`
+Fastly API token not provided
+Fastly API endpoint: https://api.fastly.com
+Service ID: 123
+Version: 1
+	Kinesis 1/2
+		Service ID: 123
+		Version: 1
+		Name: logs
+		Stream name: my-logs
+		Region: us-east-1
+		Access key: 1234
+		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+	Kinesis 2/2
+		Service ID: 123
+		Version: 1
+		Name: analytics
+		Stream name: analytics
+		Region: us-east-1
+		Access key: 1234
+		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
+		Format: %h %l %u %t "%r" %>s %b
+		Format version: 2
+		Response condition: Prevent default logging
+		Placement: none
+`) + "\n\n"
+
+func getKinesisOK(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
+	return &fastly.Kinesis{
+		ServiceID:         i.ServiceID,
+		ServiceVersion:    i.ServiceVersion,
+		Name:              "logs",
+		StreamName:        "my-logs",
+		AccessKey:         "1234",
+		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+		Region:            "us-east-1",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func getKinesisError(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
+	return nil, errTest
+}
+
+var describeKinesisOutput = strings.TrimSpace(`
+Service ID: 123
+Version: 1
+Name: logs
+Stream name: my-logs
+Region: us-east-1
+Access key: 1234
+Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
+Format: %h %l %u %t "%r" %>s %b
+Format version: 2
+Response condition: Prevent default logging
+Placement: none
+`) + "\n"
+
+func updateKinesisOK(i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
+	return &fastly.Kinesis{
+		ServiceID:         i.ServiceID,
+		ServiceVersion:    i.ServiceVersion,
+		Name:              "log",
+		StreamName:        "my-logs",
+		AccessKey:         "1234",
+		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA",
+		Region:            "us-west-1",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}
+
+func updateKinesisError(i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
+	return nil, errTest
+}
+
+func deleteKinesisOK(i *fastly.DeleteKinesisInput) error {
+	return nil
+}
+
+func deleteKinesisError(i *fastly.DeleteKinesisInput) error {
+	return errTest
+}

--- a/pkg/logging/kinesis/kinesis_test.go
+++ b/pkg/logging/kinesis/kinesis_test.go
@@ -1,0 +1,209 @@
+package kinesis
+
+import (
+	"testing"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v2/fastly"
+)
+
+func TestCreateKinesisInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *CreateCommand
+		want      *fastly.CreateKinesisInput
+		wantError string
+	}{
+		{
+			name: "required values set flag serviceID",
+			cmd:  createCommandRequired(),
+			want: &fastly.CreateKinesisInput{
+				ServiceID:      "123",
+				ServiceVersion: 2,
+				Name:           "log",
+				StreamName:     "stream",
+				AccessKey:      "access",
+				SecretKey:      "secret",
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  createCommandAll(),
+			want: &fastly.CreateKinesisInput{
+				ServiceID:         "123",
+				ServiceVersion:    2,
+				Name:              "logs",
+				StreamName:        "stream",
+				Region:            "us-east-1",
+				AccessKey:         "access",
+				SecretKey:         "secret",
+				Format:            `%h %l %u %t "%r" %>s %b`,
+				FormatVersion:     2,
+				ResponseCondition: "Prevent default logging",
+				Placement:         "none",
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       createCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func TestUpdateKinesisInput(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		cmd       *UpdateCommand
+		api       mock.API
+		want      *fastly.UpdateKinesisInput
+		wantError string
+	}{
+		{
+			name: "no updates",
+			cmd:  updateCommandNoUpdates(),
+			api:  mock.API{GetKinesisFn: getKinesisOK},
+			want: &fastly.UpdateKinesisInput{
+				ServiceID:         "123",
+				ServiceVersion:    2,
+				Name:              "logs",
+				NewName:           fastly.String("logs"),
+				StreamName:        fastly.String("stream"),
+				AccessKey:         fastly.String("access"),
+				SecretKey:         fastly.String("secret"),
+				Region:            fastly.String("us-east-1"),
+				Format:            fastly.String(`%h %l %u %t "%r" %>s %b`),
+				FormatVersion:     fastly.Uint(2),
+				ResponseCondition: fastly.String("Prevent default logging"),
+				Placement:         fastly.String("none"),
+			},
+		},
+		{
+			name: "all values set flag serviceID",
+			cmd:  updateCommandAll(),
+			api:  mock.API{GetKinesisFn: getKinesisOK},
+			want: &fastly.UpdateKinesisInput{
+				ServiceID:         "123",
+				ServiceVersion:    2,
+				Name:              "logs",
+				NewName:           fastly.String("new1"),
+				StreamName:        fastly.String("new2"),
+				AccessKey:         fastly.String("new3"),
+				SecretKey:         fastly.String("new4"),
+				Region:            fastly.String("new5"),
+				Format:            fastly.String("new7"),
+				FormatVersion:     fastly.Uint(3),
+				ResponseCondition: fastly.String("new9"),
+				Placement:         fastly.String("new11"),
+			},
+		},
+		{
+			name:      "error missing serviceID",
+			cmd:       updateCommandMissingServiceID(),
+			want:      nil,
+			wantError: errors.ErrNoServiceID.Error(),
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			testcase.cmd.Base.Globals.Client = testcase.api
+
+			have, err := testcase.cmd.createInput()
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertEqual(t, testcase.want, have)
+		})
+	}
+}
+
+func createCommandRequired() *CreateCommand {
+	return &CreateCommand{
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		Version:      2,
+		StreamName:   "stream",
+		AccessKey:    "access",
+		SecretKey:    "secret",
+	}
+}
+
+func createCommandAll() *CreateCommand {
+	return &CreateCommand{
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "logs",
+		Version:           2,
+		StreamName:        "stream",
+		AccessKey:         "access",
+		SecretKey:         "secret",
+		Region:            "us-east-1",
+		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+	}
+}
+
+func createCommandMissingServiceID() *CreateCommand {
+	res := createCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func updateCommandNoUpdates() *UpdateCommand {
+	return &UpdateCommand{
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "logs",
+		Version:      2,
+	}
+}
+
+func updateCommandAll() *UpdateCommand {
+	return &UpdateCommand{
+		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName:      "logs",
+		Version:           2,
+		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
+		StreamName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
+		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
+		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
+		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
+		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
+		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
+	}
+}
+
+func updateCommandMissingServiceID() *UpdateCommand {
+	res := updateCommandAll()
+	res.manifest = manifest.Data{}
+	return res
+}
+
+func getKinesisOK(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
+	return &fastly.Kinesis{
+		ServiceID:         i.ServiceID,
+		ServiceVersion:    i.ServiceVersion,
+		Name:              "logs",
+		StreamName:        "stream",
+		Region:            "us-east-1",
+		AccessKey:         "access",
+		SecretKey:         "secret",
+		Format:            `%h %l %u %t "%r" %>s %b`,
+		FormatVersion:     2,
+		ResponseCondition: "Prevent default logging",
+		Placement:         "none",
+	}, nil
+}

--- a/pkg/logging/kinesis/list.go
+++ b/pkg/logging/kinesis/list.go
@@ -1,0 +1,75 @@
+package kinesis
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v2/fastly"
+)
+
+// ListCommand calls the Fastly API to list Amazon Kinesis logging endpoints.
+type ListCommand struct {
+	common.Base
+	manifest manifest.Data
+	Input    fastly.ListKinesesInput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List Kinesis endpoints on a Fastly service version")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.ServiceID = serviceID
+
+	kineses, err := c.Globals.Client.ListKineses(&c.Input)
+	if err != nil {
+		return err
+	}
+
+	if !c.Globals.Verbose() {
+		tw := text.NewTable(out)
+		tw.AddHeader("SERVICE", "VERSION", "NAME")
+		for _, kinesis := range kineses {
+			tw.AddLine(kinesis.ServiceID, kinesis.ServiceVersion, kinesis.Name)
+		}
+		tw.Print()
+		return nil
+	}
+
+	fmt.Fprintf(out, "Service ID: %s\n", c.Input.ServiceID)
+	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
+	for i, kinesis := range kineses {
+		fmt.Fprintf(out, "\tKinesis %d/%d\n", i+1, len(kineses))
+		fmt.Fprintf(out, "\t\tService ID: %s\n", kinesis.ServiceID)
+		fmt.Fprintf(out, "\t\tVersion: %d\n", kinesis.ServiceVersion)
+		fmt.Fprintf(out, "\t\tName: %s\n", kinesis.Name)
+		fmt.Fprintf(out, "\t\tStream name: %s\n", kinesis.StreamName)
+		fmt.Fprintf(out, "\t\tRegion: %s\n", kinesis.Region)
+		fmt.Fprintf(out, "\t\tAccess key: %s\n", kinesis.AccessKey)
+		fmt.Fprintf(out, "\t\tSecret key: %s\n", kinesis.SecretKey)
+		fmt.Fprintf(out, "\t\tFormat: %s\n", kinesis.Format)
+		fmt.Fprintf(out, "\t\tFormat version: %d\n", kinesis.FormatVersion)
+		fmt.Fprintf(out, "\t\tResponse condition: %s\n", kinesis.ResponseCondition)
+		fmt.Fprintf(out, "\t\tPlacement: %s\n", kinesis.Placement)
+	}
+	fmt.Fprintln(out)
+
+	return nil
+}

--- a/pkg/logging/kinesis/root.go
+++ b/pkg/logging/kinesis/root.go
@@ -1,0 +1,28 @@
+package kinesis
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("kinesis", "Manipulate Fastly service version Kinesis logging endpoints")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logging/kinesis/root.go
+++ b/pkg/logging/kinesis/root.go
@@ -18,7 +18,7 @@ type RootCommand struct {
 func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
-	c.CmdClause = parent.Command("kinesis", "Manipulate Fastly service version Kinesis logging endpoints")
+	c.CmdClause = parent.Command("kinesis", "Manipulate a Kinesis logging endpoint for a specific Fastly service version")
 	return &c
 }
 

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -40,7 +40,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 
 	c.CmdClause = parent.Command("update", "Update a Kinesis logging endpoint on a Fastly service version")
 
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("service-id", "Service ID").Required().Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.EndpointName)
 

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -1,0 +1,144 @@
+package kinesis
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v2/fastly"
+)
+
+// UpdateCommand calls the Fastly API to update Amazon Kinesis logging endpoints.
+type UpdateCommand struct {
+	common.Base
+	manifest manifest.Data
+
+	// required
+	EndpointName string // Can't shaddow common.Base method Name().
+	Version      int
+
+	// optional
+	NewName           common.OptionalString
+	StreamName        common.OptionalString
+	AccessKey         common.OptionalString
+	SecretKey         common.OptionalString
+	Region            common.OptionalString
+	Format            common.OptionalString
+	FormatVersion     common.OptionalUint
+	ResponseCondition common.OptionalString
+	Placement         common.OptionalString
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+
+	c.CmdClause = parent.Command("update", "Update a Kinesis logging endpoint on a Fastly service version")
+
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.EndpointName)
+
+	c.CmdClause.Flag("new-name", "New name of the Kinesis logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
+	c.CmdClause.Flag("stream-name", "Your Kinesis stream name").Action(c.StreamName.Set).StringVar(&c.StreamName.Value)
+	c.CmdClause.Flag("access-key", "Your Kinesis account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)
+	c.CmdClause.Flag("secret-key", "Your Kinesis account secret key").Action(c.SecretKey.Set).StringVar(&c.SecretKey.Value)
+	c.CmdClause.Flag("region", "The AWS region where the Kinesis stream exists").Action(c.Region.Set).StringVar(&c.Region.Value)
+	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
+	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
+	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
+	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+
+	return &c
+}
+
+// createInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) createInput() (*fastly.UpdateKinesisInput, error) {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return nil, errors.ErrNoServiceID
+	}
+
+	kinesis, err := c.Globals.Client.GetKinesis(&fastly.GetKinesisInput{
+		ServiceID:      serviceID,
+		Name:           c.EndpointName,
+		ServiceVersion: c.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	input := fastly.UpdateKinesisInput{
+		ServiceID:         kinesis.ServiceID,
+		ServiceVersion:    kinesis.ServiceVersion,
+		Name:              kinesis.Name,
+		NewName:           fastly.String(kinesis.Name),
+		StreamName:        fastly.String(kinesis.StreamName),
+		Region:            fastly.String(kinesis.Region),
+		AccessKey:         fastly.String(kinesis.AccessKey),
+		SecretKey:         fastly.String(kinesis.SecretKey),
+		Format:            fastly.String(kinesis.Format),
+		FormatVersion:     fastly.Uint(kinesis.FormatVersion),
+		ResponseCondition: fastly.String(kinesis.ResponseCondition),
+		Placement:         fastly.String(kinesis.Placement),
+	}
+
+	if c.NewName.WasSet {
+		input.NewName = fastly.String(c.NewName.Value)
+	}
+
+	if c.StreamName.WasSet {
+		input.StreamName = fastly.String(c.StreamName.Value)
+	}
+
+	if c.AccessKey.WasSet {
+		input.AccessKey = fastly.String(c.AccessKey.Value)
+	}
+
+	if c.SecretKey.WasSet {
+		input.SecretKey = fastly.String(c.SecretKey.Value)
+	}
+
+	if c.Region.WasSet {
+		input.Region = fastly.String(c.Region.Value)
+	}
+
+	if c.Format.WasSet {
+		input.Format = fastly.String(c.Format.Value)
+	}
+
+	if c.FormatVersion.WasSet {
+		input.FormatVersion = fastly.Uint(c.FormatVersion.Value)
+	}
+
+	if c.ResponseCondition.WasSet {
+		input.ResponseCondition = fastly.String(c.ResponseCondition.Value)
+	}
+
+	if c.Placement.WasSet {
+		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	return &input, nil
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	input, err := c.createInput()
+	if err != nil {
+		return err
+	}
+
+	kinesis, err := c.Globals.Client.UpdateKinesis(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Updated Kinesis logging endpoint %s (service %s version %d)", kinesis.Name, kinesis.ServiceID, kinesis.ServiceVersion)
+	return nil
+}

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/go-fastly/v2/fastly"
 )
 
-// UpdateCommand calls the Fastly API to update Amazon Kinesis logging endpoints.
+// UpdateCommand calls the Fastly API to update an Amazon Kinesis logging endpoint.
 type UpdateCommand struct {
 	common.Base
 	manifest manifest.Data

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -17,7 +17,7 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shaddow common.Base method Name().
+	EndpointName string // Can't shadow common.Base method Name().
 	Version      int
 
 	// optional

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -40,10 +40,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 
 	c.CmdClause = parent.Command("update", "Update a Kinesis logging endpoint on a Fastly service version")
 
-	c.CmdClause.Flag("service-id", "Service ID").Required().Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.EndpointName)
 
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Kinesis logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("stream-name", "Your Kinesis stream name").Action(c.StreamName.Set).StringVar(&c.StreamName.Value)
 	c.CmdClause.Flag("access-key", "Your Kinesis account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -74,6 +74,12 @@ type API struct {
 	UpdateS3Fn func(*fastly.UpdateS3Input) (*fastly.S3, error)
 	DeleteS3Fn func(*fastly.DeleteS3Input) error
 
+	CreateKinesisFn func(*fastly.CreateKinesisInput) (*fastly.Kinesis, error)
+	ListKinesesFn   func(*fastly.ListKinesesInput) ([]*fastly.Kinesis, error)
+	GetKinesisFn    func(*fastly.GetKinesisInput) (*fastly.Kinesis, error)
+	UpdateKinesisFn func(*fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
+	DeleteKinesisFn func(*fastly.DeleteKinesisInput) error
+
 	CreateSyslogFn func(*fastly.CreateSyslogInput) (*fastly.Syslog, error)
 	ListSyslogsFn  func(*fastly.ListSyslogsInput) ([]*fastly.Syslog, error)
 	GetSyslogFn    func(*fastly.GetSyslogInput) (*fastly.Syslog, error)
@@ -480,6 +486,31 @@ func (m API) UpdateS3(i *fastly.UpdateS3Input) (*fastly.S3, error) {
 // DeleteS3 implements Interface.
 func (m API) DeleteS3(i *fastly.DeleteS3Input) error {
 	return m.DeleteS3Fn(i)
+}
+
+// CreateKinesis implements Interface.
+func (m API) CreateKinesis(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
+	return m.CreateKinesisFn(i)
+}
+
+// ListKineses implements Interface.
+func (m API) ListKineses(i *fastly.ListKinesesInput) ([]*fastly.Kinesis, error) {
+	return m.ListKinesesFn(i)
+}
+
+// GetKinesis implements Interface.
+func (m API) GetKinesis(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
+	return m.GetKinesisFn(i)
+}
+
+// UpdateKinesis implements Interface.
+func (m API) UpdateKinesis(i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
+	return m.UpdateKinesisFn(i)
+}
+
+// DeleteKinesis implements Interface.
+func (m API) DeleteKinesis(i *fastly.DeleteKinesisInput) error {
+	return m.DeleteKinesisFn(i)
 }
 
 // CreateSyslog implements Interface.


### PR DESCRIPTION
This requires moving to version 2.1.0 of `go-fastly`. If there's other work that needs to be done before that can happen that's fine, but I wanted to go ahead and get the PR out there even if it can't be merged right away.