### PR TITLE
Fix goreleaser version lookup

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: v2.4.1
+        version: v0.155.2 # goreleaser version (NOT goreleaser-action version)
         args: release --rm-dist --release-notes=RELEASE_CHANGELOG.md
       env:
         GOVERSION: ${{ env.GOVERSION }}


### PR DESCRIPTION
**Problem**: the version specified in the workflow script was incorrect. It was referencing the version of the goreleaser-_action_.