### PR TITLE
Fix CI workflow by switching from old syntax to new

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ archives:
 brews:
   - name: fastly
     ids: [nix]
-    github:
+    tap:
       owner: fastly
       name: homebrew-tap
     skip_upload: auto


### PR DESCRIPTION
Based this fix off:  
https://goreleaser.com/deprecations/#brewsgithub