### PR TITLE
Add support for compression_codec to logging file sink endpoints

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -807,6 +807,15 @@ COMMANDS
         --server-side-encryption-kms-key-id=SERVER-SIDE-ENCRYPTION-KMS-KEY-ID
                                  Server-side KMS Key ID. Must be set if
                                  server-side-encryption is set to aws:kms
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging s3 list --version=VERSION [<flags>]
     List S3 endpoints on a Fastly service version
@@ -869,6 +878,15 @@ COMMANDS
         --server-side-encryption-kms-key-id=SERVER-SIDE-ENCRYPTION-KMS-KEY-ID
                                  Server-side KMS Key ID. Must be set if
                                  server-side-encryption is set to aws:kms
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging s3 delete --version=VERSION --name=NAME [<flags>]
     Delete a S3 logging endpoint on a Fastly service version
@@ -1332,6 +1350,15 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging gcs list --version=VERSION [<flags>]
     List GCS endpoints on a Fastly service version
@@ -1389,6 +1416,15 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging gcs delete --version=VERSION --name=NAME [<flags>]
     Delete a GCS logging endpoint on a Fastly service version
@@ -1431,6 +1467,15 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging ftp list --version=VERSION [<flags>]
     List FTP endpoints on a Fastly service version
@@ -1487,6 +1532,15 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging ftp delete --version=VERSION --name=NAME [<flags>]
     Delete an FTP logging endpoint on a Fastly service version
@@ -1906,6 +1960,15 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging sftp list --version=VERSION [<flags>]
     List SFTP endpoints on a Fastly service version
@@ -1969,6 +2032,15 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging sftp delete --version=VERSION --name=NAME [<flags>]
     Delete an SFTP logging endpoint on a Fastly service version
@@ -2084,6 +2156,15 @@ COMMANDS
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging cloudfiles list --version=VERSION [<flags>]
     List Cloudfiles endpoints on a Fastly service version
@@ -2139,6 +2220,15 @@ COMMANDS
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging cloudfiles delete --version=VERSION --name=NAME [<flags>]
     Delete a Cloudfiles logging endpoint on a Fastly service version
@@ -2186,6 +2276,15 @@ COMMANDS
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging digitalocean list --version=VERSION [<flags>]
     List DigitalOcean Spaces logging endpoints on a Fastly service version
@@ -2243,6 +2342,15 @@ COMMANDS
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging digitalocean delete --version=VERSION --name=NAME [<flags>]
     Delete a DigitalOcean Spaces logging endpoint on a Fastly service version
@@ -2432,6 +2540,15 @@ COMMANDS
                                  disk
         --file-max-bytes=FILE-MAX-BYTES
                                  The maximum size of a log file in bytes
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging azureblob list --version=VERSION [<flags>]
     List Azure Blob Storage logging endpoints on a Fastly service version
@@ -2495,6 +2612,15 @@ COMMANDS
                                  disk
         --file-max-bytes=FILE-MAX-BYTES
                                  The maximum size of a log file in bytes
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging azureblob delete --version=VERSION --name=NAME [<flags>]
     Delete an Azure Blob Storage logging endpoint on a Fastly service version
@@ -2982,6 +3108,15 @@ COMMANDS
         --placement=PLACEMENT    Where in the generated VCL the logging call
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging openstack list --version=VERSION [<flags>]
     List OpenStack logging endpoints on a Fastly service version
@@ -3035,6 +3170,15 @@ COMMANDS
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
+        --compression-codec=COMPRESSION-CODEC
+                                 The codec used for compression of your logs.
+                                 Valid values are zstd, snappy, and gzip. If the
+                                 specified codec is "gzip", gzip_level will
+                                 default to 3. To specify a different level,
+                                 leave compression_codec blank and explicitly
+                                 set the level using gzip_level. Specifying both
+                                 compression_codec and gzip_level in the same
+                                 API request will result in an error.
 
   logging openstack delete --version=VERSION --name=NAME [<flags>]
     Delete an OpenStack logging endpoint on a Fastly service version

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -45,6 +45,11 @@ func TestBlobStorageCreate(t *testing.T) {
 			api:       mock.API{CreateBlobStorageFn: createBlobStorageError},
 			wantError: errTest.Error(),
 		},
+		{
+			args:      []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
+			api:       mock.API{CreateBlobStorageFn: createBlobStorageError},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (
@@ -258,13 +263,13 @@ func createBlobStorageOK(i *fastly.CreateBlobStorageInput) (*fastly.BlobStorage,
 		SASToken:          "token",
 		Period:            3600,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:         9,
 		PublicKey:         pgpPublicKey(),
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		MessageType:       "classic",
 		Placement:         "none",
 		ResponseCondition: "Prevent default logging",
+		CompressionCodec:  "zstd",
 	}
 
 	return &s, nil
@@ -286,13 +291,13 @@ func listBlobStoragesOK(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage,
 			SASToken:          "token",
 			Period:            3600,
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-			GzipLevel:         9,
 			PublicKey:         pgpPublicKey(),
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			MessageType:       "classic",
 			Placement:         "none",
 			ResponseCondition: "Prevent default logging",
+			CompressionCodec:  "zstd",
 		},
 		{
 			ServiceID:         i.ServiceID,
@@ -303,7 +308,6 @@ func listBlobStoragesOK(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage,
 			SASToken:          "token",
 			Path:              "/logs",
 			Period:            86400,
-			GzipLevel:         9,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			MessageType:       "classic",
@@ -311,6 +315,7 @@ func listBlobStoragesOK(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage,
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
 			PublicKey:         pgpPublicKey(),
+			CompressionCodec:  "zstd",
 		},
 	}, nil
 }
@@ -339,7 +344,7 @@ Version: 1
 		SAS token: token
 		Path: /logs
 		Period: 3600
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -348,6 +353,7 @@ Version: 1
 		Placement: none
 		Public key: `+pgpPublicKey()+`
 		File max bytes: 0
+		Compression codec: zstd
 	BlobStorage 2/2
 		Service ID: 123
 		Version: 1
@@ -357,7 +363,7 @@ Version: 1
 		SAS token: token
 		Path: /logs
 		Period: 86400
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -366,6 +372,7 @@ Version: 1
 		Placement: none
 		Public key: `+pgpPublicKey()+`
 		File max bytes: 0
+		Compression codec: zstd
 `) + "\n\n"
 
 func getBlobStorageOK(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
@@ -378,7 +385,7 @@ func getBlobStorageOK(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error
 		SASToken:          "token",
 		Path:              "/logs",
 		Period:            3600,
-		GzipLevel:         9,
+		GzipLevel:         0,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
@@ -386,6 +393,7 @@ func getBlobStorageOK(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
 		PublicKey:         pgpPublicKey(),
+		CompressionCodec:  "zstd",
 	}, nil
 }
 
@@ -402,7 +410,7 @@ Account name: account
 SAS token: token
 Path: /logs
 Period: 3600
-GZip level: 9
+GZip level: 0
 Format: %h %l %u %t "%r" %>s %b
 Format version: 2
 Response condition: Prevent default logging
@@ -411,6 +419,7 @@ Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
 Public key: `+pgpPublicKey()+`
 File max bytes: 0
+Compression codec: zstd
 `) + "\n"
 
 func updateBlobStorageOK(i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {
@@ -423,7 +432,6 @@ func updateBlobStorageOK(i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage,
 		SASToken:          "token",
 		Path:              "/logs",
 		Period:            3600,
-		GzipLevel:         9,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
@@ -431,6 +439,7 @@ func updateBlobStorageOK(i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
 		PublicKey:         pgpPublicKey(),
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/azureblob/azureblob_test.go
+++ b/pkg/logging/azureblob/azureblob_test.go
@@ -44,7 +44,7 @@ func TestCreateBlobStorageInput(t *testing.T) {
 				SASToken:          "token",
 				Path:              "/log",
 				Period:            3600,
-				GzipLevel:         2,
+				GzipLevel:         0,
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				MessageType:       "classic",
 				FormatVersion:     2,
@@ -52,6 +52,7 @@ func TestCreateBlobStorageInput(t *testing.T) {
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				Placement:         "none",
 				PublicKey:         pgpPublicKey(),
+				CompressionCodec:  "zstd",
 			},
 		},
 		{
@@ -91,7 +92,7 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 				SASToken:          fastly.String("new4"),
 				Path:              fastly.String("new5"),
 				Period:            fastly.Uint(3601),
-				GzipLevel:         fastly.Uint(3),
+				GzipLevel:         fastly.Uint(0),
 				Format:            fastly.String("new6"),
 				FormatVersion:     fastly.Uint(3),
 				ResponseCondition: fastly.String("new7"),
@@ -99,6 +100,7 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 				TimestampFormat:   fastly.String("new9"),
 				Placement:         fastly.String("new10"),
 				PublicKey:         fastly.String("new11"),
+				CompressionCodec:  fastly.String("new12"),
 			},
 		},
 		{
@@ -149,7 +151,6 @@ func createCommandAll() *CreateCommand {
 		SASToken:          "token",
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/log"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
@@ -157,6 +158,7 @@ func createCommandAll() *CreateCommand {
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -187,7 +189,7 @@ func updateCommandAll() *UpdateCommand {
 		SASToken:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
@@ -195,6 +197,7 @@ func updateCommandAll() *UpdateCommand {
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
 	}
 }
 
@@ -215,13 +218,14 @@ func getBlobStorageOK(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error
 		SASToken:          "token",
 		Period:            3600,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		GzipLevel:         2,
+		GzipLevel:         0,
 		PublicKey:         pgpPublicKey(),
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		MessageType:       "classic",
 		Placement:         "none",
 		ResponseCondition: "Prevent default logging",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/azureblob/describe.go
+++ b/pkg/logging/azureblob/describe.go
@@ -61,6 +61,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Placement: %s\n", azureblob.Placement)
 	fmt.Fprintf(out, "Public key: %s\n", azureblob.PublicKey)
 	fmt.Fprintf(out, "File max bytes: %d\n", azureblob.FileMaxBytes)
+	fmt.Fprintf(out, "Compression codec: %s\n", azureblob.CompressionCodec)
 
 	return nil
 }

--- a/pkg/logging/azureblob/list.go
+++ b/pkg/logging/azureblob/list.go
@@ -75,6 +75,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", azureblob.Placement)
 		fmt.Fprintf(out, "\t\tPublic key: %s\n", azureblob.PublicKey)
 		fmt.Fprintf(out, "\t\tFile max bytes: %d\n", azureblob.FileMaxBytes)
+		fmt.Fprintf(out, "\t\tCompression codec: %s\n", azureblob.CompressionCodec)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/logging/azureblob/update.go
+++ b/pkg/logging/azureblob/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 	Placement         common.OptionalString
 	PublicKey         common.OptionalString
 	FileMaxBytes      common.OptionalUint
+	CompressionCodec  common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -66,6 +67,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("file-max-bytes", "The maximum size of a log file in bytes").Action(c.FileMaxBytes.Set).UintVar(&c.FileMaxBytes.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -142,6 +144,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateBlobStorageInput, error) {
 
 	if c.FileMaxBytes.WasSet {
 		input.FileMaxBytes = fastly.Uint(c.FileMaxBytes.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	return &input, nil

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -45,6 +45,10 @@ func TestCloudfilesCreate(t *testing.T) {
 			api:       mock.API{CreateCloudfilesFn: createCloudfilesError},
 			wantError: errTest.Error(),
 		},
+		{
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9"},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -46,13 +46,14 @@ func TestCreateCloudfilesInput(t *testing.T) {
 				Region:            "abc",
 				Placement:         "none",
 				Period:            3600,
-				GzipLevel:         2,
+				GzipLevel:         0,
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				FormatVersion:     2,
 				ResponseCondition: "Prevent default logging",
 				MessageType:       "classic",
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				PublicKey:         pgpPublicKey(),
+				CompressionCodec:  "zstd",
 			},
 		},
 		{
@@ -103,7 +104,7 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 				Region:            fastly.String("new5"),
 				Placement:         fastly.String("new6"),
 				Period:            fastly.Uint(3601),
-				GzipLevel:         fastly.Uint(3),
+				GzipLevel:         fastly.Uint(0),
 				Format:            fastly.String("new7"),
 				FormatVersion:     fastly.Uint(3),
 				ResponseCondition: fastly.String("new8"),
@@ -111,6 +112,7 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 				TimestampFormat:   fastly.String("new10"),
 				PublicKey:         fastly.String("new11"),
 				User:              fastly.String("new12"),
+				CompressionCodec:  fastly.String("new13"),
 			},
 		},
 		{
@@ -153,13 +155,13 @@ func createCommandAll() *CreateCommand {
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "abc"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -191,7 +193,7 @@ func updateCommandAll() *UpdateCommand {
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
@@ -199,6 +201,7 @@ func updateCommandAll() *UpdateCommand {
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
 		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
 	}
 }
 
@@ -220,13 +223,14 @@ func getCloudfilesOK(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
 		Region:            "abc",
 		Placement:         "none",
 		Period:            3600,
-		GzipLevel:         2,
+		GzipLevel:         0,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
 		MessageType:       "classic",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		PublicKey:         pgpPublicKey(),
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 	MessageType       common.OptionalString
 	TimestampFormat   common.OptionalString
 	PublicKey         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -66,6 +67,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -142,6 +144,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateCloudfilesInput, error) {
 
 	if c.PublicKey.WasSet {
 		input.PublicKey = fastly.String(c.PublicKey.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	return &input, nil

--- a/pkg/logging/digitalocean/create.go
+++ b/pkg/logging/digitalocean/create.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
@@ -35,6 +36,7 @@ type CreateCommand struct {
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
 	PublicKey         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -64,6 +66,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -83,6 +86,12 @@ func (c *CreateCommand) createInput() (*fastly.CreateDigitalOceanInput, error) {
 	input.BucketName = c.BucketName
 	input.AccessKey = c.AccessKey
 	input.SecretKey = c.SecretKey
+
+	// The following blocks enforces the mutual exclusivity of the
+	// CompressionCodec and GzipLevel flags.
+	if c.CompressionCodec.WasSet && c.GzipLevel.WasSet {
+		return nil, fmt.Errorf("error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag")
+	}
 
 	if c.Domain.WasSet {
 		input.Domain = c.Domain.Value
@@ -126,6 +135,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateDigitalOceanInput, error) {
 
 	if c.PublicKey.WasSet {
 		input.PublicKey = c.PublicKey.Value
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = c.CompressionCodec.Value
 	}
 
 	return &input, nil

--- a/pkg/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/logging/digitalocean/digitalocean_integration_test.go
@@ -45,6 +45,10 @@ func TestDigitalOceanCreate(t *testing.T) {
 			api:       mock.API{CreateDigitalOceanFn: createDigitalOceanError},
 			wantError: errTest.Error(),
 		},
+		{
+			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (

--- a/pkg/logging/digitalocean/digitalocean_test.go
+++ b/pkg/logging/digitalocean/digitalocean_test.go
@@ -45,7 +45,7 @@ func TestCreateDigitalOceanInput(t *testing.T) {
 				SecretKey:         "secret",
 				Path:              "/log",
 				Period:            3600,
-				GzipLevel:         2,
+				GzipLevel:         0,
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				MessageType:       "classic",
 				FormatVersion:     2,
@@ -53,6 +53,7 @@ func TestCreateDigitalOceanInput(t *testing.T) {
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				Placement:         "none",
 				PublicKey:         pgpPublicKey(),
+				CompressionCodec:  "zstd",
 			},
 		},
 		{
@@ -93,7 +94,7 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 				SecretKey:         fastly.String("new5"),
 				Path:              fastly.String("new6"),
 				Period:            fastly.Uint(3601),
-				GzipLevel:         fastly.Uint(3),
+				GzipLevel:         fastly.Uint(0),
 				Format:            fastly.String("new7"),
 				FormatVersion:     fastly.Uint(3),
 				ResponseCondition: fastly.String("new8"),
@@ -101,6 +102,7 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 				TimestampFormat:   fastly.String("new10"),
 				Placement:         fastly.String("new11"),
 				PublicKey:         fastly.String("new12"),
+				CompressionCodec:  fastly.String("new13"),
 			},
 		},
 		{
@@ -152,7 +154,6 @@ func createCommandAll() *CreateCommand {
 		Domain:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "nyc3.digitaloceanspaces.com"},
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/log"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
@@ -160,6 +161,7 @@ func createCommandAll() *CreateCommand {
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -191,7 +193,7 @@ func updateCommandAll() *UpdateCommand {
 		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
@@ -199,6 +201,7 @@ func updateCommandAll() *UpdateCommand {
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
 	}
 }
 
@@ -219,7 +222,7 @@ func getDigitalOceanOK(i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, er
 		SecretKey:         "secret",
 		Path:              "/log",
 		Period:            3600,
-		GzipLevel:         2,
+		GzipLevel:         0,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
@@ -227,6 +230,7 @@ func getDigitalOceanOK(i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, er
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
 		PublicKey:         pgpPublicKey(),
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/digitalocean/update.go
+++ b/pkg/logging/digitalocean/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
 	PublicKey         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -66,6 +67,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -142,6 +144,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateDigitalOceanInput, error) {
 
 	if c.PublicKey.WasSet {
 		input.PublicKey = fastly.String(c.PublicKey.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	return &input, nil

--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -1,6 +1,7 @@
 package ftp
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
@@ -33,6 +34,7 @@ type CreateCommand struct {
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -59,6 +61,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -78,6 +81,12 @@ func (c *CreateCommand) createInput() (*fastly.CreateFTPInput, error) {
 	input.Address = c.Address
 	input.Username = c.Username
 	input.Password = c.Password
+
+	// The following blocks enforces the mutual exclusivity of the
+	// CompressionCodec and GzipLevel flags.
+	if c.CompressionCodec.WasSet && c.GzipLevel.WasSet {
+		return nil, fmt.Errorf("error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag")
+	}
 
 	if c.Port.WasSet {
 		input.Port = c.Port.Value
@@ -113,6 +122,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateFTPInput, error) {
 
 	if c.Placement.WasSet {
 		input.Placement = c.Placement.Value
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = c.CompressionCodec.Value
 	}
 
 	return &input, nil

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -60,6 +60,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Response condition: %s\n", ftp.ResponseCondition)
 	fmt.Fprintf(out, "Timestamp format: %s\n", ftp.TimestampFormat)
 	fmt.Fprintf(out, "Placement: %s\n", ftp.Placement)
+	fmt.Fprintf(out, "Compression codec: %s\n", ftp.CompressionCodec)
 
 	return nil
 }

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -36,7 +36,7 @@ func TestFTPCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --password not provided",
 		},
 		{
-			args:       []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
+			args:       []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd"},
 			api:        mock.API{CreateFTPFn: createFTPOK},
 			wantOutput: "Created FTP logging endpoint log (service 123 version 1)",
 		},
@@ -44,6 +44,10 @@ func TestFTPCreate(t *testing.T) {
 			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
 			api:       mock.API{CreateFTPFn: createFTPError},
 			wantError: errTest.Error(),
+		},
+		{
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -249,9 +253,10 @@ var errTest = errors.New("fixture error")
 
 func createFTPOK(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
 	return &fastly.FTP{
-		ServiceID:      i.ServiceID,
-		ServiceVersion: i.ServiceVersion,
-		Name:           i.Name,
+		ServiceID:        i.ServiceID,
+		ServiceVersion:   i.ServiceVersion,
+		Name:             i.Name,
+		CompressionCodec: i.CompressionCodec,
 	}, nil
 }
 
@@ -278,6 +283,7 @@ func listFTPsOK(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
+			CompressionCodec:  "zstd",
 		},
 		{
 			ServiceID:         i.ServiceID,
@@ -296,6 +302,7 @@ func listFTPsOK(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
+			CompressionCodec:  "zstd",
 		},
 	}, nil
 }
@@ -332,6 +339,7 @@ Version: 1
 		Response condition: Prevent default logging
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Compression codec: zstd
 	FTP 2/2
 		Service ID: 123
 		Version: 1
@@ -349,6 +357,7 @@ Version: 1
 		Response condition: Prevent default logging
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Compression codec: zstd
 `) + "\n\n"
 
 func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
@@ -369,6 +378,7 @@ func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 
@@ -393,6 +403,7 @@ Format version: 2
 Response condition: Prevent default logging
 Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
+Compression codec: zstd
 `) + "\n"
 
 func updateFTPOK(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
@@ -413,6 +424,7 @@ func updateFTPOK(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -45,11 +45,11 @@ func TestCreateFTPInput(t *testing.T) {
 				Path:              "/logs",
 				Period:            3600,
 				FormatVersion:     2,
-				GzipLevel:         2,
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				ResponseCondition: "Prevent default logging",
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				Placement:         "none",
+				CompressionCodec:  "zstd",
 			},
 		},
 		{
@@ -102,11 +102,12 @@ func TestUpdateFTPInput(t *testing.T) {
 				Path:              fastly.String("new5"),
 				Period:            fastly.Uint(3601),
 				FormatVersion:     fastly.Uint(3),
-				GzipLevel:         fastly.Uint8(3),
+				GzipLevel:         fastly.Uint8(0),
 				Format:            fastly.String("new6"),
 				ResponseCondition: fastly.String("new7"),
 				TimestampFormat:   fastly.String("new8"),
 				Placement:         fastly.String("new9"),
+				CompressionCodec:  fastly.String("new11"),
 			},
 		},
 		{
@@ -148,12 +149,12 @@ func createCommandAll() *CreateCommand {
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22},
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/logs"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 2},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -186,12 +187,13 @@ func updateCommandAll() *UpdateCommand {
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 0},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
 	}
 }
 
@@ -212,11 +214,12 @@ func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
 		Password:          "password",
 		Path:              "/logs",
 		Period:            3600,
-		GzipLevel:         2,
+		GzipLevel:         0,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }

--- a/pkg/logging/ftp/list.go
+++ b/pkg/logging/ftp/list.go
@@ -74,6 +74,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tResponse condition: %s\n", ftp.ResponseCondition)
 		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", ftp.TimestampFormat)
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", ftp.Placement)
+		fmt.Fprintf(out, "\t\tCompression codec: %s\n", ftp.CompressionCodec)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -35,6 +35,7 @@ type UpdateCommand struct {
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -64,6 +65,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -136,6 +138,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateFTPInput, error) {
 
 	if c.Placement.WasSet {
 		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	return &input, nil

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -59,6 +59,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Message type: %s\n", gcs.MessageType)
 	fmt.Fprintf(out, "Timestamp format: %s\n", gcs.TimestampFormat)
 	fmt.Fprintf(out, "Placement: %s\n", gcs.Placement)
+	fmt.Fprintf(out, "Compression codec: %s\n", gcs.CompressionCodec)
 
 	return nil
 }

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -45,6 +45,10 @@ func TestGCSCreate(t *testing.T) {
 			api:       mock.API{CreateGCSFn: createGCSError},
 			wantError: errTest.Error(),
 		},
+		{
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--compression-codec", "zstd", "--gzip-level", "9"},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (
@@ -270,13 +274,14 @@ func listGCSsOK(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
 			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
 			Path:              "logs/",
 			Period:            3600,
-			GzipLevel:         9,
+			GzipLevel:         0,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			MessageType:       "classic",
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
+			CompressionCodec:  "zstd",
 		},
 		{
 			ServiceID:         i.ServiceID,
@@ -287,13 +292,14 @@ func listGCSsOK(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
 			SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
 			Path:              "logs/",
 			Period:            86400,
-			GzipLevel:         9,
+			GzipLevel:         0,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			MessageType:       "classic",
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
+			CompressionCodec:  "zstd",
 		},
 	}, nil
 }
@@ -322,13 +328,14 @@ Version: 1
 		Secret key: -----BEGIN RSA PRIVATE KEY-----foo
 		Path: logs/
 		Period: 3600
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
 		Message type: classic
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Compression codec: zstd
 	GCS 2/2
 		Service ID: 123
 		Version: 1
@@ -338,13 +345,14 @@ Version: 1
 		Secret key: -----BEGIN RSA PRIVATE KEY-----foo
 		Path: logs/
 		Period: 86400
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
 		Message type: classic
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Compression codec: zstd
 `) + "\n\n"
 
 func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
@@ -357,13 +365,14 @@ func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
 		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
 		Path:              "logs/",
 		Period:            3600,
-		GzipLevel:         9,
+		GzipLevel:         0,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 
@@ -380,13 +389,14 @@ User: foo@example.com
 Secret key: -----BEGIN RSA PRIVATE KEY-----foo
 Path: logs/
 Period: 3600
-GZip level: 9
+GZip level: 0
 Format: %h %l %u %t "%r" %>s %b
 Format version: 2
 Response condition: Prevent default logging
 Message type: classic
 Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
+Compression codec: zstd
 `) + "\n"
 
 func updateGCSOK(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
@@ -399,13 +409,14 @@ func updateGCSOK(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
 		SecretKey:         "-----BEGIN RSA PRIVATE KEY-----foo",
 		Path:              "logs/",
 		Period:            3600,
-		GzipLevel:         9,
+		GzipLevel:         0,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
 		MessageType:       "classic",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -44,13 +44,12 @@ func TestCreateGCSInput(t *testing.T) {
 				Path:              "/logs",
 				Period:            3600,
 				FormatVersion:     2,
-				GzipLevel:         2,
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				MessageType:       "classic",
 				ResponseCondition: "Prevent default logging",
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				Placement:         "none",
-			},
+				CompressionCodec:  "zstd"},
 		},
 		{
 			name:      "error missing serviceID",
@@ -100,12 +99,13 @@ func TestUpdateGCSInput(t *testing.T) {
 				Path:              fastly.String("new5"),
 				Period:            fastly.Uint(3601),
 				FormatVersion:     fastly.Uint(3),
-				GzipLevel:         fastly.Uint8(3),
+				GzipLevel:         fastly.Uint8(0),
 				Format:            fastly.String("new6"),
 				ResponseCondition: fastly.String("new7"),
 				TimestampFormat:   fastly.String("new8"),
 				Placement:         fastly.String("new9"),
 				MessageType:       fastly.String("new10"),
+				CompressionCodec:  fastly.String("new11"),
 			},
 		},
 		{
@@ -146,13 +146,13 @@ func createCommandAll() *CreateCommand {
 		SecretKey:         "-----BEGIN PRIVATE KEY-----foo",
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/logs"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 2},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -183,13 +183,14 @@ func updateCommandAll() *UpdateCommand {
 		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 0},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
 	}
 }
 
@@ -209,12 +210,12 @@ func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
 		SecretKey:         "-----BEGIN PRIVATE KEY-----foo",
 		Path:              "/logs",
 		Period:            3600,
-		GzipLevel:         2,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }

--- a/pkg/logging/gcs/list.go
+++ b/pkg/logging/gcs/list.go
@@ -73,6 +73,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tMessage type: %s\n", gcs.MessageType)
 		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", gcs.TimestampFormat)
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", gcs.Placement)
+		fmt.Fprintf(out, "\t\tCompression codec: %s\n", gcs.CompressionCodec)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 	TimestampFormat   common.OptionalString
 	MessageType       common.OptionalString
 	Placement         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -62,6 +63,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -130,6 +132,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateGCSInput, error) {
 
 	if c.Placement.WasSet {
 		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	return &input, nil

--- a/pkg/logging/openstack/create.go
+++ b/pkg/logging/openstack/create.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
@@ -35,6 +36,7 @@ type CreateCommand struct {
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -63,6 +65,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -83,6 +86,12 @@ func (c *CreateCommand) createInput() (*fastly.CreateOpenstackInput, error) {
 	input.AccessKey = c.AccessKey
 	input.User = c.User
 	input.URL = c.URL
+
+	// The following blocks enforces the mutual exclusivity of the
+	// CompressionCodec and GzipLevel flags.
+	if c.CompressionCodec.WasSet && c.GzipLevel.WasSet {
+		return nil, fmt.Errorf("error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag")
+	}
 
 	if c.PublicKey.WasSet {
 		input.PublicKey = c.PublicKey.Value
@@ -122,6 +131,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateOpenstackInput, error) {
 
 	if c.Placement.WasSet {
 		input.Placement = c.Placement.Value
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = c.CompressionCodec.Value
 	}
 
 	return &input, nil

--- a/pkg/logging/openstack/describe.go
+++ b/pkg/logging/openstack/describe.go
@@ -61,6 +61,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Timestamp format: %s\n", openstack.TimestampFormat)
 	fmt.Fprintf(out, "Placement: %s\n", openstack.Placement)
 	fmt.Fprintf(out, "Public key: %s\n", openstack.PublicKey)
+	fmt.Fprintf(out, "Compression codec: %s\n", openstack.CompressionCodec)
 
 	return nil
 }

--- a/pkg/logging/openstack/list.go
+++ b/pkg/logging/openstack/list.go
@@ -75,6 +75,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", openstack.TimestampFormat)
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", openstack.Placement)
 		fmt.Fprintf(out, "\t\tPublic key: %s\n", openstack.PublicKey)
+		fmt.Fprintf(out, "\t\tCompression codec: %s\n", openstack.CompressionCodec)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/logging/openstack/openstack_integration_test.go
+++ b/pkg/logging/openstack/openstack_integration_test.go
@@ -49,6 +49,10 @@ func TestOpenstackCreate(t *testing.T) {
 			api:       mock.API{CreateOpenstackFn: createOpenstackError},
 			wantError: errTest.Error(),
 		},
+		{
+			args:      []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (
@@ -280,7 +284,7 @@ func listOpenstacksOK(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
 			URL:               "https://example.com",
 			Path:              "logs/",
 			Period:            3600,
-			GzipLevel:         9,
+			GzipLevel:         0,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			ResponseCondition: "Prevent default logging",
@@ -288,6 +292,7 @@ func listOpenstacksOK(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
 			PublicKey:         pgpPublicKey(),
+			CompressionCodec:  "zstd",
 		},
 		{
 			ServiceID:         i.ServiceID,
@@ -299,7 +304,7 @@ func listOpenstacksOK(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
 			URL:               "https://two.example.com",
 			Path:              "logs/",
 			Period:            86400,
-			GzipLevel:         9,
+			GzipLevel:         0,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			MessageType:       "classic",
@@ -307,6 +312,7 @@ func listOpenstacksOK(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
 			PublicKey:         pgpPublicKey(),
+			CompressionCodec:  "zstd",
 		},
 	}, nil
 }
@@ -336,7 +342,7 @@ Version: 1
 		URL: https://example.com
 		Path: logs/
 		Period: 3600
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -344,6 +350,7 @@ Version: 1
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
 		Public key: `+pgpPublicKey()+`
+		Compression codec: zstd
 	Openstack 2/2
 		Service ID: 123
 		Version: 1
@@ -354,7 +361,7 @@ Version: 1
 		URL: https://two.example.com
 		Path: logs/
 		Period: 86400
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -362,6 +369,7 @@ Version: 1
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
 		Public key: `+pgpPublicKey()+`
+		Compression codec: zstd
 `) + "\n\n"
 
 func getOpenstackOK(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
@@ -375,7 +383,7 @@ func getOpenstackOK(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 		URL:               "https://example.com",
 		Path:              "logs/",
 		Period:            3600,
-		GzipLevel:         9,
+		GzipLevel:         0,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
@@ -383,6 +391,7 @@ func getOpenstackOK(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
 		PublicKey:         pgpPublicKey(),
+		CompressionCodec:  "zstd",
 	}, nil
 }
 
@@ -400,7 +409,7 @@ User: user
 URL: https://example.com
 Path: logs/
 Period: 3600
-GZip level: 9
+GZip level: 0
 Format: %h %l %u %t "%r" %>s %b
 Format version: 2
 Response condition: Prevent default logging
@@ -408,6 +417,7 @@ Message type: classic
 Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
 Public key: `+pgpPublicKey()+`
+Compression codec: zstd
 `) + "\n"
 
 func updateOpenstackOK(i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error) {
@@ -421,7 +431,6 @@ func updateOpenstackOK(i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error
 		URL:               "https://update.example.com",
 		Path:              "logs/",
 		Period:            3600,
-		GzipLevel:         9,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
@@ -429,6 +438,7 @@ func updateOpenstackOK(i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
 		PublicKey:         pgpPublicKey(),
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/openstack/openstack_test.go
+++ b/pkg/logging/openstack/openstack_test.go
@@ -46,7 +46,6 @@ func TestCreateOpenstackInput(t *testing.T) {
 				URL:               "https://example.com",
 				Path:              "/log",
 				Period:            3600,
-				GzipLevel:         2,
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				MessageType:       "classic",
 				FormatVersion:     2,
@@ -54,6 +53,7 @@ func TestCreateOpenstackInput(t *testing.T) {
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				Placement:         "none",
 				PublicKey:         pgpPublicKey(),
+				CompressionCodec:  "zstd",
 			},
 		},
 		{
@@ -94,7 +94,7 @@ func TestUpdateOpenstackInput(t *testing.T) {
 				URL:               fastly.String("new5"),
 				Path:              fastly.String("new6"),
 				Period:            fastly.Uint(3601),
-				GzipLevel:         fastly.Uint(3),
+				GzipLevel:         fastly.Uint(0),
 				Format:            fastly.String("new7"),
 				FormatVersion:     fastly.Uint(3),
 				ResponseCondition: fastly.String("new8"),
@@ -102,6 +102,7 @@ func TestUpdateOpenstackInput(t *testing.T) {
 				TimestampFormat:   fastly.String("new10"),
 				Placement:         fastly.String("new11"),
 				PublicKey:         fastly.String("new12"),
+				CompressionCodec:  fastly.String("new13"),
 			},
 		},
 		{
@@ -154,7 +155,6 @@ func createCommandAll() *CreateCommand {
 		URL:               "https://example.com",
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/log"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
@@ -162,6 +162,7 @@ func createCommandAll() *CreateCommand {
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -193,7 +194,7 @@ func updateCommandAll() *UpdateCommand {
 		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
 		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
@@ -201,6 +202,7 @@ func updateCommandAll() *UpdateCommand {
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
 		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
 	}
 }
 
@@ -221,7 +223,6 @@ func getOpenstackOK(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 		URL:               "https://example.com",
 		Path:              "/log",
 		Period:            3600,
-		GzipLevel:         2,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		ResponseCondition: "Prevent default logging",
@@ -229,6 +230,7 @@ func getOpenstackOK(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
 		PublicKey:         pgpPublicKey(),
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/openstack/update.go
+++ b/pkg/logging/openstack/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
 	PublicKey         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -66,6 +67,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -142,6 +144,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateOpenstackInput, error) {
 
 	if c.PublicKey.WasSet {
 		input.PublicKey = fastly.String(c.PublicKey.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	return &input, nil

--- a/pkg/logging/s3/create.go
+++ b/pkg/logging/s3/create.go
@@ -43,6 +43,7 @@ type CreateCommand struct {
 	PublicKey                    common.OptionalString
 	ServerSideEncryption         common.OptionalString
 	ServerSideEncryptionKMSKeyID common.OptionalString
+	CompressionCodec             common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -76,6 +77,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("server-side-encryption", "Set to enable S3 Server Side Encryption. Can be either AES256 or aws:kms").Action(c.ServerSideEncryption.Set).EnumVar(&c.ServerSideEncryption.Value, string(fastly.S3ServerSideEncryptionAES), string(fastly.S3ServerSideEncryptionKMS))
 	c.CmdClause.Flag("server-side-encryption-kms-key-id", "Server-side KMS Key ID. Must be set if server-side-encryption is set to aws:kms").Action(c.ServerSideEncryptionKMSKeyID.Set).StringVar(&c.ServerSideEncryptionKMSKeyID.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -111,6 +113,12 @@ func (c *CreateCommand) createInput() (*fastly.CreateS3Input, error) {
 	} else if !c.AccessKey.WasSet && c.SecretKey.WasSet {
 		return nil, fmt.Errorf("error parsing arguments: required flag --access-key not provided")
 
+	}
+
+	// The following blocks enforces the mutual exclusivity of the
+	// CompressionCodec and GzipLevel flags.
+	if c.CompressionCodec.WasSet && c.GzipLevel.WasSet {
+		return nil, fmt.Errorf("error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag")
 	}
 
 	if c.AccessKey.WasSet {
@@ -171,6 +179,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateS3Input, error) {
 
 	if c.ServerSideEncryptionKMSKeyID.WasSet {
 		input.ServerSideEncryptionKMSKeyID = c.ServerSideEncryptionKMSKeyID.Value
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = c.CompressionCodec.Value
 	}
 
 	if c.Redundancy.WasSet {

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -68,6 +68,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Redundancy: %s\n", s3.Redundancy)
 	fmt.Fprintf(out, "Server-side encryption: %s\n", s3.ServerSideEncryption)
 	fmt.Fprintf(out, "Server-side encryption KMS key ID: %s\n", s3.ServerSideEncryption)
+	fmt.Fprintf(out, "Compression codec: %s\n", s3.CompressionCodec)
 
 	return nil
 }

--- a/pkg/logging/s3/list.go
+++ b/pkg/logging/s3/list.go
@@ -82,6 +82,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tRedundancy: %s\n", s3.Redundancy)
 		fmt.Fprintf(out, "\t\tServer-side encryption: %s\n", s3.ServerSideEncryption)
 		fmt.Fprintf(out, "\t\tServer-side encryption KMS key ID: %s\n", s3.ServerSideEncryption)
+		fmt.Fprintf(out, "\t\tCompression codec: %s\n", s3.CompressionCodec)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -67,6 +67,10 @@ func TestS3Create(t *testing.T) {
 			api:       mock.API{CreateS3Fn: createS3Error},
 			wantError: errTest.Error(),
 		},
+		{
+			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--compression-codec", "zstd", "--gzip-level", "9"},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (
@@ -276,9 +280,10 @@ var errTest = errors.New("fixture error")
 
 func createS3OK(i *fastly.CreateS3Input) (*fastly.S3, error) {
 	return &fastly.S3{
-		ServiceID:      i.ServiceID,
-		ServiceVersion: i.ServiceVersion,
-		Name:           i.Name,
+		ServiceID:        i.ServiceID,
+		ServiceVersion:   i.ServiceVersion,
+		Name:             i.Name,
+		CompressionCodec: "zstd",
 	}, nil
 }
 
@@ -299,7 +304,6 @@ func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 			Domain:                       "https://s3.us-east-1.amazonaws.com",
 			Path:                         "logs/",
 			Period:                       3600,
-			GzipLevel:                    9,
 			Format:                       `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:                2,
 			MessageType:                  "classic",
@@ -310,6 +314,7 @@ func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 			PublicKey:                    pgpPublicKey(),
 			ServerSideEncryption:         "aws:kms",
 			ServerSideEncryptionKMSKeyID: "1234",
+			CompressionCodec:             "zstd",
 		},
 		{
 			ServiceID:                    i.ServiceID,
@@ -321,7 +326,6 @@ func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 			Domain:                       "https://s3.us-east-2.amazonaws.com",
 			Path:                         "logs/",
 			Period:                       86400,
-			GzipLevel:                    9,
 			Format:                       `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:                2,
 			MessageType:                  "classic",
@@ -332,6 +336,7 @@ func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 			PublicKey:                    pgpPublicKey(),
 			ServerSideEncryption:         "aws:kms",
 			ServerSideEncryptionKMSKeyID: "1234",
+			CompressionCodec:             "zstd",
 		},
 	}, nil
 }
@@ -360,7 +365,7 @@ Version: 1
 		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
 		Path: logs/
 		Period: 3600
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -371,6 +376,7 @@ Version: 1
 		Redundancy: standard
 		Server-side encryption: aws:kms
 		Server-side encryption KMS key ID: aws:kms
+		Compression codec: zstd
 	S3 2/2
 		Service ID: 123
 		Version: 1
@@ -380,7 +386,7 @@ Version: 1
 		Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
 		Path: logs/
 		Period: 86400
-		GZip level: 9
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Response condition: Prevent default logging
@@ -391,6 +397,7 @@ Version: 1
 		Redundancy: standard
 		Server-side encryption: aws:kms
 		Server-side encryption KMS key ID: aws:kms
+		Compression codec: zstd
 `) + "\n\n"
 
 func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
@@ -404,7 +411,6 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 		Domain:                       "https://s3.us-east-1.amazonaws.com",
 		Path:                         "logs/",
 		Period:                       3600,
-		GzipLevel:                    9,
 		Format:                       `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:                2,
 		MessageType:                  "classic",
@@ -415,6 +421,7 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 		PublicKey:                    pgpPublicKey(),
 		ServerSideEncryption:         "aws:kms",
 		ServerSideEncryptionKMSKeyID: "1234",
+		CompressionCodec:             "zstd",
 	}, nil
 }
 
@@ -431,7 +438,7 @@ Access key: 1234
 Secret key: -----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA
 Path: logs/
 Period: 3600
-GZip level: 9
+GZip level: 0
 Format: %h %l %u %t "%r" %>s %b
 Format version: 2
 Response condition: Prevent default logging
@@ -442,6 +449,7 @@ Public key: `+pgpPublicKey()+`
 Redundancy: standard
 Server-side encryption: aws:kms
 Server-side encryption KMS key ID: aws:kms
+Compression codec: zstd
 `) + "\n"
 
 func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
@@ -455,7 +463,6 @@ func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
 		Domain:                       "https://s3.us-east-1.amazonaws.com",
 		Path:                         "logs/",
 		Period:                       3600,
-		GzipLevel:                    9,
 		Format:                       `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:                2,
 		MessageType:                  "classic",
@@ -466,6 +473,7 @@ func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
 		PublicKey:                    pgpPublicKey(),
 		ServerSideEncryption:         "aws:kms",
 		ServerSideEncryptionKMSKeyID: "1234",
+		CompressionCodec:             "zstd",
 	}, nil
 }
 

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -56,7 +56,6 @@ func TestCreateS3Input(t *testing.T) {
 				SecretKey:                    "secret",
 				Path:                         "path",
 				Period:                       3600,
-				GzipLevel:                    2,
 				Format:                       `%h %l %u %t "%r" %>s %b`,
 				MessageType:                  "classic",
 				FormatVersion:                2,
@@ -67,6 +66,7 @@ func TestCreateS3Input(t *testing.T) {
 				PublicKey:                    pgpPublicKey(),
 				ServerSideEncryptionKMSKeyID: "kmskey",
 				ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
+				CompressionCodec:             "zstd",
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestUpdateS3Input(t *testing.T) {
 				Domain:                       fastly.String("new5"),
 				Path:                         fastly.String("new6"),
 				Period:                       fastly.Uint(3601),
-				GzipLevel:                    fastly.Uint(3),
+				GzipLevel:                    fastly.Uint(0),
 				Format:                       fastly.String("new7"),
 				FormatVersion:                fastly.Uint(3),
 				MessageType:                  fastly.String("new8"),
@@ -129,6 +129,7 @@ func TestUpdateS3Input(t *testing.T) {
 				ServerSideEncryption:         fastly.S3ServerSideEncryptionKMS,
 				ServerSideEncryptionKMSKeyID: fastly.String("new12"),
 				PublicKey:                    fastly.String("new13"),
+				CompressionCodec:             fastly.String("new14"),
 			},
 		},
 		{
@@ -180,7 +181,6 @@ func createCommandAll() *CreateCommand {
 		Domain:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "domain"},
 		Path:                         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "path"},
 		Period:                       common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		GzipLevel:                    common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		Format:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:                common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		MessageType:                  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
@@ -191,6 +191,7 @@ func createCommandAll() *CreateCommand {
 		Redundancy:                   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: string(fastly.S3RedundancyStandard)},
 		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: string(fastly.S3ServerSideEncryptionAES)},
 		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "kmskey"},
+		CompressionCodec:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -223,7 +224,7 @@ func updateCommandAll() *UpdateCommand {
 		Domain:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
 		Path:                         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
 		Period:                       common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:                    common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:                    common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
 		Format:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
 		FormatVersion:                common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
 		MessageType:                  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
@@ -234,6 +235,7 @@ func updateCommandAll() *UpdateCommand {
 		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: string(fastly.S3ServerSideEncryptionKMS)},
 		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
 		PublicKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
+		CompressionCodec:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new14"},
 	}
 }
 
@@ -254,7 +256,6 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 		SecretKey:                    "secret",
 		Path:                         "path",
 		Period:                       3600,
-		GzipLevel:                    2,
 		Format:                       `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:                2,
 		ResponseCondition:            "Prevent default logging",
@@ -265,6 +266,7 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 		Redundancy:                   fastly.S3RedundancyStandard,
 		ServerSideEncryptionKMSKeyID: "kmskey",
 		ServerSideEncryption:         fastly.S3ServerSideEncryptionAES,
+		CompressionCodec:             "zstd",
 	}, nil
 }
 

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -41,6 +41,7 @@ type UpdateCommand struct {
 	Redundancy                   common.OptionalString
 	ServerSideEncryption         common.OptionalString
 	ServerSideEncryptionKMSKeyID common.OptionalString
+	CompressionCodec             common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -75,6 +76,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("server-side-encryption", "Set to enable S3 Server Side Encryption. Can be either AES256 or aws:kms").Action(c.ServerSideEncryption.Set).EnumVar(&c.ServerSideEncryption.Value, string(fastly.S3ServerSideEncryptionAES), string(fastly.S3ServerSideEncryptionKMS))
 	c.CmdClause.Flag("server-side-encryption-kms-key-id", "Server-side KMS Key ID. Must be set if server-side-encryption is set to aws:kms").Action(c.ServerSideEncryptionKMSKeyID.Set).StringVar(&c.ServerSideEncryptionKMSKeyID.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -158,6 +160,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateS3Input, error) {
 
 	if c.ServerSideEncryptionKMSKeyID.WasSet {
 		input.ServerSideEncryptionKMSKeyID = fastly.String(c.ServerSideEncryptionKMSKeyID.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	if c.Redundancy.WasSet {

--- a/pkg/logging/sftp/create.go
+++ b/pkg/logging/sftp/create.go
@@ -1,6 +1,7 @@
 package sftp
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
@@ -37,6 +38,7 @@ type CreateCommand struct {
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -69,6 +71,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -88,6 +91,12 @@ func (c *CreateCommand) createInput() (*fastly.CreateSFTPInput, error) {
 	input.Address = c.Address
 	input.User = c.User
 	input.SSHKnownHosts = c.SSHKnownHosts
+
+	// The following blocks enforces the mutual exclusivity of the
+	// CompressionCodec and GzipLevel flags.
+	if c.CompressionCodec.WasSet && c.GzipLevel.WasSet {
+		return nil, fmt.Errorf("error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag")
+	}
 
 	if c.Port.WasSet {
 		input.Port = c.Port.Value
@@ -139,6 +148,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateSFTPInput, error) {
 
 	if c.Placement.WasSet {
 		input.Placement = c.Placement.Value
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = c.CompressionCodec.Value
 	}
 
 	return &input, nil

--- a/pkg/logging/sftp/describe.go
+++ b/pkg/logging/sftp/describe.go
@@ -63,6 +63,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Response condition: %s\n", sftp.ResponseCondition)
 	fmt.Fprintf(out, "Timestamp format: %s\n", sftp.TimestampFormat)
 	fmt.Fprintf(out, "Placement: %s\n", sftp.Placement)
+	fmt.Fprintf(out, "Compression codec: %s\n", sftp.CompressionCodec)
 
 	return nil
 }

--- a/pkg/logging/sftp/list.go
+++ b/pkg/logging/sftp/list.go
@@ -77,6 +77,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tResponse condition: %s\n", sftp.ResponseCondition)
 		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", sftp.TimestampFormat)
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", sftp.Placement)
+		fmt.Fprintf(out, "\t\tCompression codec: %s\n", sftp.CompressionCodec)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -45,6 +45,10 @@ func TestSFTPCreate(t *testing.T) {
 			api:       mock.API{CreateSFTPFn: createSFTPError},
 			wantError: errTest.Error(),
 		},
+		{
+			args:      []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--ssh-known-hosts", knownHosts(), "--port", "80", "--compression-codec", "zstd", "--gzip-level", "9"},
+			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (
@@ -249,8 +253,9 @@ var errTest = errors.New("fixture error")
 
 func createSFTPOK(i *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
 	s := fastly.SFTP{
-		ServiceID:      i.ServiceID,
-		ServiceVersion: i.ServiceVersion,
+		ServiceID:        i.ServiceID,
+		ServiceVersion:   i.ServiceVersion,
+		CompressionCodec: "zstd",
 	}
 
 	if i.Name != "" {
@@ -279,13 +284,13 @@ func listSFTPsOK(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 			SSHKnownHosts:     knownHosts(),
 			Path:              "/logs",
 			Period:            3600,
-			GzipLevel:         2,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			FormatVersion:     2,
 			MessageType:       "classic",
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
+			CompressionCodec:  "zstd",
 		},
 		{
 			ServiceID:         i.ServiceID,
@@ -300,13 +305,13 @@ func listSFTPsOK(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 			SSHKnownHosts:     knownHosts(),
 			Path:              "/analytics",
 			Period:            3600,
-			GzipLevel:         3,
 			Format:            `%h %l %u %t "%r" %>s %b`,
 			MessageType:       "classic",
 			FormatVersion:     2,
 			ResponseCondition: "Prevent default logging",
 			TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 			Placement:         "none",
+			CompressionCodec:  "zstd",
 		},
 	}, nil
 }
@@ -339,13 +344,14 @@ Version: 1
 		SSH known hosts: `+knownHosts()+`
 		Path: /logs
 		Period: 3600
-		GZip level: 2
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Message type: classic
 		Response condition: Prevent default logging
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Compression codec: zstd
 	SFTP 2/2
 		Service ID: 123
 		Version: 1
@@ -359,13 +365,14 @@ Version: 1
 		SSH known hosts: `+knownHosts()+`
 		Path: /analytics
 		Period: 3600
-		GZip level: 3
+		GZip level: 0
 		Format: %h %l %u %t "%r" %>s %b
 		Format version: 2
 		Message type: classic
 		Response condition: Prevent default logging
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
+		Compression codec: zstd
 `) + "\n\n"
 
 func getSFTPOK(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
@@ -389,6 +396,7 @@ func getSFTPOK(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 
@@ -416,6 +424,7 @@ Message type: classic
 Response condition: Prevent default logging
 Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
+Compression codec: zstd
 `) + "\n"
 
 func updateSFTPOK(i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
@@ -432,13 +441,13 @@ func updateSFTPOK(i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
 		SSHKnownHosts:     knownHosts(),
 		Path:              "/logs",
 		Period:            3600,
-		GzipLevel:         3,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
 		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/sftp/sftp_test.go
+++ b/pkg/logging/sftp/sftp_test.go
@@ -49,12 +49,12 @@ func TestCreateSFTPInput(t *testing.T) {
 				Path:              "/log",
 				Period:            3600,
 				FormatVersion:     2,
-				GzipLevel:         2,
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				ResponseCondition: "Prevent default logging",
 				MessageType:       "classic",
 				TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 				Placement:         "none",
+				CompressionCodec:  "zstd",
 			},
 		},
 		{
@@ -99,12 +99,13 @@ func TestUpdateSFTPInput(t *testing.T) {
 				Path:              fastly.String("new8"),
 				Period:            fastly.Uint(3601),
 				FormatVersion:     fastly.Uint(3),
-				GzipLevel:         fastly.Uint(3),
+				GzipLevel:         fastly.Uint(0),
 				Format:            fastly.String("new9"),
 				ResponseCondition: fastly.String("new10"),
 				TimestampFormat:   fastly.String("new11"),
 				Placement:         fastly.String("new12"),
 				MessageType:       fastly.String("new13"),
+				CompressionCodec:  fastly.String("new14"),
 			},
 		},
 		{
@@ -161,11 +162,11 @@ func createCommandAll() *CreateCommand {
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -202,11 +203,12 @@ func updateCommandAll() *UpdateCommand {
 		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
 		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
 		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
 		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
+		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new14"},
 	}
 }
 
@@ -232,11 +234,11 @@ func getSFTPOK(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 		Period:            3600,
 		Format:            `%h %l %u %t "%r" %>s %b`,
 		FormatVersion:     2,
-		GzipLevel:         2,
 		MessageType:       "classic",
 		ResponseCondition: "Prevent default logging",
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
 		Placement:         "none",
+		CompressionCodec:  "zstd",
 	}, nil
 }
 

--- a/pkg/logging/sftp/update.go
+++ b/pkg/logging/sftp/update.go
@@ -38,6 +38,7 @@ type UpdateCommand struct {
 	ResponseCondition common.OptionalString
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
+	CompressionCodec  common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -70,6 +71,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
+	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 
 	return &c
 }
@@ -153,6 +155,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSFTPInput, error) {
 
 	if c.Placement.WasSet {
 		input.Placement = fastly.String(c.Placement.Value)
+	}
+
+	if c.CompressionCodec.WasSet {
+		input.CompressionCodec = fastly.String(c.CompressionCodec.Value)
 	}
 
 	return &input, nil


### PR DESCRIPTION
This follows from [this](https://github.com/fastly/go-fastly/pull/235) `go-fastly` PR.