### PR TITLE
Handle prerelease versions of the Rust crate more gracefully

### DIFF
--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -431,6 +431,28 @@ func TestBuildRust(t *testing.T) {
 			wantRemediationError: "fastly = \"^0.4.0\"",
 		},
 		{
+			name:           "fastly crate prerelease",
+			args:           []string{"compute", "build"},
+			fastlyManifest: "name = \"test\"\nlanguage = \"rust\"\n",
+			cargoManifest: strings.Join([]string{
+				"[package]",
+				"name = \"test\"",
+				"version = \"0.1.0\"\n",
+				"[dependencies]",
+				"fastly = \"0.6.0-beta2\"",
+			}, "\n"),
+			cargoLock: strings.Join([]string{
+				"[[package]]",
+				"name = \"fastly-sys\"",
+				"version = \"0.3.7-beta2\"\n",
+				"[[package]]",
+				"name = \"fastly\"",
+				"version = \"0.6.0-beta2\"",
+			}, "\n"),
+			client:             versionClient{[]string{"0.5.0"}},
+			wantOutputContains: "Built rust package test",
+		},
+		{
 			name:               "Rust success",
 			args:               []string{"compute", "build"},
 			fastlyManifest:     "name = \"test\"\nlanguage = \"rust\"\n",

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -347,6 +347,11 @@ func TestGetLatestCrateVersion(t *testing.T) {
 			inputClient: &versionClient{[]string{"1.2.3", "0.8.3", "0.3.2"}},
 			wantVersion: semver.MustParse("1.2.3"),
 		},
+		{
+			name:        "contains pre-release",
+			inputClient: &versionClient{[]string{"0.2.3", "0.8.3", "0.3.2", "0.9.0-beta.2"}},
+			wantVersion: semver.MustParse("0.8.3"),
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			v, err := getLatestCrateVersion(testcase.inputClient, "fastly")

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -117,7 +117,7 @@ func (r Rust) Verify(out io.Writer) error {
 
 	fmt.Fprintf(out, "Found rustup at %s\n", p)
 
-	// 2) Check that the `1.43.0` toolchain is installed
+	// 2) Check that the desired toolchain version is installed
 	//
 	// We use rustup to assert that the toolchain is installed by streaming the output of
 	// `rustup toolchain list` and looking for a toolchain whose prefix matches our desired

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -389,7 +389,8 @@ func getLatestCrateVersion(client api.HTTPClient, name string) (*semver.Version,
 
 	var versions []*semver.Version
 	for _, v := range crate.Versions {
-		if version, err := semver.NewVersion(v.Version); err == nil {
+		// Parse version string and only append if not a prerelease.
+		if version, err := semver.NewVersion(v.Version); err == nil && version.Prerelease() == "" {
 			versions = append(versions, version)
 		}
 	}


### PR DESCRIPTION
Fixes: #168

### TL;DR
Updates the `rust.Verify()` verification logic of Rust packages to ensure we handle prerelease versions of the `fastly` crate more gracefully by:

- Exit early out of verification if a prerelease is found to ensure we don't display any confusing messages to "upgrade" an older version.
- Don't suggest prereleases as an optional upgrade if a newer one exists.