### PR TITLE
Update URL for default Rust starter

### DIFF
--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -46,7 +46,7 @@ var (
 		"rust": {
 			{
 				Name:   "Default",
-				Path:   "https://github.com/fastly/fastly-template-rust-default.git",
+				Path:   "https://github.com/fastly/compute-starter-kit-rust-default.git",
 				Branch: "0.5.0",
 			},
 		},


### PR DESCRIPTION
Minor: The name of the repository referenced was changed to `compute-starter-kit-rust-default`.