### PR TITLE
Add docker to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,3 +93,17 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
+dockers:
+- image_templates: ["ghcr.io/fastly/cli:{{ .Version }}"]
+  dockerfile: Dockerfile
+  build_flag_templates:
+  - --label=org.opencontainers.image.title={{ .ProjectName }}
+  - --label=org.opencontainers.image.description={{ .ProjectName }}
+  - --label=org.opencontainers.image.url=https://github.com/fastly/cli
+  - --label=org.opencontainers.image.source=https://github.com/fastly/cli
+  - --label=org.opencontainers.image.version={{ .Version }}
+  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+  - --label=org.opencontainers.image.revision={{ .FullCommit }}
+  - --label=org.opencontainers.image.licenses=Apache-2.0
+  extra_files:
+    - dockerfiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:latest
+
+WORKDIR /tmp
+# Add some files to satisfy fastly compute build
+COPY dockerfiles/* dockerfiles/.cargo ./
+# Run once to force installation of some common packages
+RUN fastly compute build || true
+RUN rm -rf /tmp/* /tmp/.cargo
+
+WORKDIR /app
+ENTRYPOINT ["fastly"]
+CMD ["--help"]

--- a/dockerfiles/.cargo/config
+++ b/dockerfiles/.cargo/config
@@ -1,0 +1,5 @@
+[target.wasm32-wasi]
+rustflags = ["-C", "debuginfo=2"]
+
+[build]
+target = "wasm32-wasi"

--- a/dockerfiles/Cargo.toml
+++ b/dockerfiles/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "unused"
+version = "0.1.0"
+authors = []
+edition = "2018"
+
+[profile.release]
+debug = true
+
+[dependencies]
+fastly = "^0.7.1"
+log-fastly = "^0.2.0"
+log = "^0.4.11"

--- a/dockerfiles/fastly.toml
+++ b/dockerfiles/fastly.toml
@@ -1,0 +1,6 @@
+authors = ["unused"]
+description = "unused"
+language = "rust"
+manifest_version = 1
+name = "unused"
+service_id = "unused"

--- a/dockerfiles/rust-toolchain
+++ b/dockerfiles/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.49.0"
+targets = [ "wasm32-wasi" ]


### PR DESCRIPTION
It's very useful to have a Docker version of the Fastly CLI in order to use it on CI tools such as Github Actions and Cloud Build.

This PR adds Dockerfile and some temporary files to build an image.
I'm not sure it's going to work out of the box, but I figured it's easier for you to tweak it since you have all the correct permissions.

