### PR TITLE
Prepend fastly.toml reference link to manifest

### DIFF
--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -390,6 +390,8 @@ func prependSpecRefToManifest(fp io.ReadWriteSeeker) error {
 		}
 	}
 
+	fp.Seek(0, 0)
+
 	return nil
 }
 

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -41,7 +41,7 @@ const (
 	SourceFlag
 
 	// SpecIntro informs the user of what the manifest file is for.
-	SpecIntro = "This file describes a Fastly compute@edge package. To learn more visit:"
+	SpecIntro = "This file describes a Fastly Compute@Edge package. To learn more visit:"
 
 	// SpecURL points to the fastly.toml manifest specification reference.
 	SpecURL = "https://developer.fastly.com/reference/fastly-toml/"

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -41,10 +41,10 @@ const (
 	SourceFlag
 
 	// SpecIntro
-	SpecIntro = "# This file describes a Fastly compute@edge package. To learn more visit:"
+	SpecIntro = "This file describes a Fastly compute@edge package. To learn more visit:"
 
 	// SpecURL
-	SpecURL = "# https://developer.fastly.com/reference/fastly-toml/"
+	SpecURL = "https://developer.fastly.com/reference/fastly-toml/"
 )
 
 var once sync.Once

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -15,21 +15,21 @@ import (
 	toml "github.com/pelletier/go-toml"
 )
 
-// Filename is the name of the package manifest file.
-// It is expected to be a project specific configuration file.
-const Filename = "fastly.toml"
-
-// ManifestLatestVersion represents the latest known manifest schema version
-// supported by the CLI.
-const ManifestLatestVersion = 1
-
-// FilePermissions represents a read/write file mode.
-const FilePermissions = 0666
-
 // Source enumerates where a manifest parameter is taken from.
 type Source uint8
 
 const (
+	// Filename is the name of the package manifest file.
+	// It is expected to be a project specific configuration file.
+	Filename = "fastly.toml"
+
+	// ManifestLatestVersion represents the latest known manifest schema version
+	// supported by the CLI.
+	ManifestLatestVersion = 1
+
+	// FilePermissions represents a read/write file mode.
+	FilePermissions = 0666
+
 	// SourceUndefined indicates the parameter isn't provided in any of the
 	// available sources, similar to "not found".
 	SourceUndefined Source = iota
@@ -39,6 +39,12 @@ const (
 
 	// SourceFlag indicates the parameter came from an explicit flag.
 	SourceFlag
+
+	// SpecIntro
+	SpecIntro = "# This file describes a Fastly compute@edge package. To learn more visit:"
+
+	// SpecURL
+	SpecURL = "# https://developer.fastly.com/reference/fastly-toml/"
 )
 
 var once sync.Once
@@ -356,9 +362,6 @@ func (f *File) Write(filename string) error {
 // because this would indicate a problem with us getting back all of the
 // original content.
 func prependSpecRefToManifest(fp io.ReadWriteSeeker) error {
-	line1 := "# fastly.toml reference"
-	line2 := "# https://developer.fastly.com/reference/fastly-toml/"
-
 	if _, err := fp.Seek(0, 0); err == nil {
 		content := make([]string, 0)
 		scanner := bufio.NewScanner(fp)
@@ -371,10 +374,10 @@ func prependSpecRefToManifest(fp io.ReadWriteSeeker) error {
 			return err
 		}
 
-		if content[0] != line1 || content[1] != line2 {
+		if content[0] != SpecIntro || content[1] != SpecURL {
 			if _, err := fp.Seek(0, 0); err == nil {
 				writer := bufio.NewWriter(fp)
-				writer.WriteString(fmt.Sprintf("%s\n%s\n\n", line1, line2))
+				writer.WriteString(fmt.Sprintf("# %s\n# %s\n\n", SpecIntro, SpecURL))
 
 				for _, line := range content {
 					_, err := writer.WriteString(line + "\n")

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -254,7 +254,7 @@ func (f *File) Read(fpath string) error {
 		once.Do(func() {
 			text.Warning(f.output, "The fastly.toml was missing a `manifest_version` field. A default schema version of `1` will be used.")
 			text.Break(f.output)
-			text.Output(f.output, "Refer to the fastly.toml package manifest format: https://developer.fastly.com/reference/fastly-toml/")
+			text.Output(f.output, fmt.Sprintf("Refer to the fastly.toml package manifest format: %s", SpecURL))
 			text.Break(f.output)
 			f.Write(fpath)
 		})

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -40,10 +40,10 @@ const (
 	// SourceFlag indicates the parameter came from an explicit flag.
 	SourceFlag
 
-	// SpecIntro
+	// SpecIntro informs the user of what the manifest file is for.
 	SpecIntro = "This file describes a Fastly compute@edge package. To learn more visit:"
 
-	// SpecURL
+	// SpecURL points to the fastly.toml manifest specification reference.
 	SpecURL = "https://developer.fastly.com/reference/fastly-toml/"
 )
 

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -105,7 +105,7 @@ func TestManifest(t *testing.T) {
 				//
 				// This is validating the write operation called when the
 				// manifest_version is invalid. We have a separate test function for
-				// validating the function that prepends the reference.
+				// validating the function that prepends the reference more explicitly.
 				if tc.checkRef {
 					b, err := os.ReadFile(path)
 					if err != nil {

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	errs "github.com/fastly/cli/pkg/errors"
@@ -16,6 +17,7 @@ func TestManifest(t *testing.T) {
 		manifest      string
 		valid         bool
 		expectedError error
+		checkRef      bool
 	}{
 		"valid: semver": {
 			manifest: "fastly-valid-semver.toml",
@@ -28,6 +30,7 @@ func TestManifest(t *testing.T) {
 		"invalid: missing manifest_version causes default to be set": {
 			manifest: "fastly-invalid-missing-version.toml",
 			valid:    true,
+			checkRef: true,
 		},
 		"invalid: manifest_version as a section causes default to be set": {
 			manifest: "fastly-invalid-section-version.toml",
@@ -91,6 +94,31 @@ func TestManifest(t *testing.T) {
 				// that's unexpected behaviour.
 				if err != nil {
 					t.Fatal(err)
+				}
+
+				// NOTE: we only assign checkRef to one of the invalid test cases, even
+				// though in practice the reference link will be added anytime a write
+				// operation is executed on the manifest file, because as far as the
+				// test suite is concerned it's constrained by the use of `once.Do()`
+				// at the package level of the manifest package.
+				//
+				// This is validating the write operation called when the
+				// manifest_version is invalid. We have a separate test function for
+				// validating the function that prepends the reference.
+				if tc.checkRef {
+					b, err := os.ReadFile(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					content := string(b)
+
+					line1 := "# fastly.toml reference"
+					line2 := "# https://developer.fastly.com/reference/fastly-toml/"
+
+					if !strings.Contains(content, line1) || !strings.Contains(content, line2) {
+						t.Fatal("missing fastly.toml specification reference link")
+					}
 				}
 			} else {
 				// otherwise if we expect the manifest to be invalid/unrecognised then

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -114,10 +114,7 @@ func TestManifest(t *testing.T) {
 
 					content := string(b)
 
-					line1 := "# fastly.toml reference"
-					line2 := "# https://developer.fastly.com/reference/fastly-toml/"
-
-					if !strings.Contains(content, line1) || !strings.Contains(content, line2) {
+					if !strings.Contains(content, SpecIntro) || !strings.Contains(content, SpecURL) {
 						t.Fatal("missing fastly.toml specification reference link")
 					}
 				}
@@ -178,10 +175,7 @@ func TestManifestPrepend(t *testing.T) {
 
 	content := string(bs)
 
-	line1 := "# fastly.toml reference"
-	line2 := "# https://developer.fastly.com/reference/fastly-toml/"
-
-	if !strings.Contains(content, line1) || !strings.Contains(content, line2) {
+	if !strings.Contains(content, SpecIntro) || !strings.Contains(content, SpecURL) {
 		t.Fatal("missing fastly.toml specification reference link")
 	}
 


### PR DESCRIPTION
**Problem**: lack of visibility for the fastly.toml manifest specification.
**Solution**: prepend link to the spec to the top of the manifest.