### PR TITLE
Extra error handling around loading remote configuration data.

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -78,7 +78,7 @@ func main() {
 		}
 	}
 
-	// We currently have seen a situation where loading data from the remote
+	// We have seen a situation where loading data from the remote
 	// config endpoint has caused a user to end up with a config in the
 	// non-legacy format but with empty values.
 	//

--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -78,6 +78,36 @@ func main() {
 		}
 	}
 
+	// We currently have seen a situation where loading data from the remote
+	// config endpoint has caused a user to end up with a config in the
+	// non-legacy format but with empty values.
+	//
+	// It's unclear how this happens and so as a temporary measure we'll check if
+	// the in-memory data structure is missing a specific value that's set by the
+	// CLI, and if so we'll know something bad has happened because at this point
+	// we expect the data structure to have a non-empty string value.
+	//
+	// If we discover we're in that scenario we'll attempt to re-load the
+	// configuration from the remote endpoint.
+	if file.CLI.LastChecked == "" {
+		if verboseOutput {
+			text.Warning(out, `
+				There was a problem loading the compatibility and versioning information for the Fastly CLI.
+				The operation will be retried as this configuration is required.
+			`)
+			text.Break(out)
+		}
+
+		err := file.Load(config.RemoteEndpoint, httpClient)
+		if err != nil {
+			errors.RemediationError{
+				Inner:       err,
+				Remediation: errors.NetworkRemediation,
+			}.Print(os.Stderr)
+			os.Exit(1)
+		}
+	}
+
 	// When the local configuration file is stale we'll need to acquire the
 	// latest version and write that back to disk. To ensure the CLI program
 	// doesn't complete before the write has finished, we block via a channel.

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -11,7 +11,9 @@ import (
 func Stale(lastVersionCheck string, dur string) bool {
 	d, err := time.ParseDuration("-" + dur)
 	if err != nil {
-		return false
+		// if there' is no duration provided, then we should presume the loading of
+		// remote configuration failed and that we should retry that operation.
+		return true
 	}
 
 	if t, _ := time.Parse(time.RFC3339, lastVersionCheck); !t.Before(time.Now().Add(d)) {

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -11,7 +11,7 @@ import (
 func Stale(lastVersionCheck string, dur string) bool {
 	d, err := time.ParseDuration("-" + dur)
 	if err != nil {
-		// if there' is no duration provided, then we should presume the loading of
+		// if there is no duration provided, then we should presume the loading of
 		// remote configuration failed and that we should retry that operation.
 		return true
 	}

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -236,7 +236,7 @@ func (f *File) Load(configEndpoint string, httpClient api.HTTPClient) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.New("non-200 OK response")
+		return fmt.Errorf("remote config: expected '200 OK', received '%s'", resp.Status)
 	}
 
 	err = toml.NewDecoder(resp.Body).Decode(f)

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -235,6 +235,10 @@ func (f *File) Load(configEndpoint string, httpClient api.HTTPClient) error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("non-200 OK response")
+	}
+
 	err = toml.NewDecoder(resp.Body).Decode(f)
 	if err != nil {
 		return err

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -236,7 +236,7 @@ func (f *File) Load(configEndpoint string, httpClient api.HTTPClient) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("remote config: expected '200 OK', received '%s'", resp.Status)
+		return fmt.Errorf("fetching remote configuration: expected '200 OK', received '%s'", resp.Status)
 	}
 
 	err = toml.NewDecoder(resp.Body).Decode(f)

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -115,10 +115,12 @@ func TestCheckAsync(t *testing.T) {
 			file: config.File{
 				CLI: config.CLI{
 					LastChecked: time.Now().Add(-4 * time.Hour).Format(time.RFC3339),
+					TTL:         "5m",
 				},
 			},
 			currentVersion: "0.0.1",
 			versioner:      mock.Versioner{Version: "0.0.2"},
+			wantOutput:     "\nA new version of the Fastly CLI is available.\nCurrent version: 0.0.1\nLatest version: 0.0.2\nRun `fastly update` to get the latest version.\n\n",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {


### PR DESCRIPTION
**Problem**: we received a couple of reports that configuration data was missing and causing subsequently CLI flows to fail.
**Solution**: add extra error handling checks and retry specific operations.
**Notes**: Patrick and I ran through the code and were unable to pin-point an obvious source of the error and so we've made some 'best effort' modifications to hopefully help mitigate the problem.