### PR TITLE
Add `compute publish` subcommand.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ LDFLAGS = -ldflags "\
 fastly:
 	@go build -trimpath $(LDFLAGS) -o "$@" ./cmd/fastly
 
+# useful for attaching a debugger such as https://github.com/go-delve/delve
+debug:
+	@go build -gcflags="all=-N -l" -o "fastly" ./cmd/fastly
+
 .PHONY: all
 all: tidy fmt vet staticcheck lint gosec test build install
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -137,6 +137,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	computeInit := compute.NewInitCommand(computeRoot.CmdClause, httpClient, &globals)
 	computeBuild := compute.NewBuildCommand(computeRoot.CmdClause, httpClient, &globals)
 	computeDeploy := compute.NewDeployCommand(computeRoot.CmdClause, httpClient, &globals)
+	computePublish := compute.NewPublishCommand(computeRoot.CmdClause, &globals, computeBuild, computeDeploy)
 	computeUpdate := compute.NewUpdateCommand(computeRoot.CmdClause, httpClient, &globals)
 	computeValidate := compute.NewValidateCommand(computeRoot.CmdClause, &globals)
 
@@ -387,6 +388,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		computeInit,
 		computeBuild,
 		computeDeploy,
+		computePublish,
 		computeUpdate,
 		computeValidate,
 

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -303,6 +303,10 @@ COMMANDS
         --version=VERSION        Number of version to activate
     -p, --path=PATH              Path to package
 
+  compute publish
+    Runs "build" then "deploy" using fastly.toml manifest configuration
+
+
   compute update --service-id=SERVICE-ID --version=VERSION --path=PATH
     Update a package on a Fastly Compute@Edge service version
 

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -303,9 +303,16 @@ COMMANDS
         --version=VERSION        Number of version to activate
     -p, --path=PATH              Path to package
 
-  compute publish
-    Runs "build" then "deploy" using fastly.toml manifest configuration
+  compute publish [<flags>]
+    Composite of "build", then "deploy"
 
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of version to activate
+    -p, --path=PATH              Path to package
+        --name=NAME              Package name
+        --language=LANGUAGE      Language type
+        --include-source         Include source code in built package
+        --force                  Skip verification steps and force build
 
   compute update --service-id=SERVICE-ID --version=VERSION --path=PATH
     Update a package on a Fastly Compute@Edge service version

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -304,7 +304,7 @@ COMMANDS
     -p, --path=PATH              Path to package
 
   compute publish [<flags>]
-    Composite of "build", then "deploy"
+    Build a Compute@Edge package and deploy it to a Fastly service
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of version to activate

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -304,7 +304,7 @@ COMMANDS
     -p, --path=PATH              Path to package
 
   compute publish [<flags>]
-    Build a Compute@Edge package and deploy it to a Fastly service
+    Build and deploy a Compute@Edge package to a Fastly service
 
         --name=NAME              Package name
         --language=LANGUAGE      Language type

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -306,13 +306,13 @@ COMMANDS
   compute publish [<flags>]
     Build a Compute@Edge package and deploy it to a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version to activate
-    -p, --path=PATH              Path to package
         --name=NAME              Package name
         --language=LANGUAGE      Language type
         --include-source         Include source code in built package
         --force                  Skip verification steps and force build
+    -s, --service-id=SERVICE-ID  Service ID
+        --version=VERSION        Number of version to activate
+    -p, --path=PATH              Path to package
 
   compute update --service-id=SERVICE-ID --version=VERSION --path=PATH
     Update a package on a Fastly Compute@Edge service version

--- a/pkg/compute/build.go
+++ b/pkg/compute/build.go
@@ -81,10 +81,14 @@ func NewBuildCommand(parent common.Registerer, client api.HTTPClient, globals *c
 	c.Globals = globals
 	c.client = client
 	c.CmdClause = parent.Command("build", "Build a Compute@Edge package locally")
+
+	// NOTE: when updating these flags, be sure to update the composite command:
+	// `compute publish`.
 	c.CmdClause.Flag("name", "Package name").StringVar(&c.PackageName)
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Lang)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.IncludeSrc)
 	c.CmdClause.Flag("force", "Skip verification steps and force build").BoolVar(&c.Force)
+
 	return &c
 }
 

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -1178,6 +1178,128 @@ func TestDeploy(t *testing.T) {
 	}
 }
 
+func TestPublish(t *testing.T) {
+	for _, testcase := range []struct {
+		name              string
+		args              []string
+		applicationConfig config.File
+		fastlyManifest    string
+		cargoManifest     string
+		cargoLock         string
+		client            api.HTTPClient
+		api               mock.API
+		wantError         string
+		wantOutput        []string
+		manifestIncludes  string
+	}{
+		{
+			name: "success",
+			args: []string{"compute", "publish", "-t", "123"},
+			applicationConfig: config.File{
+				Language: config.Language{
+					Rust: config.Rust{
+						ToolchainVersion:    "1.49.0",
+						WasmWasiTarget:      "wasm32-wasi",
+						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
+					},
+				},
+			},
+			fastlyManifest: `
+			manifest_version = 1
+			service_id = "123"
+			name = "test"
+			language = "rust"`,
+			cargoManifest: `
+			[package]
+			name = "test"
+			version = "0.1.0"
+
+			[dependencies]
+			fastly = "=0.6.0"`,
+			cargoLock: `
+			[[package]]
+			name = "fastly"
+			version = "0.6.0"
+
+			[[package]]
+			name = "fastly-sys"
+			version = "0.3.7"`,
+			client: versionClient{
+				fastlyVersions: []string{"0.6.0"},
+			},
+			api: mock.API{
+				ListVersionsFn:    listVersionsActiveOk,
+				GetPackageFn:      getPackageOk,
+				CloneVersionFn:    cloneVersionOk,
+				UpdatePackageFn:   updatePackageOk,
+				ActivateVersionFn: activateVersionOk,
+				ListDomainsFn:     listDomainsOk,
+			},
+			wantOutput: []string{
+				"Built rust package test",
+				"Reading package manifest...",
+				"Validating package...",
+				"Fetching latest version...",
+				"Cloning latest version...",
+				"Uploading package...",
+				"Activating version...",
+				"Manage this service at:",
+				"https://manage.fastly.com/configure/services/123",
+				"View this service at:",
+				"https://directly-careful-coyote.edgecompute.app",
+				"Deployed package (service 123, version 2)",
+			},
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			// We're going to chdir to a deploy environment,
+			// so save the PWD to return to, afterwards.
+			pwd, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create our publish environment in a temp dir.
+			// Defer a call to clean it up.
+			rootdir := makePublishEnvironment(t, testcase.fastlyManifest, testcase.cargoManifest, testcase.cargoLock)
+			defer os.RemoveAll(rootdir)
+
+			// Before running the test, chdir into the build environment.
+			// When we're done, chdir back to our original location.
+			// This is so we can reliably copy the testdata/ fixtures.
+			if err := os.Chdir(rootdir); err != nil {
+				t.Fatal(err)
+			}
+			defer os.Chdir(pwd)
+
+			var (
+				args                           = testcase.args
+				env                            = config.Environment{}
+				file                           = testcase.applicationConfig
+				appConfigFile                  = "/dev/null"
+				clientFactory                  = mock.APIClient(testcase.api)
+				httpClient                     = testcase.client
+				cliVersioner  update.Versioner = nil
+				in            io.Reader        = nil
+				buf           bytes.Buffer
+				out           io.Writer = common.NewSyncWriter(&buf)
+			)
+			err = app.Run(args, env, file, appConfigFile, clientFactory, httpClient, cliVersioner, in, out)
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			for _, s := range testcase.wantOutput {
+				testutil.AssertStringContains(t, buf.String(), s)
+			}
+			if testcase.manifestIncludes != "" {
+				content, err := os.ReadFile(filepath.Join(rootdir, compute.ManifestFilename))
+				if err != nil {
+					t.Fatal(err)
+				}
+				testutil.AssertStringContains(t, string(content), testcase.manifestIncludes)
+			}
+		})
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	for _, testcase := range []struct {
 		name       string
@@ -1437,6 +1559,64 @@ func makeDeployEnvironment(t *testing.T, manifestContent string) (rootdir string
 		if err := os.WriteFile(filename, []byte(manifestContent), 0777); err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	return rootdir
+}
+
+func makePublishEnvironment(t *testing.T, fastlyManifestContent, cargoManifestContent, cargoLockContent string) (rootdir string) {
+	t.Helper()
+
+	rootdir, err := os.MkdirTemp("", "fastly-publish-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(rootdir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// BUILD REQUIREMENTS
+
+	for _, filename := range [][]string{
+		{"Cargo.toml"},
+		{"Cargo.lock"},
+		{"src", "main.rs"},
+	} {
+		fromFilename := filepath.Join("testdata", "build", filepath.Join(filename...))
+		toFilename := filepath.Join(rootdir, filepath.Join(filename...))
+		copyFile(t, fromFilename, toFilename)
+	}
+
+	if fastlyManifestContent != "" {
+		filename := filepath.Join(rootdir, compute.ManifestFilename)
+		if err := os.WriteFile(filename, []byte(fastlyManifestContent), 0777); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if cargoManifestContent != "" {
+		filename := filepath.Join(rootdir, "Cargo.toml")
+		if err := os.WriteFile(filename, []byte(cargoManifestContent), 0777); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if cargoLockContent != "" {
+		filename := filepath.Join(rootdir, "Cargo.lock")
+		if err := os.WriteFile(filename, []byte(cargoLockContent), 0777); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// DEPLOY REQUIREMENTS
+
+	for _, filename := range [][]string{
+		{"pkg", "package.tar.gz"},
+	} {
+		fromFilename := filepath.Join("testdata", "deploy", filepath.Join(filename...))
+		toFilename := filepath.Join(rootdir, filepath.Join(filename...))
+		copyFile(t, fromFilename, toFilename)
 	}
 
 	return rootdir

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -35,9 +35,13 @@ func NewDeployCommand(parent common.Registerer, client api.HTTPClient, globals *
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("deploy", "Deploy a package to a Fastly Compute@Edge service")
+
+	// NOTE: when updating these flags, be sure to update the composite command:
+	// `compute publish`.
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("version", "Number of version to activate").Action(c.Version.Set).IntVar(&c.Version.Value)
 	c.CmdClause.Flag("path", "Path to package").Short('p').StringVar(&c.Path)
+
 	return &c
 }
 

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -21,8 +21,11 @@ import (
 type DeployCommand struct {
 	common.Base
 	manifest manifest.Data
-	path     string
-	version  common.OptionalInt
+
+	// NOTE: these are public so that the "publish" composite command can set the
+	// values appropriately before calling the Exec() function.
+	Path    string
+	Version common.OptionalInt
 }
 
 // NewDeployCommand returns a usable command registered under the parent.
@@ -33,8 +36,8 @@ func NewDeployCommand(parent common.Registerer, client api.HTTPClient, globals *
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("deploy", "Deploy a package to a Fastly Compute@Edge service")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of version to activate").Action(c.version.Set).IntVar(&c.version.Value)
-	c.CmdClause.Flag("path", "Path to package").Short('p').StringVar(&c.path)
+	c.CmdClause.Flag("version", "Number of version to activate").Action(c.Version.Set).IntVar(&c.Version.Value)
+	c.CmdClause.Flag("path", "Path to package").Short('p').StringVar(&c.Path)
 	return &c
 }
 
@@ -59,7 +62,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	// If path flag was empty, default to package tar inside pkg directory
 	// and get filename from the manifest.
-	if c.path == "" {
+	if c.Path == "" {
 		progress.Step("Reading package manifest...")
 
 		name, source := c.manifest.Name()
@@ -67,7 +70,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			return fmt.Errorf("error reading package manifest")
 		}
 
-		c.path = filepath.Join("pkg", fmt.Sprintf("%s.tar.gz", sanitize.BaseName(name)))
+		c.Path = filepath.Join("pkg", fmt.Sprintf("%s.tar.gz", sanitize.BaseName(name)))
 	}
 
 	serviceID, source := c.manifest.ServiceID()
@@ -77,7 +80,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	// Set the version we want to operate on.
 	// If version not provided infer the latest ideal version from the service.
-	if !c.version.WasSet {
+	if !c.Version.WasSet {
 		progress.Step("Fetching latest version...")
 		versions, err := c.Globals.Client.ListVersions(&fastly.ListVersionsInput{
 			ServiceID: serviceID,
@@ -91,12 +94,12 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			return fmt.Errorf("error finding latest service version")
 		}
 	} else {
-		version = &fastly.Version{Number: c.version.Value}
+		version = &fastly.Version{Number: c.Version.Value}
 	}
 
 	progress.Step("Validating package...")
 
-	if err := validate(c.path); err != nil {
+	if err := validate(c.Path); err != nil {
 		return err
 	}
 
@@ -106,7 +109,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		ServiceID:      serviceID,
 		ServiceVersion: version.Number,
 	}); err == nil {
-		hashSum, err := getHashSum(c.path)
+		hashSum, err := getHashSum(c.Path)
 		if err != nil {
 			return fmt.Errorf("error getting package hashsum: %w", err)
 		}
@@ -120,7 +123,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	// If a version wasn't supplied and the ideal version is currently active
 	// or locked, clone it.
-	if !c.version.WasSet && version.Active || version.Locked {
+	if !c.Version.WasSet && version.Active || version.Locked {
 		progress.Step("Cloning latest version...")
 		version, err = c.Globals.Client.CloneVersion(&fastly.CloneVersionInput{
 			ServiceID:      serviceID,
@@ -135,7 +138,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	_, err = c.Globals.Client.UpdatePackage(&fastly.UpdatePackageInput{
 		ServiceID:      serviceID,
 		ServiceVersion: version.Number,
-		PackagePath:    c.path,
+		PackagePath:    c.Path,
 	})
 	if err != nil {
 		return fmt.Errorf("error uploading package: %w", err)

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -1,0 +1,50 @@
+package compute
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// PublishCommand produces and deploys an artifact from files on the local disk.
+type PublishCommand struct {
+	common.Base
+	build  *BuildCommand
+	deploy *DeployCommand
+}
+
+// NewPublishCommand returns a usable command registered under the parent.
+func NewPublishCommand(parent common.Registerer, globals *config.Data, build *BuildCommand, deploy *DeployCommand) *PublishCommand {
+	var c PublishCommand
+	c.Globals = globals
+	c.build = build
+	c.deploy = deploy
+	c.CmdClause = parent.Command("publish", "Runs \"build\" then \"deploy\" using fastly.toml manifest configuration")
+	return &c
+}
+
+// Exec implements the command interface.
+//
+// NOTE: unlike other non-aggregate commands that initialize a new
+// text.Progress type for displaying progress information to the user, we don't
+// use that in this command because the nested commands overlap the output in
+// non-deterministic ways. It's best to leave those nested commands to handle
+// the progress indicator.
+func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
+	err = c.build.Exec(in, out)
+	if err != nil {
+		return fmt.Errorf("error building package: %w", err)
+	}
+
+	text.Break(out)
+
+	err = c.deploy.Exec(in, out)
+	if err != nil {
+		return fmt.Errorf("error deploying package: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -36,7 +36,7 @@ func NewPublishCommand(parent common.Registerer, globals *config.Data, build *Bu
 	c.manifest.File.Read(manifest.Filename)
 	c.build = build
 	c.deploy = deploy
-	c.CmdClause = parent.Command("publish", "Build a Compute@Edge package and deploy it to a Fastly service")
+	c.CmdClause = parent.Command("publish", "Build and deploy a Compute@Edge package to a Fastly service")
 
 	// Deploy flags
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -1,7 +1,6 @@
 package compute
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
@@ -76,7 +75,7 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	err = c.build.Exec(in, out)
 	if err != nil {
-		return fmt.Errorf("error building package: %w", err)
+		return err
 	}
 
 	text.Break(out)
@@ -91,7 +90,7 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	err = c.deploy.Exec(in, out)
 	if err != nil {
-		return fmt.Errorf("error deploying package: %w", err)
+		return err
 	}
 
 	return nil

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -36,7 +36,7 @@ func NewPublishCommand(parent common.Registerer, globals *config.Data, build *Bu
 	c.manifest.File.Read(manifest.Filename)
 	c.build = build
 	c.deploy = deploy
-	c.CmdClause = parent.Command("publish", "Composite of \"build\", then \"deploy\"")
+	c.CmdClause = parent.Command("publish", "Build a Compute@Edge package and deploy it to a Fastly service")
 
 	// Deploy flags
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 )
@@ -12,17 +13,42 @@ import (
 // PublishCommand produces and deploys an artifact from files on the local disk.
 type PublishCommand struct {
 	common.Base
-	build  *BuildCommand
-	deploy *DeployCommand
+	manifest manifest.Data
+	build    *BuildCommand
+	deploy   *DeployCommand
+
+	// Deploy fields
+	path    string
+	version common.OptionalInt
+
+	// Build fields
+	name       string
+	lang       string
+	includeSrc bool
+	force      bool
 }
 
 // NewPublishCommand returns a usable command registered under the parent.
 func NewPublishCommand(parent common.Registerer, globals *config.Data, build *BuildCommand, deploy *DeployCommand) *PublishCommand {
 	var c PublishCommand
 	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
+	c.manifest.File.Read(manifest.Filename)
 	c.build = build
 	c.deploy = deploy
-	c.CmdClause = parent.Command("publish", "Runs \"build\" then \"deploy\" using fastly.toml manifest configuration")
+	c.CmdClause = parent.Command("publish", "Composite of \"build\", then \"deploy\"")
+
+	// Deploy flags
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of version to activate").Action(c.version.Set).IntVar(&c.version.Value)
+	c.CmdClause.Flag("path", "Path to package").Short('p').StringVar(&c.path)
+
+	// Build flags
+	c.CmdClause.Flag("name", "Package name").StringVar(&c.name)
+	c.CmdClause.Flag("language", "Language type").StringVar(&c.lang)
+	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.includeSrc)
+	c.CmdClause.Flag("force", "Skip verification steps and force build").BoolVar(&c.force)
+
 	return &c
 }
 
@@ -34,12 +60,22 @@ func NewPublishCommand(parent common.Registerer, globals *config.Data, build *Bu
 // non-deterministic ways. It's best to leave those nested commands to handle
 // the progress indicator.
 func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
+	// Reset the fields on the BuildCommand based on PublishCommand values.
+	c.build.PackageName = c.name
+	c.build.Lang = c.lang
+	c.build.IncludeSrc = c.includeSrc
+	c.build.Force = c.force
+
 	err = c.build.Exec(in, out)
 	if err != nil {
 		return fmt.Errorf("error building package: %w", err)
 	}
 
 	text.Break(out)
+
+	// Reset the fields on the DeployCommand based on PublishCommand values.
+	c.deploy.Path = c.path
+	c.deploy.Version = c.version
 
 	err = c.deploy.Exec(in, out)
 	if err != nil {

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -38,16 +38,16 @@ func NewPublishCommand(parent common.Registerer, globals *config.Data, build *Bu
 	c.deploy = deploy
 	c.CmdClause = parent.Command("publish", "Build and deploy a Compute@Edge package to a Fastly service")
 
-	// Deploy flags
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of version to activate").Action(c.version.Set).IntVar(&c.version.Value)
-	c.CmdClause.Flag("path", "Path to package").Short('p').Action(c.path.Set).StringVar(&c.path.Value)
-
 	// Build flags
 	c.CmdClause.Flag("name", "Package name").Action(c.name.Set).StringVar(&c.name.Value)
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("force", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
+
+	// Deploy flags
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("version", "Number of version to activate").Action(c.version.Set).IntVar(&c.version.Value)
+	c.CmdClause.Flag("path", "Path to package").Short('p').Action(c.path.Set).StringVar(&c.path.Value)
 
 	return &c
 }


### PR DESCRIPTION
**Problem**: Having to run two separate commands when the common behaviour is to need both can become tedious. 
**Solution**: aggregate the `compute build` and `compute deploy` behaviours into a single `compute publish`.

Fixes issue #232