### PR TITLE
Default to port 443 if UseSSL set.

### DIFF
--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -41,7 +41,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			args:       []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com", "--use-ssl", "--verbose"},
 			api:        mock.API{CreateBackendFn: createBackendOK},
-			wantOutput: "SSL to the backend was set but no port was specified, so default port :443 will be used",
+			wantOutput: "Use-ssl was set but no port was specified, so default port 443 will be used",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -38,6 +38,11 @@ func TestBackendCreate(t *testing.T) {
 			api:        mock.API{CreateBackendFn: createBackendOK},
 			wantOutput: "Created backend www.test.com (service 123 version 1)",
 		},
+		{
+			args:       []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com", "--use-ssl", "--verbose"},
+			api:        mock.API{CreateBackendFn: createBackendOK},
+			wantOutput: "SSL to the backend was set but no port was specified, so default port :443 will be used",
+		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var (

--- a/pkg/backend/create.go
+++ b/pkg/backend/create.go
@@ -14,7 +14,7 @@ type CreateCommand struct {
 	common.Base
 	Input fastly.CreateBackendInput
 
-	// We must store all of the boolean flags seperatly to the input structure
+	// We must store all of the boolean flags separately to the input structure
 	// so they can be casted to go-fastly's custom `Compatibool` type later.
 	AutoLoadbalance bool
 	UseSSL          bool
@@ -66,6 +66,13 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 	c.Input.AutoLoadbalance = fastly.Compatibool(c.AutoLoadbalance)
 	c.Input.UseSSL = fastly.Compatibool(c.UseSSL)
 	c.Input.SSLCheckCert = fastly.Compatibool(c.SSLCheckCert)
+
+	if c.UseSSL && c.Input.Port == 0 {
+		if c.Globals.Flag.Verbose {
+			text.Warning(out, "SSL to the backend was set but no port was specified, so default port :443 will be used")
+			c.Input.Port = 443
+		}
+	}
 
 	b, err := c.Globals.Client.CreateBackend(&c.Input)
 	if err != nil {

--- a/pkg/backend/create.go
+++ b/pkg/backend/create.go
@@ -69,7 +69,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 
 	if c.UseSSL && c.Input.Port == 0 {
 		if c.Globals.Flag.Verbose {
-			text.Warning(out, "SSL to the backend was set but no port was specified, so default port :443 will be used")
+			text.Warning(out, "Use-ssl was set but no port was specified, so default port 443 will be used")
 			c.Input.Port = 443
 		}
 	}


### PR DESCRIPTION
**Problem**: if `--use-ssl` flag is provided but no port is set, then we should default to port 443 and also warn the user about this behaviour if the `--verbose` flag is provided.

**Notes**: you can't set a port number as part of the `address` field (e.g. `127.0.0.1:443`) as the API considers that invalid...

```bash
$ curl -s -H "Accept:application/vnd.api+json" -H "Fastly-Key: $FASTLY_API_KEY" -X PUT -d "address=127.0.0.1:443" https://api.fastly.com/service/4nE2aoohVrsds0OZGpSIP8/version/1/backend/httpbin | jq

{              
  "errors": [   
    {                     
      "detail": "Address 'address' is not a valid IPv4, IPv6 or hostname",
      "title": "Bad request"
    }                                                                                                                                                                                                                                         
  ]            
}   
```