### PR TITLE
Don't run "cargo update" before building rust app.

### DIFF
--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -279,18 +279,6 @@ func (r Rust) Initialize(out io.Writer) error { return nil }
 // Build implements the Toolchain interface and attempts to compile the package
 // Rust source to a Wasm binary.
 func (r Rust) Build(out io.Writer, verbose bool) error {
-	args := []string{"update"}
-	if verbose {
-		args = append(args, "--verbose")
-	}
-	// Execute `cargo update` command, to ensure we are using latest version
-	// of fastly-sys transient dependency and avoid misleading/confusing
-	// compiler error messages.
-	cmd := common.NewStreamingExec("cargo", args, os.Environ(), verbose, out)
-	if err := cmd.Exec(); err != nil {
-		return err
-	}
-
 	// Get binary name from Cargo.toml.
 	var m CargoManifest
 	if err := m.Read("Cargo.toml"); err != nil {
@@ -301,7 +289,7 @@ func (r Rust) Build(out io.Writer, verbose bool) error {
 	// Specify the toolchain using the `cargo +<version>` syntax.
 	toolchain := fmt.Sprintf("+%s", r.config.File.Language.Rust.ToolchainVersion)
 
-	args = []string{
+	args := []string{
 		toolchain,
 		"build",
 		"--bin",
@@ -321,7 +309,7 @@ func (r Rust) Build(out io.Writer, verbose bool) error {
 
 	// Execute the `cargo build` commands with the Wasm WASI target, release
 	// flags and env vars.
-	cmd = common.NewStreamingExec("cargo", args, env, verbose, out)
+	cmd := common.NewStreamingExec("cargo", args, env, verbose, out)
 	if err := cmd.Exec(); err != nil {
 		return err
 	}


### PR DESCRIPTION
**Problem**: users have had issues with the fact that "cargo update" is called at the start of the `compute build` subcommand.
**Solution**: remove the `cargo update` now we have dynamic config as it is determining the fastly-sys constraints.
**Notes**: background context on the changes this PR reverts can be found here: https://github.com/fastly/cli/pull/179