### PR TITLE
Add support for file_max_bytes configuration for azure logging endpoint

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2430,6 +2430,8 @@ COMMANDS
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
+        --file-max-bytes=FILE-MAX-BYTES
+                                 The maximum size of a log file in bytes
 
   logging azureblob list --version=VERSION [<flags>]
     List Azure Blob Storage logging endpoints on a Fastly service version
@@ -2491,6 +2493,8 @@ COMMANDS
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
+        --file-max-bytes=FILE-MAX-BYTES
+                                 The maximum size of a log file in bytes
 
   logging azureblob delete --version=VERSION --name=NAME [<flags>]
     Delete an Azure Blob Storage logging endpoint on a Fastly service version

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -347,6 +347,7 @@ Version: 1
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
 		Public key: `+pgpPublicKey()+`
+		File max bytes: 0
 	BlobStorage 2/2
 		Service ID: 123
 		Version: 1
@@ -364,6 +365,7 @@ Version: 1
 		Timestamp format: %Y-%m-%dT%H:%M:%S.000
 		Placement: none
 		Public key: `+pgpPublicKey()+`
+		File max bytes: 0
 `) + "\n\n"
 
 func getBlobStorageOK(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
@@ -408,6 +410,7 @@ Message type: classic
 Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Placement: none
 Public key: `+pgpPublicKey()+`
+File max bytes: 0
 `) + "\n"
 
 func updateBlobStorageOK(i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {

--- a/pkg/logging/azureblob/create.go
+++ b/pkg/logging/azureblob/create.go
@@ -34,6 +34,7 @@ type CreateCommand struct {
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
 	PublicKey         common.OptionalString
+	FileMaxBytes      common.OptionalUint
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -61,6 +62,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+	c.CmdClause.Flag("file-max-bytes", "The maximum size of a log file in bytes").Action(c.FileMaxBytes.Set).UintVar(&c.FileMaxBytes.Value)
 
 	return &c
 }
@@ -119,6 +121,10 @@ func (c *CreateCommand) createInput() (*fastly.CreateBlobStorageInput, error) {
 
 	if c.PublicKey.WasSet {
 		input.PublicKey = c.PublicKey.Value
+	}
+
+	if c.FileMaxBytes.WasSet {
+		input.FileMaxBytes = c.FileMaxBytes.Value
 	}
 
 	return &input, nil

--- a/pkg/logging/azureblob/describe.go
+++ b/pkg/logging/azureblob/describe.go
@@ -60,6 +60,7 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Timestamp format: %s\n", azureblob.TimestampFormat)
 	fmt.Fprintf(out, "Placement: %s\n", azureblob.Placement)
 	fmt.Fprintf(out, "Public key: %s\n", azureblob.PublicKey)
+	fmt.Fprintf(out, "File max bytes: %d\n", azureblob.FileMaxBytes)
 
 	return nil
 }

--- a/pkg/logging/azureblob/list.go
+++ b/pkg/logging/azureblob/list.go
@@ -74,6 +74,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		fmt.Fprintf(out, "\t\tTimestamp format: %s\n", azureblob.TimestampFormat)
 		fmt.Fprintf(out, "\t\tPlacement: %s\n", azureblob.Placement)
 		fmt.Fprintf(out, "\t\tPublic key: %s\n", azureblob.PublicKey)
+		fmt.Fprintf(out, "\t\tFile max bytes: %d\n", azureblob.FileMaxBytes)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/logging/azureblob/update.go
+++ b/pkg/logging/azureblob/update.go
@@ -35,6 +35,7 @@ type UpdateCommand struct {
 	TimestampFormat   common.OptionalString
 	Placement         common.OptionalString
 	PublicKey         common.OptionalString
+	FileMaxBytes      common.OptionalUint
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
@@ -64,6 +65,7 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
+	c.CmdClause.Flag("file-max-bytes", "The maximum size of a log file in bytes").Action(c.FileMaxBytes.Set).UintVar(&c.FileMaxBytes.Value)
 
 	return &c
 }
@@ -81,6 +83,7 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateBlobStorageInput, error) {
 		Name:           c.EndpointName,
 	}
 
+	// Set new values if set by user.
 	if c.NewName.WasSet {
 		input.NewName = fastly.String(c.NewName.Value)
 	}
@@ -135,6 +138,10 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateBlobStorageInput, error) {
 
 	if c.PublicKey.WasSet {
 		input.PublicKey = fastly.String(c.PublicKey.Value)
+	}
+
+	if c.FileMaxBytes.WasSet {
+		input.FileMaxBytes = fastly.Uint(c.FileMaxBytes.Value)
 	}
 
 	return &input, nil


### PR DESCRIPTION
Support file_max_bytes configuration option for azure blob storage logging endpoint. Follows from https://github.com/fastly/go-fastly/pull/255.