### PR TITLE
Clean-out service_id from manifest when deleting a service.

### DIFF
--- a/pkg/service/delete.go
+++ b/pkg/service/delete.go
@@ -66,6 +66,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		}
 	}
 
+	if err := c.manifest.File.Read(manifest.Filename); err != nil {
+		return fmt.Errorf("error reading package manifest: %w", err)
+	}
+
+	c.manifest.File.ServiceID = ""
+
+	if err := c.manifest.File.Write(manifest.Filename); err != nil {
+		return fmt.Errorf("error updating package manifest: %w", err)
+	}
+
 	text.Success(out, "Deleted service ID %s", c.Input.ID)
 	return nil
 }

--- a/pkg/service/delete.go
+++ b/pkg/service/delete.go
@@ -66,14 +66,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		}
 	}
 
-	if err := c.manifest.File.Read(manifest.Filename); err != nil {
-		return fmt.Errorf("error reading package manifest: %w", err)
-	}
-
-	c.manifest.File.ServiceID = ""
-
-	if err := c.manifest.File.Write(manifest.Filename); err != nil {
-		return fmt.Errorf("error updating package manifest: %w", err)
+	// Ensure that VCL service users are unaffected by checking if the Service ID
+	// was acquired via the fastly.toml manifest.
+	if source == manifest.SourceFile {
+		if err := c.manifest.File.Read(manifest.Filename); err != nil {
+			return fmt.Errorf("error reading package manifest: %w", err)
+		}
+		c.manifest.File.ServiceID = ""
+		if err := c.manifest.File.Write(manifest.Filename); err != nil {
+			return fmt.Errorf("error updating package manifest: %w", err)
+		}
 	}
 
 	text.Success(out, "Deleted service ID %s", c.Input.ID)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -337,9 +337,8 @@ func TestServiceDelete(t *testing.T) {
 		{
 			args:                 []string{"service", "delete", "--service-id", "001"},
 			api:                  mock.API{DeleteServiceFn: deleteServiceOK},
-			manifest:             "fastly-valid.toml",
 			wantOutput:           "Deleted service ID 001",
-			expectEmptyServiceID: true,
+			expectEmptyServiceID: false,
 		},
 		{
 			args:      []string{"service", "delete", "--service-id", "001"},
@@ -384,14 +383,16 @@ func TestServiceDelete(t *testing.T) {
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, out.String(), testcase.wantOutput)
 
-			m := filepath.Join(rootdir, manifest.Filename)
-			b, err := os.ReadFile(m)
-			if err != nil {
-				t.Fatal(err)
-			}
+			if testcase.manifest != "" {
+				m := filepath.Join(rootdir, manifest.Filename)
+				b, err := os.ReadFile(m)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			if testcase.expectEmptyServiceID {
-				testutil.AssertStringContains(t, string(b), `service_id = ""`)
+				if testcase.expectEmptyServiceID {
+					testutil.AssertStringContains(t, string(b), `service_id = ""`)
+				}
 			}
 		})
 	}
@@ -409,19 +410,21 @@ func makeTempEnvironment(t *testing.T, fixture string) (rootdir string) {
 		t.Fatal(err)
 	}
 
-	path, err := filepath.Abs(filepath.Join("testdata", fixture))
-	if err != nil {
-		t.Fatal(err)
-	}
+	if fixture != "" {
+		path, err := filepath.Abs(filepath.Join("testdata", fixture))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	filename := filepath.Join(rootdir, manifest.Filename)
-	if err := os.WriteFile(filename, b, 0777); err != nil {
-		t.Fatal(err)
+		filename := filepath.Join(rootdir, manifest.Filename)
+		if err := os.WriteFile(filename, b, 0777); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	return rootdir

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -341,6 +341,13 @@ func TestServiceDelete(t *testing.T) {
 			expectEmptyServiceID: false,
 		},
 		{
+			args:                 []string{"service", "delete", "--service-id", "001"},
+			api:                  mock.API{DeleteServiceFn: deleteServiceOK},
+			manifest:             "fastly-valid.toml",
+			wantOutput:           "Deleted service ID 001",
+			expectEmptyServiceID: false,
+		},
+		{
 			args:      []string{"service", "delete", "--service-id", "001"},
 			api:       mock.API{DeleteServiceFn: deleteServiceError},
 			manifest:  "fastly-valid.toml",

--- a/pkg/service/testdata/fastly-no-serviceid.toml
+++ b/pkg/service/testdata/fastly-no-serviceid.toml
@@ -1,0 +1,5 @@
+manifest_version = 1
+name = "Default Rust template"
+description = "Default package template for Rust based edge compute projects."
+authors = ["phamann <patrick@fastly.com>"]
+language = "rust"

--- a/pkg/service/testdata/fastly-valid.toml
+++ b/pkg/service/testdata/fastly-valid.toml
@@ -1,0 +1,6 @@
+manifest_version = 1
+name = "Default Rust template"
+description = "Default package template for Rust based edge compute projects."
+authors = ["phamann <patrick@fastly.com>"]
+language = "rust"
+service_id = "123"


### PR DESCRIPTION
**Problem**: When you delete a service, the `service_id` in the manifest persists. Which (depending on what subcommands you execute next) could cause an unexpected error.
**Solution**: When deleting a service, be sure to clean-out the Service ID value from the manifest.