### PR TITLE
Add isBool to command flags

### DIFF
--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -22,6 +22,7 @@ type flagJSON struct {
 	Placeholder string `json:"placeholder"`
 	Required    bool   `json:"required"`
 	Default     string `json:"default"`
+	IsBool      bool   `json:"isBool"`
 }
 
 type commandJSON struct {
@@ -40,6 +41,7 @@ func getFlagJSON(models []*kingpin.ClauseModel) []flagJSON {
 		flag.Placeholder = f.PlaceHolder
 		flag.Required = f.Required
 		flag.Default = strings.Join(f.Default, ",")
+		flag.IsBool = f.IsBoolFlag()
 		flags = append(flags, flag)
 	}
 	return flags


### PR DESCRIPTION
This is to support https://github.com/kailan/figly/commit/0e9c2f2a8513e7f1e909fea6f6bc739200be071d

By adding this flag, we can determine if args are booleans or take a value based on the output of `fastly help --format json`.