### PR TITLE
Support for Compute@Edge Log Tailing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/nicksnyder/go-i18n v1.10.1 // indirect
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
 	github.com/segmentio/textio v1.2.0
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -229,6 +229,8 @@ type Interface interface {
 
 	GetRegions() (*fastly.RegionsResponse, error)
 	GetStatsJSON(*fastly.GetStatsInput, interface{}) error
+
+	CreateManagedLogging(*fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
 }
 
 // RealtimeStatsInterface is the subset of go-fastly's realtime stats API used here.

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -47,6 +47,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/splunk"
 	"github.com/fastly/cli/pkg/logging/sumologic"
 	"github.com/fastly/cli/pkg/logging/syslog"
+	"github.com/fastly/cli/pkg/logs"
 	"github.com/fastly/cli/pkg/service"
 	"github.com/fastly/cli/pkg/serviceversion"
 	"github.com/fastly/cli/pkg/stats"
@@ -351,6 +352,9 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	openstackUpdate := openstack.NewUpdateCommand(openstackRoot.CmdClause, &globals)
 	openstackDelete := openstack.NewDeleteCommand(openstackRoot.CmdClause, &globals)
 
+	logsRoot := logs.NewRootCommand(app, &globals)
+	logsTail := logs.NewTailCommand(logsRoot.CmdClause, &globals)
+
 	statsRoot := stats.NewRootCommand(app, &globals)
 	statsRegions := stats.NewRegionsCommand(statsRoot.CmdClause, &globals)
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
@@ -597,6 +601,9 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		openstackDescribe,
 		openstackUpdate,
 		openstackDelete,
+
+		logsRoot,
+		logsTail,
 
 		statsRoot,
 		statsRegions,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -114,6 +114,7 @@ COMMANDS
   dictionary       Manipulate Fastly edge dictionaries
   dictionaryitem   Manipulate Fastly edge dictionary items
   logging          Manipulate Fastly service version logging endpoints
+  logs             Compute@Edge Log Tailing
   stats            View statistics (historical and realtime) for a Fastly
                    service
 `) + "\n\n"
@@ -3020,6 +3021,21 @@ COMMANDS
         --version=VERSION        Number of service version
     -n, --name=NAME              The name of the OpenStack logging object
     -s, --service-id=SERVICE-ID  Service ID
+
+  logs tail [<flags>]
+    Tail Compute@Edge logs
+
+    -s, --service-id=SERVICE-ID  Service ID
+        --from=FROM              From time, in unix seconds
+        --to=TO                  To time, in unix seconds
+        --sort-buffer=1s         Sort buffer is how long to buffer logs,
+                                 attempting to sort them before printing,
+                                 defaults to 1s (second)
+        --search-padding=2s      Search padding is how much of a window on
+                                 either side of From and To to use for
+                                 searching, defaults to 2s (seconds)
+        --stream=STREAM          Stream specifies which of 'stdout' or 'stderr'
+                                 to output, defaults to undefined (all streams)
 
   stats regions
     List stats regions

--- a/pkg/logs/doc.go
+++ b/pkg/logs/doc.go
@@ -1,0 +1,2 @@
+// Package logs contains commands to view Fastly managed logs.
+package logs

--- a/pkg/logs/root.go
+++ b/pkg/logs/root.go
@@ -1,0 +1,28 @@
+package logs
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	common.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("logs", "Compute@Edge Log Tailing")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/logs/tail.go
+++ b/pkg/logs/tail.go
@@ -1,0 +1,604 @@
+package logs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/tomnomnom/linkheader"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+type (
+	TailCommand struct {
+		common.Base
+		manifest manifest.Data
+		Input    fastly.CreateManagedLoggingInput
+
+		cfg cfg
+
+		dieCh   chan struct{} // channel to end output/printing
+		batchCh chan Batch    // send batches to output loop
+		doneCh  chan struct{} // channel to signal we've reached the end of the run
+
+		hClient *http.Client // TODO: this will go away when GET is in go-fastly
+		token   string       // TODO: this will go away when GET is in go-fastly
+	}
+
+	// cfg holds the configuration parameters passed in through
+	// command line arguments.
+	cfg struct {
+		// path is the full path to fetch
+		path string
+
+		// from is how far in the past to start showing logs.
+		from int64
+
+		// to is when to get logs until.
+		to int64
+
+		// sortBuffer is how long to buffer logs from when the cli
+		// receives them to when the cli prints them. It will sort
+		// by RequestID for that buffer period.
+		sortBuffer time.Duration
+		// searchPadding is how much of a window on either side of
+		// from and to to use for searching for the beginning or
+		// through the end timestamps.
+		searchPadding time.Duration
+		// stream specifies which of stdout or stderr or both the
+		// customer wants to consume.
+		// Undefined == both stderr and stdout.
+		stream string
+	}
+
+	// Log defines the message envelope that compute@edge (C@E) wraps the
+	// user messages in.
+	Log struct {
+		// SequenceNum is the message sequence number used to reorder
+		// messages.
+		SequenceNum int `json:"sequence_number"`
+		// RequestTime is the time in microseconds when the request
+		// was received.
+		RequestStart int64 `json:"request_start_us"`
+		// Stream is the C@E stream, either stdout or stderr.
+		Stream string `json:"stream"`
+		// RequestID is a UUID representing individual requests to the
+		// particular WASM service.
+		RequestID string `json:"id"`
+		// Message is the actual message body the user wants printed.
+		Message string `json:"message"`
+	}
+
+	// Batch encompasses a batch ID and the logs for this batch.
+	Batch struct {
+		ID   string `json:"batch_id"`
+		Logs []Log  `json:"logs"`
+	}
+)
+
+// NewTailCommand returns a usable command registered under the parent.
+func NewTailCommand(parent common.Registerer, globals *config.Data) *TailCommand {
+	var c TailCommand
+	c.Globals = globals
+	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("tail", "Tail Compute@Edge logs")
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("from", "From time, in unix seconds").Int64Var(&c.cfg.from)
+	c.CmdClause.Flag("to", "To time, in unix seconds").Int64Var(&c.cfg.to)
+	c.CmdClause.Flag("sort-buffer",
+		"Sort buffer is how long to buffer logs, attempting to sort them before printing, defaults to 1s (second)").Default("1s").DurationVar(&c.cfg.sortBuffer)
+	c.CmdClause.Flag("search-padding",
+		"Search padding is how much of a window on either side of From and To to use for searching, defaults to 2s (seconds)").Default("2s").DurationVar(&c.cfg.searchPadding)
+	c.CmdClause.Flag("stream", "Stream specifies which of 'stdout' or 'stderr' to output, defaults to undefined (all streams)").StringVar(&c.cfg.stream)
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *TailCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, source := c.manifest.ServiceID()
+	if source == manifest.SourceUndefined {
+		return errors.ErrNoServiceID
+	}
+	c.Input.ServiceID = serviceID
+
+	c.Input.Kind = fastly.ManagedLoggingInstanceOutput
+	c.cfg.path = fmt.Sprintf("%s/service/%s/log_stream/managed/instance_output", config.DefaultEndpoint, c.Input.ServiceID)
+
+	c.dieCh = make(chan struct{})
+	c.batchCh = make(chan Batch)
+	c.doneCh = make(chan struct{})
+
+	c.hClient = http.DefaultClient
+	c.token, _ = c.Globals.Token()
+
+	// Adjust the from/to times if they are
+	// defined. We adjust the times based on searchPadding.
+	c.adjustTimes()
+
+	// Enable managed logging if not already enabled.
+	if err := c.enableManagedLogging(out); err != nil {
+		return err
+	}
+
+	sigs := make(chan os.Signal, 2)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+	// Start the output loop.
+	go c.outputLoop(out)
+
+	// Start tailing the logs.
+	go c.tail(out)
+
+	<-sigs
+	close(c.dieCh)
+
+	return nil
+}
+
+//
+// Client
+//
+
+// Tail starts the virtual tail process. Tail fetches data from the eventbuffer
+// API. It hands off the requested logs to the outputloop for the actual
+// printing.
+func (c *TailCommand) tail(out io.Writer) {
+	// Start this with --from and --to if set.
+	curWindow := c.cfg.from
+	toWindow := c.cfg.to
+
+	// Start the loop with an initial address to query.
+	path := makeNewPath(out, c.cfg.path, curWindow, "")
+
+	// lastBatchID keeps the last successfully read Batch.ID in case we need
+	// re-request on failure.
+	var lastBatchID string
+
+	for {
+		// Check to see if we already passed the "to" requirement.
+		if toWindow != 0 && curWindow > toWindow {
+			text.Info(out, "Reached window: %v which is newer than the requested 'to': %v", curWindow, toWindow)
+			// We are done, but we still want printing to finish.
+			close(c.doneCh)
+			break
+		}
+
+		req, err := http.NewRequest("GET", path, nil)
+		req.Header.Add("Fastly-Key", c.token)
+		if err != nil {
+			text.Error(out, "unable to create new request: %v", err)
+			os.Exit(1)
+		}
+
+		resp, err := c.doReq(req)
+		if err != nil {
+			text.Error(out, "unable to request: %v", err)
+			os.Exit(1)
+		}
+
+		// Check that our request was successful. If the server is
+		// having trouble, retry after waiting for some time.
+		if resp.StatusCode != http.StatusOK {
+			// In an effort to clean up the output, do not print on
+			// 503's.
+			if resp.StatusCode != http.StatusServiceUnavailable {
+				text.Warning(out, "non-200 resp %d", resp.StatusCode)
+			}
+			io.Copy(ioutil.Discard, resp.Body)
+			// Try the response again after a 1 second wait.
+			if resp.StatusCode/100 == 5 && resp.StatusCode != 501 ||
+				resp.StatusCode == 429 {
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			// Failing at this point is unrecoverable,
+			return
+		}
+
+		// Read and parse response, send batches to the output loop.
+		scanner := bufio.NewScanner(resp.Body)
+		// Use a 10MB buffer for the bufio scanner, as we don't know
+		// how big some of the responses will be.
+		const tmb = 10 << 20
+		buf := make([]byte, tmb)
+		scanner.Buffer(buf, tmb)
+
+		for scanner.Scan() {
+			// Scan one line at a time, and get only one batch
+			// at a time.
+			b := scanner.Bytes()
+			batch, err := parseResponseData(b)
+			if err != nil {
+				// We can't parse the response, attempt to
+				// re-request from the last window & batch.
+				text.Warning(out, "unable to parse resp body: %v", err)
+				path = makeNewPath(out, path, curWindow, lastBatchID)
+				continue
+			}
+
+			// If we got a batch back, there will be an ID.
+			if batch.ID != "" {
+				// Record last batchID in case
+				// anything fails along the way, we
+				// can re-request.
+				lastBatchID = batch.ID
+				// Send batch down batchCh to the output loop.
+				c.batchCh <- batch
+			}
+
+		}
+		resp.Body.Close()
+
+		if err := scanner.Err(); err != nil {
+			// ErrUnexpectedEOFs need to be retried, but they
+			// produce a lot of noise for the user, so don't log.
+			if err != io.ErrUnexpectedEOF {
+				text.Warning(out, "error scanning response body: %v", err)
+			}
+			// Something happened in the scanner, re-request the
+			// current batchID.
+			path = makeNewPath(out, path, curWindow, lastBatchID)
+			continue
+		}
+
+		// Get our next time window to request.
+		_, next := getLinks(resp.Header)
+		curWindow, err = getTimeFromLink(next)
+		if err != nil {
+			text.Error(out, "error generating window from next link")
+		}
+
+		// We do NOT want to specify a batchID, as this
+		// request was successful.
+		lastBatchID = ""
+		path = makeNewPath(out, path, curWindow, lastBatchID)
+	}
+
+}
+
+// adjustTimes adjusts the passed in from and to flags based on the
+// specified padding.
+func (c *TailCommand) adjustTimes() {
+	if c.cfg.from != 0 {
+		// Adjust from based on search padding, we want to
+		// look back further.
+		c.cfg.from = c.cfg.from - int64(c.cfg.searchPadding.Seconds())
+	}
+
+	if c.cfg.to != 0 {
+		// Adjust to based on search padding, we want look forward more.
+		c.cfg.to = c.cfg.to + int64(c.cfg.searchPadding.Seconds())
+	}
+}
+
+// enableManagedLogging enables managed logging in our API.
+func (c *TailCommand) enableManagedLogging(out io.Writer) error {
+	_, err := c.Globals.Client.CreateManagedLogging(&c.Input)
+	if err != nil && err != fastly.ErrManagedLoggingEnabled {
+		return err
+	}
+
+	text.Info(out, "Managed logging enabled on service %s", c.Input.ServiceID)
+	return nil
+}
+
+// outputLoop processes the logs out of band from the request/response loop.
+func (c *TailCommand) outputLoop(out io.Writer) {
+	type (
+		bufferedLog struct {
+			reqID string
+			seq   int
+		}
+
+		receive struct {
+			when    time.Time
+			highSeq int
+		}
+
+		logrecv struct {
+			logs     []Log
+			receives []receive
+		}
+	)
+
+	// Channel for timers to notify they are done buffering.
+	tdCh := make(chan bufferedLog)
+
+	// Single map to keep all buffered logs by RequestID as
+	// well recording when logs were received.
+	logmap := make(map[string]logrecv)
+
+	for {
+		select {
+		case <-c.dieCh:
+			return
+		case batch := <-c.batchCh: // Got new batch.
+			// Range through batch logs, for each
+			// RequestID we create a timer based on the
+			// highest SequenceNum we got in this batch
+			// for that RequestID.  If a timer already
+			// exists for the RequestID, we append the new
+			// time.Now() and high SequenceNum.  At most
+			// there should be one timer per RequestID.
+			for reqid, logs := range splitByReqID(batch.Logs) {
+				// Required for use in AfterFunc below.
+				req := reqid
+
+				// Record highest SequenceNum in this new batch
+				// for this RequestID
+				highSeq := highSequence(logs)
+
+				// Whether we have the RequestID or not, we
+				// append and sort the logs slice.
+				reqLogs := logmap[req]
+				reqLogs.logs = append(reqLogs.logs, logs...)
+				// Sort the current batch of logs by their sequence number.
+				sort.Slice(reqLogs.logs,
+					func(i, j int) bool {
+						return reqLogs.logs[i].SequenceNum < reqLogs.logs[j].SequenceNum
+					})
+
+				// Check to see if we already have a timer
+				// running or if the current high sequence is
+				// higher than the one with the timer.
+				// The timer will always be running on the head
+				// of the slice.
+				recv := reqLogs.receives
+
+				// In either case append to the receives slice.
+				if len(recv) == 0 || recv[0].highSeq < highSeq {
+					reqLogs.receives = append(recv, receive{
+						when:    time.Now(),
+						highSeq: highSeq,
+					})
+				}
+
+				// In only the empty case, start a new timer
+				// since this is the head of the slice.
+				if len(recv) == 0 {
+					time.AfterFunc(c.cfg.sortBuffer, func() {
+						tdCh <- bufferedLog{
+							reqID: req,
+							seq:   highSeq,
+						}
+					})
+				}
+
+				// Set the new log and receive info back to the
+				// logmap for this RequestID.
+				logmap[req] = reqLogs
+			}
+
+		case bufdLogs := <-tdCh: // A timer expired for a particular request.
+			reqID, seq := bufdLogs.reqID, bufdLogs.seq
+
+			// Get the logs for this RequestID and
+			// find the index of the sequence in our current logs.
+			reqLogs := logmap[reqID]
+			idx := findIdxBySeq(reqLogs.logs, seq)
+
+			// Split off the source of this timer, leave
+			// remaining logs to be printed later.
+			toPrint, remainingLogs := reqLogs.logs[:idx], reqLogs.logs[idx:]
+			reqLogs.logs = remainingLogs
+			c.printLogs(out, toPrint)
+
+			// Special case if we just printed the entire set of
+			// logs, we remove the keys from the maps and finish.
+			if len(remainingLogs) == 0 {
+				delete(logmap, reqID)
+				break
+			}
+
+			// Drop the front of the batchReqReceives map and start
+			// another timer for any remaining recorded sequences.
+			recv := reqLogs.receives[1:]
+			reqLogs.receives = recv
+
+			// If anything is left...
+			if len(recv) > 0 {
+				// We create a new timer, we subtract
+				// off time already served from the
+				// user defined sortBuffer.
+				time.AfterFunc(c.cfg.sortBuffer-time.Since(recv[0].when), func() {
+					tdCh <- bufferedLog{
+						reqID: reqID,
+						seq:   recv[0].highSeq,
+					}
+				})
+			}
+
+			// Set the new log and receive info back to the
+			// logmap for this RequestID.
+			logmap[reqID] = reqLogs
+
+		case <-c.doneCh:
+			os.Exit(0)
+		}
+	}
+}
+
+// printLogs is a simple printer for Log slices, only printing requested
+// streams.
+func (c *TailCommand) printLogs(out io.Writer, logs []Log) {
+	if len(logs) > 0 {
+		filtered := filterStream(c.cfg.stream, logs)
+
+		for _, l := range filtered {
+			fmt.Fprintln(out, l.String())
+		}
+	}
+}
+
+// doReq runs the http.Request, returning a http.Response or error.
+func (c *TailCommand) doReq(req *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-c.dieCh:
+			cancel()
+		}
+	}()
+
+	resp, err := c.hClient.Do(req)
+	return resp, err
+}
+
+//
+// Log
+//
+
+// RequestStartFromRaw return a time.Time object representing the
+// RequestStart data.
+func (l *Log) RequestStartFromRaw() time.Time {
+	// RequestTime comes as unix time in microseconds. Convert to
+	// nanoseconds, then parse with stdlib.
+	nano := l.RequestStart * 1000
+	return time.Unix(0, nano)
+}
+
+// String is used to print a log for the tail output.
+func (l *Log) String() string {
+	// Trim the RequestID for nicer output, it might be a long UUID.
+	return fmt.Sprintf("%6s | %8.8s | %s",
+		l.Stream,
+		l.RequestID,
+		l.Message)
+}
+
+//
+// Helpers
+//
+
+// makeNewPath generates a new request path based on current
+// path, window, and batchID.
+func makeNewPath(out io.Writer, path string, window int64, batchID string) string {
+	basePath, err := url.Parse(path)
+	if err != nil {
+		// No reasonable way to carry on from an error at this point
+		// and it should never happen, so error & exit.
+		text.Error(out, "error generating request URL: %v", err)
+		os.Exit(1)
+	}
+
+	// Unset anything in the query parameters that might already exist.
+	basePath.RawQuery = ""
+
+	q := basePath.Query()
+	if window != 0 {
+		q.Set("from", strconv.FormatInt(window, 10))
+	}
+
+	if batchID != "" {
+		q.Set("batch_id", batchID)
+	}
+
+	basePath.RawQuery = q.Encode()
+	return basePath.String()
+}
+
+// splitByReqID splits slices of logs based on RequestID,
+func splitByReqID(in []Log) map[string][]Log {
+	out := make(map[string][]Log)
+	for _, l := range in {
+		out[l.RequestID] = append(out[l.RequestID], l)
+	}
+	return out
+}
+
+// parseResponseData returns the batch from a response.
+func parseResponseData(data []byte) (Batch, error) {
+	var batch Batch
+	reader := bytes.NewReader(data)
+	d := json.NewDecoder(reader)
+
+	if err := d.Decode(&batch); err != nil && err != io.EOF {
+		return batch, err
+	}
+
+	return batch, nil
+}
+
+// filterStream returns only logs that are requested by the stream flag.
+func filterStream(stream string, logs []Log) []Log {
+	// If unset, do not filter out any logs.
+	if stream == "" {
+		return logs
+	}
+
+	var out []Log
+	for _, l := range logs {
+		// If the stream matches what they wanted, keep it.
+		if stream == l.Stream {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// getTimeFromLink splits a link header format, returning
+// the time.
+func getTimeFromLink(link string) (int64, error) {
+	s := strings.SplitN(link, "=", 2)[1]
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// getLinks returns the prev and next links from a header.
+func getLinks(head http.Header) (prev, next string) {
+	links := linkheader.ParseMultiple(head["Link"])
+	for _, link := range links {
+		switch link.Rel {
+		case "prev":
+			prev = link.URL
+		case "next":
+			next = link.URL
+		}
+	}
+	return
+}
+
+// findIdxBySeq returns the slice index after the
+// SequenceNum we are searching for.
+func findIdxBySeq(logs []Log, seq int) int {
+	for i, v := range logs {
+		if v.SequenceNum > seq {
+			return i
+		}
+	}
+	return len(logs)
+}
+
+// highSequence returns the highest SequenceNum
+// in a slice of logs.
+func highSequence(logs []Log) int {
+	var max int
+	for _, l := range logs {
+		if l.SequenceNum > max {
+			max = l.SequenceNum
+		}
+	}
+	return max
+}

--- a/pkg/logs/tail_test.go
+++ b/pkg/logs/tail_test.go
@@ -1,0 +1,342 @@
+package logs
+
+import (
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const responseFile = "testdata/response.json"
+
+// TestAdjustTimes tests that the from and to times are adjusted accordingly
+// based on the searchPadding.
+func TestAdjustTimes(t *testing.T) {
+	dur, _ := time.ParseDuration("10s")
+	for i, test := range []struct {
+		in  cfg
+		exp cfg
+	}{
+		{
+			in:  cfg{from: 1601480668, to: 1601480768, searchPadding: dur},
+			exp: cfg{from: 1601480658, to: 1601480778, searchPadding: dur},
+		},
+		{
+			in:  cfg{from: 1601480668, to: 1601480768},
+			exp: cfg{from: 1601480668, to: 1601480768},
+		},
+		{
+			in:  cfg{searchPadding: dur},
+			exp: cfg{searchPadding: dur},
+		},
+	} {
+		c := TailCommand{cfg: test.in}
+		c.adjustTimes()
+		if equal := reflect.DeepEqual(test.exp, c.cfg); !equal {
+			t.Errorf("#%d: adjustTimes mismatch: got: %#+v  want: %#+v", i, c.cfg, test.exp)
+		}
+	}
+}
+
+// TestSplitByReqID tests that logs are properly grouped and sorted
+// by their RequestID and SequenceNum.
+func TestSplitByReqID(t *testing.T) {
+	full := []Log{
+		{SequenceNum: 1, RequestID: "41f82900"},
+		{SequenceNum: 2, RequestID: "41f82900"},
+		{SequenceNum: 3, RequestID: "2bef4613"},
+		{SequenceNum: 4, RequestID: "2bef4613"},
+		{SequenceNum: 5, RequestID: "41f82900"},
+		{SequenceNum: 6, RequestID: "41f82900"},
+		{SequenceNum: 6, RequestID: "2bef4613"},
+		{SequenceNum: 1, RequestID: "2bef4613"},
+		{SequenceNum: 5, RequestID: "2bef4613"},
+		{SequenceNum: 2, RequestID: "2bef4613"},
+		{SequenceNum: 3, RequestID: "41f82900"},
+		{SequenceNum: 4, RequestID: "41f82900"},
+	}
+
+	expfull := map[string][]Log{
+		"41f82900": {
+			{SequenceNum: 1, RequestID: "41f82900"},
+			{SequenceNum: 2, RequestID: "41f82900"},
+			{SequenceNum: 5, RequestID: "41f82900"},
+			{SequenceNum: 6, RequestID: "41f82900"},
+			{SequenceNum: 3, RequestID: "41f82900"},
+			{SequenceNum: 4, RequestID: "41f82900"},
+		},
+		"2bef4613": {
+			{SequenceNum: 3, RequestID: "2bef4613"},
+			{SequenceNum: 4, RequestID: "2bef4613"},
+			{SequenceNum: 6, RequestID: "2bef4613"},
+			{SequenceNum: 1, RequestID: "2bef4613"},
+			{SequenceNum: 5, RequestID: "2bef4613"},
+			{SequenceNum: 2, RequestID: "2bef4613"},
+		},
+	}
+
+	single := []Log{
+		{SequenceNum: 1, RequestID: "41f82900"},
+	}
+
+	expsingle := map[string][]Log{
+		"41f82900": {{SequenceNum: 1, RequestID: "41f82900"}},
+	}
+
+	for i, test := range []struct {
+		in   []Log
+		want map[string][]Log
+	}{
+		{in: full, want: expfull},
+		{in: single, want: expsingle},
+		{in: []Log{}, want: make(map[string][]Log)},
+	} {
+		got := splitByReqID(test.in)
+		if diff := cmp.Diff(test.want, got); diff != "" {
+			t.Errorf("#%d: splitByReqID mismatch (-want +got):\n%s", i, diff)
+		}
+	}
+}
+
+// TestParseResponseData validates we're correctly decoding a batch JSON log
+// response into a logs.Batch type.
+func TestParseResponseData(t *testing.T) {
+	data, err := ioutil.ReadFile(responseFile)
+	if err != nil {
+		t.Fatalf("cannot read from file: %v", err)
+	}
+
+	got, err := parseResponseData(data)
+	if err != nil {
+		t.Fatalf("error parsing response data: %v", err)
+	}
+
+	want := Batch{
+		ID: "MC0x",
+		Logs: []Log{
+			{SequenceNum: 1, RequestStart: 1601645172164667, Stream: "stdout", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"},
+			{SequenceNum: 2, RequestStart: 1601645172164667, Stream: "stdout", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2"},
+			{SequenceNum: 3, RequestStart: 1601645172164667, Stream: "stdout", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3"},
+			{SequenceNum: 4, RequestStart: 1601645172164667, Stream: "stdout", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4"},
+			{SequenceNum: 5, RequestStart: 1601645172164667, Stream: "stderr", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5"},
+			{SequenceNum: 6, RequestStart: 1601645172164667, Stream: "stderr", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6"},
+			{SequenceNum: 7, RequestStart: 1601645172164667, Stream: "stdout", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7"},
+			{SequenceNum: 8, RequestStart: 1601645172164667, Stream: "stdout", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8"},
+			{SequenceNum: 9, RequestStart: 1601645172164667, Stream: "stderr", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9"},
+			{SequenceNum: 10, RequestStart: 1601645172164667, Stream: "stdout", RequestID: "44a1eedd-5831-49fe-b094-7435908ba1fb", Message: "10 10 10 10 10 10 10 10 10 10 10 10 10 10"},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("parseResponseData mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestFilterStream tests that a passed in stream will filter out
+// unwanted output.
+func TestFilterStream(t *testing.T) {
+	for i, test := range []struct {
+		stream string
+		logs   []Log
+		explen int
+	}{
+		{
+			stream: "stdout",
+			logs: []Log{
+				{Stream: "stdout"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+				{Stream: "stdout"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+			},
+			explen: 5,
+		},
+		{
+			stream: "stderr",
+			logs: []Log{
+				{Stream: "stdout"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+				{Stream: "stdout"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+			},
+			explen: 3,
+		},
+		{
+			logs: []Log{
+				{Stream: "stdout"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+				{Stream: "stderr"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+				{Stream: "stdout"},
+				{Stream: "stderr"},
+			},
+			explen: 8,
+		},
+	} {
+		out := filterStream(test.stream, test.logs)
+		if len(out) != test.explen {
+			t.Errorf("#%d: exp: %d != got: %d", i, test.explen, len(out))
+		}
+	}
+}
+
+// TestGetLinks tests that we can parse next and prev links from a Link HTTP
+// header.
+func TestGetLinks(t *testing.T) {
+	rawNexPrev := `</service/sid/log_stream/managed/instance_output%3Ffrom=1601412640>; rel="next", </service/sid/log_stream/managed/instance_output%3Ffrom=1601412620>; rel="prev"`
+	head := make(http.Header)
+	head.Set("Link", rawNexPrev)
+
+	prev, next := getLinks(head)
+	prevexp := "/service/sid/log_stream/managed/instance_output%3Ffrom=1601412620"
+	if prev != prevexp {
+		t.Errorf("prev header exp: %s != got: %s", prevexp, prev)
+	}
+
+	nextexp := "/service/sid/log_stream/managed/instance_output%3Ffrom=1601412640"
+	if next != nextexp {
+		t.Errorf("next header exp: %s != got: %s", nextexp, next)
+	}
+
+	pTime, err := getTimeFromLink(prev)
+	if err != nil {
+		t.Fatalf("unexpected error parsing prev link: %s", err)
+	}
+	exp := int64(1601412620)
+	if pTime != exp {
+		t.Errorf("prev time exp: %v != got: %v", exp, pTime)
+	}
+
+	nTime, err := getTimeFromLink(next)
+	if err != nil {
+		t.Fatalf("unexpected error parsing next link: %s", err)
+	}
+	exp = int64(1601412640)
+	if nTime != exp {
+		t.Errorf("next time exp: %v != got: %v", exp, nTime)
+	}
+}
+
+// TestSplitOnIdx tests both findIdxBySeq() and the split functionality
+// that is used when a timer expires in the outputLoop() function. Indexes
+// and splitting (especially at slice boundaries) are particularly error prone.
+func TestSplitOnIdx(t *testing.T) {
+	for i, test := range []struct {
+		seq      int
+		logs     []Log
+		expleft  int
+		expright int
+	}{
+		{
+			seq: 4,
+			logs: []Log{
+				{SequenceNum: 0},
+				{SequenceNum: 1},
+				{SequenceNum: 2},
+				{SequenceNum: 3},
+				{SequenceNum: 4},
+				{SequenceNum: 5},
+				{SequenceNum: 6},
+				{SequenceNum: 7},
+			},
+			expleft:  5,
+			expright: 3,
+		},
+		{
+			seq: 1,
+			logs: []Log{
+				{SequenceNum: 0},
+				{SequenceNum: 1},
+				{SequenceNum: 2},
+				{SequenceNum: 3},
+			},
+			expleft:  2,
+			expright: 2,
+		},
+		{
+			seq: 4,
+			logs: []Log{
+				{SequenceNum: 1},
+				{SequenceNum: 2},
+				{SequenceNum: 3},
+				{SequenceNum: 4},
+			},
+			expleft:  4,
+			expright: 0,
+		},
+		{
+			seq: 6,
+			logs: []Log{
+				{SequenceNum: 1},
+				{SequenceNum: 3},
+				{SequenceNum: 5},
+			},
+			expleft:  3,
+			expright: 0,
+		},
+	} {
+		idx := findIdxBySeq(test.logs, test.seq)
+		left, right := test.logs[:idx], test.logs[idx:]
+		if len(left) != test.expleft {
+			t.Errorf("#%d: exp: %d != got: %d", i, test.expleft, len(left))
+		}
+
+		if len(right) != test.expright {
+			t.Errorf("#%d: exp: %d != got: %d", i, test.expright, len(right))
+		}
+
+	}
+}
+
+// TestHighSequence tests that we correctly get the highest
+// SequenceNum in a slice of logs.
+func TestHighSequence(t *testing.T) {
+	for i, test := range []struct {
+		logs []Log
+		exp  int
+	}{
+		{
+			logs: []Log{
+				{SequenceNum: 0},
+				{SequenceNum: 1},
+				{SequenceNum: 2},
+			},
+			exp: 2,
+		},
+		{
+			logs: []Log{
+				{SequenceNum: 2},
+				{SequenceNum: 1},
+				{SequenceNum: 0},
+			},
+			exp: 2,
+		},
+		{
+			logs: []Log{
+				{SequenceNum: 1},
+				{SequenceNum: 1},
+			},
+			exp: 1,
+		},
+		{
+			logs: []Log{},
+			exp:  0,
+		},
+	} {
+		if got := highSequence(test.logs); got != test.exp {
+			t.Errorf("#%d: exp: %d != got: %d", i, test.exp, got)
+		}
+	}
+}

--- a/pkg/logs/testdata/response.json
+++ b/pkg/logs/testdata/response.json
@@ -1,0 +1,75 @@
+{
+  "batch_id": "MC0x",
+  "logs": [
+    {
+      "sequence_number": 1,
+      "request_start_us": 1601645172164667,
+      "stream": "stdout",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+    },
+    {
+      "sequence_number": 2,
+      "request_start_us": 1601645172164667,
+      "stream": "stdout",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2"
+    },
+    {
+      "sequence_number": 3,
+      "request_start_us": 1601645172164667,
+      "stream": "stdout",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3"
+    },
+    {
+      "sequence_number": 4,
+      "request_start_us": 1601645172164667,
+      "stream": "stdout",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4"
+    },
+    {
+      "sequence_number": 5,
+      "request_start_us": 1601645172164667,
+      "stream": "stderr",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5"
+    },
+    {
+      "sequence_number": 6,
+      "request_start_us": 1601645172164667,
+      "stream": "stderr",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6"
+    },
+    {
+      "sequence_number": 7,
+      "request_start_us": 1601645172164667,
+      "stream": "stdout",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7"
+    },
+    {
+      "sequence_number": 8,
+      "request_start_us": 1601645172164667,
+      "stream": "stdout",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8"
+    },
+    {
+      "sequence_number": 9,
+      "request_start_us": 1601645172164667,
+      "stream": "stderr",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9"
+    },
+    {
+      "sequence_number": 10,
+      "request_start_us": 1601645172164667,
+      "stream": "stdout",
+      "id": "44a1eedd-5831-49fe-b094-7435908ba1fb",
+      "message": "10 10 10 10 10 10 10 10 10 10 10 10 10 10"
+    }
+  ]
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -216,6 +216,8 @@ type API struct {
 
 	GetRegionsFn   func() (*fastly.RegionsResponse, error)
 	GetStatsJSONFn func(i *fastly.GetStatsInput, dst interface{}) error
+
+	CreateManagedLoggingFn func(*fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
 }
 
 // GetTokenSelf implements Interface.
@@ -1076,4 +1078,9 @@ func (m API) GetRegions() (*fastly.RegionsResponse, error) {
 // GetStatsJSON implements Interface.
 func (m API) GetStatsJSON(i *fastly.GetStatsInput, dst interface{}) error {
 	return m.GetStatsJSONFn(i, dst)
+}
+
+// CreateManagedLogging implements Interface.
+func (m API) CreateManagedLogging(i *fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error) {
+	return m.CreateManagedLoggingFn(i)
 }


### PR DESCRIPTION
## What does it do?

Adds command: fastly logs tail --service-id=<sid>

## Output

Because this doesn't run w/o the above mentioned go-fastly, the following is what a log tail session looks like with three requests that just print out a simple message.

```
fastly/cli [ ./fastly logs tail -s <redacted>

INFO: Managed logging enabled on service <redacted>
stdout | 3fbf507b | Hello from the root path!
stdout | 3fbf507b | 2nd println in this request
stdout | 3fbf507b | 3rd println in this request
stdout | 3fbf507b | 4th println in this request
stdout | 3fbf507b | 5th println in this request
stdout | 3fbf507b | 6th println in this request
stdout | c5035791 | Hello from the root path!
stdout | c5035791 | 2nd println in this request
stdout | c5035791 | 3rd println in this request
stdout | c5035791 | 4th println in this request
stdout | c5035791 | 5th println in this request
stdout | c5035791 | 6th println in this request
stdout | 9154fde8 | Hello from the root path!
stdout | 9154fde8 | 2nd println in this request
stdout | 9154fde8 | 3rd println in this request
stdout | 9154fde8 | 4th println in this request
stdout | 9154fde8 | 5th println in this request
stdout | 9154fde8 | 6th println in this request
```
