### PR TITLE
Update the fastly.toml manifest if missing manifest_version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ lint:
 .PHONY: test
 test:
 	go test -race $(TESTARGS)
+
 .PHONY: build
 build:
 	go build ./cmd/fastly

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,6 +41,29 @@ func TestManifest(t *testing.T) {
 			expectedError: errs.ErrUnrecognisedManifestVersion,
 		},
 	}
+
+	// NOTE: the fixture file "fastly-invalid-missing-version.toml" will be
+	// overwritten by the test as the internal logic is supposed to add back into
+	// the manifest a manifest_version field if one isn't found.
+	//
+	// To ensure future test runs complete successfully we do an initial read of
+	// the data and then write it back out when the tests have completed.
+	path, err := filepath.Abs(filepath.Join(prefix, "fastly-invalid-missing-version.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err = ioutil.WriteFile(path, b, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
**Problem**: the error message (see below) was being shown every time `fastly compute build` was executed. This happened because although the logic set a correct manifest_version value, that only happened in-memory and so the same error would happen each time the CLI was used (unless the user manually updated the file).

```
The fastly.toml was missing a `manifest_version` field. A default schema version of `1` will be used.
```

Additionally to this I discovered that the current implementation wouldn't write the manifest_version to the file correctly. It would be written as a separate block `[manifest_version]` rather than as a top-level field. So I've refactored the logic to fix that bug.