### PR TITLE
Set GOVERSION for goreleaser.

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -15,6 +15,9 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.16.x'
+    - name: Set GOVERSION
+      id: set_goversion
+      run: echo "GOVERSION=$(go version)" >> $GITHUB_ENV
     - name: Install Ruby
       uses: actions/setup-ruby@v1
       with:


### PR DESCRIPTION
**Problem**: noticed the golang version used to build the released binary was not being included in the `fastly version` output.
**Notes**: see [GitHub Actions documentation](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable) for details.