### PR TITLE
compute/deploy: clear Service ID from manifest when service is deleted

### DIFF
--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -889,25 +889,36 @@ func TestDeploy(t *testing.T) {
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
 			wantError: "error fetching service backends: fixture error",
 		},
+		// The following test doesn't just validate the package API error behaviour
+		// but as a side effect it validates that when deleting the created
+		// service, the Service ID is also cleared out from the manifest.
 		{
 			name: "package API error",
 			args: []string{"compute", "deploy", "--token", "123"},
+			in:   strings.NewReader(""),
 			api: mock.API{
 				GetServiceFn:    getServiceOK,
 				ListVersionsFn:  listVersionsActiveOk,
 				CloneVersionFn:  cloneVersionOk,
 				ListDomainsFn:   listDomainsOk,
 				ListBackendsFn:  listBackendsOk,
+				CreateServiceFn: createServiceOK,
+				CreateDomainFn:  createDomainOK,
+				CreateBackendFn: createBackendOK,
 				GetPackageFn:    getPackageOk,
 				UpdatePackageFn: updatePackageError,
+				DeleteBackendFn: deleteBackendOK,
+				DeleteDomainFn:  deleteDomainOK,
+				DeleteServiceFn: deleteServiceOK,
 			},
-			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
+			manifest:  `name = "package"`,
 			wantError: "error uploading package: fixture error",
 			wantOutput: []string{
 				"Reading package manifest...",
 				"Validating package...",
 				"Uploading package...",
 			},
+			manifestIncludes: `service_id = ""`,
 		},
 		// The following test doesn't provide a Service ID by either a flag nor the
 		// manifest, so this will result in the deploy script attempting to create

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -190,6 +190,10 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 
 		undoStack.Push(func() error {
+			return clearServiceID(&c.manifest.File, ManifestFilename)
+		})
+
+		undoStack.Push(func() error {
 			return c.Globals.Client.DeleteService(&fastly.DeleteServiceInput{
 				ID: serviceID,
 			})
@@ -242,7 +246,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// provided by the flag and not the file, then we'll also store that ID
 	// within the manifest.
 	if sidSrc == manifest.SourceUndefined || sidSrc != manifest.SourceFile {
-		err = updateManifestServiceID(ManifestFilename, progress, serviceID)
+		err = updateManifestServiceID(&c.manifest.File, ManifestFilename, progress, serviceID)
 		if err != nil {
 			return err
 		}
@@ -291,6 +295,22 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 
 	text.Success(out, "Deployed package (service %s, version %v)", serviceID, version.Number)
+	return nil
+}
+
+// clearServiceID removes the Service ID from the manifest.
+//
+// This needs to happen when there is an error in the deploy flow, otherwise
+// the service itself will be deleted while the manifest will continue to hold
+// a reference to it.
+func clearServiceID(m *manifest.File, manifestFilename string) error {
+	if err := m.Read(manifestFilename); err != nil {
+		return fmt.Errorf("error reading package manifest: %w", err)
+	}
+	m.ServiceID = ""
+	if err := m.Write(manifestFilename); err != nil {
+		return fmt.Errorf("error updating package manifest: %w", err)
+	}
 	return nil
 }
 
@@ -434,9 +454,7 @@ func createService(progress text.Progress, client api.Interface, name string, de
 }
 
 // updateManifestServiceID updates the Service ID in the manifest.
-func updateManifestServiceID(manifestFilename string, progress text.Progress, serviceID string) error {
-	var m manifest.File
-
+func updateManifestServiceID(m *manifest.File, manifestFilename string, progress text.Progress, serviceID string) error {
 	if err := m.Read(manifestFilename); err != nil {
 		return fmt.Errorf("error reading package manifest: %w", err)
 	}


### PR DESCRIPTION
**Problem**: during the `deploy` logic flow, if there is an error at any point, we clean up by deleting the service/domain/backend. But we don't clear the Service ID from the manifest, which means on the next run of `deploy` a different flow branch is executed and the user can get into an unexpected state where they can't activate their service as the service defined in the manifest is being used and that service has since been deleted.