### PR TITLE
Host troubleshooting pages on fastly.help for common CLI issues

### DIFF
--- a/.fastly/help/README.md
+++ b/.fastly/help/README.md
@@ -4,7 +4,7 @@ This directory contains troubleshooting pages for common issues in this project,
 
 To update or create a help page, add or edit the Markdown files in this directory. Changes will be deployed on Developer Hub within 24 hours.
 
-## Example Page
+## Example Page
 
 ```md
 ---

--- a/.fastly/help/README.md
+++ b/.fastly/help/README.md
@@ -1,0 +1,18 @@
+# Developer Hub Help Pages
+
+This directory contains troubleshooting pages for common issues in this project, which are ingested by the [Developer Hub](https://developer.fastly.com) and served on the `fastly.help` domain.
+
+To update or create a help page, add or edit the Markdown files in this directory. Changes will be deployed on Developer Hub within 24 hours.
+
+## Example Page
+
+```md
+---
+id: ecp-feature
+title: Compute@Edge is not enabled on your account
+template: help
+---
+
+Our edge compute platform is in limited availability and not yet available to all customers. Contact [Fastly Support](https://support.fastly.com/hc/en-us) or your account manager to have the feature enabled on your account.
+
+```

--- a/.fastly/help/README.md
+++ b/.fastly/help/README.md
@@ -13,6 +13,6 @@ title: Compute@Edge is not enabled on your account
 template: help
 ---
 
-Our edge compute platform is in limited availability and not yet available to all customers. Contact [Fastly Support](https://support.fastly.com/hc/en-us) or your account manager to have the feature enabled on your account.
+Our edge compute platform is in limited availability and not yet available to all customers. Contact [Fastly Support](https://support.fastly.com/) or your account manager to have the feature enabled on your account.
 
 ```

--- a/.fastly/help/ecp-feature.mdx
+++ b/.fastly/help/ecp-feature.mdx
@@ -1,0 +1,7 @@
+---
+id: ecp-feature
+title: Compute@Edge is not enabled on your account
+template: help
+---
+
+Our edge compute platform is in limited availability and not yet available to all customers. Contact [Fastly Support](https://support.fastly.com/hc/en-us) or your account manager to have the feature enabled on your account.

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -424,7 +424,7 @@ func createService(progress text.Progress, client api.Interface, name string, de
 		if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
 			return nil, "", errors.RemediationError{
 				Inner:       fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account"),
-				Remediation: "See more at https://fastly.help/cli/ecp-feature",
+				Remediation: "For more help with this error see fastly.help/cli/ecp-feature",
 			}
 		}
 		return nil, "", fmt.Errorf("error creating service: %w", err)

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -424,7 +424,7 @@ func createService(progress text.Progress, client api.Interface, name string, de
 		if strings.Contains(err.Error(), "Valid values for 'type' are: 'vcl'") {
 			return nil, "", errors.RemediationError{
 				Inner:       fmt.Errorf("error creating service: you do not have the Compute@Edge feature flag enabled on your Fastly account"),
-				Remediation: "See more at https://fastly.dev/learning/compute/#create-a-new-fastly-account-and-invite-your-collaborators",
+				Remediation: "See more at https://fastly.help/cli/ecp-feature",
 			}
 		}
 		return nil, "", fmt.Errorf("error creating service: %w", err)


### PR DESCRIPTION
The first page will be live at https://fastly.help/cli/ecp-feature after this PR and https://github.com/fastly/Developer-Portal/pull/653 have been merged.
