### PR TITLE
Make GitHub Versioner configurable.

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -33,7 +33,7 @@ func main() {
 		configFilePath           = config.FilePath // write-only for `fastly configure`
 		clientFactory            = app.FastlyAPIClient
 		httpClient               = http.DefaultClient
-		cliVersioner             = update.NewGitHub(context.Background(), "fastly", "cli")
+		cliVersioner             = update.NewGitHub(context.Background(), "fastly", "cli", "fastly")
 		in             io.Reader = os.Stdin
 		out            io.Writer = common.NewSyncWriter(os.Stdout)
 	)

--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -33,7 +33,7 @@ func main() {
 		configFilePath           = config.FilePath // write-only for `fastly configure`
 		clientFactory            = app.FastlyAPIClient
 		httpClient               = http.DefaultClient
-		versioner                = update.NewGitHub(context.Background())
+		cliVersioner             = update.NewGitHub(context.Background(), "fastly", "cli")
 		in             io.Reader = os.Stdin
 		out            io.Writer = common.NewSyncWriter(os.Stdout)
 	)
@@ -142,7 +142,7 @@ Compatibility and versioning information for the Fastly CLI is being updated in 
 	}
 
 	// Main is basically just a shim to call Run, so we do that here.
-	if err := app.Run(args, env, file, configFilePath, clientFactory, httpClient, versioner, in, out); err != nil {
+	if err := app.Run(args, env, file, configFilePath, clientFactory, httpClient, cliVersioner, in, out); err != nil {
 		errors.Deduce(err).Print(os.Stderr)
 
 		// NOTE: if we have an error processing the command, then we should be sure

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -73,7 +73,7 @@ var (
 // The Run helper should NOT output any error-related information to the out
 // io.Writer. All error-related information should be encoded into an error type
 // and returned to the caller. This includes usage text.
-func Run(args []string, env config.Environment, file config.File, configFilePath string, cf APIClientFactory, httpClient api.HTTPClient, versioner update.Versioner, in io.Reader, out io.Writer) error {
+func Run(args []string, env config.Environment, file config.File, configFilePath string, cf APIClientFactory, httpClient api.HTTPClient, cliVersioner update.Versioner, in io.Reader, out io.Writer) error {
 	// The globals will hold generally-applicable configuration parameters
 	// from a variety of sources, and is provided to each concrete command.
 	globals := config.Data{
@@ -115,7 +115,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	configureRoot := configure.NewRootCommand(app, configFilePath, configure.APIClientFactory(cf), &globals)
 	whoamiRoot := whoami.NewRootCommand(app, httpClient, &globals)
 	versionRoot := version.NewRootCommand(app)
-	updateRoot := update.NewRootCommand(app, versioner, httpClient)
+	updateRoot := update.NewRootCommand(app, cliVersioner, httpClient)
 
 	serviceRoot := service.NewRootCommand(app, &globals)
 	serviceCreate := service.NewCreateCommand(serviceRoot.CmdClause, &globals)
@@ -725,10 +725,10 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		return errors.RemediationError{Prefix: usage, Inner: fmt.Errorf("command not found")}
 	}
 
-	if versioner != nil && name != "update" && !version.IsPreRelease(revision.AppVersion) {
+	if cliVersioner != nil && name != "update" && !version.IsPreRelease(revision.AppVersion) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel() // push cancel on the defer stack first...
-		f := update.CheckAsync(ctx, file, configFilePath, revision.AppVersion, versioner)
+		f := update.CheckAsync(ctx, file, configFilePath, revision.AppVersion, cliVersioner)
 		defer f(out) // ...and the printing function second, so we hit the timeout
 	}
 

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -56,12 +56,12 @@ func TestApplication(t *testing.T) {
 				configFilePath                  = "/dev/null"
 				clientFactory                   = mock.APIClient(mock.API{})
 				httpClient     api.HTTPClient   = nil
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				stdin          io.Reader        = nil
 				stdout         bytes.Buffer
 				stderr         bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFilePath, clientFactory, httpClient, versioner, stdin, &stdout)
+			err := app.Run(args, env, file, configFilePath, clientFactory, httpClient, cliVersioner, stdin, &stdout)
 			if err != nil {
 				errors.Deduce(err).Print(&stderr)
 			}

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -52,11 +52,11 @@ func TestBackendCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -109,11 +109,11 @@ func TestBackendList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -151,11 +151,11 @@ func TestBackendDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -207,11 +207,11 @@ func TestBackendUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -249,11 +249,11 @@ func TestBackendDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -499,12 +499,12 @@ func TestInit(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = bytes.NewBufferString(testcase.stdin)
 				buf           bytes.Buffer
 				out           io.Writer = common.NewSyncWriter(&buf)
 			)
-			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, out)
+			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			for _, file := range testcase.wantFiles {
 				if _, err := os.Stat(filepath.Join(rootdir, file)); err != nil {
@@ -791,12 +791,12 @@ func TestBuildRust(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(mock.API{})
 				httpClient                     = testcase.client
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				buf           bytes.Buffer
 				out           io.Writer = common.NewSyncWriter(&buf)
 			)
-			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, out)
+			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertRemediationErrorContains(t, err, testcase.wantRemediationError)
 			if testcase.wantOutputContains != "" {
@@ -888,12 +888,12 @@ func TestBuildAssemblyScript(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(mock.API{})
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				buf           bytes.Buffer
 				out           io.Writer = common.NewSyncWriter(&buf)
 			)
-			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, out)
+			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertRemediationErrorContains(t, err, testcase.wantRemediationError)
 			if testcase.wantOutputContains != "" {
@@ -1156,12 +1156,12 @@ func TestDeploy(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				buf           bytes.Buffer
 				out           io.Writer = common.NewSyncWriter(&buf)
 			)
-			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, out)
+			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			for _, s := range testcase.wantOutput {
 				testutil.AssertStringContains(t, buf.String(), s)
@@ -1239,12 +1239,12 @@ func TestUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				buf           bytes.Buffer
 				out           io.Writer = common.NewSyncWriter(&buf)
 			)
-			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, out)
+			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			for _, s := range testcase.wantOutput {
 				testutil.AssertStringContains(t, buf.String(), s)
@@ -1295,12 +1295,12 @@ func TestValidate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(mock.API{})
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				buf           bytes.Buffer
 				out           io.Writer = common.NewSyncWriter(&buf)
 			)
-			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, out)
+			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, buf.String(), testcase.wantOutput)
 		})

--- a/pkg/configure/configure_test.go
+++ b/pkg/configure/configure_test.go
@@ -323,11 +323,11 @@ func TestConfigure(t *testing.T) {
 				file                           = testcase.file
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = strings.NewReader(testcase.stdin)
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFilePath, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFilePath, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			for _, s := range testcase.wantOutput {
 				testutil.AssertStringContains(t, out.String(), s)

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -47,11 +47,11 @@ func TestDomainCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -104,11 +104,11 @@ func TestDomainList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -146,11 +146,11 @@ func TestDomainDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -193,11 +193,11 @@ func TestDomainUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -235,11 +235,11 @@ func TestDomainDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/edgedictionary/edgedictionary_test.go
+++ b/pkg/edgedictionary/edgedictionary_test.go
@@ -56,11 +56,11 @@ func TestDictionaryDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -106,11 +106,11 @@ func TestDictionaryCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})

--- a/pkg/edgedictionaryitem/edgedictionaryitem_test.go
+++ b/pkg/edgedictionaryitem/edgedictionaryitem_test.go
@@ -53,11 +53,11 @@ func TestDictionaryItemDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -90,11 +90,11 @@ func TestDictionaryItemsList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -132,11 +132,11 @@ func TestDictionaryItemCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -174,11 +174,11 @@ func TestDictionaryItemUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -216,11 +216,11 @@ func TestDictionaryItemDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -291,11 +291,11 @@ func TestDictionaryItemBatchModify(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -47,11 +47,11 @@ func TestHealthCheckCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -104,11 +104,11 @@ func TestHealthCheckList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -146,11 +146,11 @@ func TestHealthCheckDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -192,11 +192,11 @@ func TestHealthCheckUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -234,11 +234,11 @@ func TestHealthCheckDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -54,11 +54,11 @@ func TestBlobStorageCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -111,11 +111,11 @@ func TestBlobStorageList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -152,11 +152,11 @@ func TestBlobStorageDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -193,11 +193,11 @@ func TestBlobStorageUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -234,11 +234,11 @@ func TestBlobStorageDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/logging/bigquery/bigquery_integration_test.go
@@ -47,11 +47,11 @@ func TestBigQueryCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -104,11 +104,11 @@ func TestBigQueryList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -146,11 +146,11 @@ func TestBigQueryDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -188,11 +188,11 @@ func TestBigQueryUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -230,11 +230,11 @@ func TestBigQueryDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -54,11 +54,11 @@ func TestCloudfilesCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -111,11 +111,11 @@ func TestCloudfilesList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -152,11 +152,11 @@ func TestCloudfilesDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -193,11 +193,11 @@ func TestCloudfilesUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -234,11 +234,11 @@ func TestCloudfilesDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/datadog/datadog_integration_test.go
+++ b/pkg/logging/datadog/datadog_integration_test.go
@@ -46,11 +46,11 @@ func TestDatadogCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestDatadogList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestDatadogDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestDatadogUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestDatadogDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/logging/digitalocean/digitalocean_integration_test.go
@@ -54,11 +54,11 @@ func TestDigitalOceanCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -111,11 +111,11 @@ func TestDigitalOceanList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -152,11 +152,11 @@ func TestDigitalOceanDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -193,11 +193,11 @@ func TestDigitalOceanUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -234,11 +234,11 @@ func TestDigitalOceanDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_integration_test.go
@@ -50,11 +50,11 @@ func TestElasticsearchCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -107,11 +107,11 @@ func TestElasticsearchList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -148,11 +148,11 @@ func TestElasticsearchDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -189,11 +189,11 @@ func TestElasticsearchUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -230,11 +230,11 @@ func TestElasticsearchDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -54,11 +54,11 @@ func TestFTPCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -111,11 +111,11 @@ func TestFTPList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -152,11 +152,11 @@ func TestFTPDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -193,11 +193,11 @@ func TestFTPUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -234,11 +234,11 @@ func TestFTPDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -54,11 +54,11 @@ func TestGCSCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -111,11 +111,11 @@ func TestGCSList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -152,11 +152,11 @@ func TestGCSDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -193,11 +193,11 @@ func TestGCSUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -234,11 +234,11 @@ func TestGCSDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_integration_test.go
@@ -58,11 +58,11 @@ func TestGooglePubSubCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -115,11 +115,11 @@ func TestGooglePubSubList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -156,11 +156,11 @@ func TestGooglePubSubDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -197,11 +197,11 @@ func TestGooglePubSubUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -238,11 +238,11 @@ func TestGooglePubSubDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/heroku/heroku_integration_test.go
+++ b/pkg/logging/heroku/heroku_integration_test.go
@@ -50,11 +50,11 @@ func TestHerokuCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -107,11 +107,11 @@ func TestHerokuList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -148,11 +148,11 @@ func TestHerokuDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -189,11 +189,11 @@ func TestHerokuUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -230,11 +230,11 @@ func TestHerokuDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/logging/honeycomb/honeycomb_integration_test.go
@@ -50,11 +50,11 @@ func TestHoneycombCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -107,11 +107,11 @@ func TestHoneycombList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -148,11 +148,11 @@ func TestHoneycombDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -189,11 +189,11 @@ func TestHoneycombUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -230,11 +230,11 @@ func TestHoneycombDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/https/https_integration_test.go
+++ b/pkg/logging/https/https_integration_test.go
@@ -46,11 +46,11 @@ func TestHTTPSCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestHTTPSList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestHTTPSDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestHTTPSUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestHTTPSDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/kafka/kafka_integration_test.go
+++ b/pkg/logging/kafka/kafka_integration_test.go
@@ -50,11 +50,11 @@ func TestKafkaCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -107,11 +107,11 @@ func TestKafkaList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -148,11 +148,11 @@ func TestKafkaDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -194,11 +194,11 @@ func TestKafkaUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -235,11 +235,11 @@ func TestKafkaDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -46,11 +46,11 @@ func TestKinesisCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestKinesisList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestKinesisDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestKinesisUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestKinesisDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/logentries/logentries_integration_test.go
+++ b/pkg/logging/logentries/logentries_integration_test.go
@@ -42,11 +42,11 @@ func TestLogentriesCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -99,11 +99,11 @@ func TestLogentriesList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -140,11 +140,11 @@ func TestLogentriesDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -181,11 +181,11 @@ func TestLogentriesUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -222,11 +222,11 @@ func TestLogentriesDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/loggly/loggly_integration_test.go
+++ b/pkg/logging/loggly/loggly_integration_test.go
@@ -46,11 +46,11 @@ func TestLogglyCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestLogglyList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestLogglyDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestLogglyUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestLogglyDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/logging/logshuttle/logshuttle_integration_test.go
@@ -50,11 +50,11 @@ func TestLogshuttleCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -107,11 +107,11 @@ func TestLogshuttleList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -148,11 +148,11 @@ func TestLogshuttleDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -189,11 +189,11 @@ func TestLogshuttleUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -230,11 +230,11 @@ func TestLogshuttleDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/openstack/openstack_integration_test.go
+++ b/pkg/logging/openstack/openstack_integration_test.go
@@ -58,11 +58,11 @@ func TestOpenstackCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -115,11 +115,11 @@ func TestOpenstackList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -156,11 +156,11 @@ func TestOpenstackDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -197,11 +197,11 @@ func TestOpenstackUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -238,11 +238,11 @@ func TestOpenstackDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/logging/papertrail/papertrail_integration_test.go
@@ -46,11 +46,11 @@ func TestPapertrailCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestPapertrailList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestPapertrailDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestPapertrailUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestPapertrailDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -46,11 +46,11 @@ func TestS3Create(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestS3List(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestS3Describe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestS3Update(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestS3Delete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -55,11 +55,11 @@ func TestScalyrCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -112,11 +112,11 @@ func TestScalyrList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -153,11 +153,11 @@ func TestScalyrDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -194,11 +194,11 @@ func TestScalyrUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -235,11 +235,11 @@ func TestScalyrDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -54,11 +54,11 @@ func TestSFTPCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -111,11 +111,11 @@ func TestSFTPList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -152,11 +152,11 @@ func TestSFTPDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -193,11 +193,11 @@ func TestSFTPUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -234,11 +234,11 @@ func TestSFTPDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/splunk/splunk_integration_test.go
+++ b/pkg/logging/splunk/splunk_integration_test.go
@@ -46,11 +46,11 @@ func TestSplunkCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestSplunkList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestSplunkDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestSplunkUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestSplunkDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/logging/sumologic/sumologic_integration_test.go
@@ -46,11 +46,11 @@ func TestSumologicCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestSumologicList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestSumologicDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestSumologicUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestSumologicDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/logging/syslog/syslog_integration_test.go
+++ b/pkg/logging/syslog/syslog_integration_test.go
@@ -46,11 +46,11 @@ func TestSyslogCreate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -103,11 +103,11 @@ func TestSyslogList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -144,11 +144,11 @@ func TestSyslogDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -185,11 +185,11 @@ func TestSyslogUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -226,11 +226,11 @@ func TestSyslogDelete(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -67,11 +67,11 @@ func TestServiceCreate(t *testing.T) {
 				configFileName                  = "/dev/null"
 				clientFactory                   = mock.APIClient(testcase.api)
 				httpClient                      = http.DefaultClient
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				in             io.Reader        = nil
 				out            bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -124,11 +124,11 @@ func TestServiceList(t *testing.T) {
 				configFileName                  = "/dev/null"
 				clientFactory                   = mock.APIClient(testcase.api)
 				httpClient                      = http.DefaultClient
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				in             io.Reader        = nil
 				out            bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -186,11 +186,11 @@ func TestServiceDescribe(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -228,11 +228,11 @@ func TestServiceSearch(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -298,11 +298,11 @@ func TestServiceUpdate(t *testing.T) {
 				configFileName                  = "/dev/null"
 				clientFactory                   = mock.APIClient(testcase.api)
 				httpClient                      = http.DefaultClient
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				in             io.Reader        = nil
 				out            bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -345,11 +345,11 @@ func TestServiceDelete(t *testing.T) {
 				configFileName                  = "/dev/null"
 				clientFactory                   = mock.APIClient(testcase.api)
 				httpClient                      = http.DefaultClient
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				in             io.Reader        = nil
 				out            bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/serviceversion/serviceversion_test.go
+++ b/pkg/serviceversion/serviceversion_test.go
@@ -52,11 +52,11 @@ func TestVersionClone(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -109,11 +109,11 @@ func TestVersionList(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, out.String())
 		})
@@ -151,11 +151,11 @@ func TestVersionUpdate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -193,11 +193,11 @@ func TestVersionActivate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -235,11 +235,11 @@ func TestVersionDeactivate(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})
@@ -277,11 +277,11 @@ func TestVersionLock(t *testing.T) {
 				appConfigFile                  = "/dev/null"
 				clientFactory                  = mock.APIClient(testcase.api)
 				httpClient                     = http.DefaultClient
-				versioner     update.Versioner = nil
+				cliVersioner  update.Versioner = nil
 				in            io.Reader        = nil
 				out           bytes.Buffer
 			)
-			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/stats/historical_test.go
+++ b/pkg/stats/historical_test.go
@@ -47,11 +47,11 @@ func TestHistorical(t *testing.T) {
 				configFileName                  = "/dev/null"
 				clientFactory                   = mock.APIClient(testcase.api)
 				httpClient                      = http.DefaultClient
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				in             io.Reader        = nil
 				out            bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/stats/regions_test.go
+++ b/pkg/stats/regions_test.go
@@ -42,11 +42,11 @@ func TestRegions(t *testing.T) {
 				configFileName                  = "/dev/null"
 				clientFactory                   = mock.APIClient(testcase.api)
 				httpClient                      = http.DefaultClient
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				in             io.Reader        = nil
 				out            bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -91,13 +91,13 @@ func TestCheckAsync(t *testing.T) {
 		name           string
 		file           config.File
 		currentVersion string
-		versioner      update.Versioner
+		cliVersioner   update.Versioner
 		wantOutput     string
 	}{
 		{
 			name:           "no last_check same version",
 			currentVersion: "0.0.1",
-			versioner:      mock.Versioner{Version: "0.0.1"},
+			cliVersioner:   mock.Versioner{Version: "0.0.1"},
 		},
 		{
 			name: "no last_check new version",
@@ -107,7 +107,7 @@ func TestCheckAsync(t *testing.T) {
 				},
 			},
 			currentVersion: "0.0.1",
-			versioner:      mock.Versioner{Version: "0.0.2"},
+			cliVersioner:   mock.Versioner{Version: "0.0.2"},
 			wantOutput:     "\nA new version of the Fastly CLI is available.\nCurrent version: 0.0.1\nLatest version: 0.0.2\nRun `fastly update` to get the latest version.\n\n",
 		},
 		{
@@ -119,7 +119,7 @@ func TestCheckAsync(t *testing.T) {
 				},
 			},
 			currentVersion: "0.0.1",
-			versioner:      mock.Versioner{Version: "0.0.2"},
+			cliVersioner:   mock.Versioner{Version: "0.0.2"},
 			wantOutput:     "\nA new version of the Fastly CLI is available.\nCurrent version: 0.0.1\nLatest version: 0.0.2\nRun `fastly update` to get the latest version.\n\n",
 		},
 	} {
@@ -130,7 +130,7 @@ func TestCheckAsync(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
-			f := update.CheckAsync(ctx, testcase.file, configFilePath, testcase.currentVersion, testcase.versioner)
+			f := update.CheckAsync(ctx, testcase.file, configFilePath, testcase.currentVersion, testcase.cliVersioner)
 			var buf bytes.Buffer
 			f(&buf)
 

--- a/pkg/update/root.go
+++ b/pkg/update/root.go
@@ -18,15 +18,15 @@ import (
 // It should be installed under the primary root command.
 type RootCommand struct {
 	common.Base
-	versioner Versioner
-	client    api.HTTPClient
+	cliVersioner Versioner
+	client       api.HTTPClient
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, v Versioner, client api.HTTPClient) *RootCommand {
+func NewRootCommand(parent common.Registerer, cliVersioner Versioner, client api.HTTPClient) *RootCommand {
 	var c RootCommand
 	c.CmdClause = parent.Command("update", "Update the CLI to the latest version")
-	c.versioner = v
+	c.cliVersioner = cliVersioner
 	c.client = client
 	return &c
 }
@@ -35,7 +35,7 @@ func NewRootCommand(parent common.Registerer, v Versioner, client api.HTTPClient
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	progress := text.NewQuietProgress(out)
 
-	current, latest, shouldUpdate, err := Check(context.Background(), revision.AppVersion, c.versioner)
+	current, latest, shouldUpdate, err := Check(context.Background(), revision.AppVersion, c.cliVersioner)
 	if err != nil {
 		return fmt.Errorf("error checking for latest version: %w", err)
 	}
@@ -48,7 +48,7 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	progress.Step("Fetching latest release...")
-	latestPath, err := c.versioner.Download(context.Background(), latest)
+	latestPath, err := c.cliVersioner.Download(context.Background(), latest)
 	if err != nil {
 		progress.Fail()
 		return fmt.Errorf("error downloading latest release: %w", err)

--- a/pkg/update/versioner.go
+++ b/pkg/update/versioner.go
@@ -25,21 +25,25 @@ type Versioner interface {
 // GitHub is a versioner that uses GitHub releases.
 type GitHub struct {
 	client *github.Client
+	org    string
+	repo   string
 }
 
 // NewGitHub returns a usable GitHub versioner utilizing the provided token.
-func NewGitHub(ctx context.Context) *GitHub {
+func NewGitHub(ctx context.Context, org string, repo string) *GitHub {
 	var (
 		githubClient = github.NewClient(nil)
 	)
 	return &GitHub{
 		client: githubClient,
+		org:    org,
+		repo:   repo,
 	}
 }
 
 // LatestVersion implements the Versioner interface.
 func (g GitHub) LatestVersion(ctx context.Context) (semver.Version, error) {
-	release, _, err := g.client.Repositories.GetLatestRelease(ctx, "fastly", "cli")
+	release, _, err := g.client.Repositories.GetLatestRelease(ctx, g.org, g.repo)
 	if err != nil {
 		return semver.Version{}, err
 	}
@@ -53,7 +57,7 @@ func (g GitHub) Download(ctx context.Context, version semver.Version) (filename 
 		return filename, err
 	}
 
-	release, _, err := g.client.Repositories.GetRelease(ctx, "fastly", "cli", releaseID)
+	release, _, err := g.client.Repositories.GetRelease(ctx, g.org, g.repo, releaseID)
 	if err != nil {
 		return filename, fmt.Errorf("error fetching release: %w", err)
 	}
@@ -63,7 +67,7 @@ func (g GitHub) Download(ctx context.Context, version semver.Version) (filename 
 		return filename, err
 	}
 
-	rc, redir, err := g.client.Repositories.DownloadReleaseAsset(ctx, "fastly", "cli", assetID)
+	rc, redir, err := g.client.Repositories.DownloadReleaseAsset(ctx, g.org, g.repo, assetID)
 	if err != nil {
 		return filename, err
 	}
@@ -83,7 +87,7 @@ func (g GitHub) Download(ctx context.Context, version semver.Version) (filename 
 	}
 	defer rc.Close()
 
-	archivePath := filepath.Join(os.TempDir(), fmt.Sprintf("fastly_%s.tgz", version))
+	archivePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%s.tgz", g.org, version))
 	dst, err := os.Create(archivePath)
 	if err != nil {
 		return filename, fmt.Errorf("error creating temp file: %w", err)
@@ -99,12 +103,12 @@ func (g GitHub) Download(ctx context.Context, version semver.Version) (filename 
 		return filename, fmt.Errorf("error closing release file: %w", err)
 	}
 
-	binaryPath := filepath.Join(os.TempDir(), fmt.Sprintf("fastly_%s_%d", version, time.Now().UnixNano()))
-	if err := archiver.NewTarGz().Extract(archivePath, "fastly", binaryPath); err != nil {
+	binaryPath := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%s_%d", g.org, version, time.Now().UnixNano()))
+	if err := archiver.NewTarGz().Extract(archivePath, g.org, binaryPath); err != nil {
 		return filename, fmt.Errorf("error extracting binary: %w", err)
 	}
 
-	return filepath.Join(binaryPath, "fastly"), nil
+	return filepath.Join(binaryPath, g.org), nil
 }
 
 func (g GitHub) getReleaseID(ctx context.Context, version semver.Version) (id int64, err error) {
@@ -114,7 +118,7 @@ func (g GitHub) getReleaseID(ctx context.Context, version semver.Version) (id in
 		vVersionStr = "v" + versionStr
 	)
 	for {
-		releases, resp, err := g.client.Repositories.ListReleases(ctx, "fastly", "cli", &github.ListOptions{
+		releases, resp, err := g.client.Repositories.ListReleases(ctx, g.org, g.repo, &github.ListOptions{
 			Page:    page,
 			PerPage: 100,
 		})
@@ -135,7 +139,7 @@ func (g GitHub) getReleaseID(ctx context.Context, version semver.Version) (id in
 }
 
 func (g GitHub) getAssetID(assets []github.ReleaseAsset, version semver.Version) (id int64, err error) {
-	target := fmt.Sprintf("fastly_v%s_%s-%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
+	target := fmt.Sprintf("%s_v%s_%s-%s.tar.gz", g.org, version, runtime.GOOS, runtime.GOARCH)
 	for _, asset := range assets {
 		if asset.GetName() == target {
 			return asset.GetID(), nil

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -22,11 +22,11 @@ func TestVersion(t *testing.T) {
 		configFileName                  = "/dev/null"
 		clientFactory                   = mock.APIClient(mock.API{})
 		httpClient     api.HTTPClient   = nil
-		versioner      update.Versioner = mock.Versioner{Version: "v1.2.3"}
+		cliVersioner   update.Versioner = mock.Versioner{Version: "v1.2.3"}
 		in             io.Reader        = nil
 		out            bytes.Buffer
 	)
-	err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+	err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, strings.Join([]string{
 		"Fastly CLI version v0.0.0-unknown (unknown)",

--- a/pkg/whoami/whoami_test.go
+++ b/pkg/whoami/whoami_test.go
@@ -88,11 +88,11 @@ func TestWhoami(t *testing.T) {
 				configFileName                  = "/dev/null"
 				clientFactory                   = mock.APIClient(mock.API{})
 				httpClient                      = testcase.client
-				versioner      update.Versioner = nil
+				cliVersioner   update.Versioner = nil
 				in             io.Reader        = nil
 				out            bytes.Buffer
 			)
-			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, versioner, in, &out)
+			err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 		})


### PR DESCRIPTION
**Problem**: We want to start integrating a new binary for local testing, which will be published as a public GitHub release, but the current Versioner type has hardcoded references to the CLI binary.

**Notes**: Because in future there will be two instances of a Versioner type in the code, I decided it best to rename all references to the variable `v` or `versioner` to be `cliVersioner` so it's clearer what versioner instance is being referred to.

The primary change is in `pkg/update/versioner.go`