### PR TITLE
Fix CI binary overlap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
     id: generate-usage
     goos: [linux]
     goarch: [amd64]
+    binary: 'fastly-usage' # we rename the binary to prevent an error caused by the earlier 'linux/amd64' step
+                           # which already creates a 'fastly' binary in '/usr/local/bin'.
     hooks:
       post:
         - cmd: "scripts/documentation.sh {{ .Path }}"


### PR DESCRIPTION
**Problem**: noticed that when using newer goreleaser that the Linux AMD64 distribution step would generate the fastly binary and stick it in the workspace's `/usr/local/bin` directory. Later when another build step (e.g. the generation of `usage.json`) tries to install the fastly binary it can't because the binary already exists.

**Solution**: rename the binary for the step which generates the usage.json as the binary used to doesn't need to be explicitly set to `fastly`.

**Notes**: this should work as we call the binary within our generation script by using `.Path` template value, which according to the docs is the full path to the binary, and so it should be set to the renamed binary name (see docs for reference material: https://goreleaser.com/customization/build)