### PR TITLE
add port prompt for compute init

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -285,6 +285,7 @@ COMMANDS
                                    package
         --backend=BACKEND          A hostname, IPv4, or IPv6 address for the
                                    package backend
+        --port=PORT 	             A port number for the package backend
 
   compute build [<flags>]
     Build a Compute@Edge package locally

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -285,7 +285,8 @@ COMMANDS
                                    package
         --backend=BACKEND          A hostname, IPv4, or IPv6 address for the
                                    package backend
-        --port=PORT 	             A port number for the package backend
+        --backend-port=BACKEND-PORT
+                                   A port number for the package backend
 
   compute build [<flags>]
     Build a Compute@Edge package locally

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -51,7 +51,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "unkown repository",
-			args:       []string{"compute", "init", "--from", "https://example.com/template"},
+			args:       []string{"compute", "init", "--from", "https://example.com/template", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -67,7 +67,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "create service error",
-			args:       []string{"compute", "init"},
+			args:       []string{"compute", "init", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -78,7 +78,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "create domain error",
-			args:       []string{"compute", "init"},
+			args:       []string{"compute", "init", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -91,7 +91,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "create backend error",
-			args:       []string{"compute", "init"},
+			args:       []string{"compute", "init", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -106,7 +106,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with name",
-			args:       []string{"compute", "init", "--name", "test"},
+			args:       []string{"compute", "init", "--name", "test", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -124,7 +124,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with service",
-			args:       []string{"compute", "init", "-s", "test"},
+			args:       []string{"compute", "init", "-s", "test", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -144,7 +144,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with description",
-			args:       []string{"compute", "init", "--description", "test"},
+			args:       []string{"compute", "init", "--description", "test", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -162,7 +162,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with author",
-			args:       []string{"compute", "init", "--author", "test@example.com"},
+			args:       []string{"compute", "init", "--author", "test@example.com", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -180,7 +180,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with multiple authors",
-			args:       []string{"compute", "init", "--author", "test1@example.com", "--author", "test2@example.com"},
+			args:       []string{"compute", "init", "--author", "test1@example.com", "--author", "test2@example.com", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -199,7 +199,7 @@ func TestInit(t *testing.T) {
 
 		{
 			name:       "with from repository and branch",
-			args:       []string{"compute", "init", "--from", "https://github.com/fastly/compute-starter-kit-rust-default.git", "--branch", "main"},
+			args:       []string{"compute", "init", "--from", "https://github.com/fastly/compute-starter-kit-rust-default.git", "--branch", "main", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -216,7 +216,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with existing package manifest",
-			args:       []string{"compute", "init"},
+			args:       []string{"compute", "init", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			manifest: strings.Join([]string{
 				"service_id = \"1234\"",
@@ -243,7 +243,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "default",
-			args: []string{"compute", "init"},
+			args: []string{"compute", "init", "--backend-port", "80"},
 			configFile: config.File{
 				Token: "123",
 				Email: "test@example.com",
@@ -275,7 +275,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with default name inferred from directory",
-			args:       []string{"compute", "init"},
+			args:       []string{"compute", "init", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -288,7 +288,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with AssemblyScript language",
-			args:       []string{"compute", "init", "--language", "assemblyscript"},
+			args:       []string{"compute", "init", "--language", "assemblyscript", "--backend-port", "80"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -51,7 +51,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "unkown repository",
-			args:       []string{"compute", "init", "--from", "https://example.com/template", "--backend-port", "80"},
+			args:       []string{"compute", "init", "--from", "https://example.com/template"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -67,7 +67,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "create service error",
-			args:       []string{"compute", "init", "--backend-port", "80"},
+			args:       []string{"compute", "init"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -78,7 +78,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "create domain error",
-			args:       []string{"compute", "init", "--backend-port", "80"},
+			args:       []string{"compute", "init"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -91,7 +91,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "create backend error",
-			args:       []string{"compute", "init", "--backend-port", "80"},
+			args:       []string{"compute", "init"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -106,7 +106,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with name",
-			args:       []string{"compute", "init", "--name", "test", "--backend-port", "80"},
+			args:       []string{"compute", "init", "--name", "test"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -124,7 +124,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with service",
-			args:       []string{"compute", "init", "-s", "test", "--backend-port", "80"},
+			args:       []string{"compute", "init", "-s", "test"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -144,7 +144,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with description",
-			args:       []string{"compute", "init", "--description", "test", "--backend-port", "80"},
+			args:       []string{"compute", "init", "--description", "test"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -162,7 +162,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with author",
-			args:       []string{"compute", "init", "--author", "test@example.com", "--backend-port", "80"},
+			args:       []string{"compute", "init", "--author", "test@example.com"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -180,7 +180,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with multiple authors",
-			args:       []string{"compute", "init", "--author", "test1@example.com", "--author", "test2@example.com", "--backend-port", "80"},
+			args:       []string{"compute", "init", "--author", "test1@example.com", "--author", "test2@example.com"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -199,7 +199,7 @@ func TestInit(t *testing.T) {
 
 		{
 			name:       "with from repository and branch",
-			args:       []string{"compute", "init", "--from", "https://github.com/fastly/compute-starter-kit-rust-default.git", "--branch", "main", "--backend-port", "80"},
+			args:       []string{"compute", "init", "--from", "https://github.com/fastly/compute-starter-kit-rust-default.git", "--branch", "main"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -216,7 +216,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with existing package manifest",
-			args:       []string{"compute", "init", "--backend-port", "80"},
+			args:       []string{"compute", "init"},
 			configFile: config.File{Token: "123"},
 			manifest: strings.Join([]string{
 				"service_id = \"1234\"",
@@ -243,7 +243,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "default",
-			args: []string{"compute", "init", "--backend-port", "80"},
+			args: []string{"compute", "init"},
 			configFile: config.File{
 				Token: "123",
 				Email: "test@example.com",
@@ -275,7 +275,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with default name inferred from directory",
-			args:       []string{"compute", "init", "--backend-port", "80"},
+			args:       []string{"compute", "init"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,
@@ -288,7 +288,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:       "with AssemblyScript language",
-			args:       []string{"compute", "init", "--language", "assemblyscript", "--backend-port", "80"},
+			args:       []string{"compute", "init", "--language", "assemblyscript"},
 			configFile: config.File{Token: "123"},
 			api: mock.API{
 				GetTokenSelfFn:  tokenOK,

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -295,6 +295,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 		if c.backend == "" || c.backend == "originless" {
 			c.backend = "127.0.0.1"
+			c.backendPort = uint(80)
 		}
 	}
 

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -299,8 +299,6 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 
 	if c.backendPort == 0 {
-		c.backendPort = 80
-
 		input, err := text.Input(out, "Backend port number: [80] ", in)
 		if err != nil {
 			return fmt.Errorf("error reading input %w", err)
@@ -308,7 +306,8 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 		portnumber, err := strconv.Atoi(input)
 		if err != nil {
-			return fmt.Errorf("error converting input %w", err)
+			text.Warning(out, "error converting input: %v. We'll use the default port number: [80].", err)
+			portnumber = 80
 		}
 
 		c.backendPort = uint(portnumber)

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -69,16 +69,16 @@ type StarterKit struct {
 // InitCommand initializes a Compute@Edge project package on the local machine.
 type InitCommand struct {
 	common.Base
-	client   api.HTTPClient
-	manifest manifest.Data
-	language string
-	from     string
-	branch   string
-	tag      string
-	path     string
-	domain   string
-	backend  string
-	port     uint
+	client      api.HTTPClient
+	manifest    manifest.Data
+	language    string
+	from        string
+	branch      string
+	tag         string
+	path        string
+	domain      string
+	backend     string
+	backendPort uint
 }
 
 // NewInitCommand returns a usable command registered under the parent.
@@ -99,7 +99,7 @@ func NewInitCommand(parent common.Registerer, client api.HTTPClient, globals *co
 	c.CmdClause.Flag("path", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.path)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.domain)
 	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").StringVar(&c.backend)
-	c.CmdClause.Flag("port", "A port number for the package backend").UintVar(&c.port)
+	c.CmdClause.Flag("backend-port", "A port number for the package backend").UintVar(&c.backendPort)
 
 	return &c
 }
@@ -298,8 +298,8 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 	}
 
-	if c.port == 0 {
-		c.port = 80
+	if c.backendPort == 0 {
+		c.backendPort = 80
 
 		input, err := text.Input(out, "Backend port number: [80] ", in)
 		if err != nil {
@@ -311,7 +311,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			return fmt.Errorf("error converting input %w", err)
 		}
 
-		c.port = uint(portnumber)
+		c.backendPort = uint(portnumber)
 	}
 
 	text.Break(out)
@@ -388,7 +388,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		ServiceVersion: version,
 		Name:           c.backend,
 		Address:        c.backend,
-		Port:           c.port,
+		Port:           c.backendPort,
 	})
 	if err != nil {
 		return fmt.Errorf("error creating backend: %w", err)


### PR DESCRIPTION
When specifying a backend as part of the interactive prompt input for the `fastly compute init` command the default behaviour is to create the backend without TLS (i.e. HTTPS/port 443).

This is the prompt currently displayed: 

```
Backend (originless, hostname or IP address): [originless] mock-s3.edgecompute.app
```

When the Backend is created it's actually assigned port 80 (i.e. HTTP) which the mock backend isn't accessible via.

We should provide a prompt for specifying the port so the user has control over this value.

