### PR TITLE
Refactor UserAgent.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,9 +11,9 @@ builds:
   - <<: &build_defaults
       main: ./cmd/fastly
       ldflags:
-        - -s -w -X "github.com/fastly/cli/pkg/version.AppVersion={{ .Version }}"
-        - -X "github.com/fastly/cli/pkg/version.GitRevision={{ .ShortCommit }}"
-        - -X "github.com/fastly/cli/pkg/version.GoVersion={{ .Env.GOVERSION }}"
+        - -s -w -X "github.com/fastly/cli/pkg/revision.AppVersion={{ .Version }}"
+        - -X "github.com/fastly/cli/pkg/revision.GitCommit={{ .ShortCommit }}"
+        - -X "github.com/fastly/cli/pkg/revision.GoVersion={{ .Env.GOVERSION }}"
     id: macos
     goos: [darwin]
     goarch: [amd64]

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD
 TESTARGS ?= ./{cmd,pkg}/...
 
 LDFLAGS = -ldflags "\
- -X 'github.com/fastly/cli/pkg/version.AppVersion=${VERSION}' \
- -X 'github.com/fastly/cli/pkg/version.GitRevision=$(shell git rev-parse --short HEAD || echo unknown)' \
- -X 'github.com/fastly/cli/pkg/version.GoVersion=$(shell go version)' \
+ -X 'github.com/fastly/cli/pkg/revision.AppVersion=${VERSION}' \
+ -X 'github.com/fastly/cli/pkg/revision.GitCommit=$(shell git rev-parse --short HEAD || echo unknown)' \
+ -X 'github.com/fastly/cli/pkg/revision.GoVersion=$(shell go version)' \
  "
 
 fastly:

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -47,6 +47,7 @@ import (
 	"github.com/fastly/cli/pkg/logging/sumologic"
 	"github.com/fastly/cli/pkg/logging/syslog"
 	"github.com/fastly/cli/pkg/logs"
+	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/service"
 	"github.com/fastly/cli/pkg/serviceversion"
 	"github.com/fastly/cli/pkg/stats"
@@ -724,10 +725,10 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		return errors.RemediationError{Prefix: usage, Inner: fmt.Errorf("command not found")}
 	}
 
-	if versioner != nil && name != "update" && !version.IsPreRelease(version.AppVersion) {
+	if versioner != nil && name != "update" && !version.IsPreRelease(revision.AppVersion) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel() // push cancel on the defer stack first...
-		f := update.CheckAsync(ctx, file, configFilePath, version.AppVersion, versioner)
+		f := update.CheckAsync(ctx, file, configFilePath, revision.AppVersion, versioner)
 		defer f(out) // ...and the printing function second, so we hit the timeout
 	}
 

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/filesystem"
+	"github.com/fastly/cli/pkg/useragent"
 	toml "github.com/pelletier/go-toml"
 )
 
@@ -227,6 +228,7 @@ func (f *File) Load(configEndpoint string, httpClient api.HTTPClient) error {
 		return err
 	}
 
+	req.Header.Set("User-Agent", useragent.Name)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err

--- a/pkg/revision/revision.go
+++ b/pkg/revision/revision.go
@@ -1,0 +1,32 @@
+// Package revision defines variables that will be populated with values from
+// the Makefile at build time via LDFLAGS.
+package revision
+
+var (
+	// AppVersion is the semver for this version of the client, or
+	// "v0.0.0-unknown". Set by `make release`.
+	AppVersion string
+
+	// GitCommit is the short git SHA associated with this build, or
+	// "unknown". Set by `make release`.
+	GitCommit string
+
+	// GoVersion is the output of `go version` associated with this build, or
+	// "go version unknown". Set by `make release`.
+	GoVersion string
+)
+
+// None is the AppVersion string for local (unversioned) builds.
+const None = "v0.0.0-unknown"
+
+func init() {
+	if AppVersion == "" {
+		AppVersion = None
+	}
+	if GitCommit == "" {
+		GitCommit = "unknown"
+	}
+	if GoVersion == "" {
+		GoVersion = "go version unknown"
+	}
+}

--- a/pkg/update/root.go
+++ b/pkg/update/root.go
@@ -10,8 +10,8 @@ import (
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/filesystem"
+	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/cli/pkg/version"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
@@ -35,7 +35,7 @@ func NewRootCommand(parent common.Registerer, v Versioner, client api.HTTPClient
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	progress := text.NewQuietProgress(out)
 
-	current, latest, shouldUpdate, err := Check(context.Background(), version.AppVersion, c.versioner)
+	current, latest, shouldUpdate, err := Check(context.Background(), revision.AppVersion, c.versioner)
 	if err != nil {
 		return fmt.Errorf("error checking for latest version: %w", err)
 	}

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -1,0 +1,10 @@
+package useragent
+
+import (
+	"fmt"
+
+	"github.com/fastly/cli/pkg/revision"
+)
+
+// Name is the user agent which we report in all HTTP requests.
+var Name = fmt.Sprintf("%s/%s", "FastlyCLI", revision.AppVersion)

--- a/pkg/version/root.go
+++ b/pkg/version/root.go
@@ -6,48 +6,17 @@ import (
 	"strings"
 
 	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/revision"
+	"github.com/fastly/cli/pkg/useragent"
 	"github.com/fastly/go-fastly/v3/fastly"
 )
 
-var (
-	// AppVersion is the semver for this version of the client, or
-	// "v0.0.0-unknown". Set by `make release`.
-	AppVersion string
-
-	// GitRevision is the short git SHA associated with this build, or
-	// "unknown". Set by `make release`.
-	GitRevision string
-
-	// GoVersion is the output of `go version` associated with this build, or
-	// "go version unknown". Set by `make release`.
-	GoVersion string
-
-	// UserAgent is the user agent which we report in all HTTP requests to the
-	// API via go-fastly.
-	UserAgent string
-)
-
-// None is the AppVersion string for local (unversioned) builds.
-const None = "v0.0.0-unknown"
-
 func init() {
-	if AppVersion == "" {
-		AppVersion = None
-	}
-	if GitRevision == "" {
-		GitRevision = "unknown"
-	}
-	if GoVersion == "" {
-		GoVersion = "go version unknown"
-	}
-
-	UserAgent = fmt.Sprintf("FastlyCLI/%s", AppVersion)
-
 	// Override the go-fastly UserAgent value by prepending the CLI version.
 	//
 	// Results in a header similar too:
 	// User-Agent: FastlyCLI/0.1.0, FastlyGo/1.5.0 (1.13.0)
-	fastly.UserAgent = fmt.Sprintf("%s, %s", UserAgent, fastly.UserAgent)
+	fastly.UserAgent = fmt.Sprintf("%s, %s", useragent.Name, fastly.UserAgent)
 }
 
 // RootCommand is the parent command for all subcommands in this package.
@@ -65,8 +34,8 @@ func NewRootCommand(parent common.Registerer) *RootCommand {
 
 // Exec implements the command interface.
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
-	fmt.Fprintf(out, "Fastly CLI version %s (%s)\n", AppVersion, GitRevision)
-	fmt.Fprintf(out, "Built with %s\n", GoVersion)
+	fmt.Fprintf(out, "Fastly CLI version %s (%s)\n", revision.AppVersion, revision.GitCommit)
+	fmt.Fprintf(out, "Built with %s\n", revision.GoVersion)
 	return nil
 }
 

--- a/pkg/whoami/root.go
+++ b/pkg/whoami/root.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/cli/pkg/version"
+	"github.com/fastly/cli/pkg/useragent"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
@@ -47,7 +47,7 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 
 	req.Header.Set("Fastly-Key", token)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", version.UserAgent)
+	req.Header.Set("User-Agent", useragent.Name)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("error executing API request: %w", err)


### PR DESCRIPTION
**Problem**: we weren't setting the User-Agent HTTP request header when making requests to the dynamic config endpoint.
**Notes**: in order to support this change I needed to make a bunch of refactoring. Otherwise without the refactoring we would have had to duplicate the UserAgent logic due to 'cyclic import' issues.

Also, we already had a package named `version` which is used for a subsequent CLI subcommand. So I had to find an alternative name to encapsulate a bunch of version related types. So I settled on 'revision'. It might not be the best name so I'm open to suggestions.