### PR TITLE
Avoid setting fields that cause API to fail when given zero value.

### DIFF
--- a/pkg/backend/update.go
+++ b/pkg/backend/update.go
@@ -88,31 +88,55 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 
 	// Copy existing values from GET to UpdateBackendInput strcuture
 	input := &fastly.UpdateBackendInput{
-		ServiceID:           b.ServiceID,
-		ServiceVersion:      b.ServiceVersion,
-		Name:                b.Name,
-		NewName:             fastly.String(b.Name),
-		Address:             fastly.String(b.Address),
-		Port:                fastly.Uint(b.Port),
-		OverrideHost:        fastly.String(b.OverrideHost),
-		ConnectTimeout:      fastly.Uint(b.ConnectTimeout),
-		MaxConn:             fastly.Uint(b.MaxConn),
-		FirstByteTimeout:    fastly.Uint(b.FirstByteTimeout),
-		BetweenBytesTimeout: fastly.Uint(b.BetweenBytesTimeout),
-		AutoLoadbalance:     fastly.CBool(b.AutoLoadbalance),
-		Weight:              fastly.Uint(b.Weight),
-		RequestCondition:    fastly.String(b.RequestCondition),
-		HealthCheck:         fastly.String(b.HealthCheck),
-		Shield:              fastly.String(b.Shield),
-		UseSSL:              fastly.CBool(b.UseSSL),
-		SSLCheckCert:        fastly.CBool(b.SSLCheckCert),
-		SSLCertHostname:     fastly.String(b.SSLCertHostname),
-		SSLSNIHostname:      fastly.String(b.SSLSNIHostname),
-		SSLCiphers:          b.SSLCiphers,
+		ServiceID:      b.ServiceID,
+		ServiceVersion: b.ServiceVersion,
+		Name:           b.Name,
+		NewName:        fastly.String(b.Name),
 	}
 
-	// Avoid setting certain fields that prove to cause the API to fail when
-	// provided with zero values.
+	// Avoid setting fields unless they have a value to set.
+	if b.AutoLoadbalance {
+		input.AutoLoadbalance = fastly.CBool(b.AutoLoadbalance)
+	}
+	if b.UseSSL {
+		input.UseSSL = fastly.CBool(b.UseSSL)
+	}
+	if b.SSLCheckCert {
+		input.SSLCheckCert = fastly.CBool(b.SSLCheckCert)
+	}
+	if b.Address != "" {
+		input.Address = fastly.String(b.Address)
+	}
+	if b.Port != 0 {
+		input.Port = fastly.Uint(b.Port)
+	}
+	if b.OverrideHost != "" {
+		input.OverrideHost = fastly.String(b.OverrideHost)
+	}
+	if b.ConnectTimeout != 0 {
+		input.ConnectTimeout = fastly.Uint(b.ConnectTimeout)
+	}
+	if b.MaxConn != 0 {
+		input.MaxConn = fastly.Uint(b.MaxConn)
+	}
+	if b.FirstByteTimeout != 0 {
+		input.FirstByteTimeout = fastly.Uint(b.FirstByteTimeout)
+	}
+	if b.BetweenBytesTimeout != 0 {
+		input.BetweenBytesTimeout = fastly.Uint(b.BetweenBytesTimeout)
+	}
+	if b.Weight != 0 {
+		input.Weight = fastly.Uint(b.Weight)
+	}
+	if b.RequestCondition != "" {
+		input.RequestCondition = fastly.String(b.RequestCondition)
+	}
+	if b.HealthCheck != "" {
+		input.HealthCheck = fastly.String(b.HealthCheck)
+	}
+	if b.Shield != "" {
+		input.Shield = fastly.String(b.Shield)
+	}
 	if b.MinTLSVersion != "" {
 		input.MinTLSVersion = fastly.String(b.MinTLSVersion)
 	}
@@ -127,6 +151,15 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 	if b.SSLClientKey != "" {
 		input.SSLClientKey = fastly.String(b.SSLClientKey)
+	}
+	if b.SSLCertHostname != "" {
+		input.SSLCertHostname = fastly.String(b.SSLCertHostname)
+	}
+	if b.SSLSNIHostname != "" {
+		input.SSLSNIHostname = fastly.String(b.SSLSNIHostname)
+	}
+	if len(b.SSLCiphers) > 0 {
+		input.SSLCiphers = b.SSLCiphers
 	}
 
 	// Set values to existing ones to prevent accidental overwrite if empty.

--- a/pkg/backend/update.go
+++ b/pkg/backend/update.go
@@ -106,14 +106,27 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		Shield:              fastly.String(b.Shield),
 		UseSSL:              fastly.CBool(b.UseSSL),
 		SSLCheckCert:        fastly.CBool(b.SSLCheckCert),
-		SSLCACert:           fastly.String(b.SSLCACert),
-		SSLClientCert:       fastly.String(b.SSLClientCert),
-		SSLClientKey:        fastly.String(b.SSLClientKey),
 		SSLCertHostname:     fastly.String(b.SSLCertHostname),
 		SSLSNIHostname:      fastly.String(b.SSLSNIHostname),
-		MinTLSVersion:       fastly.String(b.MinTLSVersion),
-		MaxTLSVersion:       fastly.String(b.MaxTLSVersion),
 		SSLCiphers:          b.SSLCiphers,
+	}
+
+	// Avoid setting certain fields that prove to cause the API to fail when
+	// provided with zero values.
+	if b.MinTLSVersion != "" {
+		input.MinTLSVersion = fastly.String(b.MinTLSVersion)
+	}
+	if b.MaxTLSVersion != "" {
+		input.MaxTLSVersion = fastly.String(b.MaxTLSVersion)
+	}
+	if b.SSLCACert != "" {
+		input.SSLCACert = fastly.String(b.SSLCACert)
+	}
+	if b.SSLClientCert != "" {
+		input.SSLClientCert = fastly.String(b.SSLClientCert)
+	}
+	if b.SSLClientKey != "" {
+		input.SSLClientKey = fastly.String(b.SSLClientKey)
 	}
 
 	// Set values to existing ones to prevent accidental overwrite if empty.

--- a/pkg/backend/update.go
+++ b/pkg/backend/update.go
@@ -86,83 +86,12 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	// Copy existing values from GET to UpdateBackendInput strcuture
 	input := &fastly.UpdateBackendInput{
 		ServiceID:      b.ServiceID,
 		ServiceVersion: b.ServiceVersion,
 		Name:           b.Name,
-		NewName:        fastly.String(b.Name),
 	}
 
-	// Avoid setting fields unless they have a value to set.
-	if b.AutoLoadbalance {
-		input.AutoLoadbalance = fastly.CBool(b.AutoLoadbalance)
-	}
-	if b.UseSSL {
-		input.UseSSL = fastly.CBool(b.UseSSL)
-	}
-	if b.SSLCheckCert {
-		input.SSLCheckCert = fastly.CBool(b.SSLCheckCert)
-	}
-	if b.Address != "" {
-		input.Address = fastly.String(b.Address)
-	}
-	if b.Port != 0 {
-		input.Port = fastly.Uint(b.Port)
-	}
-	if b.OverrideHost != "" {
-		input.OverrideHost = fastly.String(b.OverrideHost)
-	}
-	if b.ConnectTimeout != 0 {
-		input.ConnectTimeout = fastly.Uint(b.ConnectTimeout)
-	}
-	if b.MaxConn != 0 {
-		input.MaxConn = fastly.Uint(b.MaxConn)
-	}
-	if b.FirstByteTimeout != 0 {
-		input.FirstByteTimeout = fastly.Uint(b.FirstByteTimeout)
-	}
-	if b.BetweenBytesTimeout != 0 {
-		input.BetweenBytesTimeout = fastly.Uint(b.BetweenBytesTimeout)
-	}
-	if b.Weight != 0 {
-		input.Weight = fastly.Uint(b.Weight)
-	}
-	if b.RequestCondition != "" {
-		input.RequestCondition = fastly.String(b.RequestCondition)
-	}
-	if b.HealthCheck != "" {
-		input.HealthCheck = fastly.String(b.HealthCheck)
-	}
-	if b.Shield != "" {
-		input.Shield = fastly.String(b.Shield)
-	}
-	if b.MinTLSVersion != "" {
-		input.MinTLSVersion = fastly.String(b.MinTLSVersion)
-	}
-	if b.MaxTLSVersion != "" {
-		input.MaxTLSVersion = fastly.String(b.MaxTLSVersion)
-	}
-	if b.SSLCACert != "" {
-		input.SSLCACert = fastly.String(b.SSLCACert)
-	}
-	if b.SSLClientCert != "" {
-		input.SSLClientCert = fastly.String(b.SSLClientCert)
-	}
-	if b.SSLClientKey != "" {
-		input.SSLClientKey = fastly.String(b.SSLClientKey)
-	}
-	if b.SSLCertHostname != "" {
-		input.SSLCertHostname = fastly.String(b.SSLCertHostname)
-	}
-	if b.SSLSNIHostname != "" {
-		input.SSLSNIHostname = fastly.String(b.SSLSNIHostname)
-	}
-	if len(b.SSLCiphers) > 0 {
-		input.SSLCiphers = b.SSLCiphers
-	}
-
-	// Set values to existing ones to prevent accidental overwrite if empty.
 	if c.NewName.WasSet {
 		input.NewName = fastly.String(c.NewName.Value)
 	}


### PR DESCRIPTION
**Problem**: The CLI was getting the backend and blanket assigning the response field values into a struct to be used to make an update to the backend. This was a problem because the zero value for some fields were being set in the update struct, which causes the API itself to fail because the zero values are invalid for the field.