### PR TITLE
Update RELEASE process

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: v0.155.2 # goreleaser version (NOT goreleaser-action version)
+        version: v0.164.0 # goreleaser version (NOT goreleaser-action version)
         args: release --rm-dist
       env:
         GOVERSION: ${{ env.GOVERSION }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -11,28 +11,18 @@ jobs:
       uses: actions/checkout@v2
     - name: Unshallow
       run: git fetch --prune --unshallow
-    - name: Install Go
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: '1.16.x'
     - name: Set GOVERSION
       id: set_goversion
       run: echo "GOVERSION=$(go version)" >> $GITHUB_ENV
-    - name: Install Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.7'
-    - name: Install github_changelog_generator
-      run: gem install github_changelog_generator -v 1.15.0
-    - name: Generate Release changelog
-      run: make release-changelog
-      env:
-        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
         version: v0.155.2 # goreleaser version (NOT goreleaser-action version)
-        args: release --rm-dist --release-notes=RELEASE_CHANGELOG.md
+        args: release --rm-dist
       env:
         GOVERSION: ${{ env.GOVERSION }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 project_name: fastly
 release:
+  draft: true
   prerelease: auto
   extra_files:
     - glob: "dist/usage.json"
@@ -92,4 +93,4 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  sort: asc
+  skip: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,6 @@
 
 Step 4. we utilize [semantic versioning](https://semver.org/) and only include relevant/significant changes within the CHANGELOG.
 
-Step 7. causes a [github action](https://github.com/fastly/cli/blob/main/.github/workflows/tag_release.yml) to be triggered which produces a 'draft' release.
+Step 7. triggers a [github action](https://github.com/fastly/cli/blob/main/.github/workflows/tag_release.yml) that produces a 'draft' release.
 
 Step 10. `#api-clients`, `#ecp-languages`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,31 +1,20 @@
-# Releasing
+# Release Process
 
-### How to cut a new release of the CLI
+1. Merge all PRs intended for the release.
+2. Rebase latest remote main branch locally (`git pull --rebase origin main`).
+3. Ensure all analysis checks and tests are passing (`make all`).
+4. Open a new PR to update CHANGELOG ([example](https://github.com/fastly/cli/pull/273)).
+5. Merge CHANGELOG.
+6. Rebase latest remote main branch locally (`git pull --rebase origin main`).
+7. Tag a new release (`git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`).
+8. Copy/paste CHANGELOG into the [draft release](https://github.com/fastly/cli/releases).
+9. Publish draft release.
+10. Communicate the release in the relevant Slack channels.
 
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html); therefore first determine the appropriate version tag based on the change set. If in doubt discuss with the team via Slack before releasing.
+## Notes
 
-1. Merge all PRs intended for the release into the `main` branch
-1. Checkout and update the main branch and ensure all tests are passing:
-    * `git checkout main`
-    * `git pull`
-    * `make all`
-1. Update the [`CHANGELOG.md`](https://github.com/fastly/cli/blob/main/CHANGELOG.md):
-    * Apply necessary labels (`enchancement`, `bug`, `documentation` etc) to all PRs intended for the release that you wish to appear in the `CHANGELOG.md`
-    * **Only add labels for relevant changes**
-    * `git checkout -b vx.x.x` where `vx.x.x` is your target version tag
-    * `CHANGELOG_GITHUB_TOKEN=xxxx SEMVER_TAG=vx.x.x make changelog`
-       * **Known Issue**: We've found that the diffs generated are non-deterministic. Just re-run `make changelog` until you get a diff with just the newest additions. For more details, visit [this link](https://github.com/github-changelog-generator/github-changelog-generator/issues/580#issuecomment-380952266).
-    * `git add CHANGELOG.md && git commit -m "vx.x.x"`
-1. Send PR for the `CHANGELOG.md`
-1. Once approved and merged, checkout and update the `main` branch:
-    * `git checkout main`
-    * `git pull`
-1. Create a new tag for `main`:
-    * `git tag -s vx.x.x -m "vx.x.x"`
-1. Push the new tag:
-    * `git push origin vx.x.x`
-1. Go to GitHub and check that the release was successful:
-    * Check the release CI job status via the [Actions](https://github.com/fastly/cli/actions?query=workflow%3ARelease) tab
-    * Check the release exists with valid assets and changelog: https://github.com/fastly/cli/releases
-1. Announce release internally via Slack
-1. Celebrate :tada:
+Step 4. we utilize [semantic versioning](https://semver.org/) and only include relevant/significant changes within the CHANGELOG.
+
+Step 7. causes a [github action](https://github.com/fastly/cli/blob/main/.github/workflows/tag_release.yml) to be triggered which produces a 'draft' release.
+
+Step 10. `#api-clients`, `#ecp-languages`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,4 +17,4 @@ Step 4. we utilize [semantic versioning](https://semver.org/) and only include r
 
 Step 7. triggers a [github action](https://github.com/fastly/cli/blob/main/.github/workflows/tag_release.yml) that produces a 'draft' release.
 
-Step 10. `#api-clients`, `#ecp-languages`.
+Step 10. Fastly make internal announcements in the Slack channels: `#api-clients`, `#ecp-languages`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,18 +3,16 @@
 1. Merge all PRs intended for the release.
 2. Rebase latest remote main branch locally (`git pull --rebase origin main`).
 3. Ensure all analysis checks and tests are passing (`make all`).
-4. Open a new PR to update CHANGELOG ([example](https://github.com/fastly/cli/pull/273)).
+4. Open a new PR to update CHANGELOG ([example](https://github.com/fastly/cli/pull/273))<sup>[1](#note1)</sup>.
 5. Merge CHANGELOG.
 6. Rebase latest remote main branch locally (`git pull --rebase origin main`).
-7. Tag a new release (`git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`).
+7. Tag a new release (`git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`)<sup>[2](#note2)</sup>.
 8. Copy/paste CHANGELOG into the [draft release](https://github.com/fastly/cli/releases).
 9. Publish draft release.
-10. Communicate the release in the relevant Slack channels.
+10. Communicate the release in the relevant Slack channels<sup>[3](#note3)</sup>.
 
-## Notes
+## Footnotes
 
-Step 4. we utilize [semantic versioning](https://semver.org/) and only include relevant/significant changes within the CHANGELOG.
-
-Step 7. triggers a [github action](https://github.com/fastly/cli/blob/main/.github/workflows/tag_release.yml) that produces a 'draft' release.
-
-Step 10. Fastly make internal announcements in the Slack channels: `#api-clients`, `#ecp-languages`.
+1. <a name="note1"></a>We utilize [semantic versioning](https://semver.org/) and only include relevant/significant changes within the CHANGELOG.
+2. <a name="note2"></a>Triggers a [github action](https://github.com/fastly/cli/blob/main/.github/workflows/tag_release.yml) that produces a 'draft' release.
+3. <a name="note3"></a>Fastly make internal announcements in the Slack channels: `#api-clients`, `#ecp-languages`.


### PR DESCRIPTION
**Problem**: The changelog generator is constantly non-deterministic/flaky and will always suggest moving prior entries around even when they shouldn't be moved. This means it's a very tedious process to git patch apply only select changes.
**Solution**: Remove the generator. It's very trivial for me to look at the commits in `main` since the last release was cut and to manually generate my own changelog entry.
**Notes**: I intend on making a similar change to go-fastly. I've also made the RELEASE document in this repo consistent with our Terraform RELEASE document (and again in go-fastly I'll look to make that one consistent).