### PR TITLE
Warn on empty directory

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -287,6 +287,8 @@ COMMANDS
                                    package backend
         --backend-port=BACKEND-PORT
                                    A port number for the package backend
+        --force                    Skip non-empty directory verification step
+                                   and force new project creation
 
   compute build [<flags>]
     Build a Compute@Edge package locally

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -419,6 +419,37 @@ func TestInit(t *testing.T) {
 			},
 		},
 		{
+			name: "non empty directory",
+			args: []string{"compute", "init"},
+			configFile: config.File{
+				User: config.User{
+					Token: "123",
+					Email: "test@example.com",
+				},
+				StarterKits: config.StarterKitLanguages{
+					Rust: []config.StarterKit{
+						{
+							Name:   "Default",
+							Path:   "https://github.com/fastly/compute-starter-kit-rust-default.git",
+							Branch: "0.6.0",
+						},
+					},
+				},
+			},
+			api: mock.API{
+				GetTokenSelfFn:  tokenOK,
+				GetUserFn:       getUserOk,
+				CreateServiceFn: createServiceOK,
+				CreateDomainFn:  createDomainOK,
+				CreateBackendFn: createBackendOK,
+			},
+			manifestIncludes: `authors = ["test@example.com"]`,
+			wantOutput: []string{
+				"The current directory isn't empty.",
+			},
+			manifest: `name = "test"`,
+		},
+		{
 			name: "with default name inferred from directory",
 			args: []string{"compute", "init"},
 			configFile: config.File{

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -336,7 +336,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with existing package manifest",
-			args: []string{"compute", "init"},
+			args: []string{"compute", "init", "--force"}, // --force will ignore that the directory isn't empty
 			configFile: config.File{
 				User: config.User{
 					Token: "123",
@@ -443,11 +443,8 @@ func TestInit(t *testing.T) {
 				CreateDomainFn:  createDomainOK,
 				CreateBackendFn: createBackendOK,
 			},
-			manifestIncludes: `authors = ["test@example.com"]`,
-			wantOutput: []string{
-				"The current directory isn't empty.",
-			},
-			manifest: `name = "test"`,
+			wantError: "project directory not empty",
+			manifest:  `name = "test"`, // causes a file to be created as part of test setup
 		},
 		{
 			name: "with default name inferred from directory",

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -90,6 +90,16 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	text.Output(out, "Press ^C at any time to quit.")
 	text.Break(out)
 
+	files, err := os.ReadDir(".")
+	if err != nil {
+		return err
+	}
+
+	if len(files) > 0 {
+		text.Warning(out, "The current directory isn't empty. This might prevent the CLI from building your project if there are conflicting language configuration files.")
+		text.Break(out)
+	}
+
 	var progress text.Progress
 	if c.Globals.Verbose() {
 		progress = text.NewVerboseProgress(out)

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -536,6 +536,8 @@ func verifyDirectory(out io.Writer, in io.Reader) (bool, error) {
 			return true, nil
 		}
 
+		// NOTE: be defensive and default to short-circuiting the execution flow if
+		// the input is unrecognised.
 		return false, nil
 	}
 

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -41,16 +41,17 @@ var (
 // InitCommand initializes a Compute@Edge project package on the local machine.
 type InitCommand struct {
 	common.Base
-	client      api.HTTPClient
-	manifest    manifest.Data
-	language    string
-	from        string
-	branch      string
-	tag         string
-	path        string
-	domain      string
-	backend     string
-	backendPort uint
+	client        api.HTTPClient
+	manifest      manifest.Data
+	language      string
+	from          string
+	branch        string
+	tag           string
+	path          string
+	domain        string
+	backend       string
+	backendPort   uint
+	forceNonEmpty bool
 }
 
 // NewInitCommand returns a usable command registered under the parent.
@@ -73,6 +74,7 @@ func NewInitCommand(parent common.Registerer, client api.HTTPClient, globals *co
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.domain)
 	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").StringVar(&c.backend)
 	c.CmdClause.Flag("backend-port", "A port number for the package backend").UintVar(&c.backendPort)
+	c.CmdClause.Flag("force", "Whether a non-empty project directory should be ignored").BoolVar(&c.forceNonEmpty)
 
 	return &c
 }
@@ -95,7 +97,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return err
 	}
 
-	if !cont {
+	if !c.forceNonEmpty && !cont {
 		return errors.RemediationError{
 			Inner:       fmt.Errorf("project directory not empty"),
 			Remediation: errors.ExistingDirRemediation,
@@ -533,6 +535,8 @@ func verifyDirectory(out io.Writer, in io.Reader) (bool, error) {
 		if contl == "y" || contl == "yes" {
 			return true, nil
 		}
+
+		return false, nil
 	}
 
 	return true, nil

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -74,7 +74,7 @@ func NewInitCommand(parent common.Registerer, client api.HTTPClient, globals *co
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.domain)
 	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").StringVar(&c.backend)
 	c.CmdClause.Flag("backend-port", "A port number for the package backend").UintVar(&c.backendPort)
-	c.CmdClause.Flag("force", "Whether a non-empty project directory should be ignored").BoolVar(&c.forceNonEmpty)
+	c.CmdClause.Flag("force", "Skip non-empty directory verification step and force new project creation").BoolVar(&c.forceNonEmpty)
 
 	return &c
 }

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -80,3 +80,9 @@ var BugRemediation = strings.Join([]string{
 var ServiceIDRemediation = strings.Join([]string{
 	"Please provide one via the --service-id flag or within your package manifest",
 }, " ")
+
+// ExistingDirRemediation suggests moving to another directory and retrying.
+var ExistingDirRemediation = strings.Join([]string{
+	"Please create a new directory and initialize a new project using:",
+	"`fastly compute init`.",
+}, " ")


### PR DESCRIPTION
**Problem**:  Not cleaning up hidden `.cargo` files has proven to cause issues for users who re-use directories.