### PR TITLE
Remove flaky test logic.

### DIFF
--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -18,7 +18,6 @@ func TestManifest(t *testing.T) {
 		manifest      string
 		valid         bool
 		expectedError error
-		checkRef      bool
 	}{
 		"valid: semver": {
 			manifest: "fastly-valid-semver.toml",
@@ -31,7 +30,6 @@ func TestManifest(t *testing.T) {
 		"invalid: missing manifest_version causes default to be set": {
 			manifest: "fastly-invalid-missing-version.toml",
 			valid:    true,
-			checkRef: true,
 		},
 		"invalid: manifest_version as a section causes default to be set": {
 			manifest: "fastly-invalid-section-version.toml",
@@ -95,28 +93,6 @@ func TestManifest(t *testing.T) {
 				// that's unexpected behaviour.
 				if err != nil {
 					t.Fatal(err)
-				}
-
-				// NOTE: we only assign checkRef to one of the invalid test cases, even
-				// though in practice the reference link will be added anytime a write
-				// operation is executed on the manifest file, because as far as the
-				// test suite is concerned it's constrained by the use of `once.Do()`
-				// at the package level of the manifest package.
-				//
-				// This is validating the write operation called when the
-				// manifest_version is invalid. We have a separate test function for
-				// validating the function that prepends the reference more explicitly.
-				if tc.checkRef {
-					b, err := os.ReadFile(path)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					content := string(b)
-
-					if !strings.Contains(content, SpecIntro) || !strings.Contains(content, SpecURL) {
-						t.Fatal("missing fastly.toml specification reference link")
-					}
 				}
 			} else {
 				// otherwise if we expect the manifest to be invalid/unrecognised then

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -132,14 +132,14 @@ func TestManifest(t *testing.T) {
 func TestManifestPrepend(t *testing.T) {
 	prefix := filepath.Join("../", "testdata", "init")
 
-	// NOTE: the fixture file "fastly-invalid-missing-version.toml" will be
+	// NOTE: the fixture file "fastly-missing-spec-url.toml" will be
 	// overwritten by the test as the internal logic is supposed to add into the
 	// manifest a reference to the fastly.toml specification.
 	//
 	// To ensure future test runs complete successfully we do an initial read of
 	// the data and then write it back out when the tests have completed.
 
-	fpath := "fastly-invalid-missing-version.toml"
+	fpath := "fastly-missing-spec-url.toml"
 
 	path, err := filepath.Abs(filepath.Join(prefix, fpath))
 	if err != nil {

--- a/pkg/compute/testdata/init/fastly-missing-spec-url.toml
+++ b/pkg/compute/testdata/init/fastly-missing-spec-url.toml
@@ -1,0 +1,5 @@
+manifest_version = 1
+name = "Default Rust template"
+description = "Default package template for Rust based edge compute projects."
+authors = ["phamann <patrick@fastly.com>"]
+language = "rust"


### PR DESCRIPTION
**Problem**: We added logic recently to prepend a specification URL to the fastly.toml manifest which introduced a flaky test.
**Solution**: Remove the flaky test logic. 
**Notes**: We have a _separate_ test to validate the prepending logic, so this just means I'm not over complicating an existing set of tests.