### PR TITLE
Remove version from fastly.toml manifest.

### DIFF
--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -1120,12 +1120,10 @@ func TestDeploy(t *testing.T) {
 				ActivateVersionFn: activateVersionOk,
 				ListDomainsFn:     listDomainsOk,
 			},
-			manifestIncludes: "version = 2",
 			wantOutput: []string{
 				"Validating package...",
 				"Uploading package...",
 				"Activating version...",
-				"Updating package manifest...",
 				"Deployed package (service 123, version 2)",
 			},
 		},

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -151,15 +151,6 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return fmt.Errorf("error activating version: %w", err)
 	}
 
-	progress.Step("Updating package manifest...")
-
-	fmt.Fprintf(progress, "Setting version in manifest to %d...\n", version.Number)
-	c.manifest.File.Version = version.Number
-
-	if err := c.manifest.File.Write(ManifestFilename); err != nil {
-		return fmt.Errorf("error saving package manifest: %w", err)
-	}
-
 	progress.Done()
 
 	text.Break(out)

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -464,9 +464,6 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	fmt.Fprintf(progress, "Setting service ID in manifest to %q...\n", service.ID)
 	m.ServiceID = service.ID
 
-	fmt.Fprintf(progress, "Setting version in manifest to %d...\n", version)
-	m.Version = version
-
 	fmt.Fprintf(progress, "Setting language in manifest to %s...\n", language.Name)
 	m.Language = language.Name
 

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -105,12 +105,9 @@ func (d *Data) Authors() ([]string, Source) {
 // manifest file that determines the configuration for a compute@edge service.
 //
 // NOTE: the File object has a field called ManifestVersion which this type is
-// assigned, while that object also has a Version field. The reason we don't
-// name this type ManifestVersion is to appease the static analysis linter
-// which complains re: stutter in the import manifest.ManifestVersion.
-//
-// In the near future release the `Version` field will be removed and so there
-// will be less ambiguity around what this type refers to.
+// assigned. The reason we don't name this type ManifestVersion is to appease
+// the static analysis linter which complains re: stutter in the import
+// manifest.ManifestVersion.
 type Version int
 
 // UnmarshalText manages multiple scenarios where historically the manifest
@@ -175,7 +172,6 @@ func (v *Version) UnmarshalText(text []byte) error {
 // manifest file schema.
 type File struct {
 	ManifestVersion Version  `toml:"manifest_version"`
-	Version         int      `toml:"version"`
 	Name            string   `toml:"name"`
 	Description     string   `toml:"description"`
 	Authors         []string `toml:"authors"`


### PR DESCRIPTION
**Problem**: storing state into fastly.toml is the signs that we're beginning to tread on the toes of a tool like terraform. Additionally, although we set the current service version within the manifest we don't actually use it for anything in the CLI so it looks to be a redundant field regardless.