### PR TITLE
Update Go-Fastly dependency to v3.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
-	github.com/fastly/go-fastly/v2 v2.1.0
+	github.com/fastly/go-fastly/v3 v3.0.0
 	github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible
 	github.com/fatih/color v1.7.0
 	github.com/frankban/quicktest v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fastly/go-fastly/v2 v2.1.0 h1:VQWCFiUZyCcknyxyhiQwU0MjLYzeK4g1mLo/US2r/P0=
 github.com/fastly/go-fastly/v2 v2.1.0/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
+github.com/fastly/go-fastly/v3 v3.0.0 h1:TtTkBnBO5CcPTAUgBL/vcoS5VL5LaKfXV6cilX8bn8U=
+github.com/fastly/go-fastly/v3 v3.0.0/go.mod h1:1GAnpEjDwBQD6DZgrgO5RoIawXFqrYC1K+JOkgZXCPk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:9
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
-github.com/fastly/go-fastly/v2 v2.1.0 h1:VQWCFiUZyCcknyxyhiQwU0MjLYzeK4g1mLo/US2r/P0=
-github.com/fastly/go-fastly/v2 v2.1.0/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
 github.com/fastly/go-fastly/v3 v3.0.0 h1:TtTkBnBO5CcPTAUgBL/vcoS5VL5LaKfXV6cilX8bn8U=
 github.com/fastly/go-fastly/v3 v3.0.0/go.mod h1:1GAnpEjDwBQD6DZgrgO5RoIawXFqrYC1K+JOkgZXCPk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // HTTPClient models a concrete http.Client. It's a consumer contract for some

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -88,7 +88,7 @@ type Interface interface {
 	DeleteS3(*fastly.DeleteS3Input) error
 
 	CreateKinesis(*fastly.CreateKinesisInput) (*fastly.Kinesis, error)
-	ListKineses(*fastly.ListKinesesInput) ([]*fastly.Kinesis, error)
+	ListKinesis(*fastly.ListKinesisInput) ([]*fastly.Kinesis, error)
 	GetKinesis(*fastly.GetKinesisInput) (*fastly.Kinesis, error)
 	UpdateKinesis(*fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
 	DeleteKinesis(*fastly.DeleteKinesisInput) error

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -54,7 +54,7 @@ import (
 	"github.com/fastly/cli/pkg/update"
 	"github.com/fastly/cli/pkg/version"
 	"github.com/fastly/cli/pkg/whoami"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/fastly/kingpin"
 )
 

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestBackendCreate(t *testing.T) {

--- a/pkg/backend/create.go
+++ b/pkg/backend/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create backends.

--- a/pkg/backend/delete.go
+++ b/pkg/backend/delete.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete backends.

--- a/pkg/backend/describe.go
+++ b/pkg/backend/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a backend.

--- a/pkg/backend/list.go
+++ b/pkg/backend/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list backends.

--- a/pkg/backend/update.go
+++ b/pkg/backend/update.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update backends.

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestInit(t *testing.T) {

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/mholt/archiver/v3"
 )
 

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/kennygrant/sanitize"
 )
 

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -20,7 +20,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )

--- a/pkg/compute/update.go
+++ b/pkg/compute/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update packages.

--- a/pkg/configure/configure_test.go
+++ b/pkg/configure/configure_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestConfigure(t *testing.T) {

--- a/pkg/configure/root.go
+++ b/pkg/configure/root.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // APIClientFactory allows the configure command to regenerate the global Fastly

--- a/pkg/domain/create.go
+++ b/pkg/domain/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create domains.

--- a/pkg/domain/delete.go
+++ b/pkg/domain/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete domains.

--- a/pkg/domain/describe.go
+++ b/pkg/domain/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a domain.

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestDomainCreate(t *testing.T) {

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -339,7 +339,7 @@ func updateDomainOK(i *fastly.UpdateDomainInput) (*fastly.Domain, error) {
 	return &fastly.Domain{
 		ServiceID:      i.ServiceID,
 		ServiceVersion: i.ServiceVersion,
-		Name:           i.NewName,
+		Name:           *i.NewName,
 		Comment:        *i.Comment,
 	}, nil
 }

--- a/pkg/domain/list.go
+++ b/pkg/domain/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list domains.

--- a/pkg/domain/update.go
+++ b/pkg/domain/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update domains.

--- a/pkg/domain/update.go
+++ b/pkg/domain/update.go
@@ -19,6 +19,7 @@ type UpdateCommand struct {
 	getInput    fastly.GetDomainInput
 	updateInput fastly.UpdateDomainInput
 
+	NewName common.OptionalString
 	Comment common.OptionalString
 }
 
@@ -30,7 +31,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.getInput.ServiceVersion)
 	c.CmdClause.Flag("name", "Domain name").Short('n').Required().StringVar(&c.getInput.Name)
-	c.CmdClause.Flag("new-name", "New domain name").StringVar(&c.updateInput.NewName)
+	c.CmdClause.Flag("new-name", "New domain name").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("comment", "A descriptive note").Action(c.Comment.Set).StringVar(&c.Comment.Value)
 	return &c
 }
@@ -44,7 +45,7 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	c.getInput.ServiceID = serviceID
 
 	// If neither arguments are provided, error with useful message.
-	if c.updateInput.NewName == "" && !c.Comment.WasSet {
+	if !c.NewName.WasSet && !c.Comment.WasSet {
 		return fmt.Errorf("error parsing arguments: must provide either --new-name or --comment to update domain")
 	}
 
@@ -59,8 +60,8 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	// Set original value, and then afterwards check if we can use the flag value.
 	c.updateInput.Comment = &d.Comment
 
-	if c.updateInput.NewName == "" {
-		c.updateInput.NewName = d.Name
+	if c.NewName.WasSet {
+		c.updateInput.NewName = fastly.String(c.NewName.Value)
 	}
 	if c.Comment.WasSet {
 		c.updateInput.Comment = fastly.String(c.Comment.Value)

--- a/pkg/edgedictionary/create.go
+++ b/pkg/edgedictionary/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a service.

--- a/pkg/edgedictionary/delete.go
+++ b/pkg/edgedictionary/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a service.

--- a/pkg/edgedictionary/describe.go
+++ b/pkg/edgedictionary/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a dictionary.

--- a/pkg/edgedictionary/edgedictionary_test.go
+++ b/pkg/edgedictionary/edgedictionary_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestDictionaryDescribe(t *testing.T) {

--- a/pkg/edgedictionary/list.go
+++ b/pkg/edgedictionary/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list dictionaries

--- a/pkg/edgedictionary/update.go
+++ b/pkg/edgedictionary/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a dictionary.

--- a/pkg/edgedictionaryitem/batch.go
+++ b/pkg/edgedictionaryitem/batch.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // BatchCommand calls the Fastly API to batch update a dictionary.

--- a/pkg/edgedictionaryitem/create.go
+++ b/pkg/edgedictionaryitem/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a dictionary item.

--- a/pkg/edgedictionaryitem/delete.go
+++ b/pkg/edgedictionaryitem/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a service.

--- a/pkg/edgedictionaryitem/describe.go
+++ b/pkg/edgedictionaryitem/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a dictionary item.

--- a/pkg/edgedictionaryitem/edgedictionaryitem_test.go
+++ b/pkg/edgedictionaryitem/edgedictionaryitem_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestDictionaryItemDescribe(t *testing.T) {

--- a/pkg/edgedictionaryitem/edgedictionaryitem_test.go
+++ b/pkg/edgedictionaryitem/edgedictionaryitem_test.go
@@ -400,7 +400,7 @@ func updateDictionaryItemOK(i *fastly.UpdateDictionaryItemInput) (*fastly.Dictio
 		ServiceID:    i.ServiceID,
 		DictionaryID: i.DictionaryID,
 		ItemKey:      i.ItemKey,
-		ItemValue:    *i.ItemValue,
+		ItemValue:    i.ItemValue,
 		CreatedAt:    testutil.MustParseTimeRFC3339("2001-02-03T04:05:06Z"),
 		UpdatedAt:    testutil.MustParseTimeRFC3339("2001-02-03T04:05:07Z"),
 	}, nil

--- a/pkg/edgedictionaryitem/list.go
+++ b/pkg/edgedictionaryitem/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list dictionary items.

--- a/pkg/edgedictionaryitem/update.go
+++ b/pkg/edgedictionaryitem/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a dictionary item.

--- a/pkg/edgedictionaryitem/update.go
+++ b/pkg/edgedictionaryitem/update.go
@@ -16,8 +16,6 @@ type UpdateCommand struct {
 	common.Base
 	manifest manifest.Data
 	Input    fastly.UpdateDictionaryItemInput
-
-	itemvalue common.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -33,7 +31,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("dictionary-id", "Dictionary ID").Required().StringVar(&c.Input.DictionaryID)
 	c.CmdClause.Flag("key", "Dictionary item key").Required().StringVar(&c.Input.ItemKey)
-	c.CmdClause.Flag("value", "Dictionary item value").Required().Action(c.itemvalue.Set).StringVar(&c.itemvalue.Value)
+	c.CmdClause.Flag("value", "Dictionary item value").Required().StringVar(&c.Input.ItemValue)
 	return &c
 }
 
@@ -44,8 +42,6 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
-
-	c.Input.ItemValue = &c.itemvalue.Value
 
 	dictionary, err := c.Globals.Client.UpdateDictionaryItem(&c.Input)
 	if err != nil {

--- a/pkg/errors/deduce.go
+++ b/pkg/errors/deduce.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // Deduce attempts to deduce a RemediationError from a plain error. If the error

--- a/pkg/errors/deduce_test.go
+++ b/pkg/errors/deduce_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestDeduce(t *testing.T) {

--- a/pkg/healthcheck/create.go
+++ b/pkg/healthcheck/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create healthchecks.

--- a/pkg/healthcheck/delete.go
+++ b/pkg/healthcheck/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete healthchecks.

--- a/pkg/healthcheck/describe.go
+++ b/pkg/healthcheck/describe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a healthcheck.

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestHealthCheckCreate(t *testing.T) {

--- a/pkg/healthcheck/list.go
+++ b/pkg/healthcheck/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list healthchecks.

--- a/pkg/healthcheck/update.go
+++ b/pkg/healthcheck/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update healthchecks.

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestBlobStorageCreate(t *testing.T) {

--- a/pkg/logging/azureblob/azureblob_test.go
+++ b/pkg/logging/azureblob/azureblob_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateBlobStorageInput(t *testing.T) {

--- a/pkg/logging/azureblob/create.go
+++ b/pkg/logging/azureblob/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Azure Blob Storage logging endpoint.

--- a/pkg/logging/azureblob/delete.go
+++ b/pkg/logging/azureblob/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Azure Blob Storage logging endpoint.

--- a/pkg/logging/azureblob/describe.go
+++ b/pkg/logging/azureblob/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Azure Blob Storage logging endpoint.

--- a/pkg/logging/azureblob/list.go
+++ b/pkg/logging/azureblob/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Azure Blob Storage logging endpoints.

--- a/pkg/logging/azureblob/update.go
+++ b/pkg/logging/azureblob/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Azure Blob Storage logging endpoint.

--- a/pkg/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/logging/bigquery/bigquery_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestBigQueryCreate(t *testing.T) {

--- a/pkg/logging/bigquery/bigquery_test.go
+++ b/pkg/logging/bigquery/bigquery_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateBigQueryInput(t *testing.T) {

--- a/pkg/logging/bigquery/create.go
+++ b/pkg/logging/bigquery/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a BigQuery logging endpoint.

--- a/pkg/logging/bigquery/delete.go
+++ b/pkg/logging/bigquery/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a BigQuery logging endpoint.

--- a/pkg/logging/bigquery/describe.go
+++ b/pkg/logging/bigquery/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a BigQuery logging endpoint.

--- a/pkg/logging/bigquery/list.go
+++ b/pkg/logging/bigquery/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list BigQuery logging endpoints.

--- a/pkg/logging/bigquery/update.go
+++ b/pkg/logging/bigquery/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a BigQuery logging endpoint.

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCloudfilesCreate(t *testing.T) {

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateCloudfilesInput(t *testing.T) {

--- a/pkg/logging/cloudfiles/create.go
+++ b/pkg/logging/cloudfiles/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Cloudfiles logging endpoint.

--- a/pkg/logging/cloudfiles/delete.go
+++ b/pkg/logging/cloudfiles/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Cloudfiles logging endpoint.

--- a/pkg/logging/cloudfiles/describe.go
+++ b/pkg/logging/cloudfiles/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Cloudfiles logging endpoint.

--- a/pkg/logging/cloudfiles/list.go
+++ b/pkg/logging/cloudfiles/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Cloudfiles logging endpoints.

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Cloudfiles logging endpoint.

--- a/pkg/logging/datadog/create.go
+++ b/pkg/logging/datadog/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Datadog logging endpoint.

--- a/pkg/logging/datadog/datadog_integration_test.go
+++ b/pkg/logging/datadog/datadog_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestDatadogCreate(t *testing.T) {

--- a/pkg/logging/datadog/datadog_test.go
+++ b/pkg/logging/datadog/datadog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateDatadogInput(t *testing.T) {

--- a/pkg/logging/datadog/delete.go
+++ b/pkg/logging/datadog/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Datadog logging endpoint.

--- a/pkg/logging/datadog/describe.go
+++ b/pkg/logging/datadog/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Datadog logging endpoint.

--- a/pkg/logging/datadog/list.go
+++ b/pkg/logging/datadog/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Datadog logging endpoints.

--- a/pkg/logging/datadog/update.go
+++ b/pkg/logging/datadog/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Datadog logging endpoint.

--- a/pkg/logging/digitalocean/create.go
+++ b/pkg/logging/digitalocean/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a DigitalOcean Spaces logging endpoint.

--- a/pkg/logging/digitalocean/delete.go
+++ b/pkg/logging/digitalocean/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a DigitalOcean Spaces logging endpoint.

--- a/pkg/logging/digitalocean/describe.go
+++ b/pkg/logging/digitalocean/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a DigitalOcean Spaces logging endpoint.

--- a/pkg/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/logging/digitalocean/digitalocean_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestDigitalOceanCreate(t *testing.T) {

--- a/pkg/logging/digitalocean/digitalocean_test.go
+++ b/pkg/logging/digitalocean/digitalocean_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateDigitalOceanInput(t *testing.T) {

--- a/pkg/logging/digitalocean/list.go
+++ b/pkg/logging/digitalocean/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list DigitalOcean Spaces logging endpoints.

--- a/pkg/logging/digitalocean/update.go
+++ b/pkg/logging/digitalocean/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a DigitalOcean Spaces logging endpoint.

--- a/pkg/logging/elasticsearch/create.go
+++ b/pkg/logging/elasticsearch/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Elasticsearch logging endpoint.

--- a/pkg/logging/elasticsearch/delete.go
+++ b/pkg/logging/elasticsearch/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Elasticsearch logging endpoint.

--- a/pkg/logging/elasticsearch/describe.go
+++ b/pkg/logging/elasticsearch/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Elasticsearch logging endpoint.

--- a/pkg/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestElasticsearchCreate(t *testing.T) {

--- a/pkg/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateElasticsearchInput(t *testing.T) {

--- a/pkg/logging/elasticsearch/list.go
+++ b/pkg/logging/elasticsearch/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Elasticsearch logging endpoints.

--- a/pkg/logging/elasticsearch/update.go
+++ b/pkg/logging/elasticsearch/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Elasticsearch logging endpoint.

--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an FTP logging endpoint.

--- a/pkg/logging/ftp/delete.go
+++ b/pkg/logging/ftp/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an FTP logging endpoint.

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an FTP logging endpoint.

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestFTPCreate(t *testing.T) {

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateFTPInput(t *testing.T) {

--- a/pkg/logging/ftp/list.go
+++ b/pkg/logging/ftp/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list FTP logging endpoints.

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an FTP logging endpoint.

--- a/pkg/logging/gcs/create.go
+++ b/pkg/logging/gcs/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a GCS logging endpoint.

--- a/pkg/logging/gcs/delete.go
+++ b/pkg/logging/gcs/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a GCS logging endpoint.

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a GCS logging endpoint.

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestGCSCreate(t *testing.T) {

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateGCSInput(t *testing.T) {

--- a/pkg/logging/gcs/list.go
+++ b/pkg/logging/gcs/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list GCS logging endpoints.

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a GCS logging endpoint.

--- a/pkg/logging/googlepubsub/create.go
+++ b/pkg/logging/googlepubsub/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/logging/googlepubsub/delete.go
+++ b/pkg/logging/googlepubsub/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/logging/googlepubsub/describe.go
+++ b/pkg/logging/googlepubsub/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestGooglePubSubCreate(t *testing.T) {

--- a/pkg/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateGooglePubSubInput(t *testing.T) {

--- a/pkg/logging/googlepubsub/list.go
+++ b/pkg/logging/googlepubsub/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Google Cloud Pub/Sub logging endpoints.

--- a/pkg/logging/googlepubsub/update.go
+++ b/pkg/logging/googlepubsub/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/logging/heroku/create.go
+++ b/pkg/logging/heroku/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Heroku logging endpoint.

--- a/pkg/logging/heroku/delete.go
+++ b/pkg/logging/heroku/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Heroku logging endpoint.

--- a/pkg/logging/heroku/describe.go
+++ b/pkg/logging/heroku/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Heroku logging endpoint.

--- a/pkg/logging/heroku/heroku_integration_test.go
+++ b/pkg/logging/heroku/heroku_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestHerokuCreate(t *testing.T) {

--- a/pkg/logging/heroku/heroku_test.go
+++ b/pkg/logging/heroku/heroku_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateHerokuInput(t *testing.T) {

--- a/pkg/logging/heroku/list.go
+++ b/pkg/logging/heroku/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Heroku logging endpoints.

--- a/pkg/logging/heroku/update.go
+++ b/pkg/logging/heroku/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Heroku logging endpoint.

--- a/pkg/logging/honeycomb/create.go
+++ b/pkg/logging/honeycomb/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Honeycomb logging endpoint.

--- a/pkg/logging/honeycomb/delete.go
+++ b/pkg/logging/honeycomb/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Honeycomb logging endpoint.

--- a/pkg/logging/honeycomb/describe.go
+++ b/pkg/logging/honeycomb/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Honeycomb logging endpoint.

--- a/pkg/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/logging/honeycomb/honeycomb_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestHoneycombCreate(t *testing.T) {

--- a/pkg/logging/honeycomb/honeycomb_test.go
+++ b/pkg/logging/honeycomb/honeycomb_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateHoneycombInput(t *testing.T) {

--- a/pkg/logging/honeycomb/list.go
+++ b/pkg/logging/honeycomb/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Honeycomb logging endpoints.

--- a/pkg/logging/honeycomb/update.go
+++ b/pkg/logging/honeycomb/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Honeycomb logging endpoint.

--- a/pkg/logging/https/create.go
+++ b/pkg/logging/https/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an HTTPS logging endpoint.

--- a/pkg/logging/https/delete.go
+++ b/pkg/logging/https/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an HTTPS logging endpoint.

--- a/pkg/logging/https/describe.go
+++ b/pkg/logging/https/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an HTTPS logging endpoint.

--- a/pkg/logging/https/https_integration_test.go
+++ b/pkg/logging/https/https_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestHTTPSCreate(t *testing.T) {

--- a/pkg/logging/https/https_test.go
+++ b/pkg/logging/https/https_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateHTTPSInput(t *testing.T) {

--- a/pkg/logging/https/list.go
+++ b/pkg/logging/https/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list HTTPS logging endpoints.

--- a/pkg/logging/https/update.go
+++ b/pkg/logging/https/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an HTTPS logging endpoint.

--- a/pkg/logging/kafka/create.go
+++ b/pkg/logging/kafka/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Kafka logging endpoint.

--- a/pkg/logging/kafka/delete.go
+++ b/pkg/logging/kafka/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Kafka logging endpoint.

--- a/pkg/logging/kafka/describe.go
+++ b/pkg/logging/kafka/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Kafka logging endpoint.

--- a/pkg/logging/kafka/kafka_integration_test.go
+++ b/pkg/logging/kafka/kafka_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestKafkaCreate(t *testing.T) {

--- a/pkg/logging/kafka/kafka_test.go
+++ b/pkg/logging/kafka/kafka_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateKafkaInput(t *testing.T) {

--- a/pkg/logging/kafka/list.go
+++ b/pkg/logging/kafka/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Kafka logging endpoints.

--- a/pkg/logging/kafka/update.go
+++ b/pkg/logging/kafka/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Kafka logging endpoint.

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Amazon Kinesis logging endpoint.

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Amazon Kinesis logging endpoint.

--- a/pkg/logging/kinesis/describe.go
+++ b/pkg/logging/kinesis/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Amazon Kinesis logging endpoint.

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -66,32 +66,32 @@ func TestKinesisList(t *testing.T) {
 	}{
 		{
 			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKinesesFn: listKinesesOK},
+			api:        mock.API{ListKinesisFn: listKinesesOK},
 			wantOutput: listKinesesShortOutput,
 		},
 		{
 			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListKinesesFn: listKinesesOK},
+			api:        mock.API{ListKinesisFn: listKinesesOK},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
 			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListKinesesFn: listKinesesOK},
+			api:        mock.API{ListKinesisFn: listKinesesOK},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
 			args:       []string{"logging", "kinesis", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKinesesFn: listKinesesOK},
+			api:        mock.API{ListKinesisFn: listKinesesOK},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
 			args:       []string{"logging", "-v", "kinesis", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKinesesFn: listKinesesOK},
+			api:        mock.API{ListKinesisFn: listKinesesOK},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
 			args:      []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListKinesesFn: listKinesesError},
+			api:       mock.API{ListKinesisFn: listKinesesError},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -265,7 +265,7 @@ func createKinesisError(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
 	return nil, errTest
 }
 
-func listKinesesOK(i *fastly.ListKinesesInput) ([]*fastly.Kinesis, error) {
+func listKinesesOK(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
 	return []*fastly.Kinesis{
 		{
 			ServiceID:         i.ServiceID,
@@ -296,7 +296,7 @@ func listKinesesOK(i *fastly.ListKinesesInput) ([]*fastly.Kinesis, error) {
 	}, nil
 }
 
-func listKinesesError(i *fastly.ListKinesesInput) ([]*fastly.Kinesis, error) {
+func listKinesesError(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
 	return nil, errTest
 }
 

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestKinesisCreate(t *testing.T) {

--- a/pkg/logging/kinesis/kinesis_test.go
+++ b/pkg/logging/kinesis/kinesis_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateKinesisInput(t *testing.T) {

--- a/pkg/logging/kinesis/list.go
+++ b/pkg/logging/kinesis/list.go
@@ -16,7 +16,7 @@ import (
 type ListCommand struct {
 	common.Base
 	manifest manifest.Data
-	Input    fastly.ListKinesesInput
+	Input    fastly.ListKinesisInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -38,7 +38,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 	c.Input.ServiceID = serviceID
 
-	kineses, err := c.Globals.Client.ListKineses(&c.Input)
+	kineses, err := c.Globals.Client.ListKinesis(&c.Input)
 	if err != nil {
 		return err
 	}

--- a/pkg/logging/kinesis/list.go
+++ b/pkg/logging/kinesis/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Amazon Kinesis logging endpoints.

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Amazon Kinesis logging endpoint.

--- a/pkg/logging/logentries/create.go
+++ b/pkg/logging/logentries/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Logentries logging endpoint.

--- a/pkg/logging/logentries/delete.go
+++ b/pkg/logging/logentries/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Logentries logging endpoint.

--- a/pkg/logging/logentries/describe.go
+++ b/pkg/logging/logentries/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Logentries logging endpoint.

--- a/pkg/logging/logentries/list.go
+++ b/pkg/logging/logentries/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Logentries logging endpoints.

--- a/pkg/logging/logentries/logentries_integration_test.go
+++ b/pkg/logging/logentries/logentries_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestLogentriesCreate(t *testing.T) {

--- a/pkg/logging/logentries/logentries_test.go
+++ b/pkg/logging/logentries/logentries_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateLogentriesInput(t *testing.T) {

--- a/pkg/logging/logentries/update.go
+++ b/pkg/logging/logentries/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Logentries logging endpoint.

--- a/pkg/logging/loggly/create.go
+++ b/pkg/logging/loggly/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Loggly logging endpoint.

--- a/pkg/logging/loggly/delete.go
+++ b/pkg/logging/loggly/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Loggly logging endpoint.

--- a/pkg/logging/loggly/describe.go
+++ b/pkg/logging/loggly/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Loggly logging endpoint.

--- a/pkg/logging/loggly/list.go
+++ b/pkg/logging/loggly/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Loggly logging endpoints.

--- a/pkg/logging/loggly/loggly_integration_test.go
+++ b/pkg/logging/loggly/loggly_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestLogglyCreate(t *testing.T) {

--- a/pkg/logging/loggly/loggly_test.go
+++ b/pkg/logging/loggly/loggly_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateLogglyInput(t *testing.T) {

--- a/pkg/logging/loggly/update.go
+++ b/pkg/logging/loggly/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Loggly logging endpoint.

--- a/pkg/logging/logshuttle/create.go
+++ b/pkg/logging/logshuttle/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Logshuttle logging endpoint.

--- a/pkg/logging/logshuttle/delete.go
+++ b/pkg/logging/logshuttle/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Logshuttle logging endpoint.

--- a/pkg/logging/logshuttle/describe.go
+++ b/pkg/logging/logshuttle/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Logshuttle logging endpoint.

--- a/pkg/logging/logshuttle/list.go
+++ b/pkg/logging/logshuttle/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Logshuttle logging endpoints.

--- a/pkg/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/logging/logshuttle/logshuttle_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestLogshuttleCreate(t *testing.T) {

--- a/pkg/logging/logshuttle/logshuttle_test.go
+++ b/pkg/logging/logshuttle/logshuttle_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateLogshuttleInput(t *testing.T) {

--- a/pkg/logging/logshuttle/update.go
+++ b/pkg/logging/logshuttle/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Logshuttle logging endpoint.

--- a/pkg/logging/openstack/create.go
+++ b/pkg/logging/openstack/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an OpenStack logging endpoint.

--- a/pkg/logging/openstack/delete.go
+++ b/pkg/logging/openstack/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an OpenStack logging endpoint.

--- a/pkg/logging/openstack/describe.go
+++ b/pkg/logging/openstack/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an OpenStack logging endpoint.

--- a/pkg/logging/openstack/list.go
+++ b/pkg/logging/openstack/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list OpenStack logging endpoints.

--- a/pkg/logging/openstack/openstack_integration_test.go
+++ b/pkg/logging/openstack/openstack_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestOpenstackCreate(t *testing.T) {

--- a/pkg/logging/openstack/openstack_test.go
+++ b/pkg/logging/openstack/openstack_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateOpenstackInput(t *testing.T) {

--- a/pkg/logging/openstack/update.go
+++ b/pkg/logging/openstack/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an OpenStack logging endpoint.

--- a/pkg/logging/papertrail/create.go
+++ b/pkg/logging/papertrail/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Papertrail logging endpoint.

--- a/pkg/logging/papertrail/delete.go
+++ b/pkg/logging/papertrail/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Papertrail logging endpoint.

--- a/pkg/logging/papertrail/describe.go
+++ b/pkg/logging/papertrail/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Papertrail logging endpoint.

--- a/pkg/logging/papertrail/list.go
+++ b/pkg/logging/papertrail/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Papertrail logging endpoints.

--- a/pkg/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/logging/papertrail/papertrail_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestPapertrailCreate(t *testing.T) {

--- a/pkg/logging/papertrail/papertrail_test.go
+++ b/pkg/logging/papertrail/papertrail_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreatePapertrailInput(t *testing.T) {

--- a/pkg/logging/papertrail/update.go
+++ b/pkg/logging/papertrail/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Papertrail logging endpoint.

--- a/pkg/logging/s3/create.go
+++ b/pkg/logging/s3/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Amazon S3 logging endpoint.

--- a/pkg/logging/s3/delete.go
+++ b/pkg/logging/s3/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Amazon S3 logging endpoint.

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Amazon S3 logging endpoint.

--- a/pkg/logging/s3/list.go
+++ b/pkg/logging/s3/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Amazon S3 logging endpoints.

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestS3Create(t *testing.T) {

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateS3Input(t *testing.T) {

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Amazon S3 logging endpoint.

--- a/pkg/logging/scalyr/create.go
+++ b/pkg/logging/scalyr/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Scalyr logging endpoint.

--- a/pkg/logging/scalyr/delete.go
+++ b/pkg/logging/scalyr/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Scalyr logging endpoint.

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Scalyr logging endpoint.

--- a/pkg/logging/scalyr/list.go
+++ b/pkg/logging/scalyr/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Scalyr logging endpoints.

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestScalyrCreate(t *testing.T) {

--- a/pkg/logging/scalyr/scalyr_test.go
+++ b/pkg/logging/scalyr/scalyr_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateScalyrInput(t *testing.T) {

--- a/pkg/logging/scalyr/update.go
+++ b/pkg/logging/scalyr/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update Scalyr logging endpoints.

--- a/pkg/logging/sftp/create.go
+++ b/pkg/logging/sftp/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an SFTP logging endpoint.

--- a/pkg/logging/sftp/delete.go
+++ b/pkg/logging/sftp/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an SFTP logging endpoint.

--- a/pkg/logging/sftp/describe.go
+++ b/pkg/logging/sftp/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an SFTP logging endpoint.

--- a/pkg/logging/sftp/list.go
+++ b/pkg/logging/sftp/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list SFTP logging endpoints.

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestSFTPCreate(t *testing.T) {

--- a/pkg/logging/sftp/sftp_test.go
+++ b/pkg/logging/sftp/sftp_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateSFTPInput(t *testing.T) {

--- a/pkg/logging/sftp/update.go
+++ b/pkg/logging/sftp/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an SFTP logging endpoint.

--- a/pkg/logging/splunk/create.go
+++ b/pkg/logging/splunk/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Splunk logging endpoint.

--- a/pkg/logging/splunk/delete.go
+++ b/pkg/logging/splunk/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Splunk logging endpoint.

--- a/pkg/logging/splunk/describe.go
+++ b/pkg/logging/splunk/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Splunk logging endpoint.

--- a/pkg/logging/splunk/list.go
+++ b/pkg/logging/splunk/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Splunk logging endpoints.

--- a/pkg/logging/splunk/splunk_integration_test.go
+++ b/pkg/logging/splunk/splunk_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestSplunkCreate(t *testing.T) {

--- a/pkg/logging/splunk/splunk_test.go
+++ b/pkg/logging/splunk/splunk_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateSplunkInput(t *testing.T) {

--- a/pkg/logging/splunk/update.go
+++ b/pkg/logging/splunk/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Splunk logging endpoint.

--- a/pkg/logging/sumologic/create.go
+++ b/pkg/logging/sumologic/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Sumologic logging endpoint.

--- a/pkg/logging/sumologic/delete.go
+++ b/pkg/logging/sumologic/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Sumologic logging endpoint.

--- a/pkg/logging/sumologic/describe.go
+++ b/pkg/logging/sumologic/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Sumologic logging endpoint.

--- a/pkg/logging/sumologic/list.go
+++ b/pkg/logging/sumologic/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Sumologic logging endpoints.

--- a/pkg/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/logging/sumologic/sumologic_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestSumologicCreate(t *testing.T) {

--- a/pkg/logging/sumologic/sumologic_test.go
+++ b/pkg/logging/sumologic/sumologic_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateSumologicInput(t *testing.T) {

--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Sumologic logging endpoint.

--- a/pkg/logging/syslog/create.go
+++ b/pkg/logging/syslog/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Syslog logging endpoint.

--- a/pkg/logging/syslog/delete.go
+++ b/pkg/logging/syslog/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Syslog logging endpoint.

--- a/pkg/logging/syslog/describe.go
+++ b/pkg/logging/syslog/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Syslog logging endpoint.

--- a/pkg/logging/syslog/list.go
+++ b/pkg/logging/syslog/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list Syslog logging endpoints.

--- a/pkg/logging/syslog/syslog_integration_test.go
+++ b/pkg/logging/syslog/syslog_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestSyslogCreate(t *testing.T) {

--- a/pkg/logging/syslog/syslog_test.go
+++ b/pkg/logging/syslog/syslog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestCreateSyslogInput(t *testing.T) {

--- a/pkg/logging/syslog/update.go
+++ b/pkg/logging/syslog/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Syslog logging endpoint.

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -1,7 +1,7 @@
 package mock
 
 import (
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // API is a mock implementation of api.Interface that's used for testing.

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -75,7 +75,7 @@ type API struct {
 	DeleteS3Fn func(*fastly.DeleteS3Input) error
 
 	CreateKinesisFn func(*fastly.CreateKinesisInput) (*fastly.Kinesis, error)
-	ListKinesesFn   func(*fastly.ListKinesesInput) ([]*fastly.Kinesis, error)
+	ListKinesisFn   func(*fastly.ListKinesisInput) ([]*fastly.Kinesis, error)
 	GetKinesisFn    func(*fastly.GetKinesisInput) (*fastly.Kinesis, error)
 	UpdateKinesisFn func(*fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
 	DeleteKinesisFn func(*fastly.DeleteKinesisInput) error
@@ -493,9 +493,9 @@ func (m API) CreateKinesis(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error
 	return m.CreateKinesisFn(i)
 }
 
-// ListKineses implements Interface.
-func (m API) ListKineses(i *fastly.ListKinesesInput) ([]*fastly.Kinesis, error) {
-	return m.ListKinesesFn(i)
+// ListKinesis implements Interface.
+func (m API) ListKinesis(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
+	return m.ListKinesisFn(i)
 }
 
 // GetKinesis implements Interface.

--- a/pkg/service/create.go
+++ b/pkg/service/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CreateCommand calls the Fastly API to create services.

--- a/pkg/service/delete.go
+++ b/pkg/service/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete services.

--- a/pkg/service/describe.go
+++ b/pkg/service/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a service.

--- a/pkg/service/list.go
+++ b/pkg/service/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list services.

--- a/pkg/service/search.go
+++ b/pkg/service/search.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // SearchCommand calls the Fastly API to describe a service.

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestServiceCreate(t *testing.T) {

--- a/pkg/service/update.go
+++ b/pkg/service/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to create services.

--- a/pkg/service/update.go
+++ b/pkg/service/update.go
@@ -66,7 +66,7 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	// set original value, and then afterwards check if we can use the flag value
-	c.updateInput.ID = s.ID
+	c.updateInput.ServiceID = s.ID
 	c.updateInput.Name = fastly.String(s.Name)
 	c.updateInput.Comment = fastly.String(s.Comment)
 

--- a/pkg/serviceversion/activate.go
+++ b/pkg/serviceversion/activate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ActivateCommand calls the Fastly API to activate a service version.

--- a/pkg/serviceversion/clone.go
+++ b/pkg/serviceversion/clone.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // CloneCommand calls the Fastly API to clone a service version.

--- a/pkg/serviceversion/deactivate.go
+++ b/pkg/serviceversion/deactivate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // DeactivateCommand calls the Fastly API to deactivate a service version.

--- a/pkg/serviceversion/list.go
+++ b/pkg/serviceversion/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // ListCommand calls the Fastly API to list services.

--- a/pkg/serviceversion/lock.go
+++ b/pkg/serviceversion/lock.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // LockCommand calls the Fastly API to lock a service version.

--- a/pkg/serviceversion/serviceversion_test.go
+++ b/pkg/serviceversion/serviceversion_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestVersionClone(t *testing.T) {

--- a/pkg/serviceversion/update.go
+++ b/pkg/serviceversion/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a service version.

--- a/pkg/stats/historical.go
+++ b/pkg/stats/historical.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 const statusSuccess = "success"

--- a/pkg/stats/historical_test.go
+++ b/pkg/stats/historical_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestHistorical(t *testing.T) {

--- a/pkg/stats/realtime.go
+++ b/pkg/stats/realtime.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 // RealtimeCommand exposes the Realtime Metrics API.

--- a/pkg/stats/realtime.go
+++ b/pkg/stats/realtime.go
@@ -65,7 +65,7 @@ func loopJSON(client api.RealtimeStatsInterface, service string, out io.Writer) 
 		}
 
 		err := client.GetRealtimeStatsJSON(&fastly.GetRealtimeStatsInput{
-			Service:   service,
+			ServiceID: service,
 			Timestamp: timestamp,
 		}, &envelope)
 		if err != nil {
@@ -87,7 +87,7 @@ func loopText(client api.RealtimeStatsInterface, service string, out io.Writer) 
 		var envelope realtimeResponse
 
 		err := client.GetRealtimeStatsJSON(&fastly.GetRealtimeStatsInput{
-			Service:   service,
+			ServiceID: service,
 			Timestamp: timestamp,
 		}, &envelope)
 		if err != nil {

--- a/pkg/stats/regions_test.go
+++ b/pkg/stats/regions_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestRegions(t *testing.T) {

--- a/pkg/stats/template.go
+++ b/pkg/stats/template.go
@@ -6,7 +6,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/mitchellh/mapstructure"
 )
 

--- a/pkg/text/backend.go
+++ b/pkg/text/backend.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/dictionary.go
+++ b/pkg/text/dictionary.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/dictionaryitem.go
+++ b/pkg/text/dictionaryitem.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/dictionaryitem_test.go
+++ b/pkg/text/dictionaryitem_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestPrintDictionaryItem(t *testing.T) {

--- a/pkg/text/healthcheck.go
+++ b/pkg/text/healthcheck.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/service_test.go
+++ b/pkg/text/service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 func TestServiceType(t *testing.T) {

--- a/pkg/version/root.go
+++ b/pkg/version/root.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/fastly/cli/pkg/common"
-	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/fastly/go-fastly/v3/fastly"
 )
 
 var (


### PR DESCRIPTION
Bump the Go-Fastly dependency from 2.x.x to the latest 3.0.0 release.