### PR TITLE
Fix manifest_version as a section bug.

### DIFF
--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -262,8 +262,7 @@ func containsManifestSection(bs []byte) (bool, error) {
 		return false, err
 	}
 
-	_, ok := tree.GetArray("manifest_version").(*toml.Tree)
-	if ok {
+	if _, ok := tree.GetArray("manifest_version").(*toml.Tree); ok {
 		return true, nil
 	}
 

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -275,7 +275,7 @@ func containsManifestSection(bs []byte) (bool, error) {
 // stripManifestSection reads the manifest line-by-line storing the lines that
 // don't contain `[manifest_version]` into a buffer to be written back to disk.
 //
-// It would've been better if we could of relied on the toml library to delete
+// It would've been better if we could have relied on the toml library to delete
 // the section but unfortunately that means it would end up deleting the entire
 // block and not just the key specified. Meaning if the manifest_version key
 // was in the middle of the manifest with other keys below it, deleting the

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -285,11 +285,7 @@ func stripManifestSection(r io.Reader, fpath string) (*bytes.Buffer, error) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		if scanner.Text() != "[manifest_version]" {
-			_, err := buf.Write(scanner.Bytes())
-			if err != nil {
-				return buf, err
-			}
-			_, err = buf.WriteString("\n")
+			_, err := buf.Write(append(scanner.Bytes(), []byte("\n"))))
 			if err != nil {
 				return buf, err
 			}

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -285,7 +285,11 @@ func stripManifestSection(r io.Reader, fpath string) (*bytes.Buffer, error) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		if scanner.Text() != "[manifest_version]" {
-			_, err := buf.Write(append(scanner.Bytes(), []byte("\n"))))
+			_, err := buf.Write(scanner.Bytes())
+			if err != nil {
+				return buf, err
+			}
+			_, err = buf.WriteString("\n")
 			if err != nil {
 				return buf, err
 			}

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -23,6 +23,9 @@ const Filename = "fastly.toml"
 // supported by the CLI.
 const ManifestLatestVersion = 1
 
+// FilePermissions represents a read/write file mode.
+const FilePermissions = 0666
+
 // Source enumerates where a manifest parameter is taken from.
 type Source uint8
 
@@ -299,7 +302,7 @@ func stripManifestSection(r io.Reader, fpath string) (*bytes.Buffer, error) {
 		return buf, err
 	}
 
-	err := os.WriteFile(fpath, buf.Bytes(), 0666)
+	err := os.WriteFile(fpath, buf.Bytes(), FilePermissions)
 	if err != nil {
 		return buf, err
 	}

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -1,6 +1,9 @@
 package manifest
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -204,6 +207,28 @@ func (f *File) Read(fpath string) error {
 		return err
 	}
 
+	// NOTE: temporary fix needed because of a bug that appeared in v0.25.0 where
+	// the manifest_version was stored in fastly.toml as a 'section', e.g.
+	// `[manifest_version]`.
+	//
+	// This subsequently would cause errors when trying to unmarshal the data, so
+	// we need to identify if it exists in the file (as a section) and remove it.
+	//
+	// We do this before trying to unmarshal the toml data into a go data
+	// structure otherwise we'll see errors from the toml library.
+	manifestSection, err := containsManifestSection(bs)
+	if err != nil {
+		return fmt.Errorf("failed to parse the fastly.toml manifest: %w", err)
+	}
+
+	if manifestSection {
+		buf, err := stripManifestSection(bytes.NewReader(bs), fpath)
+		if err != nil {
+			return errors.ErrInvalidManifestVersion
+		}
+		bs = buf.Bytes()
+	}
+
 	err = toml.Unmarshal(bs, f)
 	if err != nil {
 		return err
@@ -227,6 +252,60 @@ func (f *File) Read(fpath string) error {
 	}
 
 	return nil
+}
+
+// containsManifestSection loads the slice of bytes into a toml tree structure
+// before checking if the manifest_version is defined as a toml section block.
+func containsManifestSection(bs []byte) (bool, error) {
+	tree, err := toml.LoadBytes(bs)
+	if err != nil {
+		return false, err
+	}
+
+	_, ok := tree.GetArray("manifest_version").(*toml.Tree)
+	if ok {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// stripManifestSection reads the manifest line-by-line storing the lines that
+// don't contain `[manifest_version]` into a buffer to be written back to disk.
+//
+// It would've been better if we could of relied on the toml library to delete
+// the section but unfortunately that means it would end up deleting the entire
+// block and not just the key specified. Meaning if the manifest_version key
+// was in the middle of the manifest with other keys below it, deleting the
+// manifest_version would cause all keys below it to be deleted as they would
+// all be considered part of that section block.
+func stripManifestSection(r io.Reader, fpath string) (*bytes.Buffer, error) {
+	var bs []byte
+	buf := bytes.NewBuffer(bs)
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if scanner.Text() != "[manifest_version]" {
+			_, err := buf.Write(scanner.Bytes())
+			if err != nil {
+				return buf, err
+			}
+			_, err = buf.WriteString("\n")
+			if err != nil {
+				return buf, err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return buf, err
+	}
+
+	err := os.WriteFile(fpath, buf.Bytes(), 0666)
+	if err != nil {
+		return buf, err
+	}
+
+	return buf, nil
 }
 
 // Write persists the manifest content to disk.

--- a/pkg/compute/testdata/init/fastly-invalid-section-version.toml
+++ b/pkg/compute/testdata/init/fastly-invalid-section-version.toml
@@ -1,0 +1,5 @@
+name = "Default Rust template"
+description = "Default package template for Rust based edge compute projects."
+[manifest_version]
+authors = ["phamann <patrick@fastly.com>"]
+language = "rust"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -15,3 +15,7 @@ var ErrMissingManifestVersion = RemediationError{Inner: fmt.Errorf("no manifest_
 // ErrUnrecognisedManifestVersion means an invalid manifest (fastly.toml)
 // version has been specified.
 var ErrUnrecognisedManifestVersion = RemediationError{Inner: fmt.Errorf("unrecognised manifest_version found in the fastly.toml"), Remediation: BugRemediation}
+
+// ErrInvalidManifestVersion means the manifest_version is defined as a toml
+// section.
+var ErrInvalidManifestVersion = RemediationError{Inner: fmt.Errorf("failed to parse fastly.toml when checking if manifest_version was valid"), Remediation: "Delete `[manifest_version]` from the fastly.toml if present"}


### PR DESCRIPTION
## Problem

There was a report by someone at Fastly earlier in the week regarding an issue with the `0.25.0` CLI release. The issue was caused by an existing compute project they had which used a fastly.toml without a `manifest_version` set.

Ultimately the end result was that the `manifest_version` field was being stored in the fastly.toml as a 'section', e.g. `[manifest_version]` which completely changes the interpretation of the toml file and would cause the toml parser to error when encountering it.

Removing `[manifest_version]` before running `compute build` fixed the issue because the fixes in `0.26.0` meant we would persist the correct `manifest_version` value back to the manifest file, but this is still confusing behaviour for any users who might have stumble into this.

## Solution

Before we attempt to unmarshal the toml data we first need to identify if the manifest contains a `manifest_version` as a 'section'.

Once we've identified if it is set as a section (e.g. `[manifest_version]`), we can then proceed to remove it from the file.

## Notes

I had initially hoped to have used the toml parsing library to support the deletion of the `[manifest_version]` section (e.g. delete the section and then use the existing Write() method to overwrite the manifest file) but unfortunately because I can't guarantee the location of the manifest_version field within the manifest file it could mean we accidentally end up deleting a larger chunk of the configuration.

For example...

```
authors = ["integralist@fastly.com"]
description = "..."
language = "rust"
[manifest_version]
name = "..."
service_id = "..."
```

Using the toml parser to delete the `[manifest_version]` would cause `name` and `service_id` to also be deleted as they are mistakenly interpreted as being _within_ that same section block.

This means I have to take a different approach, which is to read the manifest line by line and to remove the `[manifest_version]` that way.