### PR TITLE
The manifest_version should default to 1 if missing.

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -50,6 +50,8 @@ func main() {
 
 	// Extract a subset of configuration options from the local application directory.
 	var file config.File
+	file.SetOutput(out)
+
 	err := file.Read(configFilePath)
 	if err != nil {
 		if verboseOutput {

--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -50,8 +50,6 @@ func main() {
 
 	// Extract a subset of configuration options from the local application directory.
 	var file config.File
-	file.SetOutput(out)
-
 	err := file.Read(configFilePath)
 	if err != nil {
 		if verboseOutput {

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -76,8 +76,9 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	// The globals will hold generally-applicable configuration parameters
 	// from a variety of sources, and is provided to each concrete command.
 	globals := config.Data{
-		File: file,
-		Env:  env,
+		File:   file,
+		Env:    env,
+		Output: out,
 	}
 
 	// Set up the main application root, including global flags, and then each

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -29,6 +29,7 @@ type DeployCommand struct {
 func NewDeployCommand(parent common.Registerer, client api.HTTPClient, globals *config.Data) *DeployCommand {
 	var c DeployCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("deploy", "Deploy a package to a Fastly Compute@Edge service")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -58,6 +58,7 @@ func NewInitCommand(parent common.Registerer, client api.HTTPClient, globals *co
 	var c InitCommand
 	c.Globals = globals
 	c.client = client
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("init", "Initialize a new Compute@Edge package locally")
 	c.CmdClause.Flag("service-id", "Existing service ID to use. By default, this command creates a new service").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -207,7 +207,7 @@ func (f *File) Read(fpath string) error {
 	f.exists = true
 
 	if f.ManifestVersion.int == 0 {
-		return errors.ErrMissingManifestVersion
+		f.ManifestVersion.int = 1
 	}
 
 	return nil

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -1,11 +1,13 @@
 package manifest
 
 import (
+	"io"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
 	toml "github.com/pelletier/go-toml"
 )
 
@@ -180,11 +182,17 @@ type File struct {
 	ServiceID       string   `toml:"service_id"`
 
 	exists bool
+	output io.Writer
 }
 
 // Exists yields whether the manifest exists.
 func (f *File) Exists() bool {
 	return f.exists
+}
+
+// SetOutput sets the output stream for any messages.
+func (f *File) SetOutput(output io.Writer) {
+	f.output = output
 }
 
 // Read loads the manifest file content from disk.
@@ -208,6 +216,9 @@ func (f *File) Read(fpath string) error {
 
 	if f.ManifestVersion.int == 0 {
 		f.ManifestVersion.int = 1
+
+		// TODO: Provide link to v1 schema once published publicly.
+		text.Warning(f.output, "The fastly.toml was missing a manifest_version so the schema version 1 will be used.")
 	}
 
 	return nil

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -218,7 +218,7 @@ func (f *File) Read(fpath string) error {
 		f.ManifestVersion.int = 1
 
 		// TODO: Provide link to v1 schema once published publicly.
-		text.Warning(f.output, "The fastly.toml was missing a manifest_version so the schema version 1 will be used.")
+		text.Warning(f.output, "The fastly.toml was missing a `manifest_version` field. A default schema version of `1` will be used.")
 	}
 
 	return nil

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -43,6 +44,7 @@ func TestManifest(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var m File
+			m.SetOutput(os.Stdout)
 
 			path, err := filepath.Abs(filepath.Join(prefix, tc.manifest))
 			if err != nil {

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -24,10 +24,9 @@ func TestManifest(t *testing.T) {
 			manifest: "fastly-valid-integer.toml",
 			valid:    true,
 		},
-		"invalid: missing manifest_version": {
-			manifest:      "fastly-invalid-missing-version.toml",
-			valid:         false,
-			expectedError: errs.ErrMissingManifestVersion,
+		"invalid: missing manifest_version causes default to be set": {
+			manifest: "fastly-invalid-missing-version.toml",
+			valid:    true,
 		},
 		"invalid: manifest_version Atoi error": {
 			manifest:      "fastly-invalid-unrecognised.toml",

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -74,9 +75,10 @@ var ErrLegacyConfig = errors.New("the configuration file is in the legacy format
 // (e.g. an email address). Otherwise, parameters should be defined in specific
 // command structs, and parsed as flags.
 type Data struct {
-	File File
-	Env  Environment
-	Flag Flag
+	File   File
+	Env    Environment
+	Output io.Writer
+	Flag   Flag
 
 	Client    api.Interface
 	RTSClient api.RealtimeStatsInterface

--- a/pkg/domain/create.go
+++ b/pkg/domain/create.go
@@ -22,6 +22,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a domain on a Fastly service version").Alias("add")
 	c.CmdClause.Flag("name", "Domain name").Short('n').Required().StringVar(&c.Input.Name)

--- a/pkg/domain/delete.go
+++ b/pkg/domain/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a domain on a Fastly service version").Alias("remove")
 	c.CmdClause.Flag("name", "Domain name").Short('n').Required().StringVar(&c.Input.Name)

--- a/pkg/domain/describe.go
+++ b/pkg/domain/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a domain on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/domain/list.go
+++ b/pkg/domain/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List domains on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionary/create.go
+++ b/pkg/edgedictionary/create.go
@@ -25,6 +25,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Fastly edge dictionary on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionary/delete.go
+++ b/pkg/edgedictionary/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Fastly edge dictionary from a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionary/describe.go
+++ b/pkg/edgedictionary/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Fastly edge dictionary").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionary/list.go
+++ b/pkg/edgedictionary/list.go
@@ -22,6 +22,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List all dictionaries on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionary/update.go
+++ b/pkg/edgedictionary/update.go
@@ -27,6 +27,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update name of dictionary on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionaryitem/batch.go
+++ b/pkg/edgedictionaryitem/batch.go
@@ -27,6 +27,7 @@ type BatchCommand struct {
 func NewBatchCommand(parent common.Registerer, globals *config.Data) *BatchCommand {
 	var c BatchCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("batchmodify", "Update multiple items in a Fastly edge dictionary")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionaryitem/create.go
+++ b/pkg/edgedictionaryitem/create.go
@@ -22,6 +22,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a new item on a Fastly edge dictionary")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionaryitem/delete.go
+++ b/pkg/edgedictionaryitem/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an item from a Fastly edge dictionary")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionaryitem/describe.go
+++ b/pkg/edgedictionaryitem/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Fastly edge dictionary item").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionaryitem/list.go
+++ b/pkg/edgedictionaryitem/list.go
@@ -22,6 +22,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List items in a Fastly edge dictionary")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/edgedictionaryitem/update.go
+++ b/pkg/edgedictionaryitem/update.go
@@ -26,6 +26,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update or insert an item on a Fastly edge dictionary")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/healthcheck/delete.go
+++ b/pkg/healthcheck/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a healthcheck on a Fastly service version").Alias("remove")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/healthcheck/describe.go
+++ b/pkg/healthcheck/describe.go
@@ -23,6 +23,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a healthcheck on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/healthcheck/list.go
+++ b/pkg/healthcheck/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List healthchecks on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/healthcheck/update.go
+++ b/pkg/healthcheck/update.go
@@ -35,6 +35,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a healthcheck on a Fastly service version")
 

--- a/pkg/logging/azureblob/create.go
+++ b/pkg/logging/azureblob/create.go
@@ -40,6 +40,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Azure Blob Storage logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/azureblob/delete.go
+++ b/pkg/logging/azureblob/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an Azure Blob Storage logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/azureblob/describe.go
+++ b/pkg/logging/azureblob/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an Azure Blob Storage logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/azureblob/list.go
+++ b/pkg/logging/azureblob/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Azure Blob Storage logging endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/azureblob/update.go
+++ b/pkg/logging/azureblob/update.go
@@ -41,6 +41,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update an Azure Blob Storage logging endpoint on a Fastly service version")

--- a/pkg/logging/bigquery/create.go
+++ b/pkg/logging/bigquery/create.go
@@ -37,6 +37,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a BigQuery logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/bigquery/delete.go
+++ b/pkg/logging/bigquery/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a BigQuery logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/bigquery/describe.go
+++ b/pkg/logging/bigquery/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a BigQuery logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/bigquery/list.go
+++ b/pkg/logging/bigquery/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List BigQuery endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/bigquery/update.go
+++ b/pkg/logging/bigquery/update.go
@@ -38,6 +38,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a BigQuery logging endpoint on a Fastly service version")

--- a/pkg/logging/cloudfiles/create.go
+++ b/pkg/logging/cloudfiles/create.go
@@ -43,6 +43,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Cloudfiles logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/cloudfiles/delete.go
+++ b/pkg/logging/cloudfiles/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Cloudfiles logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/cloudfiles/describe.go
+++ b/pkg/logging/cloudfiles/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Cloudfiles logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/cloudfiles/list.go
+++ b/pkg/logging/cloudfiles/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Cloudfiles endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -42,6 +42,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Cloudfiles logging endpoint on a Fastly service version")

--- a/pkg/logging/datadog/create.go
+++ b/pkg/logging/datadog/create.go
@@ -34,6 +34,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Datadog logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/datadog/delete.go
+++ b/pkg/logging/datadog/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Datadog logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/datadog/describe.go
+++ b/pkg/logging/datadog/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Datadog logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/datadog/list.go
+++ b/pkg/logging/datadog/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Datadog endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/datadog/update.go
+++ b/pkg/logging/datadog/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Datadog logging endpoint on a Fastly service version")

--- a/pkg/logging/digitalocean/create.go
+++ b/pkg/logging/digitalocean/create.go
@@ -41,6 +41,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/digitalocean/delete.go
+++ b/pkg/logging/digitalocean/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/digitalocean/describe.go
+++ b/pkg/logging/digitalocean/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/digitalocean/list.go
+++ b/pkg/logging/digitalocean/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List DigitalOcean Spaces logging endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/digitalocean/update.go
+++ b/pkg/logging/digitalocean/update.go
@@ -42,6 +42,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a DigitalOcean Spaces logging endpoint on a Fastly service version")

--- a/pkg/logging/elasticsearch/create.go
+++ b/pkg/logging/elasticsearch/create.go
@@ -42,6 +42,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Elasticsearch logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/elasticsearch/delete.go
+++ b/pkg/logging/elasticsearch/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an Elasticsearch logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/elasticsearch/describe.go
+++ b/pkg/logging/elasticsearch/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an Elasticsearch logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/elasticsearch/list.go
+++ b/pkg/logging/elasticsearch/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Elasticsearch endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/elasticsearch/update.go
+++ b/pkg/logging/elasticsearch/update.go
@@ -43,6 +43,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update an Elasticsearch logging endpoint on a Fastly service version")

--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -39,6 +39,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an FTP logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/ftp/delete.go
+++ b/pkg/logging/ftp/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an FTP logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an FTP logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/ftp/list.go
+++ b/pkg/logging/ftp/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List FTP endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -41,6 +41,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update an FTP logging endpoint on a Fastly service version")

--- a/pkg/logging/gcs/create.go
+++ b/pkg/logging/gcs/create.go
@@ -39,6 +39,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a GCS logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/gcs/delete.go
+++ b/pkg/logging/gcs/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a GCS logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a GCS logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/gcs/list.go
+++ b/pkg/logging/gcs/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List GCS endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -40,6 +40,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a GCS logging endpoint on a Fastly service version")

--- a/pkg/logging/googlepubsub/create.go
+++ b/pkg/logging/googlepubsub/create.go
@@ -35,6 +35,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Google Cloud Pub/Sub logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/googlepubsub/delete.go
+++ b/pkg/logging/googlepubsub/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Google Cloud Pub/Sub logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/googlepubsub/describe.go
+++ b/pkg/logging/googlepubsub/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Google Cloud Pub/Sub logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/googlepubsub/list.go
+++ b/pkg/logging/googlepubsub/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Google Cloud Pub/Sub endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/googlepubsub/update.go
+++ b/pkg/logging/googlepubsub/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Google Cloud Pub/Sub logging endpoint on a Fastly service version")

--- a/pkg/logging/heroku/create.go
+++ b/pkg/logging/heroku/create.go
@@ -34,6 +34,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Heroku logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/heroku/delete.go
+++ b/pkg/logging/heroku/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Heroku logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/heroku/describe.go
+++ b/pkg/logging/heroku/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Heroku logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/heroku/list.go
+++ b/pkg/logging/heroku/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Heroku endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/heroku/update.go
+++ b/pkg/logging/heroku/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Heroku logging endpoint on a Fastly service version")

--- a/pkg/logging/honeycomb/create.go
+++ b/pkg/logging/honeycomb/create.go
@@ -34,6 +34,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Honeycomb logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/honeycomb/delete.go
+++ b/pkg/logging/honeycomb/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Honeycomb logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/honeycomb/describe.go
+++ b/pkg/logging/honeycomb/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Honeycomb logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/honeycomb/list.go
+++ b/pkg/logging/honeycomb/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Honeycomb endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/honeycomb/update.go
+++ b/pkg/logging/honeycomb/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Honeycomb logging endpoint on a Fastly service version")

--- a/pkg/logging/https/create.go
+++ b/pkg/logging/https/create.go
@@ -44,6 +44,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an HTTPS logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/https/delete.go
+++ b/pkg/logging/https/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an HTTPS logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/https/describe.go
+++ b/pkg/logging/https/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an HTTPS logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/https/list.go
+++ b/pkg/logging/https/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List HTTPS endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/https/update.go
+++ b/pkg/logging/https/update.go
@@ -45,6 +45,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update an HTTPS logging endpoint on a Fastly service version")

--- a/pkg/logging/kafka/create.go
+++ b/pkg/logging/kafka/create.go
@@ -47,6 +47,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Kafka logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/kafka/delete.go
+++ b/pkg/logging/kafka/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Kafka logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/kafka/describe.go
+++ b/pkg/logging/kafka/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Kafka logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/kafka/list.go
+++ b/pkg/logging/kafka/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Kafka endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/kafka/update.go
+++ b/pkg/logging/kafka/update.go
@@ -49,6 +49,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Kafka logging endpoint on a Fastly service version")

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -35,6 +35,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Amazon Kinesis logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Kinesis logging endpoint on a Fastly service version").Alias("remove")
 	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)

--- a/pkg/logging/kinesis/describe.go
+++ b/pkg/logging/kinesis/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Kinesis logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/kinesis/list.go
+++ b/pkg/logging/kinesis/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Kinesis endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Kinesis logging endpoint on a Fastly service version")

--- a/pkg/logging/logentries/create.go
+++ b/pkg/logging/logentries/create.go
@@ -34,6 +34,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Logentries logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/logentries/delete.go
+++ b/pkg/logging/logentries/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Logentries logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/logentries/describe.go
+++ b/pkg/logging/logentries/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logentries logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/logentries/list.go
+++ b/pkg/logging/logentries/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Logentries endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/logentries/update.go
+++ b/pkg/logging/logentries/update.go
@@ -35,6 +35,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Logentries logging endpoint on a Fastly service version")

--- a/pkg/logging/loggly/create.go
+++ b/pkg/logging/loggly/create.go
@@ -33,6 +33,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Loggly logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/loggly/delete.go
+++ b/pkg/logging/loggly/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Loggly logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/loggly/describe.go
+++ b/pkg/logging/loggly/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Loggly logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/loggly/list.go
+++ b/pkg/logging/loggly/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Loggly endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/loggly/update.go
+++ b/pkg/logging/loggly/update.go
@@ -33,6 +33,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Loggly logging endpoint on a Fastly service version")

--- a/pkg/logging/logshuttle/create.go
+++ b/pkg/logging/logshuttle/create.go
@@ -34,6 +34,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Logshuttle logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/logshuttle/delete.go
+++ b/pkg/logging/logshuttle/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Logshuttle logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/logshuttle/describe.go
+++ b/pkg/logging/logshuttle/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logshuttle logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/logshuttle/list.go
+++ b/pkg/logging/logshuttle/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Logshuttle endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/logshuttle/update.go
+++ b/pkg/logging/logshuttle/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Logshuttle logging endpoint on a Fastly service version")

--- a/pkg/logging/openstack/create.go
+++ b/pkg/logging/openstack/create.go
@@ -41,6 +41,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an OpenStack logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/openstack/delete.go
+++ b/pkg/logging/openstack/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an OpenStack logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/openstack/describe.go
+++ b/pkg/logging/openstack/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an OpenStack logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/openstack/list.go
+++ b/pkg/logging/openstack/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List OpenStack logging endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/openstack/update.go
+++ b/pkg/logging/openstack/update.go
@@ -42,6 +42,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update an OpenStack logging endpoint on a Fastly service version")

--- a/pkg/logging/papertrail/create.go
+++ b/pkg/logging/papertrail/create.go
@@ -33,6 +33,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Papertrail logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/papertrail/delete.go
+++ b/pkg/logging/papertrail/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Papertrail logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/papertrail/describe.go
+++ b/pkg/logging/papertrail/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Papertrail logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/papertrail/list.go
+++ b/pkg/logging/papertrail/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Papertrail endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/papertrail/update.go
+++ b/pkg/logging/papertrail/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Papertrail logging endpoint on a Fastly service version")

--- a/pkg/logging/s3/create.go
+++ b/pkg/logging/s3/create.go
@@ -44,6 +44,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Amazon S3 logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/s3/delete.go
+++ b/pkg/logging/s3/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a S3 logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a S3 logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/s3/list.go
+++ b/pkg/logging/s3/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List S3 endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -46,6 +46,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a S3 logging endpoint on a Fastly service version")

--- a/pkg/logging/scalyr/create.go
+++ b/pkg/logging/scalyr/create.go
@@ -34,6 +34,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Scalyr logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/scalyr/delete.go
+++ b/pkg/logging/scalyr/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Scalyr logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Scalyr logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/scalyr/list.go
+++ b/pkg/logging/scalyr/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Scalyr endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/scalyr/update.go
+++ b/pkg/logging/scalyr/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Scalyr logging endpoint on a Fastly service version")

--- a/pkg/logging/sftp/create.go
+++ b/pkg/logging/sftp/create.go
@@ -44,6 +44,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an SFTP logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/sftp/delete.go
+++ b/pkg/logging/sftp/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an SFTP logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/sftp/describe.go
+++ b/pkg/logging/sftp/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an SFTP logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/sftp/list.go
+++ b/pkg/logging/sftp/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List SFTP endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/sftp/update.go
+++ b/pkg/logging/sftp/update.go
@@ -44,6 +44,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update an SFTP logging endpoint on a Fastly service version")

--- a/pkg/logging/splunk/create.go
+++ b/pkg/logging/splunk/create.go
@@ -38,6 +38,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Splunk logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/splunk/delete.go
+++ b/pkg/logging/splunk/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Splunk logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/splunk/describe.go
+++ b/pkg/logging/splunk/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Splunk logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/splunk/list.go
+++ b/pkg/logging/splunk/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Splunk endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/splunk/update.go
+++ b/pkg/logging/splunk/update.go
@@ -38,6 +38,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Splunk logging endpoint on a Fastly service version")

--- a/pkg/logging/sumologic/create.go
+++ b/pkg/logging/sumologic/create.go
@@ -33,6 +33,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Sumologic logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/sumologic/delete.go
+++ b/pkg/logging/sumologic/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Sumologic logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/sumologic/describe.go
+++ b/pkg/logging/sumologic/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Sumologic logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/sumologic/list.go
+++ b/pkg/logging/sumologic/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Sumologic endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -34,6 +34,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Sumologic logging endpoint on a Fastly service version")

--- a/pkg/logging/syslog/create.go
+++ b/pkg/logging/syslog/create.go
@@ -40,6 +40,7 @@ type CreateCommand struct {
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Syslog logging endpoint on a Fastly service version").Alias("add")
 

--- a/pkg/logging/syslog/delete.go
+++ b/pkg/logging/syslog/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Syslog logging endpoint on a Fastly service version").Alias("remove")
 

--- a/pkg/logging/syslog/describe.go
+++ b/pkg/logging/syslog/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Syslog logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/syslog/list.go
+++ b/pkg/logging/syslog/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Syslog endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/logging/syslog/update.go
+++ b/pkg/logging/syslog/update.go
@@ -41,6 +41,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	c.CmdClause = parent.Command("update", "Update a Syslog logging endpoint on a Fastly service version")

--- a/pkg/logs/tail.go
+++ b/pkg/logs/tail.go
@@ -100,6 +100,7 @@ type (
 func NewTailCommand(parent common.Registerer, globals *config.Data) *TailCommand {
 	var c TailCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("tail", "Tail Compute@Edge logs")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/service/delete.go
+++ b/pkg/service/delete.go
@@ -22,6 +22,7 @@ type DeleteCommand struct {
 func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Fastly service").Alias("remove")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/service/describe.go
+++ b/pkg/service/describe.go
@@ -22,6 +22,7 @@ type DescribeCommand struct {
 func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Fastly service").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/service/search.go
+++ b/pkg/service/search.go
@@ -21,6 +21,7 @@ type SearchCommand struct {
 func NewSearchCommand(parent common.Registerer, globals *config.Data) *SearchCommand {
 	var c SearchCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("search", "Search for a Fastly service by name")
 	c.CmdClause.Flag("name", "Service name").Short('n').StringVar(&c.Input.Name)

--- a/pkg/service/update.go
+++ b/pkg/service/update.go
@@ -31,6 +31,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a Fastly service")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/serviceversion/activate.go
+++ b/pkg/serviceversion/activate.go
@@ -22,6 +22,7 @@ type ActivateCommand struct {
 func NewActivateCommand(parent common.Registerer, globals *config.Data) *ActivateCommand {
 	var c ActivateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("activate", "Activate a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/serviceversion/clone.go
+++ b/pkg/serviceversion/clone.go
@@ -22,6 +22,7 @@ type CloneCommand struct {
 func NewCloneCommand(parent common.Registerer, globals *config.Data) *CloneCommand {
 	var c CloneCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("clone", "Clone a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/serviceversion/deactivate.go
+++ b/pkg/serviceversion/deactivate.go
@@ -22,6 +22,7 @@ type DeactivateCommand struct {
 func NewDeactivateCommand(parent common.Registerer, globals *config.Data) *DeactivateCommand {
 	var c DeactivateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("deactivate", "Deactivate a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/serviceversion/list.go
+++ b/pkg/serviceversion/list.go
@@ -23,6 +23,7 @@ type ListCommand struct {
 func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Fastly service versions")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/serviceversion/lock.go
+++ b/pkg/serviceversion/lock.go
@@ -22,6 +22,7 @@ type LockCommand struct {
 func NewLockCommand(parent common.Registerer, globals *config.Data) *LockCommand {
 	var c LockCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("lock", "Lock a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/serviceversion/update.go
+++ b/pkg/serviceversion/update.go
@@ -26,6 +26,7 @@ type UpdateCommand struct {
 func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)


### PR DESCRIPTION
**Problem**: Originally if the manifest_version field was missing from the fastly.toml manifest file, then we would return an error. 
**Solution**: We should instead set a default value of `1`.

**Notes**: to issue an appropriate “warning” message, it required the manifest `File` object to have access to a consistent output stream. This meant everywhere we call `c.manifest.File.Read(manifest.Filename)` (which is in every command) I’ve had to precede it with a call to `c.manifest.File.SetOutput(c.Globals.Output)`.