### PR TITLE
Fix bug where legacy creds are reset after call to configure subcommand.

### DIFF
--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -253,11 +253,11 @@ func (f *File) Load(configEndpoint string, httpClient api.HTTPClient) error {
 	f.CLI.Version = revision.SemVer(revision.AppVersion)
 	f.CLI.LastChecked = time.Now().Format(time.RFC3339)
 
-	if f.Legacy.Token != "" {
+	if f.Legacy.Token != "" && f.User.Token == "" {
 		f.User.Token = f.Legacy.Token
 	}
 
-	if f.Legacy.Email != "" {
+	if f.Legacy.Email != "" && f.User.Email == "" {
 		f.User.Email = f.Legacy.Email
 	}
 


### PR DESCRIPTION
**Problem**: when the CLI retrieves the dynamic configuration it will check if credentials stored in a legacy location of the configuration are empty. If they're not empty it will move the credentials to the correct location in the configuration object, but it doesn't first check if the credentials have already been moved, which can result in credentials updated via `fastly configure` to be overwritten the next time the remote config is fetched.