### PR TITLE
Override error message in compute init

### DIFF
--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -361,7 +361,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 					Remediation: fmt.Sprintf("see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators"),
 				}
 			}
-		  return fmt.Errorf("error creating service: %w", err)
+			return fmt.Errorf("error creating service: %w", err)
 		}
 		version = 1
 		undoStack.Push(func() error {

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -358,7 +358,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
 				return errors.RemediationError{
 					Inner:       fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account"),
-					Remediation: fmt.Sprintf("see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators"),
+					Remediation: "see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators",
 				}
 			}
 			return fmt.Errorf("error creating service: %w", err)

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -354,7 +354,9 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Type:    "wasm",
 			Comment: description,
 		})
-		if err != nil {
+		if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
+			return fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account. see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators")
+		} else if err != nil {
 			return fmt.Errorf("error creating service: %w", err)
 		}
 		version = 1

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -358,7 +358,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
 				return errors.RemediationError{
 					Inner:       fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account"),
-					Remediation: "see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators",
+					Remediation: "See more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators",
 				}
 			}
 			return fmt.Errorf("error creating service: %w", err)

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -355,7 +355,10 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Comment: description,
 		})
 		if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
-			return fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account. see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators")
+			return errors.RemediationError{
+				Inner:       fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account"),
+				Remediation: fmt.Sprintf("see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators"),
+			}
 		} else if err != nil {
 			return fmt.Errorf("error creating service: %w", err)
 		}

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -354,13 +354,14 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Type:    "wasm",
 			Comment: description,
 		})
-		if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
-			return errors.RemediationError{
-				Inner:       fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account"),
-				Remediation: fmt.Sprintf("see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators"),
+		if err != nil {
+			if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
+				return errors.RemediationError{
+					Inner:       fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account"),
+					Remediation: fmt.Sprintf("see more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators"),
+				}
 			}
-		} else if err != nil {
-			return fmt.Errorf("error creating service: %w", err)
+		  return fmt.Errorf("error creating service: %w", err)
 		}
 		version = 1
 		undoStack.Push(func() error {


### PR DESCRIPTION
As reported by @ezambrano-fastly, users without the C@E feature flag enabled currently see a relatively cryptic message: "Unable to create service: valid values for 'type' are: 'vcl'"