### PR TITLE
Loading remote config.toml should fail gracefully.

### DIFF
--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -55,7 +55,7 @@ const (
 
 	// ConfigRequestTimeout is how long we'll wait for the CLI API endpoint to
 	// return a response before timing out the request.
-	ConfigRequestTimeout = 3 * time.Second
+	ConfigRequestTimeout = 5 * time.Second
 )
 
 // ErrLegacyConfig indicates that the local configuration file is using the


### PR DESCRIPTION
**Problem**: When a timeout occurred between the client and the service that serves the dynamic config used by the CLI, the logic would print the error and then shutdown the process (the error would also appear while the user's primary command was still executing, which of course would be very confusing).

**Solution**: Firstly, increase the timeout. This won't affect the user much because the config fetch happens asynchronously in the background and we already use the stale config for the purpose of the user's current command execution. Secondly, we shouldn't shutdown the process because of an error. We should tweak the error so the user understands their config is still stale but we'll attempt a re-fetch the next time around. Thirdly, we should defer the printing of the error until _after_ their command has finished executing.

**Notes**: 
Below is an example of one of the errors seen _before_ the changes implemented as part of this PR. Notice how we were displaying an error related to the config update right in the middle of the user's primary command (which would mislead a user into thinking the error was related to the previous output line "Checking if Rust 1.49.0 is installed").

```
- Checking if Rust 1.49.0 is installed...
ERROR: Get "https://developer.fastly.com/api/internal/cli-config": context deadline exceeded.
```