### PR TITLE
Resolve issues with Rust integration tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ SHELL := /bin/bash -o pipefail
 # the output is consistent across environments.
 VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 
+TESTARGS ?= ./{cmd,pkg}/...
+
 LDFLAGS = -ldflags "\
  -X 'github.com/fastly/cli/pkg/version.AppVersion=${VERSION}' \
  -X 'github.com/fastly/cli/pkg/version.GitRevision=$(shell git rev-parse --short HEAD || echo unknown)' \
@@ -50,8 +52,7 @@ lint:
 
 .PHONY: test
 test:
-	go test -race ./{cmd,pkg}/...
-
+	go test -race $(TESTARGS)
 .PHONY: build
 build:
 	go build ./cmd/fastly

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Usage](#Usage)
 - [Bash/ZSH completion](#bashzsh-shell-completion)
 - [Development](#Development)
+- [Testing](#Testing)
 - [Issues](#Issues)
 
 ## Installation
@@ -139,6 +140,49 @@ The `make` task requires the following executables to exist in your `$PATH`:
 - [staticcheck](https://staticcheck.io/)
 
 If you have none of them installed, or don't mind them being upgraded automatically, you can run `make dependencies` to install them.
+
+## Testing
+
+To run the test suite:
+
+```sh
+make test
+```
+
+Note that by default the tests are run using `go test` with the following configuration:
+
+```
+-race ./{cmd,pkg}/...
+```
+
+To run a specific test use the `-run` flag (exposed by `go test`) and also provide the path to the directory where the test files reside (replace `...` and `<path>` with appropriate values):
+
+```sh
+make test TESTARGS="-run <...> <path>"
+```
+
+**Example**:
+
+```sh
+make test TESTARGS="-run TestBackendCreate ./pkg/backend/..."
+```
+
+Some integration tests aren't run outside of the CI environment, to enable these tests locally you'll need to set a specific environment variable relevant to the test.
+
+The available environment variables are:
+
+- `TEST_COMPUTE_INIT`: runs `TestInit`.
+- `TEST_COMPUTE_BUILD`: runs `TestBuildRust` and `TestBuildAssemblyScript`.
+- `TEST_COMPUTE_BUILD_RUST`: runs `TestBuildRust`.
+- `TEST_COMPUTE_BUILD_ASSEMBLYSCRIPT`: runs `TestBuildAssemblyScript`.
+
+**Example**:
+
+```sh
+TEST_COMPUTE_BUILD_RUST=1 make test TESTARGS="-run TestBuildRust/fastly_crate_prerelease ./pkg/compute/..." 
+```
+
+When running the tests locally, if you don't have the relevant language ecosystems set-up properly then the tests will fail to run and you'll need to review the code to see what the remediation steps are, as that output doesn't get shown when running the test suite.
 
 ## Contributing
 

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Filename is the name of the package manifest file.
+// It is expected to be a project specific configuration file.
 const Filename = "fastly.toml"
 
 // Source enumerates where a manifest parameter is taken from.
@@ -101,7 +102,7 @@ type File struct {
 	exists bool
 }
 
-// Exists yeilds whether the manifest exists.
+// Exists yields whether the manifest exists.
 func (f *File) Exists() bool {
 	return f.exists
 }

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -127,6 +127,14 @@ func (f *File) Read(filename string) error {
 }
 
 // Write the File to filename on disk.
+//
+// NOTE: the expected workflow for this method is for the caller to have
+// modified the public field(s) first so that we can write new content to the
+// config file from the receiver object itself.
+//
+// EXAMPLE:
+// file.LastVersionCheck = time.Now().Format(time.RFC3339)
+// file.Write(configFilePath)
 func (f *File) Write(filename string) error {
 	fp, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, FilePermissions)
 	if err != nil {
@@ -141,8 +149,8 @@ func (f *File) Write(filename string) error {
 	return nil
 }
 
-// Environment represents all of the configuration parmaeters that can come from
-// environment variables.
+// Environment represents all of the configuration parameters that can come
+// from environment variables.
 type Environment struct {
 	Token    string
 	Endpoint string


### PR DESCRIPTION
The latest rust `fastly` crate release `0.6.0` (and subsequent `fastly-sys` crate release `0.3.7`) bubbled up some bugs within the 'Rust Build' CLI integration tests (one example issue was not mocking the crate api endpoint sufficiently, which ultimately caused rust's cargo command to get confused).