### PR TITLE
Fix go vet error related to missing docstring

### DIFF
--- a/pkg/logs/tail.go
+++ b/pkg/logs/tail.go
@@ -30,6 +30,7 @@ import (
 )
 
 type (
+	// TailCommand represents the CLI subcommand for Log Tailing.
 	TailCommand struct {
 		common.Base
 		manifest manifest.Data


### PR DESCRIPTION
Before I cut a new release I noticed `make all` was returning a `go vet` error due to the missing comment on an exported/public variable.