### PR TITLE
Overload `--version` flag to accept multiple values

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -33,6 +33,7 @@ type Interface interface {
 
 	CloneVersion(*fastly.CloneVersionInput) (*fastly.Version, error)
 	ListVersions(*fastly.ListVersionsInput) ([]*fastly.Version, error)
+	GetVersion(*fastly.GetVersionInput) (*fastly.Version, error)
 	UpdateVersion(*fastly.UpdateVersionInput) (*fastly.Version, error)
 	ActivateVersion(*fastly.ActivateVersionInput) (*fastly.Version, error)
 	DeactivateVersion(*fastly.DeactivateVersionInput) (*fastly.Version, error)

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -16,10 +16,6 @@ type HTTPClient interface {
 
 // Interface models the methods of the Fastly API client that we use.
 // It exists to allow for easier testing, in combination with Mock.
-//
-// TODO(integralist):
-// There are missing methods such as GetVersion from this list so review in
-// future the missing features in CLI and implement here.
 type Interface interface {
 	GetTokenSelf() (*fastly.Token, error)
 

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -238,7 +238,8 @@ COMMANDS
     Clone a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   service-version list [<flags>]
     List Fastly service versions
@@ -249,7 +250,8 @@ COMMANDS
     Update a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --comment=COMMENT        Human-readable comment
@@ -258,7 +260,8 @@ COMMANDS
     Activate a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
 
@@ -266,13 +269,15 @@ COMMANDS
     Deactivate a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   service-version lock --version=VERSION [<flags>]
     Lock a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   compute init [<flags>]
     Initialize a new Compute@Edge package locally
@@ -300,7 +305,8 @@ COMMANDS
     Deploy a package to a Fastly Compute@Edge service
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -p, --path=PATH              Path to package
@@ -319,7 +325,8 @@ COMMANDS
         --include-source         Include source code in built package
         --force                  Skip verification steps and force build
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -p, --path=PATH              Path to package
@@ -339,7 +346,8 @@ COMMANDS
     Update a package on a Fastly Compute@Edge service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -p, --path=PATH              Path to package
@@ -355,7 +363,8 @@ COMMANDS
     -n, --name=NAME              Domain name
         --comment=COMMENT        A descriptive note
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
 
@@ -363,20 +372,23 @@ COMMANDS
     List domains on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   domain describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a domain on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              Name of domain
 
   domain update --version=VERSION --name=NAME [<flags>]
     Update a domain on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Domain name
@@ -388,7 +400,8 @@ COMMANDS
 
     -n, --name=NAME              Domain name
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
 
@@ -396,8 +409,8 @@ COMMANDS
     Create a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID    Service ID
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                Backend name
@@ -459,21 +472,23 @@ COMMANDS
     List backends on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   backend describe --service-id=SERVICE-ID --version=VERSION --name=NAME
     Show detailed information about a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              Name of backend
 
   backend update --service-id=SERVICE-ID --version=VERSION --name=NAME [<flags>]
     Update a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID    Service ID
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                backend name
@@ -536,7 +551,8 @@ COMMANDS
     Delete a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Backend name
@@ -545,7 +561,8 @@ COMMANDS
     Create a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Healthcheck name
@@ -572,20 +589,23 @@ COMMANDS
     List healthchecks on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   healthcheck describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              Name of healthcheck
 
   healthcheck update --version=VERSION --name=NAME [<flags>]
     Update a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Healthcheck name
@@ -613,7 +633,8 @@ COMMANDS
     Delete a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Healthcheck name
@@ -622,7 +643,8 @@ COMMANDS
     Create a Fastly edge dictionary on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Name of Dictionary
@@ -633,14 +655,16 @@ COMMANDS
     Show detailed information about a Fastly edge dictionary
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              Name of Dictionary
 
   dictionary delete --version=VERSION --name=NAME [<flags>]
     Delete a Fastly edge dictionary from a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Name of Dictionary
@@ -649,13 +673,15 @@ COMMANDS
     List all dictionaries on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   dictionary update --version=VERSION --name=NAME [<flags>]
     Update name of dictionary on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              Old name of Dictionary
@@ -717,7 +743,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the BigQuery logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --project-id=PROJECT-ID  Your Google Cloud Platform project ID
@@ -755,20 +782,23 @@ COMMANDS
     List BigQuery endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging bigquery describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a BigQuery logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the BigQuery logging object
 
   logging bigquery update --version=VERSION --name=NAME [<flags>]
     Update a BigQuery logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the BigQuery logging object
@@ -807,7 +837,8 @@ COMMANDS
   logging bigquery delete --version=VERSION --name=NAME [<flags>]
     Delete a BigQuery logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the BigQuery logging object
@@ -818,7 +849,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the S3 logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --bucket=BUCKET          Your S3 bucket name
@@ -876,20 +908,23 @@ COMMANDS
     List S3 endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging s3 describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a S3 logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the S3 logging object
 
   logging s3 update --version=VERSION --name=NAME [<flags>]
     Update a S3 logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the S3 logging object
@@ -948,7 +983,8 @@ COMMANDS
   logging s3 delete --version=VERSION --name=NAME [<flags>]
     Delete a S3 logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the S3 logging object
@@ -959,8 +995,8 @@ COMMANDS
 
     -n, --name=NAME                The name of the Kinesis logging object. Used
                                    as a primary key for API access
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --stream-name=STREAM-NAME  The Amazon Kinesis stream to send logs to
         --region=REGION            The AWS region where the Kinesis stream
                                    exists
@@ -990,21 +1026,23 @@ COMMANDS
     List Kinesis endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging kinesis describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Kinesis logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Kinesis logging object
 
   logging kinesis update --version=VERSION --name=NAME [<flags>]
     Update a Kinesis logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Kinesis logging object
@@ -1033,7 +1071,8 @@ COMMANDS
   logging kinesis delete --version=VERSION --name=NAME [<flags>]
     Delete a Kinesis logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Kinesis logging object
@@ -1044,8 +1083,8 @@ COMMANDS
 
     -n, --name=NAME                The name of the Syslog logging object. Used
                                    as a primary key for API access
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
         --address=ADDRESS          A hostname or IPv4 address
@@ -1087,21 +1126,23 @@ COMMANDS
     List Syslog endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging syslog describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Syslog logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Syslog logging object
 
   logging syslog update --version=VERSION --name=NAME [<flags>]
     Update a Syslog logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Syslog logging object
@@ -1144,7 +1185,8 @@ COMMANDS
   logging syslog delete --version=VERSION --name=NAME [<flags>]
     Delete a Syslog logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Syslog logging object
@@ -1178,7 +1220,8 @@ COMMANDS
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug. This field
                                  is not required and has no default value
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
 
@@ -1186,20 +1229,23 @@ COMMANDS
     List Logentries endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging logentries describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Logentries logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Logentries logging object
 
   logging logentries update --version=VERSION --name=NAME [<flags>]
     Update a Logentries logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logentries logging object
@@ -1231,7 +1277,8 @@ COMMANDS
   logging logentries delete --version=VERSION --name=NAME [<flags>]
     Delete a Logentries logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logentries logging object
@@ -1242,7 +1289,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Papertrail logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --address=ADDRESS        A hostname or IPv4 address
@@ -1270,20 +1318,23 @@ COMMANDS
     List Papertrail endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging papertrail describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Papertrail logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Papertrail logging object
 
   logging papertrail update --version=VERSION --name=NAME [<flags>]
     Update a Papertrail logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Papertrail logging object
@@ -1312,7 +1363,8 @@ COMMANDS
   logging papertrail delete --version=VERSION --name=NAME [<flags>]
     Delete a Papertrail logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Papertrail logging object
@@ -1323,7 +1375,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Sumologic logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --url=URL                The URL to POST to
@@ -1353,20 +1406,23 @@ COMMANDS
     List Sumologic endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging sumologic describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Sumologic logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Sumologic logging object
 
   logging sumologic update --version=VERSION --name=NAME [<flags>]
     Update a Sumologic logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Sumologic logging object
@@ -1397,7 +1453,8 @@ COMMANDS
   logging sumologic delete --version=VERSION --name=NAME [<flags>]
     Delete a Sumologic logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Sumologic logging object
@@ -1408,7 +1465,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the GCS logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --user=USER              Your GCS service account email address. The
@@ -1461,20 +1519,23 @@ COMMANDS
     List GCS endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging gcs describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a GCS logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the GCS logging object
 
   logging gcs update --version=VERSION --name=NAME [<flags>]
     Update a GCS logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the GCS logging object
@@ -1528,7 +1589,8 @@ COMMANDS
   logging gcs delete --version=VERSION --name=NAME [<flags>]
     Delete a GCS logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the GCS logging object
@@ -1539,7 +1601,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the FTP logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --address=ADDRESS        An hostname or IPv4 address
@@ -1584,20 +1647,23 @@ COMMANDS
     List FTP endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging ftp describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an FTP logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the FTP logging object
 
   logging ftp update --version=VERSION --name=NAME [<flags>]
     Update an FTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the FTP logging object
@@ -1650,7 +1716,8 @@ COMMANDS
   logging ftp delete --version=VERSION --name=NAME [<flags>]
     Delete an FTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the FTP logging object
@@ -1661,8 +1728,8 @@ COMMANDS
 
     -n, --name=NAME                The name of the Splunk logging object. Used
                                    as a primary key for API access
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
         --url=URL                  The URL to POST to
@@ -1699,21 +1766,23 @@ COMMANDS
     List Splunk endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging splunk describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Splunk logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Splunk logging object
 
   logging splunk update --version=VERSION --name=NAME [<flags>]
     Update a Splunk logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Splunk logging object
@@ -1751,7 +1820,8 @@ COMMANDS
   logging splunk delete --version=VERSION --name=NAME [<flags>]
     Delete a Splunk logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Splunk logging object
@@ -1762,7 +1832,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Scalyr logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --auth-token=AUTH-TOKEN  The token to use for authentication
@@ -1787,20 +1858,23 @@ COMMANDS
     List Scalyr endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging scalyr describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Scalyr logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Scalyr logging object
 
   logging scalyr update --version=VERSION --name=NAME [<flags>]
     Update a Scalyr logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Scalyr logging object
@@ -1826,7 +1900,8 @@ COMMANDS
   logging scalyr delete --version=VERSION --name=NAME [<flags>]
     Delete a Scalyr logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Scalyr logging object
@@ -1837,7 +1912,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Loggly logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --auth-token=AUTH-TOKEN  The token to use for authentication
@@ -1860,20 +1936,23 @@ COMMANDS
     List Loggly endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging loggly describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Loggly logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Loggly logging object
 
   logging loggly update --version=VERSION --name=NAME [<flags>]
     Update a Loggly logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Loggly logging object
@@ -1897,7 +1976,8 @@ COMMANDS
   logging loggly delete --version=VERSION --name=NAME [<flags>]
     Delete a Loggly logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Loggly logging object
@@ -1908,7 +1988,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Honeycomb logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --dataset=DATASET        The Honeycomb Dataset you want to log to
@@ -1933,20 +2014,23 @@ COMMANDS
     List Honeycomb endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging honeycomb describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Honeycomb logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Honeycomb logging object
 
   logging honeycomb update --version=VERSION --name=NAME [<flags>]
     Update a Honeycomb logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Honeycomb logging object
@@ -1972,7 +2056,8 @@ COMMANDS
   logging honeycomb delete --version=VERSION --name=NAME [<flags>]
     Delete a Honeycomb logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Honeycomb logging object
@@ -1983,7 +2068,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Heroku logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --url=URL                The url to stream logs to
@@ -2007,20 +2093,23 @@ COMMANDS
     List Heroku endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging heroku describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Heroku logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Heroku logging object
 
   logging heroku update --version=VERSION --name=NAME [<flags>]
     Update a Heroku logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Heroku logging object
@@ -2045,7 +2134,8 @@ COMMANDS
   logging heroku delete --version=VERSION --name=NAME [<flags>]
     Delete a Heroku logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Heroku logging object
@@ -2056,7 +2146,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the SFTP logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --address=ADDRESS        The hostname or IPv4 addres
@@ -2115,20 +2206,23 @@ COMMANDS
     List SFTP endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging sftp describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an SFTP logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the SFTP logging object
 
   logging sftp update --version=VERSION --name=NAME [<flags>]
     Update an SFTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the SFTP logging object
@@ -2188,7 +2282,8 @@ COMMANDS
   logging sftp delete --version=VERSION --name=NAME [<flags>]
     Delete an SFTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the SFTP logging object
@@ -2199,7 +2294,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Logshuttle logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --url=URL                Your Log Shuttle endpoint url
@@ -2223,20 +2319,23 @@ COMMANDS
     List Logshuttle endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging logshuttle describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Logshuttle logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Logshuttle logging object
 
   logging logshuttle update --version=VERSION --name=NAME [<flags>]
     Update a Logshuttle logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logshuttle logging object
@@ -2261,7 +2360,8 @@ COMMANDS
   logging logshuttle delete --version=VERSION --name=NAME [<flags>]
     Delete a Logshuttle logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logshuttle logging object
@@ -2272,7 +2372,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Cloudfiles logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --user=USER              The username for your Cloudfile account
@@ -2323,20 +2424,23 @@ COMMANDS
     List Cloudfiles endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging cloudfiles describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Cloudfiles logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Cloudfiles logging object
 
   logging cloudfiles update --version=VERSION --name=NAME [<flags>]
     Update a Cloudfiles logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Cloudfiles logging object
@@ -2388,7 +2492,8 @@ COMMANDS
   logging cloudfiles delete --version=VERSION --name=NAME [<flags>]
     Delete a Cloudfiles logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Cloudfiles logging object
@@ -2399,7 +2504,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object. Used as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --bucket=BUCKET          The name of the DigitalOcean Space
@@ -2449,21 +2555,24 @@ COMMANDS
     List DigitalOcean Spaces logging endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging digitalocean describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a DigitalOcean Spaces logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
 
   logging digitalocean update --version=VERSION --name=NAME [<flags>]
     Update a DigitalOcean Spaces logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
@@ -2516,7 +2625,8 @@ COMMANDS
   logging digitalocean delete --version=VERSION --name=NAME [<flags>]
     Delete a DigitalOcean Spaces logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
@@ -2528,8 +2638,8 @@ COMMANDS
 
     -n, --name=NAME                The name of the Elasticsearch logging object.
                                    Used as a primary key for API access
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
         --index=INDEX              The name of the Elasticsearch index to send
@@ -2587,21 +2697,23 @@ COMMANDS
     List Elasticsearch endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging elasticsearch describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an Elasticsearch logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Elasticsearch logging object
 
   logging elasticsearch update --version=VERSION --name=NAME [<flags>]
     Update an Elasticsearch logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Elasticsearch logging object
@@ -2660,7 +2772,8 @@ COMMANDS
   logging elasticsearch delete --version=VERSION --name=NAME [<flags>]
     Delete an Elasticsearch logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Elasticsearch logging object
@@ -2671,7 +2784,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object. Used as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --container=CONTAINER    The name of the Azure Blob Storage container in
@@ -2727,21 +2841,24 @@ COMMANDS
     List Azure Blob Storage logging endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging azureblob describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an Azure Blob Storage logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object
 
   logging azureblob update --version=VERSION --name=NAME [<flags>]
     Update an Azure Blob Storage logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Azure Blob Storage logging
@@ -2800,7 +2917,8 @@ COMMANDS
   logging azureblob delete --version=VERSION --name=NAME [<flags>]
     Delete an Azure Blob Storage logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Azure Blob Storage logging
@@ -2812,7 +2930,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Datadog logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --auth-token=AUTH-TOKEN  The API key from your Datadog account
@@ -2838,20 +2957,23 @@ COMMANDS
     List Datadog endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging datadog describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Datadog logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Datadog logging object
 
   logging datadog update --version=VERSION --name=NAME [<flags>]
     Update a Datadog logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Datadog logging object
@@ -2878,7 +3000,8 @@ COMMANDS
   logging datadog delete --version=VERSION --name=NAME [<flags>]
     Delete a Datadog logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Datadog logging object
@@ -2889,8 +3012,8 @@ COMMANDS
 
     -n, --name=NAME                The name of the HTTPS logging object. Used as
                                    a primary key for API access
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
         --url=URL                  URL that log data will be sent to. Must use
@@ -2951,21 +3074,23 @@ COMMANDS
     List HTTPS endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging https describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an HTTPS logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the HTTPS logging object
 
   logging https update --version=VERSION --name=NAME [<flags>]
     Update an HTTPS logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the HTTPS logging object
@@ -3027,7 +3152,8 @@ COMMANDS
   logging https delete --version=VERSION --name=NAME [<flags>]
     Delete an HTTPS logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the HTTPS logging object
@@ -3038,8 +3164,8 @@ COMMANDS
 
     -n, --name=NAME                The name of the Kafka logging object. Used as
                                    a primary key for API access
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
         --topic=TOPIC              The Kafka topic to send logs to
@@ -3101,21 +3227,23 @@ COMMANDS
     List Kafka endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging kafka describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Kafka logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Kafka logging object
 
   logging kafka update --version=VERSION --name=NAME [<flags>]
     Update a Kafka logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version, 'latest' or
-                                   'active'
+        --version=VERSION          Number of service version, 'latest', 'active'
+                                   or 'editable'
         --autoclone                Automatically clone the identified service
                                    version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Kafka logging object
@@ -3178,7 +3306,8 @@ COMMANDS
   logging kafka delete --version=VERSION --name=NAME [<flags>]
     Delete a Kafka logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Kafka logging object
@@ -3189,7 +3318,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object. Used as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --user=USER              Your Google Cloud Platform service account
@@ -3220,21 +3350,24 @@ COMMANDS
     List Google Cloud Pub/Sub endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging googlepubsub describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Google Cloud Pub/Sub logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object
 
   logging googlepubsub update --version=VERSION --name=NAME [<flags>]
     Update a Google Cloud Pub/Sub logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
@@ -3268,7 +3401,8 @@ COMMANDS
   logging googlepubsub delete --version=VERSION --name=NAME [<flags>]
     Delete a Google Cloud Pub/Sub logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
@@ -3280,7 +3414,8 @@ COMMANDS
 
     -n, --name=NAME              The name of the OpenStack logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
         --bucket=BUCKET          The name of your OpenStack container
@@ -3329,20 +3464,23 @@ COMMANDS
     List OpenStack logging endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
 
   logging openstack describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an OpenStack logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
     -n, --name=NAME              The name of the OpenStack logging object
 
   logging openstack update --version=VERSION --name=NAME [<flags>]
     Update an OpenStack logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the OpenStack logging object
@@ -3392,7 +3530,8 @@ COMMANDS
   logging openstack delete --version=VERSION --name=NAME [<flags>]
     Delete an OpenStack logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version, 'latest' or 'active'
+        --version=VERSION        Number of service version, 'latest', 'active'
+                                 or 'editable'
         --autoclone              Automatically clone the identified service
                                  version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the OpenStack logging object

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -273,8 +273,6 @@ COMMANDS
 
     -s, --service-id=SERVICE-ID  Service ID
         --version=VERSION        Number of service version, 'latest' or 'active'
-        --autoclone              Automatically clone the identified service
-                                 version if it's 'locked' or 'active'
 
   compute init [<flags>]
     Initialize a new Compute@Edge package locally

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -238,7 +238,7 @@ COMMANDS
     Clone a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version you wish to clone
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   service-version list [<flags>]
     List Fastly service versions
@@ -249,26 +249,32 @@ COMMANDS
     Update a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version you wish to update
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --comment=COMMENT        Human-readable comment
 
   service-version activate --version=VERSION [<flags>]
     Activate a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version you wish to activate
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
 
   service-version deactivate --version=VERSION [<flags>]
     Deactivate a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version you wish to deactivate
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   service-version lock --version=VERSION [<flags>]
     Lock a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version you wish to lock
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
 
   compute init [<flags>]
     Initialize a new Compute@Edge package locally
@@ -296,7 +302,9 @@ COMMANDS
     Deploy a package to a Fastly Compute@Edge service
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version to activate
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -p, --path=PATH              Path to package
         --domain=DOMAIN          The name of the domain associated to the
                                  package
@@ -313,7 +321,9 @@ COMMANDS
         --include-source         Include source code in built package
         --force                  Skip verification steps and force build
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of version to activate
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -p, --path=PATH              Path to package
         --domain=DOMAIN          The name of the domain associated to the
                                  package
@@ -327,11 +337,13 @@ COMMANDS
 
     -p, --path=PATH  Path to a pre-compiled Wasm binary
 
-  compute update --service-id=SERVICE-ID --version=VERSION --path=PATH
+  compute update --service-id=SERVICE-ID --version=VERSION --path=PATH [<flags>]
     Update a package on a Fastly Compute@Edge service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -p, --path=PATH              Path to package
 
   compute validate --path=PATH
@@ -345,26 +357,30 @@ COMMANDS
     -n, --name=NAME              Domain name
         --comment=COMMENT        A descriptive note
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
 
   domain list --version=VERSION [<flags>]
     List domains on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   domain describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a domain on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              Name of domain
 
   domain update --version=VERSION --name=NAME [<flags>]
     Update a domain on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Domain name
         --new-name=NEW-NAME      New domain name
         --comment=COMMENT        A descriptive note
@@ -374,13 +390,18 @@ COMMANDS
 
     -n, --name=NAME              Domain name
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
 
   backend create --service-id=SERVICE-ID --version=VERSION --name=NAME --address=ADDRESS [<flags>]
     Create a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID    Service ID
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                Backend name
         --address=ADDRESS          A hostname, IPv4, or IPv6 address for the
                                    backend
@@ -440,20 +461,23 @@ COMMANDS
     List backends on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   backend describe --service-id=SERVICE-ID --version=VERSION --name=NAME
     Show detailed information about a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              Name of backend
 
   backend update --service-id=SERVICE-ID --version=VERSION --name=NAME [<flags>]
     Update a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID    Service ID
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                backend name
         --new-name=NEW-NAME        New backend name
         --comment=COMMENT          A descriptive note
@@ -510,18 +534,22 @@ COMMANDS
                                    https://www.openssl.org/docs/man1.0.2/man1/ciphers
                                    for details)
 
-  backend delete --service-id=SERVICE-ID --version=VERSION --name=NAME
+  backend delete --service-id=SERVICE-ID --version=VERSION --name=NAME [<flags>]
     Delete a backend on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Backend name
 
   healthcheck create --version=VERSION --name=NAME [<flags>]
     Create a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Healthcheck name
         --comment=COMMENT        A descriptive note
         --method=METHOD          Which HTTP method to use
@@ -546,20 +574,22 @@ COMMANDS
     List healthchecks on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   healthcheck describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              Name of healthcheck
 
   healthcheck update --version=VERSION --name=NAME [<flags>]
     Update a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Healthcheck name
         --new-name=NEW-NAME      Healthcheck name
         --comment=COMMENT        A descriptive note
@@ -585,14 +615,18 @@ COMMANDS
     Delete a healthcheck on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Healthcheck name
 
   dictionary create --version=VERSION --name=NAME [<flags>]
     Create a Fastly edge dictionary on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Name of Dictionary
         --write-only=WRITE-ONLY  Whether to mark this dictionary as write-only.
                                  Can be true or false (defaults to false)
@@ -601,27 +635,31 @@ COMMANDS
     Show detailed information about a Fastly edge dictionary
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              Name of Dictionary
 
   dictionary delete --version=VERSION --name=NAME [<flags>]
     Delete a Fastly edge dictionary from a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Name of Dictionary
 
   dictionary list --version=VERSION [<flags>]
     List all dictionaries on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   dictionary update --version=VERSION --name=NAME [<flags>]
     Update name of dictionary on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              Old name of Dictionary
         --new-name=NEW-NAME      New name of Dictionary
         --write-only=WRITE-ONLY  Whether to mark this dictionary as write-only.
@@ -681,7 +719,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the BigQuery logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --project-id=PROJECT-ID  Your Google Cloud Platform project ID
         --dataset=DATASET        Your BigQuery dataset
         --table=TABLE            Your BigQuery table
@@ -717,20 +757,22 @@ COMMANDS
     List BigQuery endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging bigquery describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a BigQuery logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the BigQuery logging object
 
   logging bigquery update --version=VERSION --name=NAME [<flags>]
     Update a BigQuery logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the BigQuery logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the BigQuery logging object
@@ -767,7 +809,9 @@ COMMANDS
   logging bigquery delete --version=VERSION --name=NAME [<flags>]
     Delete a BigQuery logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the BigQuery logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -776,7 +820,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the S3 logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --bucket=BUCKET          Your S3 bucket name
         --access-key=ACCESS-KEY  Your S3 account access key
         --secret-key=SECRET-KEY  Your S3 account secret key
@@ -832,20 +878,22 @@ COMMANDS
     List S3 endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging s3 describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a S3 logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the S3 logging object
 
   logging s3 update --version=VERSION --name=NAME [<flags>]
     Update a S3 logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the S3 logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the S3 logging object
@@ -902,7 +950,9 @@ COMMANDS
   logging s3 delete --version=VERSION --name=NAME [<flags>]
     Delete a S3 logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the S3 logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -911,7 +961,8 @@ COMMANDS
 
     -n, --name=NAME                The name of the Kinesis logging object. Used
                                    as a primary key for API access
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
         --stream-name=STREAM-NAME  The Amazon Kinesis stream to send logs to
         --region=REGION            The AWS region where the Kinesis stream
                                    exists
@@ -920,6 +971,8 @@ COMMANDS
         --secret-key=SECRET-KEY    The secret key associated with the target
                                    Amazon Kinesis stream
         --iam-role=IAM-ROLE        The IAM role ARN for logging
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -s, --service-id=SERVICE-ID    Service ID
         --format=FORMAT            Apache style log formatting
         --format-version=FORMAT-VERSION
@@ -939,20 +992,23 @@ COMMANDS
     List Kinesis endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging kinesis describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Kinesis logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Kinesis logging object
 
   logging kinesis update --version=VERSION --name=NAME [<flags>]
     Update a Kinesis logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Kinesis logging object
     -s, --service-id=SERVICE-ID    Service ID
         --new-name=NEW-NAME        New name of the Kinesis logging object
@@ -979,7 +1035,9 @@ COMMANDS
   logging kinesis delete --version=VERSION --name=NAME [<flags>]
     Delete a Kinesis logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Kinesis logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -988,7 +1046,10 @@ COMMANDS
 
     -n, --name=NAME                The name of the Syslog logging object. Used
                                    as a primary key for API access
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
         --address=ADDRESS          A hostname or IPv4 address
     -s, --service-id=SERVICE-ID    Service ID
         --port=PORT                The port number
@@ -1028,20 +1089,23 @@ COMMANDS
     List Syslog endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging syslog describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Syslog logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Syslog logging object
 
   logging syslog update --version=VERSION --name=NAME [<flags>]
     Update a Syslog logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Syslog logging object
     -s, --service-id=SERVICE-ID    Service ID
         --new-name=NEW-NAME        New name of the Syslog logging object
@@ -1082,7 +1146,9 @@ COMMANDS
   logging syslog delete --version=VERSION --name=NAME [<flags>]
     Delete a Syslog logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Syslog logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1091,7 +1157,6 @@ COMMANDS
 
     -n, --name=NAME              The name of the Logentries logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
     -s, --service-id=SERVICE-ID  Service ID
         --port=PORT              The port number
         --use-tls                Whether to use TLS for secure logging. Can be
@@ -1115,25 +1180,30 @@ COMMANDS
                                  should be placed, overriding any format_version
                                  default. Can be none or waf_debug. This field
                                  is not required and has no default value
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
 
   logging logentries list --version=VERSION [<flags>]
     List Logentries endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging logentries describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Logentries logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Logentries logging object
 
   logging logentries update --version=VERSION --name=NAME [<flags>]
     Update a Logentries logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logentries logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Logentries logging object
@@ -1163,7 +1233,9 @@ COMMANDS
   logging logentries delete --version=VERSION --name=NAME [<flags>]
     Delete a Logentries logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logentries logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1172,7 +1244,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Papertrail logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --address=ADDRESS        A hostname or IPv4 address
     -s, --service-id=SERVICE-ID  Service ID
         --port=PORT              The port number
@@ -1198,20 +1272,22 @@ COMMANDS
     List Papertrail endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging papertrail describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Papertrail logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Papertrail logging object
 
   logging papertrail update --version=VERSION --name=NAME [<flags>]
     Update a Papertrail logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Papertrail logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Papertrail logging object
@@ -1238,7 +1314,9 @@ COMMANDS
   logging papertrail delete --version=VERSION --name=NAME [<flags>]
     Delete a Papertrail logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Papertrail logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1247,7 +1325,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Sumologic logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --url=URL                The URL to POST to
     -s, --service-id=SERVICE-ID  Service ID
         --format=FORMAT          Apache style log formatting
@@ -1275,20 +1355,22 @@ COMMANDS
     List Sumologic endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging sumologic describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Sumologic logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Sumologic logging object
 
   logging sumologic update --version=VERSION --name=NAME [<flags>]
     Update a Sumologic logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Sumologic logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Sumologic logging object
@@ -1317,7 +1399,9 @@ COMMANDS
   logging sumologic delete --version=VERSION --name=NAME [<flags>]
     Delete a Sumologic logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Sumologic logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1326,7 +1410,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the GCS logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --user=USER              Your GCS service account email address. The
                                  client_email field in your service account
                                  authentication JSON
@@ -1377,20 +1463,22 @@ COMMANDS
     List GCS endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging gcs describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a GCS logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the GCS logging object
 
   logging gcs update --version=VERSION --name=NAME [<flags>]
     Update a GCS logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the GCS logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the GCS logging object
@@ -1442,7 +1530,9 @@ COMMANDS
   logging gcs delete --version=VERSION --name=NAME [<flags>]
     Delete a GCS logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the GCS logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1451,7 +1541,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the FTP logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --address=ADDRESS        An hostname or IPv4 address
         --user=USER              The username for the server (can be anonymous)
         --password=PASSWORD      The password for the server (for anonymous use
@@ -1494,20 +1586,22 @@ COMMANDS
     List FTP endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging ftp describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an FTP logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the FTP logging object
 
   logging ftp update --version=VERSION --name=NAME [<flags>]
     Update an FTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the FTP logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the FTP logging object
@@ -1558,7 +1652,9 @@ COMMANDS
   logging ftp delete --version=VERSION --name=NAME [<flags>]
     Delete an FTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the FTP logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1567,7 +1663,10 @@ COMMANDS
 
     -n, --name=NAME                The name of the Splunk logging object. Used
                                    as a primary key for API access
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
         --url=URL                  The URL to POST to
     -s, --service-id=SERVICE-ID    Service ID
         --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
@@ -1602,20 +1701,23 @@ COMMANDS
     List Splunk endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging splunk describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Splunk logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Splunk logging object
 
   logging splunk update --version=VERSION --name=NAME [<flags>]
     Update a Splunk logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Splunk logging object
     -s, --service-id=SERVICE-ID    Service ID
         --new-name=NEW-NAME        New name of the Splunk logging object
@@ -1651,7 +1753,9 @@ COMMANDS
   logging splunk delete --version=VERSION --name=NAME [<flags>]
     Delete a Splunk logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Splunk logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1660,7 +1764,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Scalyr logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://www.scalyr.com/keys)
     -s, --service-id=SERVICE-ID  Service ID
@@ -1683,20 +1789,22 @@ COMMANDS
     List Scalyr endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging scalyr describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Scalyr logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Scalyr logging object
 
   logging scalyr update --version=VERSION --name=NAME [<flags>]
     Update a Scalyr logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Scalyr logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Scalyr logging object
@@ -1720,7 +1828,9 @@ COMMANDS
   logging scalyr delete --version=VERSION --name=NAME [<flags>]
     Delete a Scalyr logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Scalyr logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1729,7 +1839,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Loggly logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://www.loggly.com/docs/customer-token-authentication-token/)
     -s, --service-id=SERVICE-ID  Service ID
@@ -1750,20 +1862,22 @@ COMMANDS
     List Loggly endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging loggly describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Loggly logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Loggly logging object
 
   logging loggly update --version=VERSION --name=NAME [<flags>]
     Update a Loggly logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Loggly logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Loggly logging object
@@ -1785,7 +1899,9 @@ COMMANDS
   logging loggly delete --version=VERSION --name=NAME [<flags>]
     Delete a Loggly logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Loggly logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1794,7 +1910,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Honeycomb logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --dataset=DATASET        The Honeycomb Dataset you want to log to
         --auth-token=AUTH-TOKEN  The Write Key from the Account page of your
                                  Honeycomb account
@@ -1817,20 +1935,22 @@ COMMANDS
     List Honeycomb endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging honeycomb describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Honeycomb logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Honeycomb logging object
 
   logging honeycomb update --version=VERSION --name=NAME [<flags>]
     Update a Honeycomb logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Honeycomb logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Honeycomb logging object
@@ -1854,7 +1974,9 @@ COMMANDS
   logging honeycomb delete --version=VERSION --name=NAME [<flags>]
     Delete a Honeycomb logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Honeycomb logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1863,7 +1985,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Heroku logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --url=URL                The url to stream logs to
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://devcenter.heroku.com/articles/add-on-partner-log-integration)
@@ -1885,20 +2009,22 @@ COMMANDS
     List Heroku endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging heroku describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Heroku logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Heroku logging object
 
   logging heroku update --version=VERSION --name=NAME [<flags>]
     Update a Heroku logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Heroku logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Heroku logging object
@@ -1921,7 +2047,9 @@ COMMANDS
   logging heroku delete --version=VERSION --name=NAME [<flags>]
     Delete a Heroku logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Heroku logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -1930,7 +2058,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the SFTP logging object. Used as a
                                  primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --address=ADDRESS        The hostname or IPv4 addres
         --user=USER              The username for the server
         --ssh-known-hosts=SSH-KNOWN-HOSTS
@@ -1987,20 +2117,22 @@ COMMANDS
     List SFTP endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging sftp describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an SFTP logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the SFTP logging object
 
   logging sftp update --version=VERSION --name=NAME [<flags>]
     Update an SFTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the SFTP logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the SFTP logging object
@@ -2058,7 +2190,9 @@ COMMANDS
   logging sftp delete --version=VERSION --name=NAME [<flags>]
     Delete an SFTP logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the SFTP logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -2067,7 +2201,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Logshuttle logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --url=URL                Your Log Shuttle endpoint url
         --auth-token=AUTH-TOKEN  The data authentication token associated with
                                  this endpoint
@@ -2089,20 +2225,22 @@ COMMANDS
     List Logshuttle endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging logshuttle describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Logshuttle logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Logshuttle logging object
 
   logging logshuttle update --version=VERSION --name=NAME [<flags>]
     Update a Logshuttle logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logshuttle logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Logshuttle logging object
@@ -2125,7 +2263,9 @@ COMMANDS
   logging logshuttle delete --version=VERSION --name=NAME [<flags>]
     Delete a Logshuttle logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Logshuttle logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -2134,7 +2274,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Cloudfiles logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --user=USER              The username for your Cloudfile account
         --access-key=ACCESS-KEY  Your Cloudfile account access key
         --bucket=BUCKET          The name of your Cloudfiles container
@@ -2183,20 +2325,22 @@ COMMANDS
     List Cloudfiles endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging cloudfiles describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Cloudfiles logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Cloudfiles logging object
 
   logging cloudfiles update --version=VERSION --name=NAME [<flags>]
     Update a Cloudfiles logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Cloudfiles logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Cloudfiles logging object
@@ -2246,7 +2390,9 @@ COMMANDS
   logging cloudfiles delete --version=VERSION --name=NAME [<flags>]
     Delete a Cloudfiles logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Cloudfiles logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -2255,7 +2401,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object. Used as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --bucket=BUCKET          The name of the DigitalOcean Space
         --access-key=ACCESS-KEY  Your DigitalOcean Spaces account access key
         --secret-key=SECRET-KEY  Your DigitalOcean Spaces account secret key
@@ -2303,21 +2451,23 @@ COMMANDS
     List DigitalOcean Spaces logging endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging digitalocean describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a DigitalOcean Spaces logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
 
   logging digitalocean update --version=VERSION --name=NAME [<flags>]
     Update a DigitalOcean Spaces logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
     -s, --service-id=SERVICE-ID  Service ID
@@ -2368,7 +2518,9 @@ COMMANDS
   logging digitalocean delete --version=VERSION --name=NAME [<flags>]
     Delete a DigitalOcean Spaces logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
     -s, --service-id=SERVICE-ID  Service ID
@@ -2378,7 +2530,10 @@ COMMANDS
 
     -n, --name=NAME                The name of the Elasticsearch logging object.
                                    Used as a primary key for API access
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
         --index=INDEX              The name of the Elasticsearch index to send
                                    documents (logs) to. The index must follow
                                    the Elasticsearch index format rules
@@ -2434,20 +2589,23 @@ COMMANDS
     List Elasticsearch endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging elasticsearch describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an Elasticsearch logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Elasticsearch logging object
 
   logging elasticsearch update --version=VERSION --name=NAME [<flags>]
     Update an Elasticsearch logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Elasticsearch logging object
     -s, --service-id=SERVICE-ID    Service ID
         --new-name=NEW-NAME        New name of the Elasticsearch logging object
@@ -2504,7 +2662,9 @@ COMMANDS
   logging elasticsearch delete --version=VERSION --name=NAME [<flags>]
     Delete an Elasticsearch logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Elasticsearch logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -2513,7 +2673,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object. Used as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --container=CONTAINER    The name of the Azure Blob Storage container in
                                  which to store logs
         --account-name=ACCOUNT-NAME
@@ -2567,21 +2729,23 @@ COMMANDS
     List Azure Blob Storage logging endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging azureblob describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an Azure Blob Storage logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object
 
   logging azureblob update --version=VERSION --name=NAME [<flags>]
     Update an Azure Blob Storage logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object
     -s, --service-id=SERVICE-ID  Service ID
@@ -2638,7 +2802,9 @@ COMMANDS
   logging azureblob delete --version=VERSION --name=NAME [<flags>]
     Delete an Azure Blob Storage logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object
     -s, --service-id=SERVICE-ID  Service ID
@@ -2648,7 +2814,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Datadog logging object. Used as
                                  a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --auth-token=AUTH-TOKEN  The API key from your Datadog account
     -s, --service-id=SERVICE-ID  Service ID
         --region=REGION          The region that log data will be sent to. One
@@ -2672,20 +2840,22 @@ COMMANDS
     List Datadog endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging datadog describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Datadog logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Datadog logging object
 
   logging datadog update --version=VERSION --name=NAME [<flags>]
     Update a Datadog logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Datadog logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the Datadog logging object
@@ -2710,7 +2880,9 @@ COMMANDS
   logging datadog delete --version=VERSION --name=NAME [<flags>]
     Delete a Datadog logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Datadog logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -2719,7 +2891,10 @@ COMMANDS
 
     -n, --name=NAME                The name of the HTTPS logging object. Used as
                                    a primary key for API access
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
         --url=URL                  URL that log data will be sent to. Must use
                                    the https protocol
     -s, --service-id=SERVICE-ID    Service ID
@@ -2778,20 +2953,23 @@ COMMANDS
     List HTTPS endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging https describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an HTTPS logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the HTTPS logging object
 
   logging https update --version=VERSION --name=NAME [<flags>]
     Update an HTTPS logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the HTTPS logging object
     -s, --service-id=SERVICE-ID    Service ID
         --new-name=NEW-NAME        New name of the HTTPS logging object
@@ -2851,7 +3029,9 @@ COMMANDS
   logging https delete --version=VERSION --name=NAME [<flags>]
     Delete an HTTPS logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the HTTPS logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -2860,7 +3040,10 @@ COMMANDS
 
     -n, --name=NAME                The name of the Kafka logging object. Used as
                                    a primary key for API access
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
         --topic=TOPIC              The Kafka topic to send logs to
         --brokers=BROKERS          A comma-separated list of IP addresses or
                                    hostnames of Kafka brokers
@@ -2920,20 +3103,23 @@ COMMANDS
     List Kafka endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging kafka describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Kafka logging endpoint on a Fastly service
     version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Kafka logging object
 
   logging kafka update --version=VERSION --name=NAME [<flags>]
     Update a Kafka logging endpoint on a Fastly service version
 
-        --version=VERSION          Number of service version
+        --version=VERSION          Number of service version, 'latest' or
+                                   'active'
+        --autoclone                Automatically clone the identified service
+                                   version if it's 'locked' or 'active'
     -n, --name=NAME                The name of the Kafka logging object
     -s, --service-id=SERVICE-ID    Service ID
         --new-name=NEW-NAME        New name of the Kafka logging object
@@ -2994,7 +3180,9 @@ COMMANDS
   logging kafka delete --version=VERSION --name=NAME [<flags>]
     Delete a Kafka logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Kafka logging object
     -s, --service-id=SERVICE-ID  Service ID
 
@@ -3003,7 +3191,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object. Used as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --user=USER              Your Google Cloud Platform service account
                                  email address. The client_email field in your
                                  service account authentication JSON
@@ -3032,21 +3222,23 @@ COMMANDS
     List Google Cloud Pub/Sub endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging googlepubsub describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Google Cloud Pub/Sub logging endpoint on a
     Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object
 
   logging googlepubsub update --version=VERSION --name=NAME [<flags>]
     Update a Google Cloud Pub/Sub logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object
     -s, --service-id=SERVICE-ID  Service ID
@@ -3078,7 +3270,9 @@ COMMANDS
   logging googlepubsub delete --version=VERSION --name=NAME [<flags>]
     Delete a Google Cloud Pub/Sub logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object
     -s, --service-id=SERVICE-ID  Service ID
@@ -3088,7 +3282,9 @@ COMMANDS
 
     -n, --name=NAME              The name of the OpenStack logging object. Used
                                  as a primary key for API access
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
         --bucket=BUCKET          The name of your OpenStack container
         --access-key=ACCESS-KEY  Your OpenStack account access key
         --user=USER              The username for your OpenStack account
@@ -3135,20 +3331,22 @@ COMMANDS
     List OpenStack logging endpoints on a Fastly service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
 
   logging openstack describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about an OpenStack logging endpoint on a Fastly
     service version
 
     -s, --service-id=SERVICE-ID  Service ID
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
     -n, --name=NAME              The name of the OpenStack logging object
 
   logging openstack update --version=VERSION --name=NAME [<flags>]
     Update an OpenStack logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the OpenStack logging object
     -s, --service-id=SERVICE-ID  Service ID
         --new-name=NEW-NAME      New name of the OpenStack logging object
@@ -3196,7 +3394,9 @@ COMMANDS
   logging openstack delete --version=VERSION --name=NAME [<flags>]
     Delete an OpenStack logging endpoint on a Fastly service version
 
-        --version=VERSION        Number of service version
+        --version=VERSION        Number of service version, 'latest' or 'active'
+        --autoclone              Automatically clone the identified service
+                                 version if it's 'locked' or 'active'
     -n, --name=NAME              The name of the OpenStack logging object
     -s, --service-id=SERVICE-ID  Service ID
 

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -36,6 +36,7 @@ func TestBackendCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateBackendFn: createBackendError,
 			},
 			wantError: errTest.Error(),
@@ -47,6 +48,7 @@ func TestBackendCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateBackendFn: createBackendError,
 			},
 			wantError: errTest.Error(),
@@ -58,7 +60,6 @@ func TestBackendCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetInactiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateBackendFn: createBackendOK,
 			},
 			wantOutput: "Created backend www.test.com (service 123 version 1)",
@@ -66,7 +67,7 @@ func TestBackendCreate(t *testing.T) {
 		// The following test mocks a service version that's 'active', and
 		// subsequently we expect it to be cloned to version 2.
 		{
-			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -80,6 +81,7 @@ func TestBackendCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateBackendFn: createBackendOK,
 			},
 			wantOutput: "Use-ssl was set but no port was specified, so default port 443 will be used",
@@ -250,6 +252,7 @@ func TestBackendUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetBackendFn:   getBackendError,
 			},
 			wantError: errTest.Error(),
@@ -259,13 +262,14 @@ func TestBackendUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"backend", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--comment", "", "--autoclone"},
+			args: []string{"backend", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--comment", ""},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -311,12 +315,13 @@ func TestBackendDelete(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				DeleteBackendFn: deleteBackendError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"backend", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"backend", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -27,49 +27,50 @@ func TestBackendCreate(t *testing.T) {
 			args:      []string{"backend", "create", "--version", "1", "--service-id", "123", "--address", "example.com"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
-		{
-			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "example.com", "--name", "www.test.com"},
-			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
-				CloneVersionFn:  cloneVersionOK,
-				CreateBackendFn: createBackendError,
-			},
-			wantError: errTest.Error(),
-		},
-		// The following test mocks a service version that's 'inactive', and
-		// subsequently we expect it to be the same draft version 1.
-		{
-			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com"},
-			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionInactiveOK,
-				CloneVersionFn:  cloneVersionOK,
-				CreateBackendFn: createBackendOK,
-			},
-			wantOutput: "Created backend www.test.com (service 123 version 1)",
-		},
 		// The following test mocks a service version that's 'active', and
 		// subsequently we expect it to not be cloned as we don't provide the
 		// --autoclone flag and trying to add a backend to an activated service
 		// should cause an error.
 		{
-			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com"},
+			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "example.com", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				CreateBackendFn: createBackendError,
 			},
 			wantError: errTest.Error(),
+		},
+		// The following test is the same as above but with an IP address for the
+		// --address flag instead of a hostname.
+		{
+			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CreateBackendFn: createBackendError,
+			},
+			wantError: errTest.Error(),
+		},
+		// The following test mocks a service version that's 'inactive', and
+		// subsequently we expect it to be the same editable version 1.
+		{
+			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetInactiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
+				CreateBackendFn: createBackendOK,
+			},
+			wantOutput: "Created backend www.test.com (service 123 version 1)",
 		},
 		// The following test mocks a service version that's 'active', and
 		// subsequently we expect it to be cloned to version 2.
 		{
 			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateBackendFn: createBackendOK,
 			},
 			wantOutput: "Created backend www.test.com (service 123 version 2)",
@@ -77,8 +78,8 @@ func TestBackendCreate(t *testing.T) {
 		{
 			args: []string{"backend", "create", "--service-id", "123", "--version", "1", "--address", "127.0.0.1", "--name", "www.test.com", "--use-ssl", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				CreateBackendFn: createBackendOK,
 			},
 			wantOutput: "Use-ssl was set but no port was specified, so default port 443 will be used",
@@ -113,8 +114,8 @@ func TestBackendList(t *testing.T) {
 		{
 			args: []string{"backend", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListBackendsFn: listBackendsOK,
 			},
 			wantOutput: listBackendsShortOutput,
@@ -122,8 +123,8 @@ func TestBackendList(t *testing.T) {
 		{
 			args: []string{"backend", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListBackendsFn: listBackendsOK,
 			},
 			wantOutput: listBackendsVerboseOutput,
@@ -131,8 +132,8 @@ func TestBackendList(t *testing.T) {
 		{
 			args: []string{"backend", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListBackendsFn: listBackendsOK,
 			},
 			wantOutput: listBackendsVerboseOutput,
@@ -140,8 +141,8 @@ func TestBackendList(t *testing.T) {
 		{
 			args: []string{"backend", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListBackendsFn: listBackendsOK,
 			},
 			wantOutput: listBackendsVerboseOutput,
@@ -149,8 +150,8 @@ func TestBackendList(t *testing.T) {
 		{
 			args: []string{"-v", "backend", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListBackendsFn: listBackendsOK,
 			},
 			wantOutput: listBackendsVerboseOutput,
@@ -158,8 +159,8 @@ func TestBackendList(t *testing.T) {
 		{
 			args: []string{"backend", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListBackendsFn: listBackendsError,
 			},
 			wantError: errTest.Error(),
@@ -198,8 +199,8 @@ func TestBackendDescribe(t *testing.T) {
 		{
 			args: []string{"backend", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetBackendFn:   getBackendError,
 			},
 			wantError: errTest.Error(),
@@ -207,8 +208,8 @@ func TestBackendDescribe(t *testing.T) {
 		{
 			args: []string{"backend", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetBackendFn:   getBackendOK,
 			},
 			wantOutput: describeBackendOutput,
@@ -247,8 +248,8 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			args: []string{"backend", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--new-name", "www.example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetBackendFn:   getBackendError,
 			},
 			wantError: errTest.Error(),
@@ -256,8 +257,8 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			args: []string{"backend", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendError,
 			},
@@ -266,9 +267,9 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			args: []string{"backend", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--comment", "", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
 			},
@@ -308,8 +309,8 @@ func TestBackendDelete(t *testing.T) {
 		{
 			args: []string{"backend", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				DeleteBackendFn: deleteBackendError,
 			},
 			wantError: errTest.Error(),
@@ -317,9 +318,9 @@ func TestBackendDelete(t *testing.T) {
 		{
 			args: []string{"backend", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionActiveOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				DeleteBackendFn: deleteBackendOK,
 			},
 			wantOutput: "Deleted backend www.test.com (service 123 version 2)",
@@ -345,46 +346,6 @@ func TestBackendDelete(t *testing.T) {
 }
 
 var errTest = errors.New("fixture error")
-
-func getVersionInactiveOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    1,
-		Active:    false,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func getVersionActiveOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    1,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
-}
 
 func createBackendOK(i *fastly.CreateBackendInput) (*fastly.Backend, error) {
 	return &fastly.Backend{

--- a/pkg/backend/delete.go
+++ b/pkg/backend/delete.go
@@ -12,7 +12,9 @@ import (
 // DeleteCommand calls the Fastly API to delete backends.
 type DeleteCommand struct {
 	common.Base
-	Input fastly.DeleteBackendInput
+	Input          fastly.DeleteBackendInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -21,13 +23,24 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.Globals = globals
 	c.CmdClause = parent.Command("delete", "Delete a backend on a Fastly service version").Alias("remove")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').Required().StringVar(&c.Input.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "Backend name").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
+
 	if err := c.Globals.Client.DeleteBackend(&c.Input); err != nil {
 		return err
 	}

--- a/pkg/backend/describe.go
+++ b/pkg/backend/describe.go
@@ -13,7 +13,8 @@ import (
 // DescribeCommand calls the Fastly API to describe a backend.
 type DescribeCommand struct {
 	common.Base
-	Input fastly.GetBackendInput
+	Input          fastly.GetBackendInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -22,13 +23,19 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.Globals = globals
 	c.CmdClause = parent.Command("describe", "Show detailed information about a backend on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').Required().StringVar(&c.Input.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "Name of backend").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
+
 	backend, err := c.Globals.Client.GetBackend(&c.Input)
 	if err != nil {
 		return err

--- a/pkg/backend/list.go
+++ b/pkg/backend/list.go
@@ -13,7 +13,8 @@ import (
 // ListCommand calls the Fastly API to list backends.
 type ListCommand struct {
 	common.Base
-	Input fastly.ListBackendsInput
+	Input          fastly.ListBackendsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -22,12 +23,18 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("list", "List backends on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').Required().StringVar(&c.Input.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
+
 	backends, err := c.Globals.Client.ListBackends(&c.Input)
 	if err != nil {
 		return err

--- a/pkg/backend/update.go
+++ b/pkg/backend/update.go
@@ -12,7 +12,9 @@ import (
 // UpdateCommand calls the Fastly API to update backends.
 type UpdateCommand struct {
 	common.Base
-	Input fastly.GetBackendInput
+	Input          fastly.GetBackendInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 
 	NewName             common.OptionalString
 	Comment             common.OptionalString
@@ -46,11 +48,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	var c UpdateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("update", "Update a backend on a Fastly service version")
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').Required().StringVar(&c.Input.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "backend name").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("new-name", "New backend name").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("comment", "A descriptive note").Action(c.Comment.Set).StringVar(&c.Comment.Value)
 	c.CmdClause.Flag("address", "A hostname, IPv4, or IPv6 address for the backend").Action(c.Address.Set).StringVar(&c.Address.Value)
@@ -75,12 +76,21 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("min-tls-version", "Minimum allowed TLS version on SSL connections to this backend").Action(c.MinTLSVersion.Set).StringVar(&c.MinTLSVersion.Value)
 	c.CmdClause.Flag("max-tls-version", "Maximum allowed TLS version on SSL connections to this backend").Action(c.MaxTLSVersion.Set).StringVar(&c.MaxTLSVersion.Value)
 	c.CmdClause.Flag("ssl-ciphers", "List of OpenSSL ciphers (see https://www.openssl.org/docs/man1.0.2/man1/ciphers for details)").Action(c.SSLCiphers.Set).StringsVar(&c.SSLCiphers.Value)
-
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
+
 	b, err := c.Globals.Client.GetBackend(&c.Input)
 	if err != nil {
 		return err

--- a/pkg/common/command.go
+++ b/pkg/common/command.go
@@ -78,7 +78,7 @@ type ServiceVersionFlagOpts struct {
 // such as 'latest', 'active' and numerical values which are then converted
 // into the appropriate service version.
 func (b Base) NewServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string) {
-	clause := b.CmdClause.Flag("version", "Number of service version, 'latest' or 'active'")
+	clause := b.CmdClause.Flag("version", "Number of service version, 'latest', 'active' or 'editable'")
 	if !opts.Optional {
 		clause = clause.Required()
 	} else {
@@ -148,7 +148,7 @@ type OptionalServiceVersion struct {
 }
 
 // Parse returns a service version based on the given user input.
-func (v *OptionalServiceVersion) Parse(sid string, c api.Interface) (*fastly.Version, error) {
+func (sv *OptionalServiceVersion) Parse(sid string, c api.Interface) (*fastly.Version, error) {
 	vs, err := c.ListVersions(&fastly.ListVersionsInput{
 		ServiceID: sid,
 	})
@@ -162,25 +162,25 @@ func (v *OptionalServiceVersion) Parse(sid string, c api.Interface) (*fastly.Ver
 		return vs[i].UpdatedAt.Before(*vs[j].UpdatedAt)
 	})
 
-	var version *fastly.Version
+	var v *fastly.Version
 
-	switch strings.ToLower(v.Value) {
+	switch strings.ToLower(sv.Value) {
 	case "active":
-		version, err = getLatestActiveVersion(vs)
+		v, err = getLatestActiveVersion(vs)
 	case "latest":
-		version, err = getLatestNonActiveVersion(vs)
-	// case "editable":
-	// 	version, err = getLatestEditable(vs)
+		v, err = getLatestNonActiveVersion(vs)
+	case "editable":
+		v, err = getLatestEditable(vs)
 	case "":
-		version, err = getLatestEditable(vs)
+		v, err = getLatestEditable(vs)
 	default:
-		version, err = getSpecifiedVersion(vs, v.Value)
+		v, err = getSpecifiedVersion(vs, sv.Value)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	return version, nil
+	return v, nil
 }
 
 // OptionalAutoClone defines a method set for abstracting the logic required to

--- a/pkg/common/command.go
+++ b/pkg/common/command.go
@@ -268,7 +268,9 @@ func getLatestEditable(vs []*fastly.Version) (*fastly.Version, error) {
 			return vs[i], nil
 		}
 	}
-	// TODO: return a remediation error
+	// NOTE: We can't return a remediation error because the `errors` package
+	// already imports the `common` package, and so by trying to use the CLI
+	// errors package would cause a 'import cycle' compilation error.
 	return nil, errors.New("error retrieving an editable service version")
 }
 

--- a/pkg/common/command.go
+++ b/pkg/common/command.go
@@ -194,7 +194,7 @@ type OptionalAutoClone struct {
 // The returned version is either the same as the input argument `v` or it's a
 // cloned version if the input argument was either active or locked.
 func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, c api.Interface) (*fastly.Version, error) {
-	if ac.Value && v.Active || v.Locked {
+	if v.Active || v.Locked {
 		version, err := c.CloneVersion(&fastly.CloneVersionInput{
 			ServiceID:      sid,
 			ServiceVersion: v.Number,

--- a/pkg/common/command.go
+++ b/pkg/common/command.go
@@ -174,7 +174,7 @@ func (v *OptionalServiceVersion) Parse(sid string, c api.Interface) (*fastly.Ver
 	case "":
 		version, err = getLatestEditable(vs)
 	default:
-		version, err = getSpecifiedVersion(v.Value, sid, c)
+		version, err = getSpecifiedVersion(vs, v.Value)
 	}
 	if err != nil {
 		return nil, err
@@ -273,18 +273,17 @@ func getLatestEditable(vs []*fastly.Version) (*fastly.Version, error) {
 }
 
 // getSpecifiedVersion returns the specified service version.
-func getSpecifiedVersion(version string, sid string, c api.Interface) (*fastly.Version, error) {
+func getSpecifiedVersion(vs []*fastly.Version, version string) (*fastly.Version, error) {
 	i, err := strconv.Atoi(version)
 	if err != nil {
 		return nil, err
 	}
 
-	vs, err := c.GetVersion(&fastly.GetVersionInput{
-		ServiceID:      sid,
-		ServiceVersion: i,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error getting specified service version: %w", err)
+	for _, v := range vs {
+		if v.Number == i {
+			return v, nil
+		}
 	}
-	return vs, nil
+
+	return nil, fmt.Errorf("error getting specified service version %d: %w", i, err)
 }

--- a/pkg/common/command.go
+++ b/pkg/common/command.go
@@ -1,10 +1,15 @@
 package common
 
 import (
+	"fmt"
 	"io"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/fastly/kingpin"
 )
 
@@ -55,6 +60,38 @@ func (b Base) Name() string {
 	return b.CmdClause.FullCommand()
 }
 
+// ServiceVersionFlagOpts enables easy configuration of the --version flag
+// defined via the NewServiceVersionFlag constructor.
+//
+// NOTE: The reason we define an 'optional' field rather than a 'required'
+// field is because 99% of the use cases where --version is defined the flag
+// will be required, and so we cater for the common case. Meaning only those
+// subcommands that have --version as optional will need to set that field.
+type ServiceVersionFlagOpts struct {
+	Dst      *string
+	Optional bool
+	Action   kingpin.Action
+}
+
+// NewServiceVersionFlag defines a --version flag that accepts multiple values
+// such as 'latest', 'active' and numerical values which are then converted
+// into the appropriate service version.
+func (b Base) NewServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string) {
+	clause := b.CmdClause.Flag("version", "Number of service version, 'latest' or 'active'")
+	if !opts.Optional {
+		clause = clause.Required()
+	} else {
+		clause = clause.Action(opts.Action)
+	}
+	clause.StringVar(opts.Dst)
+}
+
+// NewAutoCloneFlag defines a --autoclone flag that will cause a clone of the
+// identified service version if its found to be active or locked.
+func (b Base) NewAutoCloneFlag(action kingpin.Action, dst *bool) {
+	b.CmdClause.Flag("autoclone", "Automatically clone the identified service version if it's 'locked' or 'active'").Action(action).BoolVar(dst)
+}
+
 // Optional models an optional type that consumers can use to assert whether the
 // inner value has been set and is therefore valid for use.
 type Optional struct {
@@ -102,4 +139,139 @@ type OptionalUint8 struct {
 type OptionalInt struct {
 	Optional
 	Value int
+}
+
+// OptionalServiceVersion represents a Fastly service version.
+type OptionalServiceVersion struct {
+	OptionalString
+}
+
+// Parse returns a service version based on the given user input.
+func (v *OptionalServiceVersion) Parse(sid string, c api.Interface) (*fastly.Version, error) {
+	vs, err := c.ListVersions(&fastly.ListVersionsInput{
+		ServiceID: sid,
+	})
+	if err != nil || len(vs) == 0 {
+		return nil, fmt.Errorf("error listing service versions: %w", err)
+	}
+
+	// NOTE: The following sort algorithm was discussed/taken from our existing
+	// implementation of the meaning of "latest" from Tango and Northstar. Refer
+	// to the following URL for the context https://github.com/fastly/cli/pull/50
+	sort.Slice(vs, func(i, j int) bool {
+		return vs[i].UpdatedAt.Before(*vs[j].UpdatedAt)
+	})
+
+	var version *fastly.Version
+
+	switch strings.ToLower(v.Value) {
+	case "latest":
+		version, err = getLatestIdealVersion(vs)
+	case "active":
+		version, err = getLatestActiveVersion(vs)
+	case "":
+		version, err = getLatestActiveVersion(vs)
+		if err != nil {
+			version, err = getLatestIdealVersion(vs)
+		}
+	default:
+		version, err = getSpecifiedVersion(sid, v.Value, c)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return version, nil
+}
+
+// OptionalAutoClone defines a method set for abstracting the logic required to
+// identify if a given service version needs to be cloned.
+type OptionalAutoClone struct {
+	OptionalBool
+}
+
+// Parse returns a service version.
+//
+// The returned version is either the same as the input argument `v` or it's a
+// cloned version if the input argument was either active or locked.
+func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, c api.Interface) (*fastly.Version, error) {
+	if ac.Value && v.Active || v.Locked {
+		version, err := c.CloneVersion(&fastly.CloneVersionInput{
+			ServiceID:      sid,
+			ServiceVersion: v.Number,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error cloning latest service version: %w", err)
+		}
+		return version, nil
+	}
+
+	// Treat the function as a no-op if the version is editable.
+	return v, nil
+}
+
+// getLatestIdealVersion gets the most ideal 'latest' service version.
+//
+// It will return the latest 'locked' version, otherwise it will return
+// the latest 'draft' version (i.e. not 'active' version).
+//
+// NOTE: We iterate over the slice in reverse as we would expect the latest
+// locked version to be nearer the end of the slice (i.e. nearer to a more
+// recently updated version than at the start of the slice) and so with this
+// implementation we can short-circuit the loop rather than iterating over the
+// entire collection, which worst case would be O(n).
+func getLatestIdealVersion(vs []*fastly.Version) (*fastly.Version, error) {
+	var locked, latest *fastly.Version
+
+	for i := len(vs) - 1; i >= 0; i-- {
+		v := vs[i]
+		if v.Locked && !v.Active {
+			locked = v
+			break
+		}
+		if !v.Active && latest == nil {
+			latest = v
+		}
+	}
+
+	v := latest
+	if locked != nil {
+		v = locked
+	}
+
+	if v == nil {
+		return nil, fmt.Errorf("error finding latest service version")
+	}
+	return v, nil
+}
+
+// getLatestActiveVersion returns the latest active service version.
+//
+// NOTE: We iterate over the slice in reverse as we would expect the latest
+// active version to be nearer the end of the slice (i.e. nearer to a more
+// recently updated version than at the start of the slice).
+func getLatestActiveVersion(vs []*fastly.Version) (*fastly.Version, error) {
+	for i := len(vs) - 1; i >= 0; i-- {
+		if vs[i].Active {
+			return vs[i], nil
+		}
+	}
+	return nil, fmt.Errorf("error locating latest active service version")
+}
+
+// getSpecifiedVersion returns the specified service version.
+func getSpecifiedVersion(sid string, version string, c api.Interface) (*fastly.Version, error) {
+	i, err := strconv.Atoi(version)
+	if err != nil {
+		return nil, err
+	}
+
+	vs, err := c.GetVersion(&fastly.GetVersionInput{
+		ServiceID:      sid,
+		ServiceVersion: i,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting specified service version: %w", err)
+	}
+	return vs, nil
 }

--- a/pkg/common/command_test.go
+++ b/pkg/common/command_test.go
@@ -1,0 +1,102 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+func TestGetIdealVersion(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+	}{
+		{
+			name: "ignore active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 1,
+		},
+		{
+			name: "draft",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "locked not latest",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "no locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+			},
+			wantVersion: 3,
+		},
+		// The sorting is now handled in OptionalServiceVersion#Parse. This means
+		// we expect the input slice to be pre-sorted, and so the following example
+		// no longer returns 4 as that was the old implementation where sorting was
+		// being done inside the getLatestIdealVersion function.
+		{
+			name: "not sorted",
+			inputVersions: []*fastly.Version{
+				{Number: 3, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 4, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-04T01:00:00Z")},
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+			},
+			wantVersion: 1,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			v, err := getLatestIdealVersion(testcase.inputVersions)
+			assertNoError(t, err)
+			if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
+		})
+	}
+}
+
+// NOTE: The common package can't import the testutil package, as that imports
+// the common package already. To avoid a cyclic import error we copy the
+// implementation of the following functions from the testutil package.
+
+// mustParseTimeRFC3339 is a small helper to initialize time constants.
+func mustParseTimeRFC3339(s string) *time.Time {
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return &tm
+}
+
+// assertNoError fatals a test if the error is not nil.
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/common/command_test.go
+++ b/pkg/common/command_test.go
@@ -1,25 +1,29 @@
 package common
 
 import (
+	"sort"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/fastly/go-fastly/v3/fastly"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestGetLatestNonActiveVersion(t *testing.T) {
+func TestGetLatestActiveVersion(t *testing.T) {
 	for _, testcase := range []struct {
 		name          string
 		inputVersions []*fastly.Version
 		wantVersion   int
+		wantError     string
 	}{
 		{
-			name: "ignore active",
+			name: "active",
 			inputVersions: []*fastly.Version{
 				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
 				{Number: 2, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
 			},
-			wantVersion: 1,
+			wantVersion: 2,
 		},
 		{
 			name: "draft",
@@ -27,49 +31,142 @@ func TestGetLatestNonActiveVersion(t *testing.T) {
 				{Number: 1, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
 				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
 			},
-			wantVersion: 2,
+			wantVersion: 1,
 		},
 		{
 			name: "locked",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 1, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
 				{Number: 2, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "locked not favoured",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "no locked",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 3,
-		},
-		{
-			name: "not sorted",
-			inputVersions: []*fastly.Version{
-				{Number: 3, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 4, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-04T01:00:00Z")},
-				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
 			},
 			wantVersion: 1,
 		},
+		{
+			name: "no active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+			},
+			wantError: "error locating latest active service version",
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			v, err := getLatestNonActiveVersion(testcase.inputVersions)
-			assertNoError(t, err)
-			if v.Number != testcase.wantVersion {
+			// NOTE: this is a duplicate of the sorting algorithm in
+			// common/command.go to make the test as realistic as possible
+			sort.Slice(testcase.inputVersions, func(i, j int) bool {
+				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
+			})
+
+			v, err := getLatestActiveVersion(testcase.inputVersions)
+			if err != nil {
+				if testcase.wantError != "" {
+					assertString(t, testcase.wantError, err.Error())
+				} else {
+					t.Errorf("unexpected error returned: %v", err)
+				}
+			} else if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
+		})
+	}
+}
+
+func TestGetLatestEditableVersion(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+		wantError     string
+	}{
+		{
+			name: "success",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "no editable",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-02-02T01:00:00Z")},
+				{Number: 3, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-03-03T01:00:00Z")},
+			},
+			wantError: "error retrieving an editable service version: no editable version found",
+		},
+		{
+			name: "editable should be ahead of last active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantError: "error retrieving an editable service version: no editable version found",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			// NOTE: this is a duplicate of the sorting algorithm in
+			// common/command.go to make the test as realistic as possible
+			sort.Slice(testcase.inputVersions, func(i, j int) bool {
+				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
+			})
+
+			v, err := getLatestEditableVersion(testcase.inputVersions)
+			if err != nil {
+				if testcase.wantError != "" {
+					assertString(t, testcase.wantError, err.Error())
+				} else {
+					t.Errorf("unexpected error returned: %v", err)
+				}
+			} else if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
+		})
+	}
+}
+
+func TestGetSpecifiedVersion(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+		wantError     string
+	}{
+		{
+			name: "success",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 1,
+		},
+		{
+			name: "no version available",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-02-02T01:00:00Z")},
+				{Number: 3, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-03-03T01:00:00Z")},
+			},
+			wantVersion: 4,
+			wantError:   "error getting specified service version: 4",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			// NOTE: this is a duplicate of the sorting algorithm in
+			// common/command.go to make the test as realistic as possible
+			sort.Slice(testcase.inputVersions, func(i, j int) bool {
+				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
+			})
+
+			v, err := getSpecifiedVersion(testcase.inputVersions, strconv.Itoa(testcase.wantVersion))
+			if err != nil {
+				if testcase.wantError != "" {
+					assertString(t, testcase.wantError, err.Error())
+				} else {
+					t.Errorf("unexpected error returned: %v", err)
+				}
+			} else if v.Number != testcase.wantVersion {
 				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
 			}
 		})
@@ -89,10 +186,10 @@ func mustParseTimeRFC3339(s string) *time.Time {
 	return &tm
 }
 
-// assertNoError fatals a test if the error is not nil.
-func assertNoError(t *testing.T, err error) {
+// assertString fatals a test if the parameters aren't equal.
+func assertString(t *testing.T, want, have string) {
 	t.Helper()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if want != have {
+		t.Fatal(cmp.Diff(want, have))
 	}
 }

--- a/pkg/common/command_test.go
+++ b/pkg/common/command_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/go-fastly/v3/fastly"
 )
 
-func TestGetLatestVersion(t *testing.T) {
+func TestGetLatestNonActiveVersion(t *testing.T) {
 	for _, testcase := range []struct {
 		name          string
 		inputVersions []*fastly.Version
@@ -38,10 +38,10 @@ func TestGetLatestVersion(t *testing.T) {
 			wantVersion: 2,
 		},
 		{
-			name: "locked not latest",
+			name: "locked not favoured",
 			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 1, Active: false, Locked: true, UpdatedAt: mustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: mustParseTimeRFC3339("2000-01-02T01:00:00Z")},
 				{Number: 3, Active: true, UpdatedAt: mustParseTimeRFC3339("2000-01-03T01:00:00Z")},
 			},
 			wantVersion: 2,
@@ -55,10 +55,6 @@ func TestGetLatestVersion(t *testing.T) {
 			},
 			wantVersion: 3,
 		},
-		// The sorting is now handled in OptionalServiceVersion#Parse. This means
-		// we expect the input slice to be pre-sorted, and so the following example
-		// no longer returns 4 as that was the old implementation where sorting was
-		// being done inside the getLatestVersion function.
 		{
 			name: "not sorted",
 			inputVersions: []*fastly.Version{
@@ -71,7 +67,7 @@ func TestGetLatestVersion(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			v, err := getLatestVersion(testcase.inputVersions)
+			v, err := getLatestNonActiveVersion(testcase.inputVersions)
 			assertNoError(t, err)
 			if v.Number != testcase.wantVersion {
 				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)

--- a/pkg/common/command_test.go
+++ b/pkg/common/command_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/go-fastly/v3/fastly"
 )
 
-func TestGetIdealVersion(t *testing.T) {
+func TestGetLatestVersion(t *testing.T) {
 	for _, testcase := range []struct {
 		name          string
 		inputVersions []*fastly.Version
@@ -58,7 +58,7 @@ func TestGetIdealVersion(t *testing.T) {
 		// The sorting is now handled in OptionalServiceVersion#Parse. This means
 		// we expect the input slice to be pre-sorted, and so the following example
 		// no longer returns 4 as that was the old implementation where sorting was
-		// being done inside the getLatestIdealVersion function.
+		// being done inside the getLatestVersion function.
 		{
 			name: "not sorted",
 			inputVersions: []*fastly.Version{
@@ -71,7 +71,7 @@ func TestGetIdealVersion(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			v, err := getLatestIdealVersion(testcase.inputVersions)
+			v, err := getLatestVersion(testcase.inputVersions)
 			assertNoError(t, err)
 			if v.Number != testcase.wantVersion {
 				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)

--- a/pkg/common/exec.go
+++ b/pkg/common/exec.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	// "sync"
 )
 
 // StreamingExec models a generic command execution that consumers can use to

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -786,13 +786,9 @@ func TestDeploy(t *testing.T) {
 			manifest:  "name = \"package\"\nservice_id = \"123\"\n",
 			wantError: "error listing service versions: fixture error",
 		},
-		// TODO: this highlights another issue with --autoclone which is related to
-		// the test suite perspective, which is we need to specify it for the clone
-		// to happen and so without it our error mocked API response doesn't get
-		// returned and so we don't fail the logic when expected.
 		{
 			name: "clone version error",
-			args: []string{"compute", "deploy", "--token", "123", "--autoclone"},
+			args: []string{"compute", "deploy", "--token", "123"},
 			api: mock.API{
 				ListVersionsFn: listVersionsActiveOk,
 				CloneVersionFn: cloneVersionError,
@@ -965,7 +961,7 @@ func TestDeploy(t *testing.T) {
 		},
 		{
 			name: "success",
-			args: []string{"compute", "deploy", "--token", "123", "--autoclone"},
+			args: []string{"compute", "deploy", "--token", "123"},
 			in:   strings.NewReader(""),
 			api: mock.API{
 				GetServiceFn:      getServiceOK,
@@ -990,7 +986,7 @@ func TestDeploy(t *testing.T) {
 		},
 		{
 			name: "success with path",
-			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--autoclone"},
+			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123"},
 			in:   strings.NewReader(""),
 			api: mock.API{
 				GetServiceFn:      getServiceOK,
@@ -1037,7 +1033,7 @@ func TestDeploy(t *testing.T) {
 		},
 		{
 			name: "success with specific version",
-			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "2", "--autoclone"},
+			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "2"},
 			in:   strings.NewReader(""),
 			api: mock.API{
 				ListVersionsFn:    listVersionsActiveOk,
@@ -1078,17 +1074,12 @@ func TestDeploy(t *testing.T) {
 				"Deployed package (service 123, version 3)",
 			},
 		},
-		// The following test appends --autoclone because it doesn't make sense to
-		// use --version=active as that implies the latest active version should
-		// need to be cloned.
-		//
-		// TODO: remove --autoclone and move/rename the .Parse() method so it can
-		// continue to be used within each command's Exec function (we know which
-		// functions auto-cloning makes sense for, so rather than push that
-		// responsibility onto the user we need to handle that).
+		// The following test uses --version=active which doesn't make practical
+		// sense, but internally the autoclone logic will ensure the active version
+		// is cloned.
 		{
 			name: "success with active version",
-			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "active", "--autoclone"},
+			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "active"},
 			in:   strings.NewReader(""),
 			api: mock.API{
 				ListVersionsFn:    listVersionsActiveOk,
@@ -1199,7 +1190,7 @@ func TestPublish(t *testing.T) {
 	}{
 		{
 			name: "success no command flags",
-			args: []string{"compute", "publish", "-t", "123", "--autoclone"},
+			args: []string{"compute", "publish", "-t", "123"},
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
@@ -1257,11 +1248,9 @@ func TestPublish(t *testing.T) {
 				"Deployed package (service 123, version 2)",
 			},
 		},
-		// TODO: another example of issues with --autoclone which is the user
-		// shouldn't have to worry about this. It should just happen internally.
 		{
 			name: "success with build command flags",
-			args: []string{"compute", "publish", "-t", "123", "--name", "test", "--language", "rust", "--include-source", "--force", "--autoclone"},
+			args: []string{"compute", "publish", "-t", "123", "--name", "test", "--language", "rust", "--include-source", "--force"},
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
@@ -1321,7 +1310,7 @@ func TestPublish(t *testing.T) {
 		},
 		{
 			name: "success with deploy command flags",
-			args: []string{"compute", "publish", "-t", "123", "--version", "2", "--path", "pkg/test.tar.gz", "--autoclone"},
+			args: []string{"compute", "publish", "-t", "123", "--version", "2", "--path", "pkg/test.tar.gz"},
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
@@ -1444,6 +1433,7 @@ func TestUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  listVersionsActiveOk,
 				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				UpdatePackageFn: updatePackageError,
 			},
 			wantError: "error uploading package: fixture error",
@@ -1454,7 +1444,7 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			name: "success",
-			args: []string{"compute", "update", "-s", "123", "--version", "2", "-p", "pkg/package.tar.gz", "-t", "123", "--autoclone"},
+			args: []string{"compute", "update", "-s", "123", "--version", "2", "-p", "pkg/package.tar.gz", "-t", "123"},
 			api: mock.API{
 				ListVersionsFn:  listVersionsActiveOk,
 				GetVersionFn:    getVersionOK,

--- a/pkg/compute/compute_integration_test.go
+++ b/pkg/compute/compute_integration_test.go
@@ -987,17 +987,13 @@ func TestDeploy(t *testing.T) {
 				"Deployed package (service 123, version 3)",
 			},
 		},
-		// The following test specifies --version=latest, which will cause version 2
-		// to be returned, and as that version is 'locked' it requires us to
-		// specify --autoclone.
 		{
 			name: "success with path",
-			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "latest", "--autoclone"},
+			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "latest"},
 			in:   strings.NewReader(""),
 			api: mock.API{
 				GetServiceFn:      getServiceOK,
 				ListVersionsFn:    testutil.ListVersions,
-				CloneVersionFn:    testutil.CloneVersionResult(4),
 				ListDomainsFn:     listDomainsOk,
 				ListBackendsFn:    listBackendsOk,
 				GetPackageFn:      getPackageOk,
@@ -1012,7 +1008,7 @@ func TestDeploy(t *testing.T) {
 				"https://manage.fastly.com/configure/services/123",
 				"View this service at:",
 				"https://directly-careful-coyote.edgecompute.app",
-				"Deployed package (service 123, version 4)",
+				"Deployed package (service 123, version 3)",
 			},
 		},
 		{
@@ -1057,27 +1053,6 @@ func TestDeploy(t *testing.T) {
 				"Deployed package (service 123, version 4)",
 			},
 		},
-		{
-			name: "success with latest version",
-			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "latest", "--autoclone"},
-			in:   strings.NewReader(""),
-			api: mock.API{
-				ListVersionsFn:    testutil.ListVersions,
-				CloneVersionFn:    testutil.CloneVersionResult(4),
-				GetServiceFn:      getServiceOK,
-				ListDomainsFn:     listDomainsOk,
-				ListBackendsFn:    listBackendsOk,
-				GetPackageFn:      getPackageOk,
-				UpdatePackageFn:   updatePackageOk,
-				ActivateVersionFn: activateVersionOk,
-			},
-			manifest: "name = \"package\"\nservice_id = \"123\"\n",
-			wantOutput: []string{
-				"Uploading package...",
-				"Activating version...",
-				"Deployed package (service 123, version 4)",
-			},
-		},
 		// The following test uses --version=active which doesn't make practical
 		// sense because it suggests the given version will be active/locked and
 		// subsequently not editable. Thus the use of --autoclone is appended.
@@ -1089,27 +1064,6 @@ func TestDeploy(t *testing.T) {
 		{
 			name: "success with active version",
 			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "active", "--autoclone"},
-			in:   strings.NewReader(""),
-			api: mock.API{
-				ListVersionsFn:    testutil.ListVersions,
-				CloneVersionFn:    testutil.CloneVersionResult(4),
-				GetServiceFn:      getServiceOK,
-				ListDomainsFn:     listDomainsOk,
-				ListBackendsFn:    listBackendsOk,
-				GetPackageFn:      getPackageOk,
-				UpdatePackageFn:   updatePackageOk,
-				ActivateVersionFn: activateVersionOk,
-			},
-			manifest: "name = \"package\"\nservice_id = \"123\"\n",
-			wantOutput: []string{
-				"Uploading package...",
-				"Activating version...",
-				"Deployed package (service 123, version 4)",
-			},
-		},
-		{
-			name: "success with latest inactive version",
-			args: []string{"compute", "deploy", "--token", "123", "-p", "pkg/package.tar.gz", "-s", "123", "--version", "latest", "--autoclone"},
 			in:   strings.NewReader(""),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,

--- a/pkg/compute/compute_test.go
+++ b/pkg/compute/compute_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/fastly/kingpin"
 	"github.com/mholt/archiver/v3"
 )
@@ -303,84 +302,6 @@ func TestGetNonIgnoredFiles(t *testing.T) {
 			output, err := getNonIgnoredFiles(testcase.path, testcase.ignoredFiles)
 			testutil.AssertNoError(t, err)
 			testutil.AssertEqual(t, testcase.wantFiles, output)
-		})
-	}
-}
-
-func TestGetIdealPackage(t *testing.T) {
-	for _, testcase := range []struct {
-		name          string
-		inputVersions []*fastly.Version
-		wantVersion   int
-	}{
-		{
-			name: "active",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "active not latest",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "active and locked",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")}},
-			wantVersion: 2,
-		},
-		{
-			name: "locked",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "locked not latest",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "no active or locked",
-			inputVersions: []*fastly.Version{
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantVersion: 3,
-		},
-		{
-			name: "not sorted",
-			inputVersions: []*fastly.Version{
-				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: 4, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z")},
-				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-			},
-			wantVersion: 4,
-		},
-	} {
-		t.Run(testcase.name, func(t *testing.T) {
-			v, err := getLatestIdealVersion(testcase.inputVersions)
-			testutil.AssertNoError(t, err)
-			if v.Number != testcase.wantVersion {
-				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
-			}
 		})
 	}
 }

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -17,11 +17,12 @@ type PublishCommand struct {
 	deploy   *DeployCommand
 
 	// Deploy fields
-	path        common.OptionalString
-	version     common.OptionalInt
-	domain      common.OptionalString
-	backend     common.OptionalString
-	backendPort common.OptionalUint
+	path           common.OptionalString
+	domain         common.OptionalString
+	backend        common.OptionalString
+	backendPort    common.OptionalUint
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 
 	// Build fields
 	name       common.OptionalString
@@ -48,7 +49,8 @@ func NewPublishCommand(parent common.Registerer, globals *config.Data, build *Bu
 
 	// Deploy flags
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of version to activate").Action(c.version.Set).IntVar(&c.version.Value)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value, Optional: true, Action: c.serviceVersion.Set})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("path", "Path to package").Short('p').Action(c.path.Set).StringVar(&c.path.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)
 	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").Action(c.backend.Set).StringVar(&c.backend.Value)
@@ -90,8 +92,11 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if c.path.WasSet {
 		c.deploy.Path = c.path.Value
 	}
-	if c.version.WasSet {
-		c.deploy.Version = c.version // deploy's field is a common.OptionalInt
+	if c.serviceVersion.WasSet {
+		c.deploy.ServiceVersion = c.serviceVersion // deploy's field is a common.OptionalServiceVersion
+	}
+	if c.autoClone.WasSet {
+		c.deploy.AutoClone = c.autoClone // deploy's field is a common.OptionalAutoClone
 	}
 	if c.domain.WasSet {
 		c.deploy.Domain = c.domain.Value

--- a/pkg/domain/create.go
+++ b/pkg/domain/create.go
@@ -14,8 +14,10 @@ import (
 // CreateCommand calls the Fastly API to create domains.
 type CreateCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.CreateDomainInput
+	manifest       manifest.Data
+	Input          fastly.CreateDomainInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -28,7 +30,8 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("name", "Domain name").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.Input.Comment)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	return &c
 }
 
@@ -39,6 +42,16 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	d, err := c.Globals.Client.CreateDomain(&c.Input)
 	if err != nil {

--- a/pkg/domain/describe.go
+++ b/pkg/domain/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a domain.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetDomainInput
+	manifest       manifest.Data
+	Input          fastly.GetDomainInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a domain on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "Name of domain").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	domain, err := c.Globals.Client.GetDomain(&c.Input)
 	if err != nil {

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -28,21 +28,21 @@ func TestDomainCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateDomainFn: createDomainOK,
 			},
-			wantOutput: "Created domain www.test.com (service 123 version 2)",
+			wantOutput: "Created domain www.test.com (service 123 version 4)",
 		},
 		{
-			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateDomainFn: createDomainError,
 			},
 			wantError: errTest.Error(),
@@ -77,8 +77,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsShortOutput,
@@ -86,8 +86,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -95,8 +95,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -104,8 +104,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -113,8 +113,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"-v", "domain", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -122,8 +122,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDomainsFn:  listDomainsError,
 			},
 			wantError: errTest.Error(),
@@ -162,8 +162,8 @@ func TestDomainDescribe(t *testing.T) {
 		{
 			args: []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetDomainFn:    getDomainError,
 			},
 			wantError: errTest.Error(),
@@ -171,8 +171,8 @@ func TestDomainDescribe(t *testing.T) {
 		{
 			args: []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetDomainFn:    getDomainOK,
 			},
 			wantOutput: describeDomainOutput,
@@ -209,34 +209,34 @@ func TestDomainUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateDomainFn: updateDomainOK,
 			},
 			wantError: "error parsing arguments: must provide either --new-name or --comment to update domain",
 		},
 		{
-			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateDomainFn: updateDomainError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateDomainFn: updateDomainOK,
 			},
-			wantOutput: "Updated domain www.example.com (service 123 version 2)",
+			wantOutput: "Updated domain www.example.com (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -270,24 +270,24 @@ func TestDomainDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteDomainFn: deleteDomainError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteDomainFn: deleteDomainOK,
 			},
-			wantOutput: "Deleted domain www.test.com (service 123 version 2)",
+			wantOutput: "Deleted domain www.test.com (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -30,9 +30,9 @@ func TestDomainCreate(t *testing.T) {
 		{
 			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateDomainFn: createDomainOK,
 			},
 			wantOutput: "Created domain www.test.com (service 123 version 2)",
@@ -40,9 +40,9 @@ func TestDomainCreate(t *testing.T) {
 		{
 			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateDomainFn: createDomainError,
 			},
 			wantError: errTest.Error(),
@@ -77,8 +77,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsShortOutput,
@@ -86,8 +86,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -95,8 +95,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -104,8 +104,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -113,8 +113,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"-v", "domain", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDomainsFn:  listDomainsOK,
 			},
 			wantOutput: listDomainsVerboseOutput,
@@ -122,8 +122,8 @@ func TestDomainList(t *testing.T) {
 		{
 			args: []string{"domain", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDomainsFn:  listDomainsError,
 			},
 			wantError: errTest.Error(),
@@ -162,8 +162,8 @@ func TestDomainDescribe(t *testing.T) {
 		{
 			args: []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetDomainFn:    getDomainError,
 			},
 			wantError: errTest.Error(),
@@ -171,8 +171,8 @@ func TestDomainDescribe(t *testing.T) {
 		{
 			args: []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetDomainFn:    getDomainOK,
 			},
 			wantOutput: describeDomainOutput,
@@ -211,9 +211,9 @@ func TestDomainUpdate(t *testing.T) {
 		{
 			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateDomainFn: updateDomainOK,
 			},
 			wantError: "error parsing arguments: must provide either --new-name or --comment to update domain",
@@ -221,9 +221,9 @@ func TestDomainUpdate(t *testing.T) {
 		{
 			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateDomainFn: updateDomainError,
 			},
 			wantError: errTest.Error(),
@@ -231,9 +231,9 @@ func TestDomainUpdate(t *testing.T) {
 		{
 			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateDomainFn: updateDomainOK,
 			},
 			wantOutput: "Updated domain www.example.com (service 123 version 2)",
@@ -272,9 +272,9 @@ func TestDomainDelete(t *testing.T) {
 		{
 			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteDomainFn: deleteDomainError,
 			},
 			wantError: errTest.Error(),
@@ -282,9 +282,9 @@ func TestDomainDelete(t *testing.T) {
 		{
 			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionActiveOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteDomainFn: deleteDomainOK,
 			},
 			wantOutput: "Deleted domain www.test.com (service 123 version 2)",
@@ -402,35 +402,4 @@ func deleteDomainOK(i *fastly.DeleteDomainInput) error {
 
 func deleteDomainError(i *fastly.DeleteDomainInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionActiveOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    1,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -28,7 +28,7 @@ func TestDomainCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -209,7 +209,7 @@ func TestDomainUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -219,7 +219,7 @@ func TestDomainUpdate(t *testing.T) {
 			wantError: "error parsing arguments: must provide either --new-name or --comment to update domain",
 		},
 		{
-			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -229,7 +229,7 @@ func TestDomainUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -270,7 +270,7 @@ func TestDomainDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -280,7 +280,7 @@ func TestDomainDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -25,17 +25,26 @@ func TestDomainCreate(t *testing.T) {
 	}{
 		{
 			args:      []string{"domain", "create", "--version", "1", "--service-id", "123"},
-			api:       mock.API{CreateDomainFn: createDomainOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:       []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:        mock.API{CreateDomainFn: createDomainOK},
-			wantOutput: "Created domain www.test.com (service 123 version 1)",
+			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateDomainFn: createDomainOK,
+			},
+			wantOutput: "Created domain www.test.com (service 123 version 2)",
 		},
 		{
-			args:      []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:       mock.API{CreateDomainFn: createDomainError},
+			args: []string{"domain", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateDomainFn: createDomainError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -66,33 +75,57 @@ func TestDomainList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"domain", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDomainsFn: listDomainsOK},
+			args: []string{"domain", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				ListDomainsFn:  listDomainsOK,
+			},
 			wantOutput: listDomainsShortOutput,
 		},
 		{
-			args:       []string{"domain", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListDomainsFn: listDomainsOK},
+			args: []string{"domain", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				ListDomainsFn:  listDomainsOK,
+			},
 			wantOutput: listDomainsVerboseOutput,
 		},
 		{
-			args:       []string{"domain", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListDomainsFn: listDomainsOK},
+			args: []string{"domain", "list", "--service-id", "123", "--version", "1", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				ListDomainsFn:  listDomainsOK,
+			},
 			wantOutput: listDomainsVerboseOutput,
 		},
 		{
-			args:       []string{"domain", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDomainsFn: listDomainsOK},
+			args: []string{"domain", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				ListDomainsFn:  listDomainsOK,
+			},
 			wantOutput: listDomainsVerboseOutput,
 		},
 		{
-			args:       []string{"-v", "domain", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDomainsFn: listDomainsOK},
+			args: []string{"-v", "domain", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				ListDomainsFn:  listDomainsOK,
+			},
 			wantOutput: listDomainsVerboseOutput,
 		},
 		{
-			args:      []string{"domain", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListDomainsFn: listDomainsError},
+			args: []string{"domain", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				ListDomainsFn:  listDomainsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -124,17 +157,24 @@ func TestDomainDescribe(t *testing.T) {
 	}{
 		{
 			args:      []string{"domain", "describe", "--service-id", "123", "--version", "1"},
-			api:       mock.API{GetDomainFn: getDomainOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:       mock.API{GetDomainFn: getDomainError},
+			args: []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				GetDomainFn:    getDomainError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:        mock.API{GetDomainFn: getDomainOK},
+			args: []string{"domain", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				GetDomainFn:    getDomainOK,
+			},
 			wantOutput: describeDomainOutput,
 		},
 	} {
@@ -165,24 +205,38 @@ func TestDomainUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"domain", "update", "--service-id", "123", "--version", "2", "--new-name", "www.test.com", "--comment", ""},
-			api:       mock.API{UpdateDomainFn: updateDomainOK},
+			args:      []string{"domain", "update", "--service-id", "123", "--version", "1", "--new-name", "www.test.com", "--comment", ""},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"domain", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com"},
-			api:       mock.API{UpdateDomainFn: updateDomainOK},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateDomainFn: updateDomainOK,
+			},
 			wantError: "error parsing arguments: must provide either --new-name or --comment to update domain",
 		},
 		{
-			args:      []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
-			api:       mock.API{UpdateDomainFn: updateDomainError},
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateDomainFn: updateDomainError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
-			api:        mock.API{UpdateDomainFn: updateDomainOK},
-			wantOutput: "Updated domain www.example.com (service 123 version 1)",
+			args: []string{"domain", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateDomainFn: updateDomainOK,
+			},
+			wantOutput: "Updated domain www.example.com (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -213,18 +267,27 @@ func TestDomainDelete(t *testing.T) {
 	}{
 		{
 			args:      []string{"domain", "delete", "--service-id", "123", "--version", "1"},
-			api:       mock.API{DeleteDomainFn: deleteDomainOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:       mock.API{DeleteDomainFn: deleteDomainError},
+			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteDomainFn: deleteDomainError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:        mock.API{DeleteDomainFn: deleteDomainOK},
-			wantOutput: "Deleted domain www.test.com (service 123 version 1)",
+			args: []string{"domain", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionActiveOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteDomainFn: deleteDomainOK,
+			},
+			wantOutput: "Deleted domain www.test.com (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -339,4 +402,35 @@ func deleteDomainOK(i *fastly.DeleteDomainInput) error {
 
 func deleteDomainError(i *fastly.DeleteDomainInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionActiveOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    1,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/domain/list.go
+++ b/pkg/domain/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list domains.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListDomainsInput
+	manifest       manifest.Data
+	Input          fastly.ListDomainsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List domains on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	domains, err := c.Globals.Client.ListDomains(&c.Input)
 	if err != nil {

--- a/pkg/domain/update.go
+++ b/pkg/domain/update.go
@@ -15,8 +15,10 @@ import (
 // UpdateCommand calls the Fastly API to update domains.
 type UpdateCommand struct {
 	common.Base
-	manifest manifest.Data
-	input    fastly.UpdateDomainInput
+	manifest       manifest.Data
+	input          fastly.UpdateDomainInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 
 	NewName common.OptionalString
 	Comment common.OptionalString
@@ -28,7 +30,8 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.CmdClause = parent.Command("update", "Update a domain on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "Domain name").Short('n').Required().StringVar(&c.input.Name)
 	c.CmdClause.Flag("new-name", "New domain name").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("comment", "A descriptive note").Action(c.Comment.Set).StringVar(&c.Comment.Value)
@@ -42,6 +45,16 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.input.ServiceVersion = v.Number
 
 	// If neither arguments are provided, error with useful message.
 	if !c.NewName.WasSet && !c.Comment.WasSet {

--- a/pkg/edgedictionary/create.go
+++ b/pkg/edgedictionary/create.go
@@ -15,8 +15,10 @@ import (
 // CreateCommand calls the Fastly API to create a service.
 type CreateCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.CreateDictionaryInput
+	manifest       manifest.Data
+	Input          fastly.CreateDictionaryInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 
 	writeOnly common.OptionalString
 }
@@ -29,7 +31,8 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Fastly edge dictionary on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "Name of Dictionary").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("write-only", "Whether to mark this dictionary as write-only. Can be true or false (defaults to false)").Action(c.writeOnly.Set).StringVar(&c.writeOnly.Value)
 	return &c
@@ -42,6 +45,16 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if c.writeOnly.WasSet {
 		writeOnly, err := strconv.ParseBool(c.writeOnly.Value)

--- a/pkg/edgedictionary/describe.go
+++ b/pkg/edgedictionary/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a dictionary.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetDictionaryInput
+	manifest       manifest.Data
+	Input          fastly.GetDictionaryInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Fastly edge dictionary").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "Name of Dictionary").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	dictionary, err := c.Globals.Client.GetDictionary(&c.Input)
 	if err != nil {

--- a/pkg/edgedictionary/edgedictionary_test.go
+++ b/pkg/edgedictionary/edgedictionary_test.go
@@ -88,7 +88,7 @@ func TestDictionaryCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--autoclone"},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -98,7 +98,7 @@ func TestDictionaryCreate(t *testing.T) {
 			wantOutput: createDictionaryOutput,
 		},
 		{
-			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "true", "--autoclone"},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "true"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -112,6 +112,7 @@ func TestDictionaryCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "strconv.ParseBool: parsing \"fish\": invalid syntax",
 		},
@@ -120,6 +121,7 @@ func TestDictionaryCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateDictionaryFn: createDictionaryDuplicate,
 			},
 			wantError: "Duplicate record",
@@ -156,7 +158,7 @@ func TestDeleteDictionary(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
+			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -166,7 +168,7 @@ func TestDeleteDictionary(t *testing.T) {
 			wantOutput: deleteDictionaryOutput,
 		},
 		{
-			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
+			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -264,7 +266,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--autoclone"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -273,7 +275,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantError: "error parsing arguments: required flag --new-name or --write-only not provided",
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -283,7 +285,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--write-only", "true", "--autoclone"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--write-only", "true"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -293,7 +295,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--write-only", "true", "--autoclone"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--write-only", "true"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -303,7 +305,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryOutput,
 		},
 		{
-			args: []string{"dictionary", "update", "-v", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
+			args: []string{"dictionary", "update", "-v", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -313,7 +315,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryOutputVerbose,
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,

--- a/pkg/edgedictionary/edgedictionary_test.go
+++ b/pkg/edgedictionary/edgedictionary_test.go
@@ -30,8 +30,8 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetDictionaryFn: describeDictionaryOK,
 			},
 			wantOutput: describeDictionaryOutput,
@@ -39,8 +39,8 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetDictionaryFn: describeDictionaryOKDeleted,
 			},
 			wantOutput: describeDictionaryOutputDeleted,
@@ -48,8 +48,8 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersionsOk,
-				GetVersionFn:          testutil.GetActiveVersionOK,
+				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetActiveVersion(1),
 				GetDictionaryFn:       describeDictionaryOK,
 				GetDictionaryInfoFn:   getDictionaryInfoOK,
 				ListDictionaryItemsFn: listDictionaryItemsOK,
@@ -88,40 +88,40 @@ func TestDictionaryCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist"},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateDictionaryFn: createDictionaryOK,
 			},
 			wantOutput: createDictionaryOutput,
 		},
 		{
-			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "true"},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "true", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateDictionaryFn: createDictionaryOK,
 			},
 			wantOutput: createDictionaryOutputWriteOnly,
 		},
 		{
-			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "fish"},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "fish", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "strconv.ParseBool: parsing \"fish\": invalid syntax",
 		},
 		{
-			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist"},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateDictionaryFn: createDictionaryDuplicate,
 			},
 			wantError: "Duplicate record",
@@ -158,21 +158,21 @@ func TestDeleteDictionary(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist"},
+			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteDictionaryFn: deleteDictionaryOK,
 			},
 			wantOutput: deleteDictionaryOutput,
 		},
 		{
-			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist"},
+			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteDictionaryFn: deleteDictionaryError,
 			},
 			wantError: errTest.Error(),
@@ -207,8 +207,8 @@ func TestListDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "list", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListDictionariesFn: listDictionariesOk,
 			},
 			wantError: "error reading service: no service ID found",
@@ -220,8 +220,8 @@ func TestListDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "list", "--version", "1", "--service-id", "123"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListDictionariesFn: listDictionariesOk,
 			},
 			wantOutput: listDictionariesOutput,
@@ -266,60 +266,60 @@ func TestUpdateDictionary(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --new-name or --write-only not provided",
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--write-only", "true"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--write-only", "true", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--write-only", "true"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--write-only", "true", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryWriteOnlyOK,
 			},
 			wantOutput: updateDictionaryOutput,
 		},
 		{
-			args: []string{"dictionary", "update", "-v", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
+			args: []string{"dictionary", "update", "-v", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
 			wantOutput: updateDictionaryOutputVerbose,
 		},
 		{
-			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryError,
 			},
 			wantError: errTest.Error(),
@@ -494,11 +494,11 @@ func updateDictionaryError(i *fastly.UpdateDictionaryInput) (*fastly.Dictionary,
 var errTest = errors.New("an expected error ocurred")
 var errFail = errors.New("this error should not be returned and indicates a failure in the code")
 
-var createDictionaryOutput = "\nSUCCESS: Created dictionary denylist (service 123 version 2)\n"
-var createDictionaryOutputWriteOnly = "\nSUCCESS: Created dictionary denylist as write-only (service 123 version 2)\n"
-var deleteDictionaryOutput = "\nSUCCESS: Deleted dictionary allowlist (service 123 version 2)\n"
-var updateDictionaryOutput = "\nSUCCESS: Updated dictionary oldname (service 123 version 2)\n"
-var updateDictionaryNameOutput = "\nSUCCESS: Updated dictionary dict-1 (service 123 version 2)\n"
+var createDictionaryOutput = "\nSUCCESS: Created dictionary denylist (service 123 version 4)\n"
+var createDictionaryOutputWriteOnly = "\nSUCCESS: Created dictionary denylist as write-only (service 123 version 4)\n"
+var deleteDictionaryOutput = "\nSUCCESS: Deleted dictionary allowlist (service 123 version 4)\n"
+var updateDictionaryOutput = "\nSUCCESS: Updated dictionary oldname (service 123 version 4)\n"
+var updateDictionaryNameOutput = "\nSUCCESS: Updated dictionary dict-1 (service 123 version 4)\n"
 
 var updateDictionaryOutputVerbose = strings.Join(
 	[]string{
@@ -512,7 +512,7 @@ var updateDictionaryOutputVerbose = strings.Join(
 
 var updateDictionaryOutputVersionCloned = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 4
 ID: 456
 Name: dict-1
 Write Only: false

--- a/pkg/edgedictionary/edgedictionary_test.go
+++ b/pkg/edgedictionary/edgedictionary_test.go
@@ -25,22 +25,31 @@ func TestDictionaryDescribe(t *testing.T) {
 	}{
 		{
 			args:      []string{"dictionary", "describe", "--version", "1", "--service-id", "123"},
-			api:       mock.API{GetDictionaryFn: describeDictionaryOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:       []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
-			api:        mock.API{GetDictionaryFn: describeDictionaryOK},
+			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetDictionaryFn: describeDictionaryOK,
+			},
 			wantOutput: describeDictionaryOutput,
 		},
 		{
-			args:       []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
-			api:        mock.API{GetDictionaryFn: describeDictionaryOKDeleted},
+			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetDictionaryFn: describeDictionaryOKDeleted,
+			},
 			wantOutput: describeDictionaryOutputDeleted,
 		},
 		{
 			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1", "--verbose"},
 			api: mock.API{
+				ListVersionsFn:        listVersionsOK,
+				GetVersionFn:          getVersionOK,
 				GetDictionaryFn:       describeDictionaryOK,
 				GetDictionaryInfoFn:   getDictionaryInfoOK,
 				ListDictionaryItemsFn: listDictionaryItemsOK,
@@ -79,22 +88,40 @@ func TestDictionaryCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:       []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist"},
-			api:        mock.API{CreateDictionaryFn: createDictionaryOK},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateDictionaryFn: createDictionaryOK,
+			},
 			wantOutput: createDictionaryOutput,
 		},
 		{
-			args:       []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "true"},
-			api:        mock.API{CreateDictionaryFn: createDictionaryOK},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "true", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateDictionaryFn: createDictionaryOK,
+			},
 			wantOutput: createDictionaryOutputWriteOnly,
 		},
 		{
-			args:      []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "fish"},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "fish"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "strconv.ParseBool: parsing \"fish\": invalid syntax",
 		},
 		{
-			args:      []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist"},
-			api:       mock.API{CreateDictionaryFn: createDictionaryDuplicate},
+			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CreateDictionaryFn: createDictionaryDuplicate,
+			},
 			wantError: "Duplicate record",
 		},
 	} {
@@ -126,17 +153,26 @@ func TestDeleteDictionary(t *testing.T) {
 	}{
 		{
 			args:      []string{"dictionary", "delete", "--service-id", "123", "--version", "1"},
-			api:       mock.API{DeleteDictionaryFn: deleteDictionaryOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:       []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist"},
-			api:        mock.API{DeleteDictionaryFn: deleteDictionaryOK},
+			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteDictionaryFn: deleteDictionaryOK,
+			},
 			wantOutput: deleteDictionaryOutput,
 		},
 		{
-			args:      []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist"},
-			api:       mock.API{DeleteDictionaryFn: deleteDictionaryError},
+			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteDictionaryFn: deleteDictionaryError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -167,18 +203,25 @@ func TestListDictionary(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"dictionary", "list", "--version", "1"},
-			api:       mock.API{ListDictionariesFn: listDictionariesOk},
+			args: []string{"dictionary", "list", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListDictionariesFn: listDictionariesOk,
+			},
 			wantError: "error reading service: no service ID found",
 		},
 		{
 			args:      []string{"dictionary", "list", "--service-id", "123"},
-			api:       mock.API{DeleteDictionaryFn: deleteDictionaryOK},
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args:       []string{"dictionary", "list", "--version", "1", "--service-id", "123"},
-			api:        mock.API{ListDictionariesFn: listDictionariesOk},
+			args: []string{"dictionary", "list", "--version", "1", "--service-id", "123"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListDictionariesFn: listDictionariesOk,
+			},
 			wantOutput: listDictionariesOutput,
 		},
 	} {
@@ -221,32 +264,62 @@ func TestUpdateDictionary(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname"},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --new-name or --write-only not provided",
 		},
 		{
-			args:       []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
-			api:        mock.API{UpdateDictionaryFn: updateDictionaryNameOK},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateDictionaryFn: updateDictionaryNameOK,
+			},
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args:       []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--write-only", "true"},
-			api:        mock.API{UpdateDictionaryFn: updateDictionaryNameOK},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--write-only", "true", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateDictionaryFn: updateDictionaryNameOK,
+			},
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args:       []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--write-only", "true"},
-			api:        mock.API{UpdateDictionaryFn: updateDictionaryWriteOnlyOK},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--write-only", "true", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateDictionaryFn: updateDictionaryWriteOnlyOK,
+			},
 			wantOutput: updateDictionaryOutput,
 		},
 		{
-			args:       []string{"dictionary", "update", "-v", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
-			api:        mock.API{UpdateDictionaryFn: updateDictionaryNameOK},
+			args: []string{"dictionary", "update", "-v", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateDictionaryFn: updateDictionaryNameOK,
+			},
 			wantOutput: updateDictionaryOutputVerbose,
 		},
 		{
-			args:      []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1"},
-			api:       mock.API{UpdateDictionaryFn: updateDictionaryError},
+			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateDictionaryFn: updateDictionaryError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -419,11 +492,11 @@ func updateDictionaryError(i *fastly.UpdateDictionaryInput) (*fastly.Dictionary,
 var errTest = errors.New("an expected error ocurred")
 var errFail = errors.New("this error should not be returned and indicates a failure in the code")
 
-var createDictionaryOutput = "\nSUCCESS: Created dictionary denylist (service 123 version 1)\n"
-var createDictionaryOutputWriteOnly = "\nSUCCESS: Created dictionary denylist as write-only (service 123 version 1)\n"
-var deleteDictionaryOutput = "\nSUCCESS: Deleted dictionary allowlist (service 123 version 1)\n"
-var updateDictionaryOutput = "\nSUCCESS: Updated dictionary oldname (service 123 version 1)\n"
-var updateDictionaryNameOutput = "\nSUCCESS: Updated dictionary dict-1 (service 123 version 1)\n"
+var createDictionaryOutput = "\nSUCCESS: Created dictionary denylist (service 123 version 2)\n"
+var createDictionaryOutputWriteOnly = "\nSUCCESS: Created dictionary denylist as write-only (service 123 version 2)\n"
+var deleteDictionaryOutput = "\nSUCCESS: Deleted dictionary allowlist (service 123 version 2)\n"
+var updateDictionaryOutput = "\nSUCCESS: Updated dictionary oldname (service 123 version 2)\n"
+var updateDictionaryNameOutput = "\nSUCCESS: Updated dictionary dict-1 (service 123 version 2)\n"
 
 var updateDictionaryOutputVerbose = strings.Join(
 	[]string{
@@ -431,9 +504,19 @@ var updateDictionaryOutputVerbose = strings.Join(
 		"Fastly API endpoint: https://api.fastly.com",
 		"",
 		strings.TrimSpace(updateDictionaryNameOutput),
-		describeDictionaryOutput,
+		updateDictionaryOutputVersionCloned,
 	},
 	"\n")
+
+var updateDictionaryOutputVersionCloned = strings.TrimSpace(`
+Service ID: 123
+Version: 2
+ID: 456
+Name: dict-1
+Write Only: false
+Created (UTC): 2001-02-03 04:05
+Last edited (UTC): 2001-02-03 04:05
+`) + "\n"
 
 var describeDictionaryOutput = strings.TrimSpace(`
 Service ID: 123
@@ -490,3 +573,34 @@ Write Only: false
 Created (UTC): 2001-02-03 04:05
 Last edited (UTC): 2001-02-03 04:05
 `) + "\n"
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    1,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
+}

--- a/pkg/edgedictionary/edgedictionary_test.go
+++ b/pkg/edgedictionary/edgedictionary_test.go
@@ -30,8 +30,8 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetDictionaryFn: describeDictionaryOK,
 			},
 			wantOutput: describeDictionaryOutput,
@@ -39,8 +39,8 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetDictionaryFn: describeDictionaryOKDeleted,
 			},
 			wantOutput: describeDictionaryOutputDeleted,
@@ -48,8 +48,8 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			args: []string{"dictionary", "describe", "--version", "1", "--service-id", "123", "--name", "dict-1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:        listVersionsOK,
-				GetVersionFn:          getVersionOK,
+				ListVersionsFn:        testutil.ListVersionsOk,
+				GetVersionFn:          testutil.GetActiveVersionOK,
 				GetDictionaryFn:       describeDictionaryOK,
 				GetDictionaryInfoFn:   getDictionaryInfoOK,
 				ListDictionaryItemsFn: listDictionaryItemsOK,
@@ -90,9 +90,9 @@ func TestDictionaryCreate(t *testing.T) {
 		{
 			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateDictionaryFn: createDictionaryOK,
 			},
 			wantOutput: createDictionaryOutput,
@@ -100,9 +100,9 @@ func TestDictionaryCreate(t *testing.T) {
 		{
 			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "true", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateDictionaryFn: createDictionaryOK,
 			},
 			wantOutput: createDictionaryOutputWriteOnly,
@@ -110,16 +110,16 @@ func TestDictionaryCreate(t *testing.T) {
 		{
 			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist", "--write-only", "fish"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "strconv.ParseBool: parsing \"fish\": invalid syntax",
 		},
 		{
 			args: []string{"dictionary", "create", "--version", "1", "--service-id", "123", "--name", "denylist"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				CreateDictionaryFn: createDictionaryDuplicate,
 			},
 			wantError: "Duplicate record",
@@ -158,9 +158,9 @@ func TestDeleteDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteDictionaryFn: deleteDictionaryOK,
 			},
 			wantOutput: deleteDictionaryOutput,
@@ -168,9 +168,9 @@ func TestDeleteDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "delete", "--service-id", "123", "--version", "1", "--name", "allowlist", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteDictionaryFn: deleteDictionaryError,
 			},
 			wantError: errTest.Error(),
@@ -205,8 +205,8 @@ func TestListDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "list", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListDictionariesFn: listDictionariesOk,
 			},
 			wantError: "error reading service: no service ID found",
@@ -218,8 +218,8 @@ func TestListDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "list", "--version", "1", "--service-id", "123"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListDictionariesFn: listDictionariesOk,
 			},
 			wantOutput: listDictionariesOutput,
@@ -266,18 +266,18 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --new-name or --write-only not provided",
 		},
 		{
 			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
 			wantOutput: updateDictionaryNameOutput,
@@ -285,9 +285,9 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--write-only", "true", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
 			wantOutput: updateDictionaryNameOutput,
@@ -295,9 +295,9 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--write-only", "true", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateDictionaryFn: updateDictionaryWriteOnlyOK,
 			},
 			wantOutput: updateDictionaryOutput,
@@ -305,9 +305,9 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "update", "-v", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
 			wantOutput: updateDictionaryOutputVerbose,
@@ -315,9 +315,9 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			args: []string{"dictionary", "update", "--service-id", "123", "--version", "1", "--name", "oldname", "--new-name", "dict-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateDictionaryFn: updateDictionaryError,
 			},
 			wantError: errTest.Error(),
@@ -573,34 +573,3 @@ Write Only: false
 Created (UTC): 2001-02-03 04:05
 Last edited (UTC): 2001-02-03 04:05
 `) + "\n"
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    1,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
-}

--- a/pkg/edgedictionary/list.go
+++ b/pkg/edgedictionary/list.go
@@ -14,8 +14,9 @@ import (
 // ListCommand calls the Fastly API to list dictionaries
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListDictionariesInput
+	manifest       manifest.Data
+	Input          fastly.ListDictionariesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent
@@ -26,7 +27,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List all dictionaries on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -37,6 +38,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	dictionaries, err := c.Globals.Client.ListDictionaries(&c.Input)
 	if err != nil {

--- a/pkg/edgedictionary/update.go
+++ b/pkg/edgedictionary/update.go
@@ -17,7 +17,10 @@ import (
 type UpdateCommand struct {
 	common.Base
 	manifest manifest.Data
-	input    fastly.UpdateDictionaryInput
+	// TODO: make input consistent across commands (most are title case)
+	input          fastly.UpdateDictionaryInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 
 	newname   common.OptionalString
 	writeOnly common.OptionalString
@@ -31,7 +34,8 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update name of dictionary on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "Old name of Dictionary").Short('n').Required().StringVar(&c.input.Name)
 	c.CmdClause.Flag("new-name", "New name of Dictionary").Action(c.newname.Set).StringVar(&c.newname.Value)
 	c.CmdClause.Flag("write-only", "Whether to mark this dictionary as write-only. Can be true or false (defaults to false)").Action(c.writeOnly.Set).StringVar(&c.writeOnly.Value)
@@ -45,6 +49,16 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.input.ServiceVersion = v.Number
 
 	if !c.newname.WasSet && !c.writeOnly.WasSet {
 		return errors.RemediationError{Inner: fmt.Errorf("error parsing arguments: required flag --new-name or --write-only not provided"), Remediation: "To fix this error, provide at least one of the aforementioned flags"}

--- a/pkg/healthcheck/create.go
+++ b/pkg/healthcheck/create.go
@@ -14,8 +14,10 @@ import (
 // CreateCommand calls the Fastly API to create healthchecks.
 type CreateCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.CreateHealthCheckInput
+	manifest       manifest.Data
+	Input          fastly.CreateHealthCheckInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -23,10 +25,9 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	var c CreateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("create", "Create a healthcheck on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
-
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "Healthcheck name").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.Input.Comment)
 	c.CmdClause.Flag("method", "Which HTTP method to use").StringVar(&c.Input.Method)
@@ -39,7 +40,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("window", "The number of most recent healthcheck queries to keep for this healthcheck").UintVar(&c.Input.Window)
 	c.CmdClause.Flag("threshold", "How many healthchecks must succeed to be considered healthy").UintVar(&c.Input.Threshold)
 	c.CmdClause.Flag("initial", "When loading a config, the initial number of probes to be seen as OK").UintVar(&c.Input.Initial)
-
 	return &c
 }
 
@@ -50,6 +50,16 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	h, err := c.Globals.Client.CreateHealthCheck(&c.Input)
 	if err != nil {

--- a/pkg/healthcheck/delete.go
+++ b/pkg/healthcheck/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete healthchecks.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteHealthCheckInput
+	manifest       manifest.Data
+	Input          fastly.DeleteHealthCheckInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -26,7 +28,8 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a healthcheck on a Fastly service version").Alias("remove")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "Healthcheck name").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteHealthCheck(&c.Input); err != nil {
 		return err

--- a/pkg/healthcheck/describe.go
+++ b/pkg/healthcheck/describe.go
@@ -15,8 +15,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a healthcheck.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetHealthCheckInput
+	manifest       manifest.Data
+	Input          fastly.GetHealthCheckInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a healthcheck on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "Name of healthcheck").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -39,6 +40,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	healthCheck, err := c.Globals.Client.GetHealthCheck(&c.Input)
 	if err != nil {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -30,21 +30,21 @@ func TestHealthCheckCreate(t *testing.T) {
 		{
 			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsActiveOk,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				CreateHealthCheckFn: createHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--autoclone"},
+			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsActiveOk,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				CreateHealthCheckFn: createHealthCheckOK,
 			},
-			wantOutput: "Created healthcheck www.test.com (service 123 version 3)",
+			wantOutput: "Created healthcheck www.test.com (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -74,55 +74,55 @@ func TestHealthCheckList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsActiveOk,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksShortOutput,
 		},
 		{
-			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsActiveOk,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsActiveOk,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: []string{"healthcheck", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"healthcheck", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsActiveOk,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: []string{"-v", "healthcheck", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"-v", "healthcheck", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsActiveOk,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsActiveOk,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListHealthChecksFn: listHealthChecksError,
 			},
 			wantError: errTest.Error(),
@@ -155,23 +155,23 @@ func TestHealthCheckDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"healthcheck", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"healthcheck", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "2", "--name", "www.test.com"},
+			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsActiveOk,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				GetHealthCheckFn: getHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "2", "--name", "www.test.com"},
+			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsActiveOk,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				GetHealthCheckFn: getHealthCheckOK,
 			},
 			wantOutput: describeHealthCheckOutput,
@@ -204,35 +204,35 @@ func TestHealthCheckUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--new-name", "www.test.com", "--comment", ""},
+			args:      []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--new-name", "www.test.com", "--comment", ""},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--new-name", "www.example.com"},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsActiveOk,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				UpdateHealthCheckFn: updateHealthCheckOK,
 			},
 		},
 		{
-			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--new-name", "www.example.com"},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsActiveOk,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				UpdateHealthCheckFn: updateHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsActiveOk,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				UpdateHealthCheckFn: updateHealthCheckOK,
 			},
-			wantOutput: "Updated healthcheck www.example.com (service 123 version 3)",
+			wantOutput: "Updated healthcheck www.example.com (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -262,27 +262,27 @@ func TestHealthCheckDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"healthcheck", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"healthcheck", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "2", "--name", "www.test.com"},
+			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsActiveOk,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				DeleteHealthCheckFn: deleteHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--autoclone"},
+			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsActiveOk,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				DeleteHealthCheckFn: deleteHealthCheckOK,
 			},
-			wantOutput: "Deleted healthcheck www.test.com (service 123 version 3)",
+			wantOutput: "Deleted healthcheck www.test.com (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -350,15 +350,15 @@ func listHealthChecksError(i *fastly.ListHealthChecksInput) ([]*fastly.HealthChe
 
 var listHealthChecksShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME     METHOD  HOST             PATH
-123      2        test     HEAD    www.test.com     /health
-123      2        example  HEAD    www.example.com  /health
+123      1        test     HEAD    www.test.com     /health
+123      1        example  HEAD    www.example.com  /health
 `) + "\n"
 
 var listHealthChecksVerboseOutput = strings.Join([]string{
 	"Fastly API token not provided",
 	"Fastly API endpoint: https://api.fastly.com",
 	"Service ID: 123",
-	"Version: 2",
+	"Version: 1",
 	"	Healthcheck 1/2",
 	"		Name: test",
 	"		Comment: test",
@@ -405,7 +405,7 @@ func getHealthCheckError(i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, er
 
 var describeHealthCheckOutput = strings.Join([]string{
 	"Service ID: 123",
-	"Version: 2",
+	"Version: 1",
 	"Name: test",
 	"Comment: test",
 	"Method: HEAD",

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -28,24 +28,24 @@ func TestHealthCheckCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateHealthCheckFn: createHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateHealthCheckFn: createHealthCheckOK,
 			},
-			wantOutput: "Created healthcheck www.test.com (service 123 version 2)",
+			wantOutput: "Created healthcheck www.test.com (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -77,8 +77,8 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksShortOutput,
@@ -86,8 +86,8 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
@@ -95,8 +95,8 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
@@ -104,8 +104,8 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			args: []string{"healthcheck", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
@@ -113,8 +113,8 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			args: []string{"-v", "healthcheck", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			wantOutput: listHealthChecksVerboseOutput,
@@ -122,8 +122,8 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListHealthChecksFn: listHealthChecksError,
 			},
 			wantError: errTest.Error(),
@@ -162,8 +162,8 @@ func TestHealthCheckDescribe(t *testing.T) {
 		{
 			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				GetHealthCheckFn: getHealthCheckError,
 			},
 			wantError: errTest.Error(),
@@ -171,8 +171,8 @@ func TestHealthCheckDescribe(t *testing.T) {
 		{
 			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				GetHealthCheckFn: getHealthCheckOK,
 			},
 			wantOutput: describeHealthCheckOutput,
@@ -209,33 +209,33 @@ func TestHealthCheckUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateHealthCheckFn: updateHealthCheckOK,
 			},
 		},
 		{
-			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateHealthCheckFn: updateHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateHealthCheckFn: updateHealthCheckOK,
 			},
-			wantOutput: "Updated healthcheck www.example.com (service 123 version 2)",
+			wantOutput: "Updated healthcheck www.example.com (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -269,24 +269,24 @@ func TestHealthCheckDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteHealthCheckFn: deleteHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteHealthCheckFn: deleteHealthCheckOK,
 			},
-			wantOutput: "Deleted healthcheck www.test.com (service 123 version 2)",
+			wantOutput: "Deleted healthcheck www.test.com (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -25,18 +25,26 @@ func TestHealthCheckCreate(t *testing.T) {
 	}{
 		{
 			args:      []string{"healthcheck", "create", "--version", "1", "--service-id", "123"},
-			api:       mock.API{CreateHealthCheckFn: createHealthCheckOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:       mock.API{CreateHealthCheckFn: createHealthCheckError},
+			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsActiveOk,
+				GetVersionFn:        getVersionOK,
+				CreateHealthCheckFn: createHealthCheckError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:        mock.API{CreateHealthCheckFn: createHealthCheckOK},
-			wantOutput: "Created healthcheck www.test.com (service 123 version 1)",
+			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsActiveOk,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				CreateHealthCheckFn: createHealthCheckOK,
+			},
+			wantOutput: "Created healthcheck www.test.com (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -66,33 +74,57 @@ func TestHealthCheckList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"healthcheck", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHealthChecksFn: listHealthChecksOK},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsActiveOk,
+				GetVersionFn:       getVersionOK,
+				ListHealthChecksFn: listHealthChecksOK,
+			},
 			wantOutput: listHealthChecksShortOutput,
 		},
 		{
-			args:       []string{"healthcheck", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListHealthChecksFn: listHealthChecksOK},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsActiveOk,
+				GetVersionFn:       getVersionOK,
+				ListHealthChecksFn: listHealthChecksOK,
+			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args:       []string{"healthcheck", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListHealthChecksFn: listHealthChecksOK},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsActiveOk,
+				GetVersionFn:       getVersionOK,
+				ListHealthChecksFn: listHealthChecksOK,
+			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args:       []string{"healthcheck", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHealthChecksFn: listHealthChecksOK},
+			args: []string{"healthcheck", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsActiveOk,
+				GetVersionFn:       getVersionOK,
+				ListHealthChecksFn: listHealthChecksOK,
+			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args:       []string{"-v", "healthcheck", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHealthChecksFn: listHealthChecksOK},
+			args: []string{"-v", "healthcheck", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsActiveOk,
+				GetVersionFn:       getVersionOK,
+				ListHealthChecksFn: listHealthChecksOK,
+			},
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args:      []string{"healthcheck", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListHealthChecksFn: listHealthChecksError},
+			args: []string{"healthcheck", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsActiveOk,
+				GetVersionFn:       getVersionOK,
+				ListHealthChecksFn: listHealthChecksError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -123,18 +155,25 @@ func TestHealthCheckDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"healthcheck", "describe", "--service-id", "123", "--version", "1"},
-			api:       mock.API{GetHealthCheckFn: getHealthCheckOK},
+			args:      []string{"healthcheck", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"healthcheck", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:       mock.API{GetHealthCheckFn: getHealthCheckError},
+			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "2", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsActiveOk,
+				GetVersionFn:     getVersionOK,
+				GetHealthCheckFn: getHealthCheckError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"healthcheck", "describe", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:        mock.API{GetHealthCheckFn: getHealthCheckOK},
+			args: []string{"healthcheck", "describe", "--service-id", "123", "--version", "2", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsActiveOk,
+				GetVersionFn:     getVersionOK,
+				GetHealthCheckFn: getHealthCheckOK,
+			},
 			wantOutput: describeHealthCheckOutput,
 		},
 	} {
@@ -166,22 +205,34 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}{
 		{
 			args:      []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--new-name", "www.test.com", "--comment", ""},
-			api:       mock.API{UpdateHealthCheckFn: updateHealthCheckOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--new-name", "www.example.com"},
-			api:  mock.API{UpdateHealthCheckFn: updateHealthCheckOK},
+			api: mock.API{
+				ListVersionsFn:      listVersionsActiveOk,
+				GetVersionFn:        getVersionOK,
+				UpdateHealthCheckFn: updateHealthCheckOK,
+			},
 		},
 		{
-			args:      []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
-			api:       mock.API{UpdateHealthCheckFn: updateHealthCheckError},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--new-name", "www.example.com"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsActiveOk,
+				GetVersionFn:        getVersionOK,
+				UpdateHealthCheckFn: updateHealthCheckError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
-			api:        mock.API{UpdateHealthCheckFn: updateHealthCheckOK},
-			wantOutput: "Updated healthcheck www.example.com (service 123 version 1)",
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsActiveOk,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				UpdateHealthCheckFn: updateHealthCheckOK,
+			},
+			wantOutput: "Updated healthcheck www.example.com (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -211,19 +262,27 @@ func TestHealthCheckDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"healthcheck", "delete", "--service-id", "123", "--version", "1"},
-			api:       mock.API{DeleteHealthCheckFn: deleteHealthCheckOK},
+			args:      []string{"healthcheck", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:       mock.API{DeleteHealthCheckFn: deleteHealthCheckError},
+			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "2", "--name", "www.test.com"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsActiveOk,
+				GetVersionFn:        getVersionOK,
+				DeleteHealthCheckFn: deleteHealthCheckError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
-			api:        mock.API{DeleteHealthCheckFn: deleteHealthCheckOK},
-			wantOutput: "Deleted healthcheck www.test.com (service 123 version 1)",
+			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "2", "--name", "www.test.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsActiveOk,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				DeleteHealthCheckFn: deleteHealthCheckOK,
+			},
+			wantOutput: "Deleted healthcheck www.test.com (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -291,15 +350,15 @@ func listHealthChecksError(i *fastly.ListHealthChecksInput) ([]*fastly.HealthChe
 
 var listHealthChecksShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME     METHOD  HOST             PATH
-123      1        test     HEAD    www.test.com     /health
-123      1        example  HEAD    www.example.com  /health
+123      2        test     HEAD    www.test.com     /health
+123      2        example  HEAD    www.example.com  /health
 `) + "\n"
 
 var listHealthChecksVerboseOutput = strings.Join([]string{
 	"Fastly API token not provided",
 	"Fastly API endpoint: https://api.fastly.com",
 	"Service ID: 123",
-	"Version: 1",
+	"Version: 2",
 	"	Healthcheck 1/2",
 	"		Name: test",
 	"		Comment: test",
@@ -346,7 +405,7 @@ func getHealthCheckError(i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, er
 
 var describeHealthCheckOutput = strings.Join([]string{
 	"Service ID: 123",
-	"Version: 1",
+	"Version: 2",
 	"Name: test",
 	"Comment: test",
 	"Method: HEAD",
@@ -379,4 +438,35 @@ func deleteHealthCheckOK(i *fastly.DeleteHealthCheckInput) error {
 
 func deleteHealthCheckError(i *fastly.DeleteHealthCheckInput) error {
 	return errTest
+}
+
+func listVersionsActiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -32,12 +32,13 @@ func TestHealthCheckCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				CreateHealthCheckFn: createHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"healthcheck", "create", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -212,6 +213,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				UpdateHealthCheckFn: updateHealthCheckOK,
 			},
 		},
@@ -220,12 +222,13 @@ func TestHealthCheckUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				UpdateHealthCheckFn: updateHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com", "--autoclone"},
+			args: []string{"healthcheck", "update", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--new-name", "www.example.com"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -270,12 +273,13 @@ func TestHealthCheckDelete(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				DeleteHealthCheckFn: deleteHealthCheckError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com", "--autoclone"},
+			args: []string{"healthcheck", "delete", "--service-id", "123", "--version", "1", "--name", "www.test.com"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -439,34 +439,3 @@ func deleteHealthCheckOK(i *fastly.DeleteHealthCheckInput) error {
 func deleteHealthCheckError(i *fastly.DeleteHealthCheckInput) error {
 	return errTest
 }
-
-func listVersionsActiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
-}

--- a/pkg/healthcheck/list.go
+++ b/pkg/healthcheck/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list healthchecks.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListHealthChecksInput
+	manifest       manifest.Data
+	Input          fastly.ListHealthChecksInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List healthchecks on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	healthChecks, err := c.Globals.Client.ListHealthChecks(&c.Input)
 	if err != nil {

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -32,31 +32,31 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --account-name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "2", "--name", "log", "--account-name", "account", "--container", "log", "--autoclone"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				CreateBlobStorageFn: createBlobStorageError,
 			},
 			wantError: "error parsing arguments: required flag --sas-token not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "2", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				CreateBlobStorageFn: createBlobStorageOK,
 			},
-			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "2", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				CreateBlobStorageFn: createBlobStorageError,
 			},
 			wantError: errTest.Error(),
@@ -64,9 +64,9 @@ func TestBlobStorageCreate(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				CreateBlobStorageFn: createBlobStorageError,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -99,55 +99,55 @@ func TestBlobStorageList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesShortOutput,
 		},
 		{
-			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "azureblob", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "azureblob", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "azureblob", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "azureblob", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				ListBlobStoragesFn: listBlobStoragesError,
 			},
 			wantError: errTest.Error(),
@@ -180,23 +180,23 @@ func TestBlobStorageDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				GetBlobStorageFn: getBlobStorageError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				GetBlobStorageFn: getBlobStorageOK,
 			},
 			wantOutput: describeBlobStorageOutput,
@@ -229,28 +229,28 @@ func TestBlobStorageUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				UpdateBlobStorageFn: updateBlobStorageError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				UpdateBlobStorageFn: updateBlobStorageOK,
 			},
-			wantOutput: "Updated Azure Blob Storage logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Azure Blob Storage logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -280,28 +280,28 @@ func TestBlobStorageDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				DeleteBlobStorageFn: deleteBlobStorageError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
-				CloneVersionFn:      cloneVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
+				CloneVersionFn:      testutil.CloneVersionOK,
 				DeleteBlobStorageFn: deleteBlobStorageOK,
 			},
-			wantOutput: "Deleted Azure Blob Storage logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Azure Blob Storage logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -399,18 +399,18 @@ func listBlobStoragesError(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStora
 
 var listBlobStoragesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listBlobStoragesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	BlobStorage 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Container: container
 		Account name: account
@@ -429,7 +429,7 @@ Version: 2
 		Compression codec: zstd
 	BlobStorage 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Container: analytics
 		Account name: account
@@ -476,7 +476,7 @@ func getBlobStorageError(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, er
 
 var describeBlobStorageOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Container: container
 Account name: account
@@ -560,35 +560,4 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -32,22 +32,43 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --account-name not provided",
 		},
 		{
-			args:      []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "2", "--name", "log", "--account-name", "account", "--container", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				CreateBlobStorageFn: createBlobStorageError,
+			},
 			wantError: "error parsing arguments: required flag --sas-token not provided",
 		},
 		{
-			args:       []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc"},
-			api:        mock.API{CreateBlobStorageFn: createBlobStorageOK},
-			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "2", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				CreateBlobStorageFn: createBlobStorageOK,
+			},
+			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc"},
-			api:       mock.API{CreateBlobStorageFn: createBlobStorageError},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "2", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				CreateBlobStorageFn: createBlobStorageError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
-			api:       mock.API{CreateBlobStorageFn: createBlobStorageError},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				CreateBlobStorageFn: createBlobStorageError,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -78,33 +99,57 @@ func TestBlobStorageList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListBlobStoragesFn: listBlobStoragesOK},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListBlobStoragesFn: listBlobStoragesOK,
+			},
 			wantOutput: listBlobStoragesShortOutput,
 		},
 		{
-			args:       []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListBlobStoragesFn: listBlobStoragesOK},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListBlobStoragesFn: listBlobStoragesOK,
+			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListBlobStoragesFn: listBlobStoragesOK},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListBlobStoragesFn: listBlobStoragesOK,
+			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "azureblob", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListBlobStoragesFn: listBlobStoragesOK},
+			args: []string{"logging", "azureblob", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListBlobStoragesFn: listBlobStoragesOK,
+			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "azureblob", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListBlobStoragesFn: listBlobStoragesOK},
+			args: []string{"logging", "-v", "azureblob", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListBlobStoragesFn: listBlobStoragesOK,
+			},
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListBlobStoragesFn: listBlobStoragesError},
+			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				ListBlobStoragesFn: listBlobStoragesError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -135,17 +180,25 @@ func TestBlobStorageDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetBlobStorageFn: getBlobStorageError},
+			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				GetBlobStorageFn: getBlobStorageError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetBlobStorageFn: getBlobStorageOK},
+			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				GetBlobStorageFn: getBlobStorageOK,
+			},
 			wantOutput: describeBlobStorageOutput,
 		},
 	} {
@@ -176,18 +229,28 @@ func TestBlobStorageUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateBlobStorageFn: updateBlobStorageError},
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				UpdateBlobStorageFn: updateBlobStorageError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateBlobStorageFn: updateBlobStorageOK},
-			wantOutput: "Updated Azure Blob Storage logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				UpdateBlobStorageFn: updateBlobStorageOK,
+			},
+			wantOutput: "Updated Azure Blob Storage logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -217,18 +280,28 @@ func TestBlobStorageDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteBlobStorageFn: deleteBlobStorageError},
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				DeleteBlobStorageFn: deleteBlobStorageError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteBlobStorageFn: deleteBlobStorageOK},
-			wantOutput: "Deleted Azure Blob Storage logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				CloneVersionFn:      cloneVersionOK,
+				DeleteBlobStorageFn: deleteBlobStorageOK,
+			},
+			wantOutput: "Deleted Azure Blob Storage logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -326,18 +399,18 @@ func listBlobStoragesError(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStora
 
 var listBlobStoragesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listBlobStoragesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	BlobStorage 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Container: container
 		Account name: account
@@ -356,7 +429,7 @@ Version: 1
 		Compression codec: zstd
 	BlobStorage 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Container: analytics
 		Account name: account
@@ -403,7 +476,7 @@ func getBlobStorageError(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, er
 
 var describeBlobStorageOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Container: container
 Account name: account
@@ -487,4 +560,35 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -32,41 +32,41 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --account-name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBlobStorageFn: createBlobStorageError,
 			},
 			wantError: "error parsing arguments: required flag --sas-token not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBlobStorageFn: createBlobStorageOK,
 			},
-			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBlobStorageFn: createBlobStorageError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBlobStorageFn: createBlobStorageError,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -101,8 +101,8 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesShortOutput,
@@ -110,8 +110,8 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
@@ -119,8 +119,8 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
@@ -128,8 +128,8 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
@@ -137,8 +137,8 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "azureblob", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			wantOutput: listBlobStoragesVerboseOutput,
@@ -146,8 +146,8 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				ListBlobStoragesFn: listBlobStoragesError,
 			},
 			wantError: errTest.Error(),
@@ -186,8 +186,8 @@ func TestBlobStorageDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				GetBlobStorageFn: getBlobStorageError,
 			},
 			wantError: errTest.Error(),
@@ -195,8 +195,8 @@ func TestBlobStorageDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "azureblob", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				GetBlobStorageFn: getBlobStorageOK,
 			},
 			wantOutput: describeBlobStorageOutput,
@@ -233,24 +233,24 @@ func TestBlobStorageUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateBlobStorageFn: updateBlobStorageError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateBlobStorageFn: updateBlobStorageOK,
 			},
-			wantOutput: "Updated Azure Blob Storage logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Azure Blob Storage logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -284,24 +284,24 @@ func TestBlobStorageDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteBlobStorageFn: deleteBlobStorageError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
-				CloneVersionFn:      testutil.CloneVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteBlobStorageFn: deleteBlobStorageOK,
 			},
-			wantOutput: "Deleted Azure Blob Storage logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Azure Blob Storage logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/logging/azureblob/azureblob_integration_test.go
@@ -32,7 +32,7 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --account-name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--autoclone"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -42,7 +42,7 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --sas-token not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -52,7 +52,7 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc", "--autoclone"},
+			args: []string{"logging", "azureblob", "create", "--service-id", "123", "--version", "1", "--name", "log", "--account-name", "account", "--container", "log", "--sas-token", "abc"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -233,7 +233,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -243,7 +243,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "azureblob", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -284,7 +284,7 @@ func TestBlobStorageDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,
@@ -294,7 +294,7 @@ func TestBlobStorageDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "azureblob", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersionsOk,
 				GetVersionFn:        testutil.GetActiveVersionOK,

--- a/pkg/logging/azureblob/azureblob_test.go
+++ b/pkg/logging/azureblob/azureblob_test.go
@@ -26,7 +26,7 @@ func TestCreateBlobStorageInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateBlobStorageInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "logs",
 				AccountName:    "account",
 				Container:      "container",
@@ -38,7 +38,7 @@ func TestCreateBlobStorageInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateBlobStorageInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "logs",
 				Container:         "container",
 				AccountName:       "account",
@@ -83,14 +83,14 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				GetBlobStorageFn: getBlobStorageOK,
 			},
 			want: &fastly.UpdateBlobStorageInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "logs",
 				NewName:           fastly.String("new1"),
 				Container:         fastly.String("new2"),
@@ -113,14 +113,14 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				GetBlobStorageFn: getBlobStorageOK,
 			},
 			want: &fastly.UpdateBlobStorageInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "logs",
 			},
 		},
@@ -152,9 +152,9 @@ func createCommandRequired() *CreateCommand {
 	// TODO: make consistent (in all other logging files) with syslog_test which
 	// uses a testcase.api field to assign the mock API to the global client.
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -188,9 +188,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/azureblob/azureblob_test.go
+++ b/pkg/logging/azureblob/azureblob_test.go
@@ -232,9 +232,23 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
 			OptionalString: common.OptionalString{Value: "1"},

--- a/pkg/logging/azureblob/azureblob_test.go
+++ b/pkg/logging/azureblob/azureblob_test.go
@@ -83,8 +83,9 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				GetBlobStorageFn: getBlobStorageOK,
 			},
 			want: &fastly.UpdateBlobStorageInput{
@@ -112,8 +113,9 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				GetBlobStorageFn: getBlobStorageOK,
 			},
 			want: &fastly.UpdateBlobStorageInput{
@@ -150,8 +152,9 @@ func createCommandRequired() *CreateCommand {
 	// TODO: make consistent (in all other logging files) with syslog_test which
 	// uses a testcase.api field to assign the mock API to the global client.
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -165,39 +168,15 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Container:   "container",
 		AccountName: "account",
 		SASToken:    "token",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -209,8 +188,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -224,7 +204,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Container:         "container",
 		AccountName:       "account",
@@ -254,7 +237,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -279,7 +265,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Container:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/azureblob/create.go
+++ b/pkg/logging/azureblob/create.go
@@ -18,13 +18,14 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Container    string
-	AccountName  string
-	SASToken     string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Container      string
+	AccountName    string
+	SASToken       string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Path              common.OptionalString
 	Period            common.OptionalUint
 	GzipLevel         common.OptionalUint
@@ -46,13 +47,12 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Azure Blob Storage logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Azure Blob Storage logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("container", "The name of the Azure Blob Storage container in which to store logs").Required().StringVar(&c.Container)
 	c.CmdClause.Flag("account-name", "The unique Azure Blob Storage namespace in which your data objects are stored").Required().StringVar(&c.AccountName)
 	c.CmdClause.Flag("sas-token", "The Azure shared access signature providing write access to the blob service objects. Be sure to update your token before it expires or the logging functionality will not work").Required().StringVar(&c.SASToken)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
@@ -66,7 +66,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("file-max-bytes", "The maximum size of a log file in bytes").Action(c.FileMaxBytes.Set).UintVar(&c.FileMaxBytes.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -79,8 +78,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateBlobStorageInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Container = c.Container
 	input.AccountName = c.AccountName

--- a/pkg/logging/azureblob/delete.go
+++ b/pkg/logging/azureblob/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an Azure Blob Storage logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteBlobStorageInput
+	manifest       manifest.Data
+	Input          fastly.DeleteBlobStorageInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an Azure Blob Storage logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Azure Blob Storage logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteBlobStorage(&c.Input); err != nil {
 		return err

--- a/pkg/logging/azureblob/describe.go
+++ b/pkg/logging/azureblob/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe an Azure Blob Storage logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetBlobStorageInput
+	manifest       manifest.Data
+	Input          fastly.GetBlobStorageInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an Azure Blob Storage logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Azure Blob Storage logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	azureblob, err := c.Globals.Client.GetBlobStorage(&c.Input)
 	if err != nil {

--- a/pkg/logging/azureblob/list.go
+++ b/pkg/logging/azureblob/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Azure Blob Storage logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListBlobStoragesInput
+	manifest       manifest.Data
+	Input          fastly.ListBlobStoragesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Azure Blob Storage logging endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	azureblobs, err := c.Globals.Client.ListBlobStorages(&c.Input)
 	if err != nil {

--- a/pkg/logging/azureblob/update.go
+++ b/pkg/logging/azureblob/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	//required
-	EndpointName string
-	Version      int
+	EndpointName   string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	AccountName       common.OptionalString
 	Container         common.OptionalString
@@ -45,12 +46,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update an Azure Blob Storage logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Azure Blob Storage logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Azure Blob Storage logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("container", "The name of the Azure Blob Storage container in which to store logs").Action(c.Container.Set).StringVar(&c.Container.Value)
@@ -68,7 +67,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("file-max-bytes", "The maximum size of a log file in bytes").Action(c.FileMaxBytes.Set).UintVar(&c.FileMaxBytes.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -79,9 +77,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateBlobStorageInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateBlobStorageInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/logging/bigquery/bigquery_integration_test.go
@@ -24,25 +24,25 @@ func TestBigQueryCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "2", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--autoclone"},
+			args:      []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--autoclone"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "2", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
-				CloneVersionFn:   cloneVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				CreateBigQueryFn: createBigQueryOK,
 			},
-			wantOutput: "Created BigQuery logging endpoint log (service 123 version 3)",
+			wantOutput: "Created BigQuery logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "2", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
-				CloneVersionFn:   cloneVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				CreateBigQueryFn: createBigQueryError,
 			},
 			wantError: errTest.Error(),
@@ -75,55 +75,55 @@ func TestBigQueryList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesShortOutput,
 		},
 		{
-			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "bigquery", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "bigquery", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "bigquery", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "bigquery", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListBigQueriesFn: listBigQueriesError,
 			},
 			wantError: errTest.Error(),
@@ -156,23 +156,23 @@ func TestBigQueryDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetBigQueryFn:  getBigQueryError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetBigQueryFn:  getBigQueryOK,
 			},
 			wantOutput: describeBigQueryOutput,
@@ -205,28 +205,28 @@ func TestBigQueryUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "2", "--new-name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
+			args:      []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--new-name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
-				CloneVersionFn:   cloneVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				UpdateBigQueryFn: updateBigQueryError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
-				CloneVersionFn:   cloneVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				UpdateBigQueryFn: updateBigQueryOK,
 			},
-			wantOutput: "Updated BigQuery logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated BigQuery logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,28 +256,28 @@ func TestBigQueryDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
-				CloneVersionFn:   cloneVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				DeleteBigQueryFn: deleteBigQueryError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
-				CloneVersionFn:   cloneVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
+				CloneVersionFn:   testutil.CloneVersionOK,
 				DeleteBigQueryFn: deleteBigQueryOK,
 			},
-			wantOutput: "Deleted BigQuery logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted BigQuery logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -352,18 +352,18 @@ func listBigQueriesError(i *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, err
 
 var listBigQueriesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listBigQueriesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	BigQuery 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Format: %h %l %u %t "%r" %>s %b
 		User: service-account@domain.com
@@ -377,7 +377,7 @@ Version: 2
 		Format version: 0
 	BigQuery 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Format: %h %l %u %t "%r" %>s %b
 		User: service-account@domain.com
@@ -414,7 +414,7 @@ func getBigQueryError(i *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
 
 var describeBigQueryOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Format: %h %l %u %t "%r" %>s %b
 User: service-account@domain.com
@@ -455,35 +455,4 @@ func deleteBigQueryOK(i *fastly.DeleteBigQueryInput) error {
 
 func deleteBigQueryError(i *fastly.DeleteBigQueryInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/logging/bigquery/bigquery_integration_test.go
@@ -24,11 +24,11 @@ func TestBigQueryCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--autoclone"},
+			args:      []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersionsOk,
 				GetVersionFn:     testutil.GetActiveVersionOK,
@@ -38,7 +38,7 @@ func TestBigQueryCreate(t *testing.T) {
 			wantOutput: "Created BigQuery logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersionsOk,
 				GetVersionFn:     testutil.GetActiveVersionOK,
@@ -209,7 +209,7 @@ func TestBigQueryUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersionsOk,
 				GetVersionFn:     testutil.GetActiveVersionOK,
@@ -219,7 +219,7 @@ func TestBigQueryUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersionsOk,
 				GetVersionFn:     testutil.GetActiveVersionOK,
@@ -260,7 +260,7 @@ func TestBigQueryDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersionsOk,
 				GetVersionFn:     testutil.GetActiveVersionOK,
@@ -270,7 +270,7 @@ func TestBigQueryDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersionsOk,
 				GetVersionFn:     testutil.GetActiveVersionOK,

--- a/pkg/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/logging/bigquery/bigquery_integration_test.go
@@ -24,18 +24,27 @@ func TestBigQueryCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com"},
-			api:       mock.API{CreateBigQueryFn: createBigQueryOK},
+			args:      []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "2", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--autoclone"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:       []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
-			api:        mock.API{CreateBigQueryFn: createBigQueryOK},
-			wantOutput: "Created BigQuery logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "2", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				CloneVersionFn:   cloneVersionOK,
+				CreateBigQueryFn: createBigQueryOK,
+			},
+			wantOutput: "Created BigQuery logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
-			api:       mock.API{CreateBigQueryFn: createBigQueryError},
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "2", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				CloneVersionFn:   cloneVersionOK,
+				CreateBigQueryFn: createBigQueryError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -66,33 +75,57 @@ func TestBigQueryList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListBigQueriesFn: listBigQueriesOK},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListBigQueriesFn: listBigQueriesOK,
+			},
 			wantOutput: listBigQueriesShortOutput,
 		},
 		{
-			args:       []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListBigQueriesFn: listBigQueriesOK},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListBigQueriesFn: listBigQueriesOK,
+			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListBigQueriesFn: listBigQueriesOK},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListBigQueriesFn: listBigQueriesOK,
+			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "bigquery", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListBigQueriesFn: listBigQueriesOK},
+			args: []string{"logging", "bigquery", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListBigQueriesFn: listBigQueriesOK,
+			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "bigquery", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListBigQueriesFn: listBigQueriesOK},
+			args: []string{"logging", "-v", "bigquery", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListBigQueriesFn: listBigQueriesOK,
+			},
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListBigQueriesFn: listBigQueriesError},
+			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListBigQueriesFn: listBigQueriesError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -123,18 +156,25 @@ func TestBigQueryDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1"},
-			api:       mock.API{GetBigQueryFn: getBigQueryOK},
+			args:      []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetBigQueryFn: getBigQueryError},
+			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetBigQueryFn:  getBigQueryError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetBigQueryFn: getBigQueryOK},
+			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetBigQueryFn:  getBigQueryOK,
+			},
 			wantOutput: describeBigQueryOutput,
 		},
 	} {
@@ -165,19 +205,28 @@ func TestBigQueryUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--new-name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
-			api:       mock.API{UpdateBigQueryFn: updateBigQueryOK},
+			args:      []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "2", "--new-name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateBigQueryFn: updateBigQueryError},
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				CloneVersionFn:   cloneVersionOK,
+				UpdateBigQueryFn: updateBigQueryError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateBigQueryFn: updateBigQueryOK},
-			wantOutput: "Updated BigQuery logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				CloneVersionFn:   cloneVersionOK,
+				UpdateBigQueryFn: updateBigQueryOK,
+			},
+			wantOutput: "Updated BigQuery logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -207,19 +256,28 @@ func TestBigQueryDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1"},
-			api:       mock.API{DeleteBigQueryFn: deleteBigQueryOK},
+			args:      []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteBigQueryFn: deleteBigQueryError},
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				CloneVersionFn:   cloneVersionOK,
+				DeleteBigQueryFn: deleteBigQueryError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteBigQueryFn: deleteBigQueryOK},
-			wantOutput: "Deleted BigQuery logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				CloneVersionFn:   cloneVersionOK,
+				DeleteBigQueryFn: deleteBigQueryOK,
+			},
+			wantOutput: "Deleted BigQuery logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -294,18 +352,18 @@ func listBigQueriesError(i *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, err
 
 var listBigQueriesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listBigQueriesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	BigQuery 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Format: %h %l %u %t "%r" %>s %b
 		User: service-account@domain.com
@@ -319,7 +377,7 @@ Version: 1
 		Format version: 0
 	BigQuery 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Format: %h %l %u %t "%r" %>s %b
 		User: service-account@domain.com
@@ -356,7 +414,7 @@ func getBigQueryError(i *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
 
 var describeBigQueryOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Format: %h %l %u %t "%r" %>s %b
 User: service-account@domain.com
@@ -397,4 +455,35 @@ func deleteBigQueryOK(i *fastly.DeleteBigQueryInput) error {
 
 func deleteBigQueryError(i *fastly.DeleteBigQueryInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/logging/bigquery/bigquery_integration_test.go
@@ -28,21 +28,21 @@ func TestBigQueryCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				CreateBigQueryFn: createBigQueryOK,
 			},
-			wantOutput: "Created BigQuery logging endpoint log (service 123 version 2)",
+			wantOutput: "Created BigQuery logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`},
+			args: []string{"logging", "bigquery", "create", "--service-id", "123", "--version", "1", "--name", "log", "--project-id", "project123", "--dataset", "logs", "--table", "logs", "--user", "user@domain.com", "--secret-key", `"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA"`, "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				CreateBigQueryFn: createBigQueryError,
 			},
 			wantError: errTest.Error(),
@@ -77,8 +77,8 @@ func TestBigQueryList(t *testing.T) {
 		{
 			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesShortOutput,
@@ -86,8 +86,8 @@ func TestBigQueryList(t *testing.T) {
 		{
 			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
@@ -95,8 +95,8 @@ func TestBigQueryList(t *testing.T) {
 		{
 			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
@@ -104,8 +104,8 @@ func TestBigQueryList(t *testing.T) {
 		{
 			args: []string{"logging", "bigquery", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
@@ -113,8 +113,8 @@ func TestBigQueryList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "bigquery", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			wantOutput: listBigQueriesVerboseOutput,
@@ -122,8 +122,8 @@ func TestBigQueryList(t *testing.T) {
 		{
 			args: []string{"logging", "bigquery", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListBigQueriesFn: listBigQueriesError,
 			},
 			wantError: errTest.Error(),
@@ -162,8 +162,8 @@ func TestBigQueryDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetBigQueryFn:  getBigQueryError,
 			},
 			wantError: errTest.Error(),
@@ -171,8 +171,8 @@ func TestBigQueryDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "bigquery", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetBigQueryFn:  getBigQueryOK,
 			},
 			wantOutput: describeBigQueryOutput,
@@ -209,24 +209,24 @@ func TestBigQueryUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				UpdateBigQueryFn: updateBigQueryError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "bigquery", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				UpdateBigQueryFn: updateBigQueryOK,
 			},
-			wantOutput: "Updated BigQuery logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated BigQuery logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -260,24 +260,24 @@ func TestBigQueryDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				DeleteBigQueryFn: deleteBigQueryError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "bigquery", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
-				CloneVersionFn:   testutil.CloneVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
+				CloneVersionFn:   testutil.CloneVersionResult(4),
 				DeleteBigQueryFn: deleteBigQueryOK,
 			},
-			wantOutput: "Deleted BigQuery logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted BigQuery logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/bigquery/bigquery_test.go
+++ b/pkg/logging/bigquery/bigquery_test.go
@@ -1,6 +1,7 @@
 package bigquery
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -79,7 +80,11 @@ func TestUpdateBigQueryInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetBigQueryFn: getBigQueryOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetBigQueryFn:  getBigQueryOK,
+			},
 			want: &fastly.UpdateBigQueryInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -89,7 +94,11 @@ func TestUpdateBigQueryInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetBigQueryFn: getBigQueryOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetBigQueryFn:  getBigQueryOK,
+			},
 			want: &fastly.UpdateBigQueryInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -125,23 +134,92 @@ func TestUpdateBigQueryInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		ProjectID:    "123",
-		Dataset:      "dataset",
-		Table:        "table",
-		User:         "user",
-		SecretKey:    "-----BEGIN PRIVATE KEY-----foo",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		ProjectID: "123",
+		Dataset:   "dataset",
+		Table:     "table",
+		User:      "user",
+		SecretKey: "-----BEGIN PRIVATE KEY-----foo",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		ProjectID:         "123",
 		Dataset:           "dataset",
 		Table:             "table",
@@ -162,20 +240,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		ProjectID:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Dataset:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/bigquery/bigquery_test.go
+++ b/pkg/logging/bigquery/bigquery_test.go
@@ -81,8 +81,9 @@ func TestUpdateBigQueryInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetBigQueryFn:  getBigQueryOK,
 			},
 			want: &fastly.UpdateBigQueryInput{
@@ -95,8 +96,9 @@ func TestUpdateBigQueryInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetBigQueryFn:  getBigQueryOK,
 			},
 			want: &fastly.UpdateBigQueryInput{
@@ -142,8 +144,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -157,7 +160,10 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		ProjectID: "123",
 		Dataset:   "dataset",
@@ -165,33 +171,6 @@ func createCommandRequired() *CreateCommand {
 		User:      "user",
 		SecretKey: "-----BEGIN PRIVATE KEY-----foo",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -203,8 +182,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -218,7 +198,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		ProjectID:         "123",
 		Dataset:           "dataset",
@@ -259,7 +242,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -284,7 +270,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		ProjectID:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/bigquery/bigquery_test.go
+++ b/pkg/logging/bigquery/bigquery_test.go
@@ -26,7 +26,7 @@ func TestCreateBigQueryInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateBigQueryInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				ProjectID:      "123",
 				Dataset:        "dataset",
@@ -40,7 +40,7 @@ func TestCreateBigQueryInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateBigQueryInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				ProjectID:         "123",
 				Dataset:           "dataset",
@@ -81,14 +81,14 @@ func TestUpdateBigQueryInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetBigQueryFn:  getBigQueryOK,
 			},
 			want: &fastly.UpdateBigQueryInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -96,14 +96,14 @@ func TestUpdateBigQueryInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetBigQueryFn:  getBigQueryOK,
 			},
 			want: &fastly.UpdateBigQueryInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				ProjectID:         fastly.String("new2"),
@@ -144,9 +144,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -182,9 +182,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/bigquery/create.go
+++ b/pkg/logging/bigquery/create.go
@@ -17,15 +17,16 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	ProjectID    string
-	Dataset      string
-	Table        string
-	User         string
-	SecretKey    string
+	EndpointName   string // Can't shadow common.Base method Name().
+	ProjectID      string
+	Dataset        string
+	Table          string
+	User           string
+	SecretKey      string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Template          common.OptionalString
 	Placement         common.OptionalString
 	ResponseCondition common.OptionalString
@@ -40,22 +41,20 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a BigQuery logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the BigQuery logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("project-id", "Your Google Cloud Platform project ID").Required().StringVar(&c.ProjectID)
 	c.CmdClause.Flag("dataset", "Your BigQuery dataset").Required().StringVar(&c.Dataset)
 	c.CmdClause.Flag("table", "Your BigQuery table").Required().StringVar(&c.Table)
 	c.CmdClause.Flag("user", "Your Google Cloud Platform service account email address. The client_email field in your service account authentication JSON.").Required().StringVar(&c.User)
 	c.CmdClause.Flag("secret-key", "Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON.").Required().StringVar(&c.SecretKey)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("template-suffix", "BigQuery table name suffix template").Action(c.Template.Set).StringVar(&c.Template.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. Must produce JSON that matches the schema of your BigQuery table").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
-
 	return &c
 }
 
@@ -68,8 +67,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateBigQueryInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.ProjectID = c.ProjectID
 	input.Dataset = c.Dataset

--- a/pkg/logging/bigquery/delete.go
+++ b/pkg/logging/bigquery/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a BigQuery logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteBigQueryInput
+	manifest       manifest.Data
+	Input          fastly.DeleteBigQueryInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a BigQuery logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the BigQuery logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteBigQuery(&c.Input); err != nil {
 		return err

--- a/pkg/logging/bigquery/describe.go
+++ b/pkg/logging/bigquery/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a BigQuery logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetBigQueryInput
+	manifest       manifest.Data
+	Input          fastly.GetBigQueryInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a BigQuery logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the BigQuery logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	bq, err := c.Globals.Client.GetBigQuery(&c.Input)
 	if err != nil {

--- a/pkg/logging/bigquery/list.go
+++ b/pkg/logging/bigquery/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list BigQuery logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListBigQueriesInput
+	manifest       manifest.Data
+	Input          fastly.ListBigQueriesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List BigQuery endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	bqs, err := c.Globals.Client.ListBigQueries(&c.Input)
 	if err != nil {

--- a/pkg/logging/bigquery/update.go
+++ b/pkg/logging/bigquery/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	ProjectID         common.OptionalString
 	Dataset           common.OptionalString
@@ -40,12 +41,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a BigQuery logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the BigQuery logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the BigQuery logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("project-id", "Your Google Cloud Platform project ID").Action(c.ProjectID.Set).StringVar(&c.ProjectID.Value)
@@ -68,9 +67,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateBigQueryInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateBigQueryInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -24,33 +24,33 @@ func TestCloudfilesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--access-key", "foo"},
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--access-key", "foo"},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--bucket", "log"},
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log"},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateCloudfilesFn: createCloudfilesOK,
 			},
-			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateCloudfilesFn: createCloudfilesError,
 			},
 			wantError: errTest.Error(),
@@ -58,9 +58,9 @@ func TestCloudfilesCreate(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -92,55 +92,55 @@ func TestCloudfilesList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesShortOutput,
 		},
 		{
-			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "cloudfiles", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "cloudfiles", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "cloudfiles", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListCloudfilesFn: listCloudfilesError,
 			},
 			wantError: errTest.Error(),
@@ -173,23 +173,23 @@ func TestCloudfilesDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetCloudfilesFn: getCloudfilesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetCloudfilesFn: getCloudfilesOK,
 			},
 			wantOutput: describeCloudfilesOutput,
@@ -222,28 +222,28 @@ func TestCloudfilesUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateCloudfilesFn: updateCloudfilesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateCloudfilesFn: updateCloudfilesOK,
 			},
-			wantOutput: "Updated Cloudfiles logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Cloudfiles logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -273,28 +273,28 @@ func TestCloudfilesDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteCloudfilesFn: deleteCloudfilesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteCloudfilesFn: deleteCloudfilesOK,
 			},
-			wantOutput: "Deleted Cloudfiles logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Cloudfiles logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -384,18 +384,18 @@ func listCloudfilesError(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, e
 
 var listCloudfilesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listCloudfilesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Cloudfiles 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		User: username
 		Access key: 1234
@@ -413,7 +413,7 @@ Version: 2
 		Public key: `+pgpPublicKey()+`
 	Cloudfiles 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		User: username
 		Access key: 1234
@@ -459,7 +459,7 @@ func getCloudfilesError(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error
 
 var describeCloudfilesOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 User: username
 Access key: 1234
@@ -543,35 +543,4 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -36,31 +36,31 @@ func TestCloudfilesCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateCloudfilesFn: createCloudfilesOK,
 			},
-			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateCloudfilesFn: createCloudfilesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -94,8 +94,8 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesShortOutput,
@@ -103,8 +103,8 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
@@ -112,8 +112,8 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
@@ -121,8 +121,8 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
@@ -130,8 +130,8 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			wantOutput: listCloudfilesVerboseOutput,
@@ -139,8 +139,8 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListCloudfilesFn: listCloudfilesError,
 			},
 			wantError: errTest.Error(),
@@ -179,8 +179,8 @@ func TestCloudfilesDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetCloudfilesFn: getCloudfilesError,
 			},
 			wantError: errTest.Error(),
@@ -188,8 +188,8 @@ func TestCloudfilesDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetCloudfilesFn: getCloudfilesOK,
 			},
 			wantOutput: describeCloudfilesOutput,
@@ -226,24 +226,24 @@ func TestCloudfilesUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateCloudfilesFn: updateCloudfilesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateCloudfilesFn: updateCloudfilesOK,
 			},
-			wantOutput: "Updated Cloudfiles logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Cloudfiles logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -277,24 +277,24 @@ func TestCloudfilesDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteCloudfilesFn: deleteCloudfilesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteCloudfilesFn: deleteCloudfilesOK,
 			},
-			wantOutput: "Deleted Cloudfiles logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Cloudfiles logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -36,7 +36,7 @@ func TestCloudfilesCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -46,7 +46,7 @@ func TestCloudfilesCreate(t *testing.T) {
 			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -56,7 +56,7 @@ func TestCloudfilesCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -226,7 +226,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -236,7 +236,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -277,7 +277,7 @@ func TestCloudfilesDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -287,7 +287,7 @@ func TestCloudfilesDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,

--- a/pkg/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_integration_test.go
@@ -24,29 +24,44 @@ func TestCloudfilesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--access-key", "foo"},
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--access-key", "foo"},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log"},
+			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--bucket", "log"},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args:       []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
-			api:        mock.API{CreateCloudfilesFn: createCloudfilesOK},
-			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateCloudfilesFn: createCloudfilesOK,
+			},
+			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo"},
-			api:       mock.API{CreateCloudfilesFn: createCloudfilesError},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateCloudfilesFn: createCloudfilesError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "cloudfiles", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "username", "--bucket", "log", "--access-key", "foo", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -77,33 +92,57 @@ func TestCloudfilesList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListCloudfilesFn: listCloudfilesOK,
+			},
 			wantOutput: listCloudfilesShortOutput,
 		},
 		{
-			args:       []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListCloudfilesFn: listCloudfilesOK,
+			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListCloudfilesFn: listCloudfilesOK,
+			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "cloudfiles", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			args: []string{"logging", "cloudfiles", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListCloudfilesFn: listCloudfilesOK,
+			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListCloudfilesFn: listCloudfilesOK},
+			args: []string{"logging", "-v", "cloudfiles", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListCloudfilesFn: listCloudfilesOK,
+			},
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListCloudfilesFn: listCloudfilesError},
+			args: []string{"logging", "cloudfiles", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListCloudfilesFn: listCloudfilesError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -134,17 +173,25 @@ func TestCloudfilesDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetCloudfilesFn: getCloudfilesError},
+			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetCloudfilesFn: getCloudfilesError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetCloudfilesFn: getCloudfilesOK},
+			args: []string{"logging", "cloudfiles", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetCloudfilesFn: getCloudfilesOK,
+			},
 			wantOutput: describeCloudfilesOutput,
 		},
 	} {
@@ -175,18 +222,28 @@ func TestCloudfilesUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateCloudfilesFn: updateCloudfilesError},
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateCloudfilesFn: updateCloudfilesError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateCloudfilesFn: updateCloudfilesOK},
-			wantOutput: "Updated Cloudfiles logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "cloudfiles", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateCloudfilesFn: updateCloudfilesOK,
+			},
+			wantOutput: "Updated Cloudfiles logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -216,18 +273,28 @@ func TestCloudfilesDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteCloudfilesFn: deleteCloudfilesError},
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteCloudfilesFn: deleteCloudfilesError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteCloudfilesFn: deleteCloudfilesOK},
-			wantOutput: "Deleted Cloudfiles logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "cloudfiles", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteCloudfilesFn: deleteCloudfilesOK,
+			},
+			wantOutput: "Deleted Cloudfiles logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -317,18 +384,18 @@ func listCloudfilesError(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, e
 
 var listCloudfilesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listCloudfilesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Cloudfiles 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		User: username
 		Access key: 1234
@@ -346,7 +413,7 @@ Version: 1
 		Public key: `+pgpPublicKey()+`
 	Cloudfiles 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		User: username
 		Access key: 1234
@@ -392,7 +459,7 @@ func getCloudfilesError(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error
 
 var describeCloudfilesOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 User: username
 Access key: 1234
@@ -476,4 +543,35 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -26,7 +26,7 @@ func TestCreateCloudfilesInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateCloudfilesInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				User:           "user",
 				AccessKey:      "key",
@@ -38,7 +38,7 @@ func TestCreateCloudfilesInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateCloudfilesInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				User:              "user",
 				AccessKey:         "key",
@@ -84,14 +84,14 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 			name: "no update",
 			cmd:  updateCommandNoUpdate(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetCloudfilesFn: getCloudfilesOK,
 			},
 			want: &fastly.UpdateCloudfilesInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -99,14 +99,14 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetCloudfilesFn: getCloudfilesOK,
 			},
 			want: &fastly.UpdateCloudfilesInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				AccessKey:         fastly.String("new2"),
@@ -152,9 +152,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -188,9 +188,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -84,8 +84,9 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 			name: "no update",
 			cmd:  updateCommandNoUpdate(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetCloudfilesFn: getCloudfilesOK,
 			},
 			want: &fastly.UpdateCloudfilesInput{
@@ -98,8 +99,9 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetCloudfilesFn: getCloudfilesOK,
 			},
 			want: &fastly.UpdateCloudfilesInput{
@@ -150,8 +152,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -165,39 +168,15 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		User:       "user",
 		AccessKey:  "key",
 		BucketName: "bucket",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -209,8 +188,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -224,7 +204,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		User:              "user",
 		AccessKey:         "key",
@@ -268,7 +251,10 @@ func updateCommandNoUpdate() *UpdateCommand {
 			},
 		},
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		EndpointName: "log",
 	}
@@ -293,7 +279,10 @@ func updateCommandAll() *UpdateCommand {
 			},
 		},
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		EndpointName:      "log",
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -1,6 +1,7 @@
 package cloudfiles
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -82,7 +83,11 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 		{
 			name: "no update",
 			cmd:  updateCommandNoUpdate(),
-			api:  mock.API{GetCloudfilesFn: getCloudfilesOK},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetCloudfilesFn: getCloudfilesOK,
+			},
 			want: &fastly.UpdateCloudfilesInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -92,7 +97,11 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetCloudfilesFn: getCloudfilesOK},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetCloudfilesFn: getCloudfilesOK,
+			},
 			want: &fastly.UpdateCloudfilesInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -133,21 +142,90 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		User:         "user",
-		AccessKey:    "key",
-		BucketName:   "bucket",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		User:       "user",
+		AccessKey:  "key",
+		BucketName: "bucket",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		User:              "user",
 		AccessKey:         "key",
 		BucketName:        "bucket",
@@ -172,19 +250,51 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdate() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		Version:      2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		EndpointName: "log",
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		EndpointName:      "log",
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/cloudfiles/delete.go
+++ b/pkg/logging/cloudfiles/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Cloudfiles logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteCloudfilesInput
+	manifest       manifest.Data
+	Input          fastly.DeleteCloudfilesInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Cloudfiles logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteCloudfiles(&c.Input); err != nil {
 		return err

--- a/pkg/logging/cloudfiles/describe.go
+++ b/pkg/logging/cloudfiles/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Cloudfiles logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetCloudfilesInput
+	manifest       manifest.Data
+	Input          fastly.GetCloudfilesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Cloudfiles logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	cloudfiles, err := c.Globals.Client.GetCloudfiles(&c.Input)
 	if err != nil {

--- a/pkg/logging/cloudfiles/list.go
+++ b/pkg/logging/cloudfiles/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Cloudfiles logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListCloudfilesInput
+	manifest       manifest.Data
+	Input          fastly.ListCloudfilesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Cloudfiles endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	cloudfiles, err := c.Globals.Client.ListCloudfiles(&c.Input)
 	if err != nil {

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	User              common.OptionalString
 	AccessKey         common.OptionalString
@@ -45,12 +46,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Cloudfiles logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Cloudfiles logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("user", "The username for your Cloudfile account").Action(c.User.Set).StringVar(&c.User.Value)
@@ -68,7 +67,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -79,9 +77,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateCloudfilesInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateCloudfilesInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/datadog/create.go
+++ b/pkg/logging/datadog/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Token        string
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	Token          string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Region            common.OptionalString
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
@@ -32,23 +33,20 @@ type CreateCommand struct {
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
-
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Datadog logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Datadog logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("auth-token", "The API key from your Datadog account").Required().StringVar(&c.Token)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. For details on the default value refer to the documentation (https://developer.fastly.com/reference/api/logging/datadog/)").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,8 +59,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateDatadogInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Token = c.Token
 

--- a/pkg/logging/datadog/datadog_integration_test.go
+++ b/pkg/logging/datadog/datadog_integration_test.go
@@ -24,17 +24,27 @@ func TestDatadogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "datadog", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:       []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
-			api:        mock.API{CreateDatadogFn: createDatadogOK},
-			wantOutput: "Created Datadog logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				CreateDatadogFn: createDatadogOK,
+			},
+			wantOutput: "Created Datadog logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
-			api:       mock.API{CreateDatadogFn: createDatadogError},
+			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				CreateDatadogFn: createDatadogError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -65,33 +75,57 @@ func TestDatadogList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListDatadogFn:  listDatadogsOK,
+			},
 			wantOutput: listDatadogsShortOutput,
 		},
 		{
-			args:       []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListDatadogFn:  listDatadogsOK,
+			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListDatadogFn:  listDatadogsOK,
+			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "datadog", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			args: []string{"logging", "datadog", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListDatadogFn:  listDatadogsOK,
+			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "datadog", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDatadogFn: listDatadogsOK},
+			args: []string{"logging", "-v", "datadog", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListDatadogFn:  listDatadogsOK,
+			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListDatadogFn: listDatadogsError},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListDatadogFn:  listDatadogsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -122,17 +156,25 @@ func TestDatadogDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetDatadogFn: getDatadogError},
+			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetDatadogFn:   getDatadogError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetDatadogFn: getDatadogOK},
+			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetDatadogFn:   getDatadogOK,
+			},
 			wantOutput: describeDatadogOutput,
 		},
 	} {
@@ -163,18 +205,28 @@ func TestDatadogUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "datadog", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateDatadogFn: updateDatadogError},
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				UpdateDatadogFn: updateDatadogError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateDatadogFn: updateDatadogOK},
-			wantOutput: "Updated Datadog logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				UpdateDatadogFn: updateDatadogOK,
+			},
+			wantOutput: "Updated Datadog logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -204,18 +256,28 @@ func TestDatadogDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteDatadogFn: deleteDatadogError},
+			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				DeleteDatadogFn: deleteDatadogError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteDatadogFn: deleteDatadogOK},
-			wantOutput: "Deleted Datadog logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				DeleteDatadogFn: deleteDatadogOK,
+			},
+			wantOutput: "Deleted Datadog logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -289,18 +351,18 @@ func listDatadogsError(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
 
 var listDatadogsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listDatadogsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Datadog 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Token: abc
 		Region: US
@@ -310,7 +372,7 @@ Version: 1
 		Placement: none
 	Datadog 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Token: abc
 		Region: US
@@ -340,7 +402,7 @@ func getDatadogError(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
 
 var describeDatadogOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Token: abc
 Region: US
@@ -373,4 +435,35 @@ func deleteDatadogOK(i *fastly.DeleteDatadogInput) error {
 
 func deleteDatadogError(i *fastly.DeleteDatadogInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/datadog/datadog_integration_test.go
+++ b/pkg/logging/datadog/datadog_integration_test.go
@@ -28,7 +28,7 @@ func TestDatadogCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -209,7 +209,7 @@ func TestDatadogUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -219,7 +219,7 @@ func TestDatadogUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -270,7 +270,7 @@ func TestDatadogDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,

--- a/pkg/logging/datadog/datadog_integration_test.go
+++ b/pkg/logging/datadog/datadog_integration_test.go
@@ -28,21 +28,21 @@ func TestDatadogCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateDatadogFn: createDatadogOK,
 			},
-			wantOutput: "Created Datadog logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Datadog logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateDatadogFn: createDatadogError,
 			},
 			wantError: errTest.Error(),
@@ -77,8 +77,8 @@ func TestDatadogList(t *testing.T) {
 		{
 			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsShortOutput,
@@ -86,8 +86,8 @@ func TestDatadogList(t *testing.T) {
 		{
 			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
@@ -95,8 +95,8 @@ func TestDatadogList(t *testing.T) {
 		{
 			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
@@ -104,8 +104,8 @@ func TestDatadogList(t *testing.T) {
 		{
 			args: []string{"logging", "datadog", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
@@ -113,8 +113,8 @@ func TestDatadogList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "datadog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
@@ -122,8 +122,8 @@ func TestDatadogList(t *testing.T) {
 		{
 			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListDatadogFn:  listDatadogsError,
 			},
 			wantError: errTest.Error(),
@@ -162,8 +162,8 @@ func TestDatadogDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetDatadogFn:   getDatadogError,
 			},
 			wantError: errTest.Error(),
@@ -171,8 +171,8 @@ func TestDatadogDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetDatadogFn:   getDatadogOK,
 			},
 			wantOutput: describeDatadogOutput,
@@ -209,24 +209,24 @@ func TestDatadogUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateDatadogFn: updateDatadogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateDatadogFn: updateDatadogOK,
 			},
-			wantOutput: "Updated Datadog logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Datadog logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -260,24 +260,24 @@ func TestDatadogDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteDatadogFn: deleteDatadogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteDatadogFn: deleteDatadogOK,
 			},
-			wantOutput: "Deleted Datadog logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Datadog logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/datadog/datadog_integration_test.go
+++ b/pkg/logging/datadog/datadog_integration_test.go
@@ -24,25 +24,25 @@ func TestDatadogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateDatadogFn: createDatadogOK,
 			},
-			wantOutput: "Created Datadog logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Datadog logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "datadog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateDatadogFn: createDatadogError,
 			},
 			wantError: errTest.Error(),
@@ -75,55 +75,55 @@ func TestDatadogList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsShortOutput,
 		},
 		{
-			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "datadog", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "datadog", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "datadog", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "datadog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDatadogFn:  listDatadogsOK,
 			},
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "datadog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListDatadogFn:  listDatadogsError,
 			},
 			wantError: errTest.Error(),
@@ -156,23 +156,23 @@ func TestDatadogDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetDatadogFn:   getDatadogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "datadog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetDatadogFn:   getDatadogOK,
 			},
 			wantOutput: describeDatadogOutput,
@@ -205,28 +205,28 @@ func TestDatadogUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				UpdateDatadogFn: updateDatadogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "datadog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				UpdateDatadogFn: updateDatadogOK,
 			},
-			wantOutput: "Updated Datadog logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Datadog logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,28 +256,28 @@ func TestDatadogDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				DeleteDatadogFn: deleteDatadogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "datadog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				DeleteDatadogFn: deleteDatadogOK,
 			},
-			wantOutput: "Deleted Datadog logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Datadog logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -351,18 +351,18 @@ func listDatadogsError(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
 
 var listDatadogsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listDatadogsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Datadog 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Token: abc
 		Region: US
@@ -372,7 +372,7 @@ Version: 2
 		Placement: none
 	Datadog 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Token: abc
 		Region: US
@@ -402,7 +402,7 @@ func getDatadogError(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
 
 var describeDatadogOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Token: abc
 Region: US
@@ -435,35 +435,4 @@ func deleteDatadogOK(i *fastly.DeleteDatadogInput) error {
 
 func deleteDatadogError(i *fastly.DeleteDatadogInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/datadog/datadog_test.go
+++ b/pkg/logging/datadog/datadog_test.go
@@ -25,7 +25,7 @@ func TestCreateDatadogInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateDatadogInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Token:          "tkn",
 			},
@@ -35,7 +35,7 @@ func TestCreateDatadogInput(t *testing.T) {
 			cmd:  createCommandOK(),
 			want: &fastly.CreateDatadogInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Region:            "US",
 				Format:            `%h %l %u %t "%r" %>s %b`,
@@ -72,14 +72,14 @@ func TestUpdateDatadogInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetDatadogFn:   getDatadogOK,
 			},
 			want: &fastly.UpdateDatadogInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -87,14 +87,14 @@ func TestUpdateDatadogInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetDatadogFn:   getDatadogOK,
 			},
 			want: &fastly.UpdateDatadogInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Region:            fastly.String("new2"),
@@ -131,9 +131,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -170,9 +170,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/datadog/datadog_test.go
+++ b/pkg/logging/datadog/datadog_test.go
@@ -72,8 +72,9 @@ func TestUpdateDatadogInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetDatadogFn:   getDatadogOK,
 			},
 			want: &fastly.UpdateDatadogInput{
@@ -86,8 +87,9 @@ func TestUpdateDatadogInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetDatadogFn:   getDatadogOK,
 			},
 			want: &fastly.UpdateDatadogInput{
@@ -129,8 +131,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -145,7 +148,10 @@ func createCommandOK() *CreateCommand {
 		EndpointName: "log",
 		Token:        "tkn",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "US"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
@@ -164,8 +170,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -180,36 +187,12 @@ func createCommandRequired() *CreateCommand {
 		EndpointName: "log",
 		Token:        "tkn",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandMissingServiceID() *CreateCommand {
@@ -238,7 +221,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -263,7 +249,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/datadog/datadog_test.go
+++ b/pkg/logging/datadog/datadog_test.go
@@ -1,6 +1,7 @@
 package datadog
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -70,7 +71,11 @@ func TestUpdateDatadogInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetDatadogFn: getDatadogOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetDatadogFn:   getDatadogOK,
+			},
 			want: &fastly.UpdateDatadogInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -80,7 +85,11 @@ func TestUpdateDatadogInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetDatadogFn: getDatadogOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetDatadogFn:   getDatadogOK,
+			},
 			want: &fastly.UpdateDatadogInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -112,11 +121,32 @@ func TestUpdateDatadogInput(t *testing.T) {
 }
 
 func createCommandOK() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Token:             "tkn",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		Token:        "tkn",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "US"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -126,12 +156,60 @@ func createCommandOK() *CreateCommand {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		Token:        "tkn",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
 }
 
 func createCommandMissingServiceID() *CreateCommand {
@@ -141,20 +219,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/datadog/delete.go
+++ b/pkg/logging/datadog/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Datadog logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteDatadogInput
+	manifest       manifest.Data
+	Input          fastly.DeleteDatadogInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Datadog logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteDatadog(&c.Input); err != nil {
 		return err

--- a/pkg/logging/datadog/describe.go
+++ b/pkg/logging/datadog/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Datadog logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetDatadogInput
+	manifest       manifest.Data
+	Input          fastly.GetDatadogInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Datadog logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	datadog, err := c.Globals.Client.GetDatadog(&c.Input)
 	if err != nil {

--- a/pkg/logging/datadog/list.go
+++ b/pkg/logging/datadog/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Datadog logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListDatadogInput
+	manifest       manifest.Data
+	Input          fastly.ListDatadogInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Datadog endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	datadogs, err := c.Globals.Client.ListDatadog(&c.Input)
 	if err != nil {

--- a/pkg/logging/datadog/update.go
+++ b/pkg/logging/datadog/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Token             common.OptionalString
 	Region            common.OptionalString
@@ -36,12 +37,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Datadog logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Datadog logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("auth-token", "The API key from your Datadog account").Action(c.Token.Set).StringVar(&c.Token.Value)
@@ -50,7 +49,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,9 +59,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateDatadogInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateDatadogInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/digitalocean/create.go
+++ b/pkg/logging/digitalocean/create.go
@@ -18,13 +18,14 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	BucketName   string
-	AccessKey    string
-	SecretKey    string
+	EndpointName   string // Can't shadow common.Base method Name().
+	BucketName     string
+	AccessKey      string
+	SecretKey      string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Domain            common.OptionalString
 	Path              common.OptionalString
 	Period            common.OptionalUint
@@ -46,14 +47,12 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
-
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("bucket", "The name of the DigitalOcean Space").Required().StringVar(&c.BucketName)
 	c.CmdClause.Flag("access-key", "Your DigitalOcean Spaces account access key").Required().StringVar(&c.AccessKey)
 	c.CmdClause.Flag("secret-key", "Your DigitalOcean Spaces account secret key").Required().StringVar(&c.SecretKey)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("domain", "The domain of the DigitalOcean Spaces endpoint (default 'nyc3.digitaloceanspaces.com')").Action(c.Domain.Set).StringVar(&c.Domain.Value)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
@@ -67,7 +66,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -80,8 +78,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateDigitalOceanInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.BucketName = c.BucketName
 	input.AccessKey = c.AccessKey

--- a/pkg/logging/digitalocean/delete.go
+++ b/pkg/logging/digitalocean/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a DigitalOcean Spaces logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteDigitalOceanInput
+	manifest       manifest.Data
+	Input          fastly.DeleteDigitalOceanInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteDigitalOcean(&c.Input); err != nil {
 		return err

--- a/pkg/logging/digitalocean/describe.go
+++ b/pkg/logging/digitalocean/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a DigitalOcean Spaces logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetDigitalOceanInput
+	manifest       manifest.Data
+	Input          fastly.GetDigitalOceanInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	digitalocean, err := c.Globals.Client.GetDigitalOcean(&c.Input)
 	if err != nil {

--- a/pkg/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/logging/digitalocean/digitalocean_integration_test.go
@@ -24,43 +24,43 @@ func TestDigitalOceanCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--access-key", "foo", "--secret-key", "abc"},
+			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--secret-key", "abc"},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "abc"},
+			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "abc"},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       listVersionsOK,
-				GetVersionFn:         getVersionOK,
-				CloneVersionFn:       cloneVersionOK,
+				ListVersionsFn:       testutil.ListVersionsOk,
+				GetVersionFn:         testutil.GetActiveVersionOK,
+				CloneVersionFn:       testutil.CloneVersionOK,
 				CreateDigitalOceanFn: createDigitalOceanOK,
 			},
-			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 3)",
+			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       listVersionsOK,
-				GetVersionFn:         getVersionOK,
-				CloneVersionFn:       cloneVersionOK,
+				ListVersionsFn:       testutil.ListVersionsOk,
+				GetVersionFn:         testutil.GetActiveVersionOK,
+				CloneVersionFn:       testutil.CloneVersionOK,
 				CreateDigitalOceanFn: createDigitalOceanError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -92,55 +92,55 @@ func TestDigitalOceanList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansShortOutput,
 		},
 		{
-			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: []string{"logging", "digitalocean", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "digitalocean", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "digitalocean", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "digitalocean", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListDigitalOceansFn: listDigitalOceansError,
 			},
 			wantError: errTest.Error(),
@@ -173,23 +173,23 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				GetDigitalOceanFn: getDigitalOceanError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
 			wantOutput: describeDigitalOceanOutput,
@@ -222,28 +222,28 @@ func TestDigitalOceanUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       listVersionsOK,
-				GetVersionFn:         getVersionOK,
-				CloneVersionFn:       cloneVersionOK,
+				ListVersionsFn:       testutil.ListVersionsOk,
+				GetVersionFn:         testutil.GetActiveVersionOK,
+				CloneVersionFn:       testutil.CloneVersionOK,
 				UpdateDigitalOceanFn: updateDigitalOceanError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       listVersionsOK,
-				GetVersionFn:         getVersionOK,
-				CloneVersionFn:       cloneVersionOK,
+				ListVersionsFn:       testutil.ListVersionsOk,
+				GetVersionFn:         testutil.GetActiveVersionOK,
+				CloneVersionFn:       testutil.CloneVersionOK,
 				UpdateDigitalOceanFn: updateDigitalOceanOK,
 			},
-			wantOutput: "Updated DigitalOcean Spaces logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated DigitalOcean Spaces logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -273,28 +273,28 @@ func TestDigitalOceanDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       listVersionsOK,
-				GetVersionFn:         getVersionOK,
-				CloneVersionFn:       cloneVersionOK,
+				ListVersionsFn:       testutil.ListVersionsOk,
+				GetVersionFn:         testutil.GetActiveVersionOK,
+				CloneVersionFn:       testutil.CloneVersionOK,
 				DeleteDigitalOceanFn: deleteDigitalOceanError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       listVersionsOK,
-				GetVersionFn:         getVersionOK,
-				CloneVersionFn:       cloneVersionOK,
+				ListVersionsFn:       testutil.ListVersionsOk,
+				GetVersionFn:         testutil.GetActiveVersionOK,
+				CloneVersionFn:       testutil.CloneVersionOK,
 				DeleteDigitalOceanFn: deleteDigitalOceanOK,
 			},
-			wantOutput: "Deleted DigitalOcean Spaces logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted DigitalOcean Spaces logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -384,18 +384,18 @@ func listDigitalOceansError(i *fastly.ListDigitalOceansInput) ([]*fastly.Digital
 
 var listDigitalOceansShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listDigitalOceansVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	DigitalOcean 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Bucket: my-logs
 		Domain: https://digitalocean.us-east-1.amazonaws.com
@@ -413,7 +413,7 @@ Version: 2
 		Public key: `+pgpPublicKey()+`
 	DigitalOcean 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Bucket: analytics
 		Domain: https://digitalocean.us-east-2.amazonaws.com
@@ -459,7 +459,7 @@ func getDigitalOceanError(i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean,
 
 var describeDigitalOceanOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Bucket: my-logs
 Domain: https://digitalocean.us-east-1.amazonaws.com
@@ -543,35 +543,4 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/logging/digitalocean/digitalocean_integration_test.go
@@ -24,19 +24,34 @@ func TestDigitalOceanCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--secret-key", "abc"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--secret-key", "abc"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "abc"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "abc"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc"},
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersionsOk,
 				GetVersionFn:         testutil.GetActiveVersionOK,
@@ -46,7 +61,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc"},
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersionsOk,
 				GetVersionFn:         testutil.GetActiveVersionOK,
@@ -56,7 +71,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -226,7 +241,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersionsOk,
 				GetVersionFn:         testutil.GetActiveVersionOK,
@@ -236,7 +251,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersionsOk,
 				GetVersionFn:         testutil.GetActiveVersionOK,
@@ -277,7 +292,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersionsOk,
 				GetVersionFn:         testutil.GetActiveVersionOK,
@@ -287,7 +302,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersionsOk,
 				GetVersionFn:         testutil.GetActiveVersionOK,

--- a/pkg/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/logging/digitalocean/digitalocean_integration_test.go
@@ -24,29 +24,44 @@ func TestDigitalOceanCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--secret-key", "abc"},
+			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--access-key", "foo", "--secret-key", "abc"},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "abc"},
+			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "abc"},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:       []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc"},
-			api:        mock.API{CreateDigitalOceanFn: createDigitalOceanOK},
-			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:       listVersionsOK,
+				GetVersionFn:         getVersionOK,
+				CloneVersionFn:       cloneVersionOK,
+				CreateDigitalOceanFn: createDigitalOceanOK,
+			},
+			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc"},
-			api:       mock.API{CreateDigitalOceanFn: createDigitalOceanError},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:       listVersionsOK,
+				GetVersionFn:         getVersionOK,
+				CloneVersionFn:       cloneVersionOK,
+				CreateDigitalOceanFn: createDigitalOceanError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -77,33 +92,57 @@ func TestDigitalOceanList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDigitalOceansFn: listDigitalOceansOK},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListDigitalOceansFn: listDigitalOceansOK,
+			},
 			wantOutput: listDigitalOceansShortOutput,
 		},
 		{
-			args:       []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListDigitalOceansFn: listDigitalOceansOK},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListDigitalOceansFn: listDigitalOceansOK,
+			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListDigitalOceansFn: listDigitalOceansOK},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListDigitalOceansFn: listDigitalOceansOK,
+			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "digitalocean", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDigitalOceansFn: listDigitalOceansOK},
+			args: []string{"logging", "digitalocean", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListDigitalOceansFn: listDigitalOceansOK,
+			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "digitalocean", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListDigitalOceansFn: listDigitalOceansOK},
+			args: []string{"logging", "-v", "digitalocean", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListDigitalOceansFn: listDigitalOceansOK,
+			},
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListDigitalOceansFn: listDigitalOceansError},
+			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListDigitalOceansFn: listDigitalOceansError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -134,17 +173,25 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetDigitalOceanFn: getDigitalOceanError},
+			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				GetDigitalOceanFn: getDigitalOceanError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetDigitalOceanFn: getDigitalOceanOK},
+			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				GetDigitalOceanFn: getDigitalOceanOK,
+			},
 			wantOutput: describeDigitalOceanOutput,
 		},
 	} {
@@ -175,18 +222,28 @@ func TestDigitalOceanUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateDigitalOceanFn: updateDigitalOceanError},
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:       listVersionsOK,
+				GetVersionFn:         getVersionOK,
+				CloneVersionFn:       cloneVersionOK,
+				UpdateDigitalOceanFn: updateDigitalOceanError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateDigitalOceanFn: updateDigitalOceanOK},
-			wantOutput: "Updated DigitalOcean Spaces logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:       listVersionsOK,
+				GetVersionFn:         getVersionOK,
+				CloneVersionFn:       cloneVersionOK,
+				UpdateDigitalOceanFn: updateDigitalOceanOK,
+			},
+			wantOutput: "Updated DigitalOcean Spaces logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -216,18 +273,28 @@ func TestDigitalOceanDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteDigitalOceanFn: deleteDigitalOceanError},
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:       listVersionsOK,
+				GetVersionFn:         getVersionOK,
+				CloneVersionFn:       cloneVersionOK,
+				DeleteDigitalOceanFn: deleteDigitalOceanError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteDigitalOceanFn: deleteDigitalOceanOK},
-			wantOutput: "Deleted DigitalOcean Spaces logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:       listVersionsOK,
+				GetVersionFn:         getVersionOK,
+				CloneVersionFn:       cloneVersionOK,
+				DeleteDigitalOceanFn: deleteDigitalOceanOK,
+			},
+			wantOutput: "Deleted DigitalOcean Spaces logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -317,18 +384,18 @@ func listDigitalOceansError(i *fastly.ListDigitalOceansInput) ([]*fastly.Digital
 
 var listDigitalOceansShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listDigitalOceansVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	DigitalOcean 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Bucket: my-logs
 		Domain: https://digitalocean.us-east-1.amazonaws.com
@@ -346,7 +413,7 @@ Version: 1
 		Public key: `+pgpPublicKey()+`
 	DigitalOcean 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Bucket: analytics
 		Domain: https://digitalocean.us-east-2.amazonaws.com
@@ -392,7 +459,7 @@ func getDigitalOceanError(i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean,
 
 var describeDigitalOceanOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Bucket: my-logs
 Domain: https://digitalocean.us-east-1.amazonaws.com
@@ -476,4 +543,35 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/logging/digitalocean/digitalocean_integration_test.go
@@ -24,58 +24,58 @@ func TestDigitalOceanCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--secret-key", "abc"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "abc"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       testutil.ListVersionsOk,
-				GetVersionFn:         testutil.GetActiveVersionOK,
-				CloneVersionFn:       testutil.CloneVersionOK,
+				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetActiveVersion(1),
+				CloneVersionFn:       testutil.CloneVersionResult(4),
 				CreateDigitalOceanFn: createDigitalOceanOK,
 			},
-			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 2)",
+			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       testutil.ListVersionsOk,
-				GetVersionFn:         testutil.GetActiveVersionOK,
-				CloneVersionFn:       testutil.CloneVersionOK,
+				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetActiveVersion(1),
+				CloneVersionFn:       testutil.CloneVersionResult(4),
 				CreateDigitalOceanFn: createDigitalOceanError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "digitalocean", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "abc", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -109,8 +109,8 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansShortOutput,
@@ -118,8 +118,8 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
@@ -127,8 +127,8 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
@@ -136,8 +136,8 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			args: []string{"logging", "digitalocean", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
@@ -145,8 +145,8 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "digitalocean", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			wantOutput: listDigitalOceansVerboseOutput,
@@ -154,8 +154,8 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			args: []string{"logging", "digitalocean", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListDigitalOceansFn: listDigitalOceansError,
 			},
 			wantError: errTest.Error(),
@@ -194,8 +194,8 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				GetDigitalOceanFn: getDigitalOceanError,
 			},
 			wantError: errTest.Error(),
@@ -203,8 +203,8 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "digitalocean", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
 			wantOutput: describeDigitalOceanOutput,
@@ -241,24 +241,24 @@ func TestDigitalOceanUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       testutil.ListVersionsOk,
-				GetVersionFn:         testutil.GetActiveVersionOK,
-				CloneVersionFn:       testutil.CloneVersionOK,
+				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetActiveVersion(1),
+				CloneVersionFn:       testutil.CloneVersionResult(4),
 				UpdateDigitalOceanFn: updateDigitalOceanError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "digitalocean", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       testutil.ListVersionsOk,
-				GetVersionFn:         testutil.GetActiveVersionOK,
-				CloneVersionFn:       testutil.CloneVersionOK,
+				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetActiveVersion(1),
+				CloneVersionFn:       testutil.CloneVersionResult(4),
 				UpdateDigitalOceanFn: updateDigitalOceanOK,
 			},
-			wantOutput: "Updated DigitalOcean Spaces logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated DigitalOcean Spaces logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -292,24 +292,24 @@ func TestDigitalOceanDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       testutil.ListVersionsOk,
-				GetVersionFn:         testutil.GetActiveVersionOK,
-				CloneVersionFn:       testutil.CloneVersionOK,
+				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetActiveVersion(1),
+				CloneVersionFn:       testutil.CloneVersionResult(4),
 				DeleteDigitalOceanFn: deleteDigitalOceanError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "digitalocean", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:       testutil.ListVersionsOk,
-				GetVersionFn:         testutil.GetActiveVersionOK,
-				CloneVersionFn:       testutil.CloneVersionOK,
+				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetActiveVersion(1),
+				CloneVersionFn:       testutil.CloneVersionResult(4),
 				DeleteDigitalOceanFn: deleteDigitalOceanOK,
 			},
-			wantOutput: "Deleted DigitalOcean Spaces logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted DigitalOcean Spaces logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/digitalocean/digitalocean_test.go
+++ b/pkg/logging/digitalocean/digitalocean_test.go
@@ -84,8 +84,9 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
 			want: &fastly.UpdateDigitalOceanInput{
@@ -114,8 +115,9 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
 			want: &fastly.UpdateDigitalOceanInput{
@@ -150,8 +152,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -165,39 +168,15 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		BucketName: "bucket",
 		AccessKey:  "access",
 		SecretKey:  "secret",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -209,8 +188,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -224,7 +204,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		BucketName:        "bucket",
 		AccessKey:         "access",
@@ -269,7 +252,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -294,7 +280,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		BucketName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/digitalocean/digitalocean_test.go
+++ b/pkg/logging/digitalocean/digitalocean_test.go
@@ -26,7 +26,7 @@ func TestCreateDigitalOceanInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateDigitalOceanInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				BucketName:     "bucket",
 				AccessKey:      "access",
@@ -38,7 +38,7 @@ func TestCreateDigitalOceanInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateDigitalOceanInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				BucketName:        "bucket",
 				Domain:            "nyc3.digitaloceanspaces.com",
@@ -84,14 +84,14 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
 			want: &fastly.UpdateDigitalOceanInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				BucketName:        fastly.String("new2"),
@@ -115,14 +115,14 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
 			want: &fastly.UpdateDigitalOceanInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -152,9 +152,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -188,9 +188,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/digitalocean/digitalocean_test.go
+++ b/pkg/logging/digitalocean/digitalocean_test.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -82,7 +83,11 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetDigitalOceanFn: getDigitalOceanOK},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				GetDigitalOceanFn: getDigitalOceanOK,
+			},
 			want: &fastly.UpdateDigitalOceanInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -108,7 +113,11 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetDigitalOceanFn: getDigitalOceanOK},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				GetDigitalOceanFn: getDigitalOceanOK,
+			},
 			want: &fastly.UpdateDigitalOceanInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -133,21 +142,90 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		BucketName:   "bucket",
-		AccessKey:    "access",
-		SecretKey:    "secret",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		BucketName: "bucket",
+		AccessKey:  "access",
+		SecretKey:  "secret",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		BucketName:        "bucket",
 		AccessKey:         "access",
 		SecretKey:         "secret",
@@ -172,20 +250,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		BucketName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Domain:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/digitalocean/list.go
+++ b/pkg/logging/digitalocean/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list DigitalOcean Spaces logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListDigitalOceansInput
+	manifest       manifest.Data
+	Input          fastly.ListDigitalOceansInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List DigitalOcean Spaces logging endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	digitaloceans, err := c.Globals.Client.ListDigitalOceans(&c.Input)
 	if err != nil {

--- a/pkg/logging/digitalocean/update.go
+++ b/pkg/logging/digitalocean/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	//required
-	EndpointName string
-	Version      int
+	EndpointName   string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	BucketName        common.OptionalString
 	Domain            common.OptionalString
@@ -45,12 +46,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a DigitalOcean Spaces logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the DigitalOcean Spaces logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("bucket", "The name of the DigitalOcean Space").Action(c.BucketName.Set).StringVar(&c.BucketName.Value)
@@ -68,7 +67,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -79,9 +77,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateDigitalOceanInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateDigitalOceanInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/elasticsearch/create.go
+++ b/pkg/logging/elasticsearch/create.go
@@ -17,12 +17,13 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Index        string
-	URL          string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Index          string
+	URL            string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Pipeline          common.OptionalString
 	RequestMaxEntries common.OptionalUint
 	RequestMaxBytes   common.OptionalUint
@@ -45,12 +46,11 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an Elasticsearch logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("index", `The name of the Elasticsearch index to send documents (logs) to. The index must follow the Elasticsearch index format rules (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). We support strftime (http://man7.org/linux/man-pages/man3/strftime.3.html) interpolated variables inside braces prefixed with a pound symbol. For example, #{%F} will interpolate as YYYY-MM-DD with today's date`).Required().StringVar(&c.Index)
 	c.CmdClause.Flag("url", "The URL to stream logs to. Must use HTTPS.").Required().StringVar(&c.URL)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("pipeline", "The ID of the Elasticsearch ingest pipeline to apply pre-process transformations to before indexing. For example my_pipeline_id. Learn more about creating a pipeline in the Elasticsearch docs (https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)").Action(c.Password.Set).StringVar(&c.Pipeline.Value)
 	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
@@ -63,7 +63,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
 	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
-
 	return &c
 }
 
@@ -76,8 +75,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateElasticsearchInput, error) 
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Index = c.Index
 	input.URL = c.URL

--- a/pkg/logging/elasticsearch/delete.go
+++ b/pkg/logging/elasticsearch/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an Elasticsearch logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteElasticsearchInput
+	manifest       manifest.Data
+	Input          fastly.DeleteElasticsearchInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an Elasticsearch logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteElasticsearch(&c.Input); err != nil {
 		return err

--- a/pkg/logging/elasticsearch/describe.go
+++ b/pkg/logging/elasticsearch/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe an Elasticsearch logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetElasticsearchInput
+	manifest       manifest.Data
+	Input          fastly.GetElasticsearchInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an Elasticsearch logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	elasticsearch, err := c.Globals.Client.GetElasticsearch(&c.Input)
 	if err != nil {

--- a/pkg/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_integration_test.go
@@ -24,15 +24,25 @@ func TestElasticsearchCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --index not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersionsOk,
 				GetVersionFn:          testutil.GetActiveVersionOK,
@@ -223,7 +233,7 @@ func TestElasticsearchUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersionsOk,
 				GetVersionFn:          testutil.GetActiveVersionOK,
@@ -274,7 +284,7 @@ func TestElasticsearchDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersionsOk,
 				GetVersionFn:          testutil.GetActiveVersionOK,

--- a/pkg/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_integration_test.go
@@ -24,21 +24,31 @@ func TestElasticsearchCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs"},
+			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--index", "logs"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
 			wantError: "error parsing arguments: required flag --index not provided",
 		},
 		{
-			args:       []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
-			api:        mock.API{CreateElasticsearchFn: createElasticsearchOK},
-			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--index", "logs", "--url", "example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:        listVersionsOK,
+				GetVersionFn:          getVersionOK,
+				CloneVersionFn:        cloneVersionOK,
+				CreateElasticsearchFn: createElasticsearchOK,
+			},
+			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
-			api:       mock.API{CreateElasticsearchFn: createElasticsearchError},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--index", "logs", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn:        listVersionsOK,
+				GetVersionFn:          getVersionOK,
+				CloneVersionFn:        cloneVersionOK,
+				CreateElasticsearchFn: createElasticsearchError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -69,33 +79,57 @@ func TestElasticsearchList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListElasticsearchFn: listElasticsearchsOK,
+			},
 			wantOutput: listElasticsearchsShortOutput,
 		},
 		{
-			args:       []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListElasticsearchFn: listElasticsearchsOK,
+			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListElasticsearchFn: listElasticsearchsOK,
+			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "elasticsearch", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			args: []string{"logging", "elasticsearch", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListElasticsearchFn: listElasticsearchsOK,
+			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListElasticsearchFn: listElasticsearchsOK},
+			args: []string{"logging", "-v", "elasticsearch", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListElasticsearchFn: listElasticsearchsOK,
+			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListElasticsearchFn: listElasticsearchsError},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:      listVersionsOK,
+				GetVersionFn:        getVersionOK,
+				ListElasticsearchFn: listElasticsearchsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -126,17 +160,25 @@ func TestElasticsearchDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetElasticsearchFn: getElasticsearchError},
+			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				GetElasticsearchFn: getElasticsearchError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetElasticsearchFn: getElasticsearchOK},
+			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				GetElasticsearchFn: getElasticsearchOK,
+			},
 			wantOutput: describeElasticsearchOutput,
 		},
 	} {
@@ -167,18 +209,28 @@ func TestElasticsearchUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateElasticsearchFn: updateElasticsearchError},
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:        listVersionsOK,
+				GetVersionFn:          getVersionOK,
+				CloneVersionFn:        cloneVersionOK,
+				UpdateElasticsearchFn: updateElasticsearchError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateElasticsearchFn: updateElasticsearchOK},
-			wantOutput: "Updated Elasticsearch logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:        listVersionsOK,
+				GetVersionFn:          getVersionOK,
+				CloneVersionFn:        cloneVersionOK,
+				UpdateElasticsearchFn: updateElasticsearchOK,
+			},
+			wantOutput: "Updated Elasticsearch logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -208,18 +260,28 @@ func TestElasticsearchDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteElasticsearchFn: deleteElasticsearchError},
+			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:        listVersionsOK,
+				GetVersionFn:          getVersionOK,
+				CloneVersionFn:        cloneVersionOK,
+				DeleteElasticsearchFn: deleteElasticsearchError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteElasticsearchFn: deleteElasticsearchOK},
-			wantOutput: "Deleted Elasticsearch logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:        listVersionsOK,
+				GetVersionFn:          getVersionOK,
+				CloneVersionFn:        cloneVersionOK,
+				DeleteElasticsearchFn: deleteElasticsearchOK,
+			},
+			wantOutput: "Deleted Elasticsearch logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -321,18 +383,18 @@ func listElasticsearchsError(i *fastly.ListElasticsearchInput) ([]*fastly.Elasti
 
 var listElasticsearchsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listElasticsearchsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Elasticsearch 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Index: logs
 		URL: example.com
@@ -349,7 +411,7 @@ Version: 1
 		Placement: none
 	Elasticsearch 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Index: analytics
 		URL: example.com
@@ -395,7 +457,7 @@ func getElasticsearchError(i *fastly.GetElasticsearchInput) (*fastly.Elasticsear
 
 var describeElasticsearchOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Index: logs
 URL: example.com
@@ -445,4 +507,35 @@ func deleteElasticsearchOK(i *fastly.DeleteElasticsearchInput) error {
 
 func deleteElasticsearchError(i *fastly.DeleteElasticsearchInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_integration_test.go
@@ -24,29 +24,29 @@ func TestElasticsearchCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--index", "logs"},
+			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			args:      []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			wantError: "error parsing arguments: required flag --index not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--index", "logs", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        listVersionsOK,
-				GetVersionFn:          getVersionOK,
-				CloneVersionFn:        cloneVersionOK,
+				ListVersionsFn:        testutil.ListVersionsOk,
+				GetVersionFn:          testutil.GetActiveVersionOK,
+				CloneVersionFn:        testutil.CloneVersionOK,
 				CreateElasticsearchFn: createElasticsearchOK,
 			},
-			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "2", "--name", "log", "--index", "logs", "--url", "example.com"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
 			api: mock.API{
-				ListVersionsFn:        listVersionsOK,
-				GetVersionFn:          getVersionOK,
-				CloneVersionFn:        cloneVersionOK,
+				ListVersionsFn:        testutil.ListVersionsOk,
+				GetVersionFn:          testutil.GetActiveVersionOK,
+				CloneVersionFn:        testutil.CloneVersionOK,
 				CreateElasticsearchFn: createElasticsearchError,
 			},
 			wantError: errTest.Error(),
@@ -79,55 +79,55 @@ func TestElasticsearchList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsShortOutput,
 		},
 		{
-			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "elasticsearch", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "elasticsearch", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "elasticsearch", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersionsOk,
+				GetVersionFn:        testutil.GetActiveVersionOK,
 				ListElasticsearchFn: listElasticsearchsError,
 			},
 			wantError: errTest.Error(),
@@ -160,23 +160,23 @@ func TestElasticsearchDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				GetElasticsearchFn: getElasticsearchError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
 				GetElasticsearchFn: getElasticsearchOK,
 			},
 			wantOutput: describeElasticsearchOutput,
@@ -209,28 +209,28 @@ func TestElasticsearchUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:        listVersionsOK,
-				GetVersionFn:          getVersionOK,
-				CloneVersionFn:        cloneVersionOK,
+				ListVersionsFn:        testutil.ListVersionsOk,
+				GetVersionFn:          testutil.GetActiveVersionOK,
+				CloneVersionFn:        testutil.CloneVersionOK,
 				UpdateElasticsearchFn: updateElasticsearchError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        listVersionsOK,
-				GetVersionFn:          getVersionOK,
-				CloneVersionFn:        cloneVersionOK,
+				ListVersionsFn:        testutil.ListVersionsOk,
+				GetVersionFn:          testutil.GetActiveVersionOK,
+				CloneVersionFn:        testutil.CloneVersionOK,
 				UpdateElasticsearchFn: updateElasticsearchOK,
 			},
-			wantOutput: "Updated Elasticsearch logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Elasticsearch logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -260,28 +260,28 @@ func TestElasticsearchDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:        listVersionsOK,
-				GetVersionFn:          getVersionOK,
-				CloneVersionFn:        cloneVersionOK,
+				ListVersionsFn:        testutil.ListVersionsOk,
+				GetVersionFn:          testutil.GetActiveVersionOK,
+				CloneVersionFn:        testutil.CloneVersionOK,
 				DeleteElasticsearchFn: deleteElasticsearchError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        listVersionsOK,
-				GetVersionFn:          getVersionOK,
-				CloneVersionFn:        cloneVersionOK,
+				ListVersionsFn:        testutil.ListVersionsOk,
+				GetVersionFn:          testutil.GetActiveVersionOK,
+				CloneVersionFn:        testutil.CloneVersionOK,
 				DeleteElasticsearchFn: deleteElasticsearchOK,
 			},
-			wantOutput: "Deleted Elasticsearch logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Elasticsearch logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -383,18 +383,18 @@ func listElasticsearchsError(i *fastly.ListElasticsearchInput) ([]*fastly.Elasti
 
 var listElasticsearchsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listElasticsearchsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Elasticsearch 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Index: logs
 		URL: example.com
@@ -411,7 +411,7 @@ Version: 2
 		Placement: none
 	Elasticsearch 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Index: analytics
 		URL: example.com
@@ -457,7 +457,7 @@ func getElasticsearchError(i *fastly.GetElasticsearchInput) (*fastly.Elasticsear
 
 var describeElasticsearchOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Index: logs
 URL: example.com
@@ -507,35 +507,4 @@ func deleteElasticsearchOK(i *fastly.DeleteElasticsearchInput) error {
 
 func deleteElasticsearchError(i *fastly.DeleteElasticsearchInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_integration_test.go
@@ -24,39 +24,39 @@ func TestElasticsearchCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --index not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersionsOk,
-				GetVersionFn:          testutil.GetActiveVersionOK,
-				CloneVersionFn:        testutil.CloneVersionOK,
+				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetActiveVersion(1),
+				CloneVersionFn:        testutil.CloneVersionResult(4),
 				CreateElasticsearchFn: createElasticsearchOK,
 			},
-			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com"},
+			args: []string{"logging", "elasticsearch", "create", "--service-id", "123", "--version", "1", "--name", "log", "--index", "logs", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersionsOk,
-				GetVersionFn:          testutil.GetActiveVersionOK,
-				CloneVersionFn:        testutil.CloneVersionOK,
+				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetActiveVersion(1),
+				CloneVersionFn:        testutil.CloneVersionResult(4),
 				CreateElasticsearchFn: createElasticsearchError,
 			},
 			wantError: errTest.Error(),
@@ -91,8 +91,8 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsShortOutput,
@@ -100,8 +100,8 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
@@ -109,8 +109,8 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
@@ -118,8 +118,8 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			args: []string{"logging", "elasticsearch", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
@@ -127,8 +127,8 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			wantOutput: listElasticsearchsVerboseOutput,
@@ -136,8 +136,8 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			args: []string{"logging", "elasticsearch", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      testutil.ListVersionsOk,
-				GetVersionFn:        testutil.GetActiveVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				ListElasticsearchFn: listElasticsearchsError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestElasticsearchDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				GetElasticsearchFn: getElasticsearchError,
 			},
 			wantError: errTest.Error(),
@@ -185,8 +185,8 @@ func TestElasticsearchDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "elasticsearch", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
 				GetElasticsearchFn: getElasticsearchOK,
 			},
 			wantOutput: describeElasticsearchOutput,
@@ -223,24 +223,24 @@ func TestElasticsearchUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersionsOk,
-				GetVersionFn:          testutil.GetActiveVersionOK,
-				CloneVersionFn:        testutil.CloneVersionOK,
+				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetActiveVersion(1),
+				CloneVersionFn:        testutil.CloneVersionResult(4),
 				UpdateElasticsearchFn: updateElasticsearchError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "elasticsearch", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersionsOk,
-				GetVersionFn:          testutil.GetActiveVersionOK,
-				CloneVersionFn:        testutil.CloneVersionOK,
+				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetActiveVersion(1),
+				CloneVersionFn:        testutil.CloneVersionResult(4),
 				UpdateElasticsearchFn: updateElasticsearchOK,
 			},
-			wantOutput: "Updated Elasticsearch logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Elasticsearch logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -274,24 +274,24 @@ func TestElasticsearchDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersionsOk,
-				GetVersionFn:          testutil.GetActiveVersionOK,
-				CloneVersionFn:        testutil.CloneVersionOK,
+				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetActiveVersion(1),
+				CloneVersionFn:        testutil.CloneVersionResult(4),
 				DeleteElasticsearchFn: deleteElasticsearchError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "elasticsearch", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersionsOk,
-				GetVersionFn:          testutil.GetActiveVersionOK,
-				CloneVersionFn:        testutil.CloneVersionOK,
+				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetActiveVersion(1),
+				CloneVersionFn:        testutil.CloneVersionResult(4),
 				DeleteElasticsearchFn: deleteElasticsearchOK,
 			},
-			wantOutput: "Deleted Elasticsearch logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Elasticsearch logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_test.go
@@ -25,7 +25,7 @@ func TestCreateElasticsearchInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateElasticsearchInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Index:          "logs",
 				URL:            "example.com",
@@ -36,7 +36,7 @@ func TestCreateElasticsearchInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateElasticsearchInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "logs",
 				ResponseCondition: "Prevent default logging",
 				Format:            `%h %l %u %t "%r" %>s %b`,
@@ -82,14 +82,14 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				GetElasticsearchFn: getElasticsearchOK,
 			},
 			want: &fastly.UpdateElasticsearchInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Index:             fastly.String("new2"),
@@ -113,14 +113,14 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				GetElasticsearchFn: getElasticsearchOK,
 			},
 			want: &fastly.UpdateElasticsearchInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -150,9 +150,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -185,9 +185,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_test.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -80,7 +81,11 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetElasticsearchFn: getElasticsearchOK},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				GetElasticsearchFn: getElasticsearchOK,
+			},
 			want: &fastly.UpdateElasticsearchInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -106,7 +111,11 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetElasticsearchFn: getElasticsearchOK},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				GetElasticsearchFn: getElasticsearchOK,
+			},
 			want: &fastly.UpdateElasticsearchInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -131,20 +140,89 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		Index:        "logs",
-		URL:          "example.com",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		Index: "logs",
+		URL:   "example.com",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "logs",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "logs",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Index:             "logs",
 		URL:               "example.com",
 		Pipeline:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "my_pipeline_id"},
@@ -170,20 +248,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Index:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_test.go
@@ -82,8 +82,9 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				GetElasticsearchFn: getElasticsearchOK,
 			},
 			want: &fastly.UpdateElasticsearchInput{
@@ -112,8 +113,9 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				GetElasticsearchFn: getElasticsearchOK,
 			},
 			want: &fastly.UpdateElasticsearchInput{
@@ -148,8 +150,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -163,38 +166,14 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Index: "logs",
 		URL:   "example.com",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -206,8 +185,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -221,7 +201,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Index:             "logs",
 		URL:               "example.com",
@@ -267,7 +250,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -292,7 +278,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Index:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/elasticsearch/list.go
+++ b/pkg/logging/elasticsearch/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Elasticsearch logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListElasticsearchInput
+	manifest       manifest.Data
+	Input          fastly.ListElasticsearchInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Elasticsearch endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	elasticsearchs, err := c.Globals.Client.ListElasticsearch(&c.Input)
 	if err != nil {

--- a/pkg/logging/elasticsearch/update.go
+++ b/pkg/logging/elasticsearch/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Index             common.OptionalString
 	URL               common.OptionalString
@@ -45,12 +46,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update an Elasticsearch logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Elasticsearch logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("index", `The name of the Elasticsearch index to send documents (logs) to. The index must follow the Elasticsearch index format rules (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). We support strftime (http://man7.org/linux/man-pages/man3/strftime.3.html) interpolated variables inside braces prefixed with a pound symbol. For example, #{%F} will interpolate as YYYY-MM-DD with today's date`).Action(c.Index.Set).StringVar(&c.Index.Value)
@@ -66,7 +65,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
 	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
-
 	return &c
 }
 
@@ -77,9 +75,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateElasticsearchInput, error) 
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateElasticsearchInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -18,13 +18,14 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Address      string
-	Username     string
-	Password     string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Address        string
+	Username       string
+	Password       string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Port              common.OptionalUint
 	Path              common.OptionalString
 	Period            common.OptionalUint
@@ -44,13 +45,12 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an FTP logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the FTP logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("address", "An hostname or IPv4 address").Required().StringVar(&c.Address)
 	c.CmdClause.Flag("user", "The username for the server (can be anonymous)").Required().StringVar(&c.Username)
 	c.CmdClause.Flag("password", "The password for the server (for anonymous use an email address)").Required().StringVar(&c.Password)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("path", "The path to upload log files to. If the path ends in / then it is treated as a directory").Action(c.Path.Set).StringVar(&c.Path.Value)
@@ -62,7 +62,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -75,8 +74,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateFTPInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Address = c.Address
 	input.Username = c.Username

--- a/pkg/logging/ftp/delete.go
+++ b/pkg/logging/ftp/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an FTP logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteFTPInput
+	manifest       manifest.Data
+	Input          fastly.DeleteFTPInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an FTP logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteFTP(&c.Input); err != nil {
 		return err

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe an FTP logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetFTPInput
+	manifest       manifest.Data
+	Input          fastly.GetFTPInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an FTP logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	ftp, err := c.Globals.Client.GetFTP(&c.Input)
 	if err != nil {

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -24,43 +24,43 @@ func TestFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous"},
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
 			wantError: "error parsing arguments: required flag --password not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--autoclone"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateFTPFn:    createFTPOK,
 			},
-			wantOutput: "Created FTP logging endpoint log (service 123 version 3)",
+			wantOutput: "Created FTP logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--autoclone"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateFTPFn:    createFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -92,55 +92,55 @@ func TestFTPList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsShortOutput,
 		},
 		{
-			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListFTPsFn:     listFTPsError,
 			},
 			wantError: errTest.Error(),
@@ -173,23 +173,23 @@ func TestFTPDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetFTPFn:       getFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetFTPFn:       getFTPOK,
 			},
 			wantOutput: describeFTPOutput,
@@ -222,28 +222,28 @@ func TestFTPUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateFTPFn:    updateFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateFTPFn:    updateFTPOK,
 			},
-			wantOutput: "Updated FTP logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated FTP logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -273,28 +273,28 @@ func TestFTPDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteFTPFn:    deleteFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteFTPFn:    deleteFTPOK,
 			},
-			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -380,18 +380,18 @@ func listFTPsError(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
 
 var listFTPsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listFTPsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	FTP 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Address: example.com
 		Port: 123
@@ -409,7 +409,7 @@ Version: 2
 		Compression codec: zstd
 	FTP 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Address: 127.0.0.1
 		Port: 456
@@ -455,7 +455,7 @@ func getFTPError(i *fastly.GetFTPInput) (*fastly.FTP, error) {
 
 var describeFTPOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Address: example.com
 Port: 123
@@ -539,35 +539,4 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -24,19 +24,34 @@ func TestFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --password not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--autoclone"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -46,7 +61,7 @@ func TestFTPCreate(t *testing.T) {
 			wantOutput: "Created FTP logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--autoclone"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -56,7 +71,7 @@ func TestFTPCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -236,7 +251,7 @@ func TestFTPUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -287,7 +302,7 @@ func TestFTPDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -24,29 +24,44 @@ func TestFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
+			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous"},
 			wantError: "error parsing arguments: required flag --password not provided",
 		},
 		{
-			args:       []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd"},
-			api:        mock.API{CreateFTPFn: createFTPOK},
-			wantOutput: "Created FTP logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateFTPFn:    createFTPOK,
+			},
+			wantOutput: "Created FTP logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
-			api:       mock.API{CreateFTPFn: createFTPError},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateFTPFn:    createFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -77,33 +92,57 @@ func TestFTPList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListFTPsFn:     listFTPsOK,
+			},
 			wantOutput: listFTPsShortOutput,
 		},
 		{
-			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListFTPsFn:     listFTPsOK,
+			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListFTPsFn:     listFTPsOK,
+			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
+			args: []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListFTPsFn:     listFTPsOK,
+			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListFTPsFn: listFTPsOK},
+			args: []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListFTPsFn:     listFTPsOK,
+			},
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListFTPsFn: listFTPsError},
+			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListFTPsFn:     listFTPsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -134,17 +173,25 @@ func TestFTPDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetFTPFn: getFTPError},
+			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetFTPFn:       getFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetFTPFn: getFTPOK},
+			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetFTPFn:       getFTPOK,
+			},
 			wantOutput: describeFTPOutput,
 		},
 	} {
@@ -175,18 +222,28 @@ func TestFTPUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateFTPFn: updateFTPError},
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateFTPFn:    updateFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateFTPFn: updateFTPOK},
-			wantOutput: "Updated FTP logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateFTPFn:    updateFTPOK,
+			},
+			wantOutput: "Updated FTP logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -216,18 +273,28 @@ func TestFTPDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteFTPFn: deleteFTPError},
+			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteFTPFn:    deleteFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteFTPFn: deleteFTPOK},
-			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteFTPFn:    deleteFTPOK,
+			},
+			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -313,18 +380,18 @@ func listFTPsError(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
 
 var listFTPsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listFTPsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	FTP 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Address: example.com
 		Port: 123
@@ -342,7 +409,7 @@ Version: 1
 		Compression codec: zstd
 	FTP 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Address: 127.0.0.1
 		Port: 456
@@ -388,7 +455,7 @@ func getFTPError(i *fastly.GetFTPInput) (*fastly.FTP, error) {
 
 var describeFTPOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Address: example.com
 Port: 123
@@ -472,4 +539,35 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/ftp/ftp_integration_test.go
+++ b/pkg/logging/ftp/ftp_integration_test.go
@@ -24,58 +24,58 @@ func TestFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "anonymous", "--password", "foo@example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--password", "foo@example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --password not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateFTPFn:    createFTPOK,
 			},
-			wantOutput: "Created FTP logging endpoint log (service 123 version 2)",
+			wantOutput: "Created FTP logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateFTPFn:    createFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "ftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--password", "foo@example.com", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -109,8 +109,8 @@ func TestFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsShortOutput,
@@ -118,8 +118,8 @@ func TestFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
@@ -127,8 +127,8 @@ func TestFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
@@ -136,8 +136,8 @@ func TestFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "ftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
@@ -145,8 +145,8 @@ func TestFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "ftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListFTPsFn:     listFTPsOK,
 			},
 			wantOutput: listFTPsVerboseOutput,
@@ -154,8 +154,8 @@ func TestFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "ftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListFTPsFn:     listFTPsError,
 			},
 			wantError: errTest.Error(),
@@ -194,8 +194,8 @@ func TestFTPDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetFTPFn:       getFTPError,
 			},
 			wantError: errTest.Error(),
@@ -203,8 +203,8 @@ func TestFTPDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "ftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetFTPFn:       getFTPOK,
 			},
 			wantOutput: describeFTPOutput,
@@ -241,24 +241,24 @@ func TestFTPUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateFTPFn:    updateFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "ftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateFTPFn:    updateFTPOK,
 			},
-			wantOutput: "Updated FTP logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated FTP logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -292,24 +292,24 @@ func TestFTPDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteFTPFn:    deleteFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "ftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteFTPFn:    deleteFTPOK,
 			},
-			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted FTP logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -25,7 +25,7 @@ func TestCreateFTPInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateFTPInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Address:        "example.com",
 				Username:       "user",
@@ -37,7 +37,7 @@ func TestCreateFTPInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateFTPInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Address:           "example.com",
 				Port:              22,
@@ -80,14 +80,14 @@ func TestUpdateFTPInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetFTPFn:       getFTPOK,
 			},
 			want: &fastly.UpdateFTPInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -95,14 +95,14 @@ func TestUpdateFTPInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetFTPFn:       getFTPOK,
 			},
 			want: &fastly.UpdateFTPInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Address:           fastly.String("new2"),
@@ -147,9 +147,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -183,9 +183,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -1,6 +1,7 @@
 package ftp
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -78,7 +79,11 @@ func TestUpdateFTPInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetFTPFn: getFTPOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetFTPFn:       getFTPOK,
+			},
 			want: &fastly.UpdateFTPInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -88,7 +93,11 @@ func TestUpdateFTPInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetFTPFn: getFTPOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetFTPFn:       getFTPOK,
+			},
 			want: &fastly.UpdateFTPInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -128,21 +137,90 @@ func TestUpdateFTPInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		Address:      "example.com",
 		Username:     "user",
 		Password:     "password",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Address:           "example.com",
 		Username:          "user",
 		Password:          "password",
@@ -165,20 +243,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -80,8 +80,9 @@ func TestUpdateFTPInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetFTPFn:       getFTPOK,
 			},
 			want: &fastly.UpdateFTPInput{
@@ -94,8 +95,9 @@ func TestUpdateFTPInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetFTPFn:       getFTPOK,
 			},
 			want: &fastly.UpdateFTPInput{
@@ -145,8 +147,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -163,36 +166,12 @@ func createCommandRequired() *CreateCommand {
 		Username:     "user",
 		Password:     "password",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -204,8 +183,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -219,7 +199,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Address:           "example.com",
 		Username:          "user",
@@ -262,7 +245,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -287,7 +273,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/ftp/list.go
+++ b/pkg/logging/ftp/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list FTP logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListFTPsInput
+	manifest       manifest.Data
+	Input          fastly.ListFTPsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List FTP endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	ftps, err := c.Globals.Client.ListFTPs(&c.Input)
 	if err != nil {

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Address           common.OptionalString
 	Port              common.OptionalUint
@@ -44,12 +45,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update an FTP logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the FTP logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "An hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
@@ -66,7 +65,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -77,9 +75,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateFTPInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateFTPInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/gcs/create.go
+++ b/pkg/logging/gcs/create.go
@@ -18,13 +18,14 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Bucket       string
-	User         string
-	SecretKey    string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Bucket         string
+	User           string
+	SecretKey      string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Path              common.OptionalString
 	Period            common.OptionalUint
 	GzipLevel         common.OptionalUint8
@@ -44,13 +45,12 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a GCS logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the GCS logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Required().StringVar(&c.User)
 	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Required().StringVar(&c.Bucket)
 	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Required().StringVar(&c.SecretKey)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
 	c.CmdClause.Flag("path", "The path to upload logs to (default '/')").Action(c.Path.Set).StringVar(&c.Path.Value)
@@ -62,7 +62,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -75,8 +74,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateGCSInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Bucket = c.Bucket
 	input.User = c.User

--- a/pkg/logging/gcs/delete.go
+++ b/pkg/logging/gcs/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a GCS logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteGCSInput
+	manifest       manifest.Data
+	Input          fastly.DeleteGCSInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,11 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a GCS logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -40,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteGCS(&c.Input); err != nil {
 		return err

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a GCS logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetGCSInput
+	manifest       manifest.Data
+	Input          fastly.GetGCSInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a GCS logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	gcs, err := c.Globals.Client.GetGCS(&c.Input)
 	if err != nil {

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -24,58 +24,58 @@ func TestGCSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateGCSFn:    createGCSOK,
 			},
-			wantOutput: "Created GCS logging endpoint log (service 123 version 2)",
+			wantOutput: "Created GCS logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateGCSFn:    createGCSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -109,8 +109,8 @@ func TestGCSList(t *testing.T) {
 		{
 			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsShortOutput,
@@ -118,8 +118,8 @@ func TestGCSList(t *testing.T) {
 		{
 			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
@@ -127,8 +127,8 @@ func TestGCSList(t *testing.T) {
 		{
 			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
@@ -136,8 +136,8 @@ func TestGCSList(t *testing.T) {
 		{
 			args: []string{"logging", "gcs", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
@@ -145,8 +145,8 @@ func TestGCSList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "gcs", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
@@ -154,8 +154,8 @@ func TestGCSList(t *testing.T) {
 		{
 			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListGCSsFn:     listGCSsError,
 			},
 			wantError: errTest.Error(),
@@ -194,8 +194,8 @@ func TestGCSDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetGCSFn:       getGCSError,
 			},
 			wantError: errTest.Error(),
@@ -203,8 +203,8 @@ func TestGCSDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetGCSFn:       getGCSOK,
 			},
 			wantOutput: describeGCSOutput,
@@ -241,24 +241,24 @@ func TestGCSUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateGCSFn:    updateGCSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateGCSFn:    updateGCSOK,
 			},
-			wantOutput: "Updated GCS logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated GCS logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -292,24 +292,24 @@ func TestGCSDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteGCSFn:    deleteGCSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteGCSFn:    deleteGCSOK,
 			},
-			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -24,19 +24,34 @@ func TestGCSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--autoclone"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -236,7 +251,7 @@ func TestGCSUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -287,7 +302,7 @@ func TestGCSDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -24,43 +24,43 @@ func TestGCSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--autoclone"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateGCSFn:    createGCSOK,
 			},
-			wantOutput: "Created GCS logging endpoint log (service 123 version 3)",
+			wantOutput: "Created GCS logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateGCSFn:    createGCSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -92,55 +92,55 @@ func TestGCSList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsShortOutput,
 		},
 		{
-			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "gcs", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "gcs", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "gcs", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "gcs", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListGCSsFn:     listGCSsOK,
 			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListGCSsFn:     listGCSsError,
 			},
 			wantError: errTest.Error(),
@@ -173,23 +173,23 @@ func TestGCSDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetGCSFn:       getGCSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetGCSFn:       getGCSOK,
 			},
 			wantOutput: describeGCSOutput,
@@ -222,28 +222,28 @@ func TestGCSUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateGCSFn:    updateGCSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateGCSFn:    updateGCSOK,
 			},
-			wantOutput: "Updated GCS logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated GCS logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -273,28 +273,28 @@ func TestGCSDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteGCSFn:    deleteGCSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteGCSFn:    deleteGCSOK,
 			},
-			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -377,18 +377,18 @@ func listGCSsError(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
 
 var listGCSsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listGCSsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	GCS 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Bucket: my-logs
 		User: foo@example.com
@@ -405,7 +405,7 @@ Version: 2
 		Compression codec: zstd
 	GCS 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Bucket: analytics
 		User: foo@example.com
@@ -449,7 +449,7 @@ func getGCSError(i *fastly.GetGCSInput) (*fastly.GCS, error) {
 
 var describeGCSOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Bucket: my-logs
 User: foo@example.com
@@ -497,35 +497,4 @@ func deleteGCSOK(i *fastly.DeleteGCSInput) error {
 
 func deleteGCSError(i *fastly.DeleteGCSInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/gcs/gcs_integration_test.go
+++ b/pkg/logging/gcs/gcs_integration_test.go
@@ -24,29 +24,44 @@ func TestGCSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "foo@example.com", "--secret-key", "foo"},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "foo"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
+			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:       []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
-			api:        mock.API{CreateGCSFn: createGCSOK},
-			wantOutput: "Created GCS logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateGCSFn:    createGCSOK,
+			},
+			wantOutput: "Created GCS logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
-			api:       mock.API{CreateGCSFn: createGCSError},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateGCSFn:    createGCSError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "gcs", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "gcs", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "foo@example.com", "--secret-key", "foo", "--period", "86400", "--compression-codec", "zstd", "--gzip-level", "9"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -77,33 +92,57 @@ func TestGCSList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListGCSsFn: listGCSsOK},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListGCSsFn:     listGCSsOK,
+			},
 			wantOutput: listGCSsShortOutput,
 		},
 		{
-			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListGCSsFn: listGCSsOK},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListGCSsFn:     listGCSsOK,
+			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListGCSsFn: listGCSsOK},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListGCSsFn:     listGCSsOK,
+			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "gcs", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListGCSsFn: listGCSsOK},
+			args: []string{"logging", "gcs", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListGCSsFn:     listGCSsOK,
+			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "gcs", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListGCSsFn: listGCSsOK},
+			args: []string{"logging", "-v", "gcs", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListGCSsFn:     listGCSsOK,
+			},
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "gcs", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListGCSsFn: listGCSsError},
+			args: []string{"logging", "gcs", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListGCSsFn:     listGCSsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -134,17 +173,25 @@ func TestGCSDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetGCSFn: getGCSError},
+			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetGCSFn:       getGCSError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetGCSFn: getGCSOK},
+			args: []string{"logging", "gcs", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetGCSFn:       getGCSOK,
+			},
 			wantOutput: describeGCSOutput,
 		},
 	} {
@@ -175,18 +222,28 @@ func TestGCSUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "gcs", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateGCSFn: updateGCSError},
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateGCSFn:    updateGCSError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "gcs", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateGCSFn: updateGCSOK},
-			wantOutput: "Updated GCS logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "gcs", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateGCSFn:    updateGCSOK,
+			},
+			wantOutput: "Updated GCS logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -216,18 +273,28 @@ func TestGCSDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteGCSFn: deleteGCSError},
+			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteGCSFn:    deleteGCSError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteGCSFn: deleteGCSOK},
-			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "gcs", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteGCSFn:    deleteGCSOK,
+			},
+			wantOutput: "Deleted GCS logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -310,18 +377,18 @@ func listGCSsError(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
 
 var listGCSsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listGCSsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	GCS 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Bucket: my-logs
 		User: foo@example.com
@@ -338,7 +405,7 @@ Version: 1
 		Compression codec: zstd
 	GCS 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Bucket: analytics
 		User: foo@example.com
@@ -382,7 +449,7 @@ func getGCSError(i *fastly.GetGCSInput) (*fastly.GCS, error) {
 
 var describeGCSOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Bucket: my-logs
 User: foo@example.com
@@ -430,4 +497,35 @@ func deleteGCSOK(i *fastly.DeleteGCSInput) error {
 
 func deleteGCSError(i *fastly.DeleteGCSInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -25,7 +25,7 @@ func TestCreateGCSInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateGCSInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Bucket:         "bucket",
 				User:           "user",
@@ -37,7 +37,7 @@ func TestCreateGCSInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateGCSInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Bucket:            "bucket",
 				User:              "user",
@@ -79,14 +79,14 @@ func TestUpdateGCSInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetGCSFn:       getGCSOK,
 			},
 			want: &fastly.UpdateGCSInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -94,14 +94,14 @@ func TestUpdateGCSInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetGCSFn:       getGCSOK,
 			},
 			want: &fastly.UpdateGCSInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Bucket:            fastly.String("new2"),
@@ -145,9 +145,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -181,9 +181,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -1,6 +1,7 @@
 package gcs
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -77,7 +78,11 @@ func TestUpdateGCSInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetGCSFn: getGCSOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetGCSFn:       getGCSOK,
+			},
 			want: &fastly.UpdateGCSInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -87,7 +92,11 @@ func TestUpdateGCSInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetGCSFn: getGCSOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetGCSFn:       getGCSOK,
+			},
 			want: &fastly.UpdateGCSInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -126,21 +135,90 @@ func TestUpdateGCSInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		Bucket:       "bucket",
-		User:         "user",
-		SecretKey:    "-----BEGIN PRIVATE KEY-----foo",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		Bucket:    "bucket",
+		User:      "user",
+		SecretKey: "-----BEGIN PRIVATE KEY-----foo",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Bucket:            "bucket",
 		User:              "user",
 		SecretKey:         "-----BEGIN PRIVATE KEY-----foo",
@@ -163,20 +241,38 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Bucket:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -79,8 +79,9 @@ func TestUpdateGCSInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetGCSFn:       getGCSOK,
 			},
 			want: &fastly.UpdateGCSInput{
@@ -93,8 +94,9 @@ func TestUpdateGCSInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetGCSFn:       getGCSOK,
 			},
 			want: &fastly.UpdateGCSInput{
@@ -143,8 +145,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -158,39 +161,15 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Bucket:    "bucket",
 		User:      "user",
 		SecretKey: "-----BEGIN PRIVATE KEY-----foo",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -202,8 +181,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -217,7 +197,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Bucket:            "bucket",
 		User:              "user",
@@ -260,7 +243,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -271,7 +257,10 @@ func updateCommandAll() *UpdateCommand {
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Bucket:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -252,9 +252,23 @@ func updateCommandNoUpdates() *UpdateCommand {
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
 			OptionalString: common.OptionalString{Value: "1"},

--- a/pkg/logging/gcs/list.go
+++ b/pkg/logging/gcs/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list GCS logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListGCSsInput
+	manifest       manifest.Data
+	Input          fastly.ListGCSsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List GCS endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	gcss, err := c.Globals.Client.ListGCSs(&c.Input)
 	if err != nil {

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Bucket            common.OptionalString
 	User              common.OptionalString
@@ -43,12 +44,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a GCS logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the GCS logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Action(c.Bucket.Set).StringVar(&c.Bucket.Value)
@@ -64,7 +63,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -75,9 +73,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateGCSInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateGCSInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/googlepubsub/create.go
+++ b/pkg/logging/googlepubsub/create.go
@@ -17,14 +17,15 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	User         string
-	SecretKey    string
-	Topic        string
-	ProjectID    string
+	EndpointName   string // Can't shadow common.Base method Name().
+	User           string
+	SecretKey      string
+	Topic          string
+	ProjectID      string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	Placement         common.OptionalString
@@ -38,20 +39,18 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Google Cloud Pub/Sub logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Google Cloud Pub/Sub logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("user", "Your Google Cloud Platform service account email address. The client_email field in your service account authentication JSON").Required().StringVar(&c.User)
 	c.CmdClause.Flag("secret-key", "Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON").Required().StringVar(&c.SecretKey)
 	c.CmdClause.Flag("topic", "The Google Cloud Pub/Sub topic to which logs will be published").Required().StringVar(&c.Topic)
 	c.CmdClause.Flag("project-id", "The ID of your Google Cloud Platform project").Required().StringVar(&c.ProjectID)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
-
 	return &c
 }
 
@@ -64,8 +63,17 @@ func (c *CreateCommand) createInput() (*fastly.CreatePubsubInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.User = c.User
 	input.SecretKey = c.SecretKey

--- a/pkg/logging/googlepubsub/delete.go
+++ b/pkg/logging/googlepubsub/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Google Cloud Pub/Sub logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeletePubsubInput
+	manifest       manifest.Data
+	Input          fastly.DeletePubsubInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Google Cloud Pub/Sub logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Google Cloud Pub/Sub logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeletePubsub(&c.Input); err != nil {
 		return err

--- a/pkg/logging/googlepubsub/describe.go
+++ b/pkg/logging/googlepubsub/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Google Cloud Pub/Sub logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetPubsubInput
+	manifest       manifest.Data
+	Input          fastly.GetPubsubInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Google Cloud Pub/Sub logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Google Cloud Pub/Sub logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	googlepubsub, err := c.Globals.Client.GetPubsub(&c.Input)
 	if err != nil {

--- a/pkg/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_integration_test.go
@@ -24,29 +24,39 @@ func TestGooglePubSubCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic"},
 			wantError: "error parsing arguments: required flag --project-id not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project"},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args:       []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
-			api:        mock.API{CreatePubsubFn: createGooglePubSubOK},
-			wantOutput: "Created Google Cloud Pub/Sub logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreatePubsubFn: createGooglePubSubOK,
+			},
+			wantOutput: "Created Google Cloud Pub/Sub logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
-			api:       mock.API{CreatePubsubFn: createGooglePubSubError},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreatePubsubFn: createGooglePubSubError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -77,33 +87,57 @@ func TestGooglePubSubList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListPubsubsFn: listGooglePubSubsOK},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListPubsubsFn:  listGooglePubSubsOK,
+			},
 			wantOutput: listGooglePubSubsShortOutput,
 		},
 		{
-			args:       []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListPubsubsFn: listGooglePubSubsOK},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListPubsubsFn:  listGooglePubSubsOK,
+			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListPubsubsFn: listGooglePubSubsOK},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListPubsubsFn:  listGooglePubSubsOK,
+			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "googlepubsub", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListPubsubsFn: listGooglePubSubsOK},
+			args: []string{"logging", "googlepubsub", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListPubsubsFn:  listGooglePubSubsOK,
+			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListPubsubsFn: listGooglePubSubsOK},
+			args: []string{"logging", "-v", "googlepubsub", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListPubsubsFn:  listGooglePubSubsOK,
+			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListPubsubsFn: listGooglePubSubsError},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListPubsubsFn:  listGooglePubSubsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -134,17 +168,25 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetPubsubFn: getGooglePubSubError},
+			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetPubsubFn:    getGooglePubSubError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetPubsubFn: getGooglePubSubOK},
+			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetPubsubFn:    getGooglePubSubOK,
+			},
 			wantOutput: describeGooglePubSubOutput,
 		},
 	} {
@@ -175,18 +217,28 @@ func TestGooglePubSubUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdatePubsubFn: updateGooglePubSubError},
+			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdatePubsubFn: updateGooglePubSubError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdatePubsubFn: updateGooglePubSubOK},
-			wantOutput: "Updated Google Cloud Pub/Sub logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdatePubsubFn: updateGooglePubSubOK,
+			},
+			wantOutput: "Updated Google Cloud Pub/Sub logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -216,18 +268,28 @@ func TestGooglePubSubDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeletePubsubFn: deleteGooglePubSubError},
+			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeletePubsubFn: deleteGooglePubSubError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeletePubsubFn: deleteGooglePubSubOK},
-			wantOutput: "Deleted Google Cloud Pub/Sub logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeletePubsubFn: deleteGooglePubSubOK,
+			},
+			wantOutput: "Deleted Google Cloud Pub/Sub logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -308,18 +370,18 @@ func listGooglePubSubsError(i *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error
 
 var listGooglePubSubsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listGooglePubSubsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Google Cloud Pub/Sub 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		User: user@example.com
 		Secret key: secret
@@ -331,7 +393,7 @@ Version: 1
 		Placement: none
 	Google Cloud Pub/Sub 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		User: user@example.com
 		Secret key: secret
@@ -365,7 +427,7 @@ func getGooglePubSubError(i *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
 
 var describeGooglePubSubOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 User: user@example.com
 Secret key: secret
@@ -403,4 +465,35 @@ func deleteGooglePubSubOK(i *fastly.DeletePubsubInput) error {
 
 func deleteGooglePubSubError(i *fastly.DeletePubsubInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_integration_test.go
@@ -24,57 +24,57 @@ func TestGooglePubSubCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --project-id not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreatePubsubFn: createGooglePubSubOK,
 			},
-			wantOutput: "Created Google Cloud Pub/Sub logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Google Cloud Pub/Sub logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreatePubsubFn: createGooglePubSubError,
 			},
 			wantError: errTest.Error(),
@@ -109,8 +109,8 @@ func TestGooglePubSubList(t *testing.T) {
 		{
 			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsShortOutput,
@@ -118,8 +118,8 @@ func TestGooglePubSubList(t *testing.T) {
 		{
 			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
@@ -127,8 +127,8 @@ func TestGooglePubSubList(t *testing.T) {
 		{
 			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
@@ -136,8 +136,8 @@ func TestGooglePubSubList(t *testing.T) {
 		{
 			args: []string{"logging", "googlepubsub", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
@@ -145,8 +145,8 @@ func TestGooglePubSubList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
@@ -154,8 +154,8 @@ func TestGooglePubSubList(t *testing.T) {
 		{
 			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListPubsubsFn:  listGooglePubSubsError,
 			},
 			wantError: errTest.Error(),
@@ -194,8 +194,8 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetPubsubFn:    getGooglePubSubError,
 			},
 			wantError: errTest.Error(),
@@ -203,8 +203,8 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetPubsubFn:    getGooglePubSubOK,
 			},
 			wantOutput: describeGooglePubSubOutput,
@@ -241,24 +241,24 @@ func TestGooglePubSubUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdatePubsubFn: updateGooglePubSubError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdatePubsubFn: updateGooglePubSubOK,
 			},
-			wantOutput: "Updated Google Cloud Pub/Sub logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Google Cloud Pub/Sub logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -292,24 +292,24 @@ func TestGooglePubSubDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeletePubsubFn: deleteGooglePubSubError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeletePubsubFn: deleteGooglePubSubOK,
 			},
-			wantOutput: "Deleted Google Cloud Pub/Sub logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Google Cloud Pub/Sub logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_integration_test.go
@@ -24,23 +24,43 @@ func TestGooglePubSubCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --project-id not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic", "--autoclone"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -231,7 +251,7 @@ func TestGooglePubSubUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -282,7 +302,7 @@ func TestGooglePubSubDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_integration_test.go
@@ -24,37 +24,37 @@ func TestGooglePubSubCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--project-id", "project", "--topic", "topic"},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--topic", "topic"},
 			wantError: "error parsing arguments: required flag --project-id not provided",
 		},
 		{
-			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project"},
+			args:      []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project"},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic", "--autoclone"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreatePubsubFn: createGooglePubSubOK,
 			},
-			wantOutput: "Created Google Cloud Pub/Sub logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Google Cloud Pub/Sub logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
+			args: []string{"logging", "googlepubsub", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user@example.com", "--secret-key", "secret", "--project-id", "project", "--topic", "topic"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreatePubsubFn: createGooglePubSubError,
 			},
 			wantError: errTest.Error(),
@@ -87,55 +87,55 @@ func TestGooglePubSubList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsShortOutput,
 		},
 		{
-			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "googlepubsub", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "googlepubsub", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "googlepubsub", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListPubsubsFn:  listGooglePubSubsOK,
 			},
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "googlepubsub", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListPubsubsFn:  listGooglePubSubsError,
 			},
 			wantError: errTest.Error(),
@@ -168,23 +168,23 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetPubsubFn:    getGooglePubSubError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "googlepubsub", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetPubsubFn:    getGooglePubSubOK,
 			},
 			wantOutput: describeGooglePubSubOutput,
@@ -217,28 +217,28 @@ func TestGooglePubSubUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdatePubsubFn: updateGooglePubSubError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "googlepubsub", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdatePubsubFn: updateGooglePubSubOK,
 			},
-			wantOutput: "Updated Google Cloud Pub/Sub logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Google Cloud Pub/Sub logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -268,28 +268,28 @@ func TestGooglePubSubDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeletePubsubFn: deleteGooglePubSubError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "googlepubsub", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeletePubsubFn: deleteGooglePubSubOK,
 			},
-			wantOutput: "Deleted Google Cloud Pub/Sub logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Google Cloud Pub/Sub logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -370,18 +370,18 @@ func listGooglePubSubsError(i *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error
 
 var listGooglePubSubsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listGooglePubSubsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Google Cloud Pub/Sub 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		User: user@example.com
 		Secret key: secret
@@ -393,7 +393,7 @@ Version: 2
 		Placement: none
 	Google Cloud Pub/Sub 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		User: user@example.com
 		Secret key: secret
@@ -427,7 +427,7 @@ func getGooglePubSubError(i *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
 
 var describeGooglePubSubOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 User: user@example.com
 Secret key: secret
@@ -465,35 +465,4 @@ func deleteGooglePubSubOK(i *fastly.DeletePubsubInput) error {
 
 func deleteGooglePubSubError(i *fastly.DeletePubsubInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_test.go
@@ -1,6 +1,7 @@
 package googlepubsub
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -75,7 +76,11 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetPubsubFn: getGooglePubSubOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetPubsubFn:    getGooglePubSubOK,
+			},
 			want: &fastly.UpdatePubsubInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -94,7 +99,11 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetPubsubFn: getGooglePubSubOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetPubsubFn:    getGooglePubSubOK,
+			},
 			want: &fastly.UpdatePubsubInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -119,22 +128,91 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		User:         "user@example.com",
-		SecretKey:    "secret",
-		ProjectID:    "project",
-		Topic:        "topic",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		User:      "user@example.com",
+		SecretKey: "secret",
+		ProjectID: "project",
+		Topic:     "topic",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "logs",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "logs",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		User:              "user@example.com",
 		ProjectID:         "project",
 		Topic:             "topic",
@@ -153,20 +231,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_test.go
@@ -25,7 +25,7 @@ func TestCreateGooglePubSubInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreatePubsubInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				User:           "user@example.com",
 				SecretKey:      "secret",
@@ -38,7 +38,7 @@ func TestCreateGooglePubSubInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreatePubsubInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "logs",
 				Topic:             "topic",
 				User:              "user@example.com",
@@ -77,14 +77,14 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetPubsubFn:    getGooglePubSubOK,
 			},
 			want: &fastly.UpdatePubsubInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				User:              fastly.String("new2"),
@@ -101,14 +101,14 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetPubsubFn:    getGooglePubSubOK,
 			},
 			want: &fastly.UpdatePubsubInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -138,9 +138,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -175,9 +175,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_test.go
@@ -77,8 +77,9 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetPubsubFn:    getGooglePubSubOK,
 			},
 			want: &fastly.UpdatePubsubInput{
@@ -100,8 +101,9 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetPubsubFn:    getGooglePubSubOK,
 			},
 			want: &fastly.UpdatePubsubInput{
@@ -136,8 +138,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -151,40 +154,16 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		User:      "user@example.com",
 		SecretKey: "secret",
 		ProjectID: "project",
 		Topic:     "topic",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -196,8 +175,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -211,7 +191,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		User:              "user@example.com",
 		ProjectID:         "project",
@@ -250,7 +233,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -275,7 +261,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/googlepubsub/list.go
+++ b/pkg/logging/googlepubsub/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Google Cloud Pub/Sub logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListPubsubsInput
+	manifest       manifest.Data
+	Input          fastly.ListPubsubsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Google Cloud Pub/Sub endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	googlepubsubs, err := c.Globals.Client.ListPubsubs(&c.Input)
 	if err != nil {

--- a/pkg/logging/heroku/create.go
+++ b/pkg/logging/heroku/create.go
@@ -17,12 +17,13 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Token        string
-	URL          string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Token          string
+	URL            string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	ResponseCondition common.OptionalString
@@ -32,24 +33,20 @@ type CreateCommand struct {
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
-
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Heroku logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Heroku logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("url", "The url to stream logs to").Required().StringVar(&c.URL)
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://devcenter.heroku.com/articles/add-on-partner-log-integration)").Required().StringVar(&c.Token)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -62,8 +59,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateHerokuInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Token = c.Token
 	input.URL = c.URL

--- a/pkg/logging/heroku/delete.go
+++ b/pkg/logging/heroku/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Heroku logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteHerokuInput
+	manifest       manifest.Data
+	Input          fastly.DeleteHerokuInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Heroku logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Heroku logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteHeroku(&c.Input); err != nil {
 		return err

--- a/pkg/logging/heroku/describe.go
+++ b/pkg/logging/heroku/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Heroku logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetHerokuInput
+	manifest       manifest.Data
+	Input          fastly.GetHerokuInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Heroku logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Heroku logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	heroku, err := c.Globals.Client.GetHeroku(&c.Input)
 	if err != nil {

--- a/pkg/logging/heroku/heroku_integration_test.go
+++ b/pkg/logging/heroku/heroku_integration_test.go
@@ -24,15 +24,25 @@ func TestHerokuCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -223,7 +233,7 @@ func TestHerokuUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -274,7 +284,7 @@ func TestHerokuDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/heroku/heroku_integration_test.go
+++ b/pkg/logging/heroku/heroku_integration_test.go
@@ -24,29 +24,29 @@ func TestHerokuCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateHerokuFn: createHerokuOK,
 			},
-			wantOutput: "Created Heroku logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Heroku logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateHerokuFn: createHerokuError,
 			},
 			wantError: errTest.Error(),
@@ -79,55 +79,55 @@ func TestHerokuList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusShortOutput,
 		},
 		{
-			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: []string{"logging", "heroku", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "heroku", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "heroku", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "heroku", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHerokusFn:  listHerokusError,
 			},
 			wantError: errTest.Error(),
@@ -160,23 +160,23 @@ func TestHerokuDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetHerokuFn:    getHerokuError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetHerokuFn:    getHerokuOK,
 			},
 			wantOutput: describeHerokuOutput,
@@ -209,28 +209,28 @@ func TestHerokuUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateHerokuFn: updateHerokuError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateHerokuFn: updateHerokuOK,
 			},
-			wantOutput: "Updated Heroku logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Heroku logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -260,28 +260,28 @@ func TestHerokuDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteHerokuFn: deleteHerokuError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteHerokuFn: deleteHerokuOK,
 			},
-			wantOutput: "Deleted Heroku logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Heroku logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -355,18 +355,18 @@ func listHerokusError(i *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
 
 var listHerokusShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listHerokusVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Heroku 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		URL: example.com
 		Token: abc
@@ -376,7 +376,7 @@ Version: 2
 		Placement: none
 	Heroku 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		URL: bar.com
 		Token: abc
@@ -406,7 +406,7 @@ func getHerokuError(i *fastly.GetHerokuInput) (*fastly.Heroku, error) {
 
 var describeHerokuOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 URL: example.com
 Token: abc
@@ -440,35 +440,4 @@ func deleteHerokuOK(i *fastly.DeleteHerokuInput) error {
 
 func deleteHerokuError(i *fastly.DeleteHerokuInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/heroku/heroku_integration_test.go
+++ b/pkg/logging/heroku/heroku_integration_test.go
@@ -24,21 +24,31 @@ func TestHerokuCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:       []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
-			api:        mock.API{CreateHerokuFn: createHerokuOK},
-			wantOutput: "Created Heroku logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--url", "example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateHerokuFn: createHerokuOK,
+			},
+			wantOutput: "Created Heroku logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
-			api:       mock.API{CreateHerokuFn: createHerokuError},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateHerokuFn: createHerokuError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -69,33 +79,57 @@ func TestHerokuList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHerokusFn: listHerokusOK},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHerokusFn:  listHerokusOK,
+			},
 			wantOutput: listHerokusShortOutput,
 		},
 		{
-			args:       []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListHerokusFn: listHerokusOK},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHerokusFn:  listHerokusOK,
+			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListHerokusFn: listHerokusOK},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHerokusFn:  listHerokusOK,
+			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "heroku", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHerokusFn: listHerokusOK},
+			args: []string{"logging", "heroku", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHerokusFn:  listHerokusOK,
+			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "heroku", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHerokusFn: listHerokusOK},
+			args: []string{"logging", "-v", "heroku", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHerokusFn:  listHerokusOK,
+			},
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListHerokusFn: listHerokusError},
+			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHerokusFn:  listHerokusError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -126,17 +160,25 @@ func TestHerokuDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetHerokuFn: getHerokuError},
+			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHerokuFn:    getHerokuError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetHerokuFn: getHerokuOK},
+			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHerokuFn:    getHerokuOK,
+			},
 			wantOutput: describeHerokuOutput,
 		},
 	} {
@@ -167,18 +209,28 @@ func TestHerokuUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "heroku", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateHerokuFn: updateHerokuError},
+			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateHerokuFn: updateHerokuError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateHerokuFn: updateHerokuOK},
-			wantOutput: "Updated Heroku logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateHerokuFn: updateHerokuOK,
+			},
+			wantOutput: "Updated Heroku logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -208,18 +260,28 @@ func TestHerokuDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteHerokuFn: deleteHerokuError},
+			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteHerokuFn: deleteHerokuError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteHerokuFn: deleteHerokuOK},
-			wantOutput: "Deleted Heroku logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteHerokuFn: deleteHerokuOK,
+			},
+			wantOutput: "Deleted Heroku logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -293,18 +355,18 @@ func listHerokusError(i *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
 
 var listHerokusShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listHerokusVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Heroku 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		URL: example.com
 		Token: abc
@@ -314,7 +376,7 @@ Version: 1
 		Placement: none
 	Heroku 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		URL: bar.com
 		Token: abc
@@ -344,7 +406,7 @@ func getHerokuError(i *fastly.GetHerokuInput) (*fastly.Heroku, error) {
 
 var describeHerokuOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 URL: example.com
 Token: abc
@@ -378,4 +440,35 @@ func deleteHerokuOK(i *fastly.DeleteHerokuInput) error {
 
 func deleteHerokuError(i *fastly.DeleteHerokuInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/heroku/heroku_integration_test.go
+++ b/pkg/logging/heroku/heroku_integration_test.go
@@ -24,39 +24,39 @@ func TestHerokuCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHerokuFn: createHerokuOK,
 			},
-			wantOutput: "Created Heroku logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Heroku logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com"},
+			args: []string{"logging", "heroku", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHerokuFn: createHerokuError,
 			},
 			wantError: errTest.Error(),
@@ -91,8 +91,8 @@ func TestHerokuList(t *testing.T) {
 		{
 			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusShortOutput,
@@ -100,8 +100,8 @@ func TestHerokuList(t *testing.T) {
 		{
 			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
@@ -109,8 +109,8 @@ func TestHerokuList(t *testing.T) {
 		{
 			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
@@ -118,8 +118,8 @@ func TestHerokuList(t *testing.T) {
 		{
 			args: []string{"logging", "heroku", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
@@ -127,8 +127,8 @@ func TestHerokuList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "heroku", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHerokusFn:  listHerokusOK,
 			},
 			wantOutput: listHerokusVerboseOutput,
@@ -136,8 +136,8 @@ func TestHerokuList(t *testing.T) {
 		{
 			args: []string{"logging", "heroku", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHerokusFn:  listHerokusError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestHerokuDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetHerokuFn:    getHerokuError,
 			},
 			wantError: errTest.Error(),
@@ -185,8 +185,8 @@ func TestHerokuDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "heroku", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetHerokuFn:    getHerokuOK,
 			},
 			wantOutput: describeHerokuOutput,
@@ -223,24 +223,24 @@ func TestHerokuUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHerokuFn: updateHerokuError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "heroku", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHerokuFn: updateHerokuOK,
 			},
-			wantOutput: "Updated Heroku logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Heroku logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -274,24 +274,24 @@ func TestHerokuDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHerokuFn: deleteHerokuError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "heroku", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHerokuFn: deleteHerokuOK,
 			},
-			wantOutput: "Deleted Heroku logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Heroku logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/heroku/heroku_test.go
+++ b/pkg/logging/heroku/heroku_test.go
@@ -25,7 +25,7 @@ func TestCreateHerokuInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateHerokuInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Token:          "tkn",
 				URL:            "example.com",
@@ -36,7 +36,7 @@ func TestCreateHerokuInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateHerokuInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				FormatVersion:     2,
@@ -73,14 +73,14 @@ func TestUpdateHerokuInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHerokuFn:    getHerokuOK,
 			},
 			want: &fastly.UpdateHerokuInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -88,14 +88,14 @@ func TestUpdateHerokuInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHerokuFn:    getHerokuOK,
 			},
 			want: &fastly.UpdateHerokuInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Format:            fastly.String("new2"),
@@ -132,9 +132,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -167,9 +167,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/heroku/heroku_test.go
+++ b/pkg/logging/heroku/heroku_test.go
@@ -73,8 +73,9 @@ func TestUpdateHerokuInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetHerokuFn:    getHerokuOK,
 			},
 			want: &fastly.UpdateHerokuInput{
@@ -87,8 +88,9 @@ func TestUpdateHerokuInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetHerokuFn:    getHerokuOK,
 			},
 			want: &fastly.UpdateHerokuInput{
@@ -130,8 +132,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -147,36 +150,12 @@ func createCommandRequired() *CreateCommand {
 		Token:        "tkn",
 		URL:          "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -188,8 +167,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -205,7 +185,10 @@ func createCommandAll() *CreateCommand {
 		Token:        "tkn",
 		URL:          "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -240,7 +223,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -265,7 +251,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/heroku/heroku_test.go
+++ b/pkg/logging/heroku/heroku_test.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -71,7 +72,11 @@ func TestUpdateHerokuInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetHerokuFn: getHerokuOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHerokuFn:    getHerokuOK,
+			},
 			want: &fastly.UpdateHerokuInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -81,7 +86,11 @@ func TestUpdateHerokuInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetHerokuFn: getHerokuOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHerokuFn:    getHerokuOK,
+			},
 			want: &fastly.UpdateHerokuInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -113,22 +122,91 @@ func TestUpdateHerokuInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		Token:        "tkn",
 		URL:          "example.com",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Token:             "tkn",
-		URL:               "example.com",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		Token:        "tkn",
+		URL:          "example.com",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
@@ -143,20 +221,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},

--- a/pkg/logging/heroku/list.go
+++ b/pkg/logging/heroku/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Heroku logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListHerokusInput
+	manifest       manifest.Data
+	Input          fastly.ListHerokusInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Heroku endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	herokus, err := c.Globals.Client.ListHerokus(&c.Input)
 	if err != nil {

--- a/pkg/logging/heroku/update.go
+++ b/pkg/logging/heroku/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
@@ -36,12 +37,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Heroku logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Heroku logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Heroku logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
@@ -50,7 +49,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://devcenter.heroku.com/articles/add-on-partner-log-integration)").Action(c.Token.Set).StringVar(&c.Token.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,9 +59,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateHerokuInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateHerokuInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/honeycomb/create.go
+++ b/pkg/logging/honeycomb/create.go
@@ -17,12 +17,13 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Token        string
-	Dataset      string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Token          string
+	Dataset        string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	ResponseCondition common.OptionalString
@@ -32,23 +33,20 @@ type CreateCommand struct {
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
-
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Honeycomb logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Honeycomb logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("dataset", "The Honeycomb Dataset you want to log to").Required().StringVar(&c.Dataset)
 	c.CmdClause.Flag("auth-token", "The Write Key from the Account page of your Honeycomb account").Required().StringVar(&c.Token)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,8 +59,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateHoneycombInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Token = c.Token
 	input.Dataset = c.Dataset

--- a/pkg/logging/honeycomb/delete.go
+++ b/pkg/logging/honeycomb/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Honeycomb logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteHoneycombInput
+	manifest       manifest.Data
+	Input          fastly.DeleteHoneycombInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Honeycomb logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteHoneycomb(&c.Input); err != nil {
 		return err

--- a/pkg/logging/honeycomb/describe.go
+++ b/pkg/logging/honeycomb/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Honeycomb logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetHoneycombInput
+	manifest       manifest.Data
+	Input          fastly.GetHoneycombInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Honeycomb logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	honeycomb, err := c.Globals.Client.GetHoneycomb(&c.Input)
 	if err != nil {

--- a/pkg/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/logging/honeycomb/honeycomb_integration_test.go
@@ -32,13 +32,23 @@ func TestHoneycombCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --dataset not provided",
 		},
 		{
-			args:       []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
-			api:        mock.API{CreateHoneycombFn: createHoneycombOK},
-			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				CreateHoneycombFn: createHoneycombOK,
+			},
+			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
-			api:       mock.API{CreateHoneycombFn: createHoneycombError},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				CreateHoneycombFn: createHoneycombError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -69,33 +79,57 @@ func TestHoneycombList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListHoneycombsFn: listHoneycombsOK,
+			},
 			wantOutput: listHoneycombsShortOutput,
 		},
 		{
-			args:       []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListHoneycombsFn: listHoneycombsOK,
+			},
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "-v"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListHoneycombsFn: listHoneycombsOK,
+			},
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "honeycomb", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			args: []string{"logging", "honeycomb", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListHoneycombsFn: listHoneycombsOK,
+			},
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "honeycomb", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHoneycombsFn: listHoneycombsOK},
+			args: []string{"logging", "-v", "honeycomb", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListHoneycombsFn: listHoneycombsOK,
+			},
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListHoneycombsFn: listHoneycombsError},
+			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListHoneycombsFn: listHoneycombsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -130,13 +164,21 @@ func TestHoneycombDescribe(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetHoneycombFn: getHoneycombError},
+			args: []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHoneycombFn: getHoneycombError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetHoneycombFn: getHoneycombOK},
+			args: []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHoneycombFn: getHoneycombOK,
+			},
 			wantOutput: describeHoneycombOutput,
 		},
 	} {
@@ -171,14 +213,24 @@ func TestHoneycombUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateHoneycombFn: updateHoneycombError},
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				UpdateHoneycombFn: updateHoneycombError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateHoneycombFn: updateHoneycombOK},
-			wantOutput: "Updated Honeycomb logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				UpdateHoneycombFn: updateHoneycombOK,
+			},
+			wantOutput: "Updated Honeycomb logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -212,14 +264,24 @@ func TestHoneycombDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteHoneycombFn: deleteHoneycombError},
+			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				DeleteHoneycombFn: deleteHoneycombError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteHoneycombFn: deleteHoneycombOK},
-			wantOutput: "Deleted Honeycomb logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				DeleteHoneycombFn: deleteHoneycombOK,
+			},
+			wantOutput: "Deleted Honeycomb logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -293,18 +355,18 @@ func listHoneycombsError(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, er
 
 var listHoneycombsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listHoneycombsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Honeycomb 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Dataset: log
 		Token: tkn
@@ -314,7 +376,7 @@ Version: 1
 		Placement: none
 	Honeycomb 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Dataset: log
 		Token: tkn
@@ -344,7 +406,7 @@ func getHoneycombError(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
 
 var describeHoneycombOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Dataset: log
 Token: tkn
@@ -378,4 +440,35 @@ func deleteHoneycombOK(i *fastly.DeleteHoneycombInput) error {
 
 func deleteHoneycombError(i *fastly.DeleteHoneycombInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/logging/honeycomb/honeycomb_integration_test.go
@@ -34,19 +34,19 @@ func TestHoneycombCreate(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				CreateHoneycombFn: createHoneycombOK,
 			},
-			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 2)",
 		},
 		{
 			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				CreateHoneycombFn: createHoneycombError,
 			},
 			wantError: errTest.Error(),
@@ -81,8 +81,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsShortOutput,
@@ -90,8 +90,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -99,8 +99,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -108,8 +108,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -117,8 +117,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "honeycomb", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -126,8 +126,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListHoneycombsFn: listHoneycombsError,
 			},
 			wantError: errTest.Error(),
@@ -166,8 +166,8 @@ func TestHoneycombDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetHoneycombFn: getHoneycombError,
 			},
 			wantError: errTest.Error(),
@@ -175,8 +175,8 @@ func TestHoneycombDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetHoneycombFn: getHoneycombOK,
 			},
 			wantOutput: describeHoneycombOutput,
@@ -215,9 +215,9 @@ func TestHoneycombUpdate(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				UpdateHoneycombFn: updateHoneycombError,
 			},
 			wantError: errTest.Error(),
@@ -225,12 +225,12 @@ func TestHoneycombUpdate(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				UpdateHoneycombFn: updateHoneycombOK,
 			},
-			wantOutput: "Updated Honeycomb logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Honeycomb logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -266,9 +266,9 @@ func TestHoneycombDelete(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				DeleteHoneycombFn: deleteHoneycombError,
 			},
 			wantError: errTest.Error(),
@@ -276,12 +276,12 @@ func TestHoneycombDelete(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				DeleteHoneycombFn: deleteHoneycombOK,
 			},
-			wantOutput: "Deleted Honeycomb logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Honeycomb logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -355,18 +355,18 @@ func listHoneycombsError(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, er
 
 var listHoneycombsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listHoneycombsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Honeycomb 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Dataset: log
 		Token: tkn
@@ -376,7 +376,7 @@ Version: 2
 		Placement: none
 	Honeycomb 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Dataset: log
 		Token: tkn
@@ -406,7 +406,7 @@ func getHoneycombError(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
 
 var describeHoneycombOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Dataset: log
 Token: tkn
@@ -440,35 +440,4 @@ func deleteHoneycombOK(i *fastly.DeleteHoneycombInput) error {
 
 func deleteHoneycombError(i *fastly.DeleteHoneycombInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/logging/honeycomb/honeycomb_integration_test.go
@@ -24,15 +24,25 @@ func TestHoneycombCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--dataset", "log"},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--dataset", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:      []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --dataset not provided",
 		},
 		{
-			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log", "--autoclone"},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,
@@ -223,7 +233,7 @@ func TestHoneycombUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,
@@ -274,7 +284,7 @@ func TestHoneycombDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,

--- a/pkg/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/logging/honeycomb/honeycomb_integration_test.go
@@ -24,39 +24,39 @@ func TestHoneycombCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--dataset", "log"},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--dataset", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --dataset not provided",
 		},
 		{
-			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateHoneycombFn: createHoneycombOK,
 			},
-			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log"},
+			args: []string{"logging", "honeycomb", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--dataset", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateHoneycombFn: createHoneycombError,
 			},
 			wantError: errTest.Error(),
@@ -91,8 +91,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsShortOutput,
@@ -100,8 +100,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -109,8 +109,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -118,8 +118,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -127,8 +127,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "honeycomb", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			wantOutput: listHoneycombsVerboseOutput,
@@ -136,8 +136,8 @@ func TestHoneycombList(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListHoneycombsFn: listHoneycombsError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestHoneycombDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetHoneycombFn: getHoneycombError,
 			},
 			wantError: errTest.Error(),
@@ -185,8 +185,8 @@ func TestHoneycombDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "honeycomb", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetHoneycombFn: getHoneycombOK,
 			},
 			wantOutput: describeHoneycombOutput,
@@ -223,24 +223,24 @@ func TestHoneycombUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateHoneycombFn: updateHoneycombError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "honeycomb", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateHoneycombFn: updateHoneycombOK,
 			},
-			wantOutput: "Updated Honeycomb logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Honeycomb logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -274,24 +274,24 @@ func TestHoneycombDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteHoneycombFn: deleteHoneycombError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "honeycomb", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteHoneycombFn: deleteHoneycombOK,
 			},
-			wantOutput: "Deleted Honeycomb logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Honeycomb logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/honeycomb/honeycomb_test.go
+++ b/pkg/logging/honeycomb/honeycomb_test.go
@@ -1,6 +1,7 @@
 package honeycomb
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -71,7 +72,11 @@ func TestUpdateHoneycombInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetHoneycombFn: getHoneycombOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHoneycombFn: getHoneycombOK,
+			},
 			want: &fastly.UpdateHoneycombInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -81,7 +86,10 @@ func TestUpdateHoneycombInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetHoneycombFn: getHoneycombOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHoneycombFn: getHoneycombOK},
 			want: &fastly.UpdateHoneycombInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -113,22 +121,91 @@ func TestUpdateHoneycombInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		Token:        "tkn",
 		Dataset:      "logs",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Token:             "tkn",
-		Dataset:           "logs",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		Token:        "tkn",
+		Dataset:      "logs",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
@@ -143,20 +220,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},

--- a/pkg/logging/honeycomb/honeycomb_test.go
+++ b/pkg/logging/honeycomb/honeycomb_test.go
@@ -25,7 +25,7 @@ func TestCreateHoneycombInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateHoneycombInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Token:          "tkn",
 				Dataset:        "logs",
@@ -36,7 +36,7 @@ func TestCreateHoneycombInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateHoneycombInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				FormatVersion:     2,
@@ -73,14 +73,14 @@ func TestUpdateHoneycombInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHoneycombFn: getHoneycombOK,
 			},
 			want: &fastly.UpdateHoneycombInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -88,13 +88,13 @@ func TestUpdateHoneycombInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHoneycombFn: getHoneycombOK},
 			want: &fastly.UpdateHoneycombInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Format:            fastly.String("new2"),
@@ -131,9 +131,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -166,9 +166,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/honeycomb/honeycomb_test.go
+++ b/pkg/logging/honeycomb/honeycomb_test.go
@@ -73,8 +73,9 @@ func TestUpdateHoneycombInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetHoneycombFn: getHoneycombOK,
 			},
 			want: &fastly.UpdateHoneycombInput{
@@ -87,8 +88,9 @@ func TestUpdateHoneycombInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetHoneycombFn: getHoneycombOK},
 			want: &fastly.UpdateHoneycombInput{
 				ServiceID:         "123",
@@ -129,8 +131,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -146,36 +149,12 @@ func createCommandRequired() *CreateCommand {
 		Token:        "tkn",
 		Dataset:      "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -187,8 +166,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -204,7 +184,10 @@ func createCommandAll() *CreateCommand {
 		Token:        "tkn",
 		Dataset:      "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -239,7 +222,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -264,7 +250,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/honeycomb/list.go
+++ b/pkg/logging/honeycomb/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Honeycomb logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListHoneycombsInput
+	manifest       manifest.Data
+	Input          fastly.ListHoneycombsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Honeycomb endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	honeycombs, err := c.Globals.Client.ListHoneycombs(&c.Input)
 	if err != nil {

--- a/pkg/logging/honeycomb/update.go
+++ b/pkg/logging/honeycomb/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
@@ -36,12 +37,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Honeycomb logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Honeycomb logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
@@ -50,7 +49,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("auth-token", "The Write Key from the Account page of your Honeycomb account").Action(c.Token.Set).StringVar(&c.Token.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,9 +59,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateHoneycombInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateHoneycombInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/https/create.go
+++ b/pkg/logging/https/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	URL          string
+	EndpointName   string // Can't shadow common.Base method Name().
+	URL            string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	RequestMaxEntries common.OptionalUint
 	RequestMaxBytes   common.OptionalUint
 	TLSCACert         common.OptionalString
@@ -47,11 +48,10 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an HTTPS logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the HTTPS logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("url", "URL that log data will be sent to. Must use the https protocol").Required().StringVar(&c.URL)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("content-type", "Content type of the header sent with the request").Action(c.ContentType.Set).StringVar(&c.ContentType.Value)
 	c.CmdClause.Flag("header-name", "Name of the custom header sent with the request").Action(c.HeaderName.Set).StringVar(&c.HeaderName.Value)
@@ -69,7 +69,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
 	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
-
 	return &c
 }
 
@@ -83,9 +82,18 @@ func (c *CreateCommand) createInput() (*fastly.CreateHTTPSInput, error) {
 	}
 
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
 	input.Name = c.EndpointName
 	input.URL = c.URL
+
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	input.ServiceVersion = v.Number
 
 	if c.ContentType.WasSet {
 		input.ContentType = c.ContentType.Value

--- a/pkg/logging/https/delete.go
+++ b/pkg/logging/https/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an HTTPS logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteHTTPSInput
+	manifest       manifest.Data
+	Input          fastly.DeleteHTTPSInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an HTTPS logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteHTTPS(&c.Input); err != nil {
 		return err

--- a/pkg/logging/https/describe.go
+++ b/pkg/logging/https/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe an HTTPS logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetHTTPSInput
+	manifest       manifest.Data
+	Input          fastly.GetHTTPSInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an HTTPS logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	https, err := c.Globals.Client.GetHTTPS(&c.Input)
 	if err != nil {

--- a/pkg/logging/https/https_integration_test.go
+++ b/pkg/logging/https/https_integration_test.go
@@ -24,30 +24,30 @@ func TestHTTPSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHTTPSFn:  createHTTPSOK,
 			},
-			wantOutput: "Created HTTPS logging endpoint log (service 123 version 2)",
+			wantOutput: "Created HTTPS logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHTTPSFn:  createHTTPSError,
 			},
 			wantError: errTest.Error(),
@@ -82,8 +82,8 @@ func TestHTTPSList(t *testing.T) {
 		{
 			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsShortOutput,
@@ -91,8 +91,8 @@ func TestHTTPSList(t *testing.T) {
 		{
 			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
@@ -100,8 +100,8 @@ func TestHTTPSList(t *testing.T) {
 		{
 			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
@@ -109,8 +109,8 @@ func TestHTTPSList(t *testing.T) {
 		{
 			args: []string{"logging", "https", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
@@ -118,8 +118,8 @@ func TestHTTPSList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "https", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
@@ -127,8 +127,8 @@ func TestHTTPSList(t *testing.T) {
 		{
 			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListHTTPSFn:    listHTTPSsError,
 			},
 			wantError: errTest.Error(),
@@ -167,8 +167,8 @@ func TestHTTPSDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetHTTPSFn:     getHTTPSError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestHTTPSDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetHTTPSFn:     getHTTPSOK,
 			},
 			wantOutput: describeHTTPSOutput,
@@ -214,24 +214,24 @@ func TestHTTPSUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHTTPSFn:  updateHTTPSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHTTPSFn:  updateHTTPSOK,
 			},
-			wantOutput: "Updated HTTPS logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated HTTPS logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -265,24 +265,24 @@ func TestHTTPSDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHTTPSFn:  deleteHTTPSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHTTPSFn:  deleteHTTPSOK,
 			},
-			wantOutput: "Deleted HTTPS logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted HTTPS logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/https/https_integration_test.go
+++ b/pkg/logging/https/https_integration_test.go
@@ -24,11 +24,16 @@ func TestHTTPSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -219,7 +224,7 @@ func TestHTTPSUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -270,7 +275,7 @@ func TestHTTPSDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/https/https_integration_test.go
+++ b/pkg/logging/https/https_integration_test.go
@@ -24,25 +24,25 @@ func TestHTTPSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateHTTPSFn:  createHTTPSOK,
 			},
-			wantOutput: "Created HTTPS logging endpoint log (service 123 version 3)",
+			wantOutput: "Created HTTPS logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateHTTPSFn:  createHTTPSError,
 			},
 			wantError: errTest.Error(),
@@ -75,55 +75,55 @@ func TestHTTPSList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsShortOutput,
 		},
 		{
-			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "https", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "https", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "https", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "https", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHTTPSFn:    listHTTPSsOK,
 			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListHTTPSFn:    listHTTPSsError,
 			},
 			wantError: errTest.Error(),
@@ -156,23 +156,23 @@ func TestHTTPSDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "https", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetHTTPSFn:     getHTTPSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetHTTPSFn:     getHTTPSOK,
 			},
 			wantOutput: describeHTTPSOutput,
@@ -205,28 +205,28 @@ func TestHTTPSUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateHTTPSFn:  updateHTTPSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateHTTPSFn:  updateHTTPSOK,
 			},
-			wantOutput: "Updated HTTPS logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated HTTPS logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,28 +256,28 @@ func TestHTTPSDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "https", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteHTTPSFn:  deleteHTTPSError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteHTTPSFn:  deleteHTTPSOK,
 			},
-			wantOutput: "Deleted HTTPS logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted HTTPS logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -385,18 +385,18 @@ func listHTTPSsError(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
 
 var listHTTPSsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listHTTPSsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	HTTPS 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		URL: example.com
 		Content type: application/json
@@ -417,7 +417,7 @@ Version: 2
 		Placement: none
 	HTTPS 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		URL: analytics.example.com
 		Content type: application/json
@@ -469,7 +469,7 @@ func getHTTPSError(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
 
 var describeHTTPSOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: log
 URL: example.com
 Content type: application/json
@@ -525,35 +525,4 @@ func deleteHTTPSOK(i *fastly.DeleteHTTPSInput) error {
 
 func deleteHTTPSError(i *fastly.DeleteHTTPSInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/https/https_integration_test.go
+++ b/pkg/logging/https/https_integration_test.go
@@ -24,17 +24,27 @@ func TestHTTPSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:       []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
-			api:        mock.API{CreateHTTPSFn: createHTTPSOK},
-			wantOutput: "Created HTTPS logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateHTTPSFn:  createHTTPSOK,
+			},
+			wantOutput: "Created HTTPS logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "https", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
-			api:       mock.API{CreateHTTPSFn: createHTTPSError},
+			args: []string{"logging", "https", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateHTTPSFn:  createHTTPSError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -65,33 +75,57 @@ func TestHTTPSList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHTTPSFn:    listHTTPSsOK,
+			},
 			wantOutput: listHTTPSsShortOutput,
 		},
 		{
-			args:       []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHTTPSFn:    listHTTPSsOK,
+			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "https", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHTTPSFn:    listHTTPSsOK,
+			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "https", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			args: []string{"logging", "https", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHTTPSFn:    listHTTPSsOK,
+			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "https", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListHTTPSFn: listHTTPSsOK},
+			args: []string{"logging", "-v", "https", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHTTPSFn:    listHTTPSsOK,
+			},
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "https", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListHTTPSFn: listHTTPSsError},
+			args: []string{"logging", "https", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListHTTPSFn:    listHTTPSsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -122,17 +156,25 @@ func TestHTTPSDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "https", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetHTTPSFn: getHTTPSError},
+			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHTTPSFn:     getHTTPSError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "https", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetHTTPSFn: getHTTPSOK},
+			args: []string{"logging", "https", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHTTPSFn:     getHTTPSOK,
+			},
 			wantOutput: describeHTTPSOutput,
 		},
 	} {
@@ -163,18 +205,28 @@ func TestHTTPSUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "https", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateHTTPSFn: updateHTTPSError},
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateHTTPSFn:  updateHTTPSError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "https", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateHTTPSFn: updateHTTPSOK},
-			wantOutput: "Updated HTTPS logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "https", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateHTTPSFn:  updateHTTPSOK,
+			},
+			wantOutput: "Updated HTTPS logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -204,18 +256,28 @@ func TestHTTPSDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "https", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "https", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteHTTPSFn: deleteHTTPSError},
+			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteHTTPSFn:  deleteHTTPSError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "https", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteHTTPSFn: deleteHTTPSOK},
-			wantOutput: "Deleted HTTPS logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "https", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteHTTPSFn:  deleteHTTPSOK,
+			},
+			wantOutput: "Deleted HTTPS logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -323,18 +385,18 @@ func listHTTPSsError(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
 
 var listHTTPSsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listHTTPSsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	HTTPS 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		URL: example.com
 		Content type: application/json
@@ -355,7 +417,7 @@ Version: 1
 		Placement: none
 	HTTPS 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		URL: analytics.example.com
 		Content type: application/json
@@ -407,7 +469,7 @@ func getHTTPSError(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
 
 var describeHTTPSOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: log
 URL: example.com
 Content type: application/json
@@ -463,4 +525,35 @@ func deleteHTTPSOK(i *fastly.DeleteHTTPSInput) error {
 
 func deleteHTTPSError(i *fastly.DeleteHTTPSInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/https/https_test.go
+++ b/pkg/logging/https/https_test.go
@@ -25,7 +25,7 @@ func TestCreateHTTPSInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateHTTPSInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				URL:            "example.com",
 			},
@@ -35,7 +35,7 @@ func TestCreateHTTPSInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateHTTPSInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "logs",
 				ResponseCondition: "Prevent default logging",
 				Format:            `%h %l %u %t "%r" %>s %b`,
@@ -83,14 +83,14 @@ func TestUpdateHTTPSInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHTTPSFn:     getHTTPSOK,
 			},
 			want: &fastly.UpdateHTTPSInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				ResponseCondition: fastly.String("new2"),
@@ -116,14 +116,14 @@ func TestUpdateHTTPSInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHTTPSFn:     getHTTPSOK,
 			},
 			want: &fastly.UpdateHTTPSInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -153,9 +153,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -187,9 +187,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/https/https_test.go
+++ b/pkg/logging/https/https_test.go
@@ -1,6 +1,7 @@
 package https
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -81,7 +82,11 @@ func TestUpdateHTTPSInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetHTTPSFn: getHTTPSOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHTTPSFn:     getHTTPSOK,
+			},
 			want: &fastly.UpdateHTTPSInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -109,7 +114,11 @@ func TestUpdateHTTPSInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetHTTPSFn: getHTTPSOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetHTTPSFn:     getHTTPSOK,
+			},
 			want: &fastly.UpdateHTTPSInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -134,19 +143,88 @@ func TestUpdateHTTPSInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		URL:          "example.com",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		URL: "example.com",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "logs",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "logs",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		URL:               "example.com",
 		ContentType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "application/json"},
 		HeaderName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "name"},
@@ -174,20 +252,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/https/https_test.go
+++ b/pkg/logging/https/https_test.go
@@ -83,8 +83,9 @@ func TestUpdateHTTPSInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetHTTPSFn:     getHTTPSOK,
 			},
 			want: &fastly.UpdateHTTPSInput{
@@ -115,8 +116,9 @@ func TestUpdateHTTPSInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetHTTPSFn:     getHTTPSOK,
 			},
 			want: &fastly.UpdateHTTPSInput{
@@ -151,8 +153,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -166,37 +169,13 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		URL: "example.com",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -208,8 +187,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -223,7 +203,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		URL:               "example.com",
 		ContentType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "application/json"},
@@ -271,7 +254,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -296,7 +282,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/https/list.go
+++ b/pkg/logging/https/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list HTTPS logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListHTTPSInput
+	manifest       manifest.Data
+	Input          fastly.ListHTTPSInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List HTTPS endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	httpss, err := c.Globals.Client.ListHTTPS(&c.Input)
 	if err != nil {

--- a/pkg/logging/https/update.go
+++ b/pkg/logging/https/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	URL               common.OptionalString
 	RequestMaxEntries common.OptionalUint
@@ -47,12 +48,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update an HTTPS logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the HTTPS logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("url", "URL that log data will be sent to. Must use the https protocol").Action(c.URL.Set).StringVar(&c.URL.Value)
@@ -72,7 +71,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
 	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
-
 	return &c
 }
 
@@ -83,9 +81,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateHTTPSInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateHTTPSInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/kafka/create.go
+++ b/pkg/logging/kafka/create.go
@@ -18,12 +18,13 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Topic        string
-	Brokers      string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Topic          string
+	Brokers        string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	UseTLS            common.OptionalBool
 	CompressionCodec  common.OptionalString
 	RequiredACKs      common.OptionalString
@@ -50,12 +51,11 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Kafka logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Kafka logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("topic", "The Kafka topic to send logs to").Required().StringVar(&c.Topic)
 	c.CmdClause.Flag("brokers", "A comma-separated list of IP addresses or hostnames of Kafka brokers").Required().StringVar(&c.Brokers)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("compression-codec", "The codec used for compression of your logs. One of: gzip, snappy, lz4").Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 	c.CmdClause.Flag("required-acks", "The Number of acknowledgements a leader must receive before a write is considered successful. One of: 1 (default) One server needs to respond. 0	No servers need to respond. -1	Wait for all in-sync replicas to respond").Action(c.RequiredACKs.Set).StringVar(&c.RequiredACKs.Value)
@@ -74,7 +74,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("auth-method", "SASL authentication method. Valid values are: plain, scram-sha-256, scram-sha-512").Action(c.AuthMethod.Set).HintOptions("plain", "scram-sha-256", "scram-sha-512").EnumVar(&c.AuthMethod.Value, "plain", "scram-sha-256", "scram-sha-512")
 	c.CmdClause.Flag("username", "SASL authentication username. Required if --auth-method is specified").Action(c.User.Set).StringVar(&c.User.Value)
 	c.CmdClause.Flag("password", "SASL authentication password. Required if --auth-method is specified").Action(c.Password.Set).StringVar(&c.Password.Value)
-
 	return &c
 }
 
@@ -86,6 +85,15 @@ func (c *CreateCommand) createInput() (*fastly.CreateKafkaInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	if c.UseSASL.WasSet && c.UseSASL.Value && (c.AuthMethod.Value == "" || c.User.Value == "" || c.Password.Value == "") {
 		return nil, fmt.Errorf("the --auth-method, --username, and --password flags must be present when using the --use-sasl flag")
 	}
@@ -95,7 +103,7 @@ func (c *CreateCommand) createInput() (*fastly.CreateKafkaInput, error) {
 	}
 
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Topic = c.Topic
 	input.Brokers = c.Brokers

--- a/pkg/logging/kafka/delete.go
+++ b/pkg/logging/kafka/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Kafka logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteKafkaInput
+	manifest       manifest.Data
+	Input          fastly.DeleteKafkaInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Kafka logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteKafka(&c.Input); err != nil {
 		return err

--- a/pkg/logging/kafka/describe.go
+++ b/pkg/logging/kafka/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Kafka logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetKafkaInput
+	manifest       manifest.Data
+	Input          fastly.GetKafkaInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Kafka logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	kafka, err := c.Globals.Client.GetKafka(&c.Input)
 	if err != nil {

--- a/pkg/logging/kafka/kafka_integration_test.go
+++ b/pkg/logging/kafka/kafka_integration_test.go
@@ -24,15 +24,25 @@ func TestKafkaCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --brokers not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -223,7 +233,7 @@ func TestKafkaUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -233,7 +243,7 @@ func TestKafkaUpdate(t *testing.T) {
 			wantOutput: "Updated Kafka logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -284,7 +294,7 @@ func TestKafkaDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/kafka/kafka_integration_test.go
+++ b/pkg/logging/kafka/kafka_integration_test.go
@@ -24,21 +24,31 @@ func TestKafkaCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
+			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs"},
+			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--topic", "logs"},
 			wantError: "error parsing arguments: required flag --brokers not provided",
 		},
 		{
-			args:       []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password"},
-			api:        mock.API{CreateKafkaFn: createKafkaOK},
-			wantOutput: "Created Kafka logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateKafkaFn:  createKafkaOK,
+			},
+			wantOutput: "Created Kafka logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2"},
-			api:       mock.API{CreateKafkaFn: createKafkaError},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateKafkaFn:  createKafkaError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -69,33 +79,57 @@ func TestKafkaList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKafkasFn: listKafkasOK},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKafkasFn:   listKafkasOK,
+			},
 			wantOutput: listKafkasShortOutput,
 		},
 		{
-			args:       []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListKafkasFn: listKafkasOK},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKafkasFn:   listKafkasOK,
+			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListKafkasFn: listKafkasOK},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKafkasFn:   listKafkasOK,
+			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "kafka", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKafkasFn: listKafkasOK},
+			args: []string{"logging", "kafka", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKafkasFn:   listKafkasOK,
+			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "kafka", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKafkasFn: listKafkasOK},
+			args: []string{"logging", "-v", "kafka", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKafkasFn:   listKafkasOK,
+			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListKafkasFn: listKafkasError},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKafkasFn:   listKafkasError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -126,17 +160,25 @@ func TestKafkaDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetKafkaFn: getKafkaError},
+			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetKafkaFn:     getKafkaError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetKafkaFn: getKafkaOK},
+			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetKafkaFn:     getKafkaOK,
+			},
 			wantOutput: describeKafkaOutput,
 		},
 	} {
@@ -167,23 +209,38 @@ func TestKafkaUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateKafkaFn: updateKafkaError},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateKafkaFn:  updateKafkaError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateKafkaFn: updateKafkaOK},
-			wantOutput: "Updated Kafka logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateKafkaFn:  updateKafkaOK,
+			},
+			wantOutput: "Updated Kafka logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:       []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password"},
-			api:        mock.API{UpdateKafkaFn: updateKafkaSASL},
-			wantOutput: "Updated Kafka logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateKafkaFn:  updateKafkaSASL,
+			},
+			wantOutput: "Updated Kafka logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -213,18 +270,28 @@ func TestKafkaDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteKafkaFn: deleteKafkaError},
+			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteKafkaFn:  deleteKafkaError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteKafkaFn: deleteKafkaOK},
-			wantOutput: "Deleted Kafka logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteKafkaFn:  deleteKafkaOK,
+			},
+			wantOutput: "Deleted Kafka logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -335,18 +402,18 @@ func listKafkasError(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
 
 var listKafkasShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listKafkasVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Kafka 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Topic: logs
 		Brokers: 127.0.0.1,127.0.0.2
@@ -368,7 +435,7 @@ Version: 1
 		SASL authentication password: 
 	Kafka 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Topic: analytics
 		Brokers: 127.0.0.1,127.0.0.2
@@ -417,7 +484,7 @@ func getKafkaError(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
 
 var describeKafkaOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: log
 Topic: logs
 Brokers: 127.0.0.1,127.0.0.2
@@ -496,4 +563,35 @@ func deleteKafkaOK(i *fastly.DeleteKafkaInput) error {
 
 func deleteKafkaError(i *fastly.DeleteKafkaInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/kafka/kafka_integration_test.go
+++ b/pkg/logging/kafka/kafka_integration_test.go
@@ -24,29 +24,29 @@ func TestKafkaCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
+			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--topic", "logs"},
+			args:      []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs"},
 			wantError: "error parsing arguments: required flag --brokers not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateKafkaFn:  createKafkaOK,
 			},
-			wantOutput: "Created Kafka logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Kafka logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "2", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateKafkaFn:  createKafkaError,
 			},
 			wantError: errTest.Error(),
@@ -79,55 +79,55 @@ func TestKafkaList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasShortOutput,
 		},
 		{
-			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: []string{"logging", "kafka", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "kafka", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "kafka", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "kafka", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKafkasFn:   listKafkasError,
 			},
 			wantError: errTest.Error(),
@@ -160,23 +160,23 @@ func TestKafkaDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetKafkaFn:     getKafkaError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetKafkaFn:     getKafkaOK,
 			},
 			wantOutput: describeKafkaOutput,
@@ -209,38 +209,38 @@ func TestKafkaUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateKafkaFn:  updateKafkaError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateKafkaFn:  updateKafkaOK,
 			},
-			wantOutput: "Updated Kafka logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Kafka logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateKafkaFn:  updateKafkaSASL,
 			},
-			wantOutput: "Updated Kafka logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Kafka logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -270,28 +270,28 @@ func TestKafkaDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteKafkaFn:  deleteKafkaError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteKafkaFn:  deleteKafkaOK,
 			},
-			wantOutput: "Deleted Kafka logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Kafka logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -402,18 +402,18 @@ func listKafkasError(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
 
 var listKafkasShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listKafkasVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Kafka 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Topic: logs
 		Brokers: 127.0.0.1,127.0.0.2
@@ -435,7 +435,7 @@ Version: 2
 		SASL authentication password: 
 	Kafka 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Topic: analytics
 		Brokers: 127.0.0.1,127.0.0.2
@@ -484,7 +484,7 @@ func getKafkaError(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
 
 var describeKafkaOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: log
 Topic: logs
 Brokers: 127.0.0.1,127.0.0.2
@@ -563,35 +563,4 @@ func deleteKafkaOK(i *fastly.DeleteKafkaInput) error {
 
 func deleteKafkaError(i *fastly.DeleteKafkaInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/kafka/kafka_integration_test.go
+++ b/pkg/logging/kafka/kafka_integration_test.go
@@ -24,39 +24,39 @@ func TestKafkaCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--brokers", "127.0.0.1,127.0.0.2", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --brokers not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateKafkaFn:  createKafkaOK,
 			},
-			wantOutput: "Created Kafka logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Kafka logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2"},
+			args: []string{"logging", "kafka", "create", "--service-id", "123", "--version", "1", "--name", "log", "--topic", "logs", "--brokers", "127.0.0.1,127.0.0.2", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateKafkaFn:  createKafkaError,
 			},
 			wantError: errTest.Error(),
@@ -91,8 +91,8 @@ func TestKafkaList(t *testing.T) {
 		{
 			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasShortOutput,
@@ -100,8 +100,8 @@ func TestKafkaList(t *testing.T) {
 		{
 			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
@@ -109,8 +109,8 @@ func TestKafkaList(t *testing.T) {
 		{
 			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
@@ -118,8 +118,8 @@ func TestKafkaList(t *testing.T) {
 		{
 			args: []string{"logging", "kafka", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
@@ -127,8 +127,8 @@ func TestKafkaList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "kafka", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKafkasFn:   listKafkasOK,
 			},
 			wantOutput: listKafkasVerboseOutput,
@@ -136,8 +136,8 @@ func TestKafkaList(t *testing.T) {
 		{
 			args: []string{"logging", "kafka", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKafkasFn:   listKafkasError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestKafkaDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetKafkaFn:     getKafkaError,
 			},
 			wantError: errTest.Error(),
@@ -185,8 +185,8 @@ func TestKafkaDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "kafka", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetKafkaFn:     getKafkaOK,
 			},
 			wantOutput: describeKafkaOutput,
@@ -223,34 +223,34 @@ func TestKafkaUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateKafkaFn:  updateKafkaError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateKafkaFn:  updateKafkaOK,
 			},
-			wantOutput: "Updated Kafka logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Kafka logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password"},
+			args: []string{"logging", "kafka", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--parse-log-keyvals", "--max-batch-size", "1024", "--use-sasl", "--auth-method", "plain", "--username", "user", "--password", "password", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateKafkaFn:  updateKafkaSASL,
 			},
-			wantOutput: "Updated Kafka logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Kafka logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -284,24 +284,24 @@ func TestKafkaDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteKafkaFn:  deleteKafkaError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "kafka", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteKafkaFn:  deleteKafkaOK,
 			},
-			wantOutput: "Deleted Kafka logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Kafka logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/kafka/kafka_test.go
+++ b/pkg/logging/kafka/kafka_test.go
@@ -25,7 +25,7 @@ func TestCreateKafkaInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateKafkaInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Topic:          "logs",
 				Brokers:        "127.0.0.1,127.0.0.2",
@@ -36,7 +36,7 @@ func TestCreateKafkaInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateKafkaInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "logs",
 				Brokers:           "127.0.0.1,127.0.0.2",
 				Topic:             "logs",
@@ -64,7 +64,7 @@ func TestCreateKafkaInput(t *testing.T) {
 			cmd:  createCommandSASL("scram-sha-512", "user1", "12345"),
 			want: &fastly.CreateKafkaInput{
 				ServiceID:       "123",
-				ServiceVersion:  2,
+				ServiceVersion:  4,
 				Name:            "log",
 				Topic:           "logs",
 				Brokers:         "127.0.0.1,127.0.0.2",
@@ -139,14 +139,14 @@ func TestUpdateKafkaInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
 			want: &fastly.UpdateKafkaInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Topic:             fastly.String("new2"),
@@ -173,14 +173,14 @@ func TestUpdateKafkaInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
 			want: &fastly.UpdateKafkaInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -193,15 +193,15 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify SASL fields",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
 			cmd: updateCommandSASL("scram-sha-512", "user1", "12345"),
 			want: &fastly.UpdateKafkaInput{
 				ServiceID:       "123",
-				ServiceVersion:  2,
+				ServiceVersion:  4,
 				Name:            "log",
 				Topic:           fastly.String("logs"),
 				Brokers:         fastly.String("127.0.0.1,127.0.0.2"),
@@ -215,15 +215,15 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify disabling SASL",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaSASL,
 			},
 			cmd: updateCommandNoSASL(),
 			want: &fastly.UpdateKafkaInput{
 				ServiceID:       "123",
-				ServiceVersion:  2,
+				ServiceVersion:  4,
 				Name:            "log",
 				Topic:           fastly.String("logs"),
 				Brokers:         fastly.String("127.0.0.1,127.0.0.2"),
@@ -237,9 +237,9 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify SASL validation: missing username",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
 			cmd:       updateCommandSASL("scram-sha-256", "", "password"),
@@ -249,9 +249,9 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify SASL validation: missing password",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
 			cmd:       updateCommandSASL("plain", "user", ""),
@@ -261,9 +261,9 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify SASL validation: username with no auth method",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
 			cmd:       updateCommandSASL("", "user1", ""),
@@ -273,9 +273,9 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify SASL validation: password with no auth method",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
 			cmd:       updateCommandSASL("", "", "password"),
@@ -302,9 +302,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -337,9 +337,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -383,9 +383,9 @@ func createCommandSASL(authMethod, user, password string) *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -424,9 +424,9 @@ func createCommandNoSASL(authMethod, user, password string) *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/kafka/list.go
+++ b/pkg/logging/kafka/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Kafka logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListKafkasInput
+	manifest       manifest.Data
+	Input          fastly.ListKafkasInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Kafka endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	kafkas, err := c.Globals.Client.ListKafkas(&c.Input)
 	if err != nil {

--- a/pkg/logging/kafka/update.go
+++ b/pkg/logging/kafka/update.go
@@ -18,10 +18,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Index             common.OptionalString
 	Topic             common.OptionalString
@@ -51,12 +52,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Kafka logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Kafka logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("topic", "The Kafka topic to send logs to").Action(c.Topic.Set).StringVar(&c.Topic.Value)
@@ -78,7 +77,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("auth-method", "SASL authentication method. Valid values are: plain, scram-sha-256, scram-sha-512").Action(c.AuthMethod.Set).HintOptions("plain", "scram-sha-256", "scram-sha-512").EnumVar(&c.AuthMethod.Value, "plain", "scram-sha-256", "scram-sha-512")
 	c.CmdClause.Flag("username", "SASL authentication username. Required if --auth-method is specified").Action(c.User.Set).StringVar(&c.User.Value)
 	c.CmdClause.Flag("password", "SASL authentication password. Required if --auth-method is specified").Action(c.Password.Set).StringVar(&c.Password.Value)
-
 	return &c
 }
 
@@ -87,6 +85,15 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateKafkaInput, error) {
 	serviceID, source := c.manifest.ServiceID()
 	if source == manifest.SourceUndefined {
 		return nil, errors.ErrNoServiceID
+	}
+
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
 	}
 
 	if c.UseSASL.WasSet && c.UseSASL.Value && (c.AuthMethod.Value == "" || c.User.Value == "" || c.Password.Value == "") {
@@ -99,7 +106,7 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateKafkaInput, error) {
 
 	input := fastly.UpdateKafkaInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an Amazon Kinesis logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteKinesisInput
+	manifest       manifest.Data
+	Input          fastly.DeleteKinesisInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,7 +27,8 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Kinesis logging endpoint on a Fastly service version").Alias("remove")
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 
@@ -39,6 +42,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteKinesis(&c.Input); err != nil {
 		return err

--- a/pkg/logging/kinesis/describe.go
+++ b/pkg/logging/kinesis/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe an Amazon Kinesis logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetKinesisInput
+	manifest       manifest.Data
+	Input          fastly.GetKinesisInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Kinesis logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	kinesis, err := c.Globals.Client.GetKinesis(&c.Input)
 	if err != nil {

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -24,89 +24,89 @@ func TestKinesisCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--region", "us-east-1"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--region", "us-east-1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1", "--autoclone"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateKinesisFn: createKinesisOK,
 			},
-			wantOutput: "Created Kinesis logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Kinesis logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateKinesisFn: createKinesisError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateKinesisFn: createKinesisOK,
 			},
-			wantOutput: "Created Kinesis logging endpoint log2 (service 123 version 3)",
+			wantOutput: "Created Kinesis logging endpoint log2 (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				CreateKinesisFn: createKinesisError,
 			},
 			wantError: errTest.Error(),
@@ -139,55 +139,55 @@ func TestKinesisList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesShortOutput,
 		},
 		{
-			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "kinesis", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "kinesis", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "kinesis", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "kinesis", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListKinesisFn:  listKinesesError,
 			},
 			wantError: errTest.Error(),
@@ -220,23 +220,23 @@ func TestKinesisDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetKinesisFn:   getKinesisError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetKinesisFn:   getKinesisOK,
 			},
 			wantOutput: describeKinesisOutput,
@@ -269,28 +269,28 @@ func TestKinesisUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				UpdateKinesisFn: updateKinesisError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--region", "us-west-1", "--autoclone"},
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				UpdateKinesisFn: updateKinesisOK,
 			},
-			wantOutput: "Updated Kinesis logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Kinesis logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -320,28 +320,28 @@ func TestKinesisDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				DeleteKinesisFn: deleteKinesisError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  cloneVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				DeleteKinesisFn: deleteKinesisOK,
 			},
-			wantOutput: "Deleted Kinesis logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Kinesis logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -414,18 +414,18 @@ func listKinesesError(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
 
 var listKinesesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listKinesesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Kinesis 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Stream name: my-logs
 		Region: us-east-1
@@ -437,7 +437,7 @@ Version: 2
 		Placement: none
 	Kinesis 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Stream name: analytics
 		Region: us-east-1
@@ -471,7 +471,7 @@ func getKinesisError(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
 
 var describeKinesisOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Stream name: my-logs
 Region: us-east-1
@@ -509,35 +509,4 @@ func deleteKinesisOK(i *fastly.DeleteKinesisInput) error {
 
 func deleteKinesisError(i *fastly.DeleteKinesisInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -24,95 +24,95 @@ func TestKinesisCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--region", "us-east-1"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--region", "us-east-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisOK,
 			},
-			wantOutput: "Created Kinesis logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Kinesis logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisOK,
 			},
-			wantOutput: "Created Kinesis logging endpoint log2 (service 123 version 2)",
+			wantOutput: "Created Kinesis logging endpoint log2 (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisError,
 			},
 			wantError: errTest.Error(),
@@ -147,8 +147,8 @@ func TestKinesisList(t *testing.T) {
 		{
 			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesShortOutput,
@@ -156,8 +156,8 @@ func TestKinesisList(t *testing.T) {
 		{
 			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
@@ -165,8 +165,8 @@ func TestKinesisList(t *testing.T) {
 		{
 			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
@@ -174,8 +174,8 @@ func TestKinesisList(t *testing.T) {
 		{
 			args: []string{"logging", "kinesis", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
@@ -183,8 +183,8 @@ func TestKinesisList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "kinesis", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKinesisFn:  listKinesesOK,
 			},
 			wantOutput: listKinesesVerboseOutput,
@@ -192,8 +192,8 @@ func TestKinesisList(t *testing.T) {
 		{
 			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListKinesisFn:  listKinesesError,
 			},
 			wantError: errTest.Error(),
@@ -232,8 +232,8 @@ func TestKinesisDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetKinesisFn:   getKinesisError,
 			},
 			wantError: errTest.Error(),
@@ -241,8 +241,8 @@ func TestKinesisDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetKinesisFn:   getKinesisOK,
 			},
 			wantOutput: describeKinesisOutput,
@@ -279,24 +279,24 @@ func TestKinesisUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateKinesisFn: updateKinesisError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1"},
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateKinesisFn: updateKinesisOK,
 			},
-			wantOutput: "Updated Kinesis logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Kinesis logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -330,24 +330,24 @@ func TestKinesisDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteKinesisFn: deleteKinesisError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteKinesisFn: deleteKinesisOK,
 			},
-			wantOutput: "Deleted Kinesis logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Kinesis logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -24,47 +24,91 @@ func TestKinesisCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--region", "us-east-1"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--region", "us-east-1"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--region", "us-east-1", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args:       []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
-			api:        mock.API{CreateKinesisFn: createKinesisOK},
-			wantOutput: "Created Kinesis logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				CreateKinesisFn: createKinesisOK,
+			},
+			wantOutput: "Created Kinesis logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
-			api:       mock.API{CreateKinesisFn: createKinesisError},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				CreateKinesisFn: createKinesisError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
-			api:        mock.API{CreateKinesisFn: createKinesisOK},
-			wantOutput: "Created Kinesis logging endpoint log2 (service 123 version 1)",
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				CreateKinesisFn: createKinesisOK,
+			},
+			wantOutput: "Created Kinesis logging endpoint log2 (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
-			api:       mock.API{CreateKinesisFn: createKinesisError},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				CreateKinesisFn: createKinesisError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -95,33 +139,57 @@ func TestKinesisList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKinesisFn: listKinesesOK},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKinesisFn:  listKinesesOK,
+			},
 			wantOutput: listKinesesShortOutput,
 		},
 		{
-			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListKinesisFn: listKinesesOK},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKinesisFn:  listKinesesOK,
+			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListKinesisFn: listKinesesOK},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKinesisFn:  listKinesesOK,
+			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "kinesis", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKinesisFn: listKinesesOK},
+			args: []string{"logging", "kinesis", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKinesisFn:  listKinesesOK,
+			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "kinesis", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListKinesisFn: listKinesesOK},
+			args: []string{"logging", "-v", "kinesis", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKinesisFn:  listKinesesOK,
+			},
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListKinesisFn: listKinesesError},
+			args: []string{"logging", "kinesis", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListKinesisFn:  listKinesesError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -152,17 +220,25 @@ func TestKinesisDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetKinesisFn: getKinesisError},
+			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetKinesisFn:   getKinesisError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetKinesisFn: getKinesisOK},
+			args: []string{"logging", "kinesis", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetKinesisFn:   getKinesisOK,
+			},
 			wantOutput: describeKinesisOutput,
 		},
 	} {
@@ -193,18 +269,28 @@ func TestKinesisUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateKinesisFn: updateKinesisError},
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				UpdateKinesisFn: updateKinesisError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1"},
-			api:        mock.API{UpdateKinesisFn: updateKinesisOK},
-			wantOutput: "Updated Kinesis logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--region", "us-west-1", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				UpdateKinesisFn: updateKinesisOK,
+			},
+			wantOutput: "Updated Kinesis logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -234,18 +320,28 @@ func TestKinesisDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteKinesisFn: deleteKinesisError},
+			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				DeleteKinesisFn: deleteKinesisError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteKinesisFn: deleteKinesisOK},
-			wantOutput: "Deleted Kinesis logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  cloneVersionOK,
+				DeleteKinesisFn: deleteKinesisOK,
+			},
+			wantOutput: "Deleted Kinesis logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -318,18 +414,18 @@ func listKinesesError(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
 
 var listKinesesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listKinesesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Kinesis 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Stream name: my-logs
 		Region: us-east-1
@@ -341,7 +437,7 @@ Version: 1
 		Placement: none
 	Kinesis 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Stream name: analytics
 		Region: us-east-1
@@ -375,7 +471,7 @@ func getKinesisError(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
 
 var describeKinesisOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Stream name: my-logs
 Region: us-east-1
@@ -413,4 +509,35 @@ func deleteKinesisOK(i *fastly.DeleteKinesisInput) error {
 
 func deleteKinesisError(i *fastly.DeleteKinesisInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/logging/kinesis/kinesis_integration_test.go
@@ -28,6 +28,7 @@ func TestKinesisCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
@@ -36,6 +37,7 @@ func TestKinesisCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
@@ -44,6 +46,7 @@ func TestKinesisCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
@@ -52,6 +55,7 @@ func TestKinesisCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
@@ -60,6 +64,7 @@ func TestKinesisCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
@@ -68,11 +73,12 @@ func TestKinesisCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1", "--autoclone"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log", "--stream-name", "log", "--access-key", "foo", "--secret-key", "bar", "--region", "us-east-1"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -92,7 +98,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess", "--autoclone"},
+			args: []string{"logging", "kinesis", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--stream-name", "log", "--region", "us-east-1", "--iam-role", "arn:aws:iam::123456789012:role/KinesisAccess"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -283,7 +289,7 @@ func TestKinesisUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1", "--autoclone"},
+			args: []string{"logging", "kinesis", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--region", "us-west-1"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,
@@ -334,7 +340,7 @@ func TestKinesisDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "kinesis", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersionsOk,
 				GetVersionFn:    testutil.GetActiveVersionOK,

--- a/pkg/logging/kinesis/kinesis_test.go
+++ b/pkg/logging/kinesis/kinesis_test.go
@@ -87,8 +87,9 @@ func TestUpdateKinesisInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetKinesisFn:   getKinesisOK,
 			},
 			want: &fastly.UpdateKinesisInput{
@@ -101,8 +102,9 @@ func TestUpdateKinesisInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetKinesisFn:   getKinesisOK,
 			},
 			want: &fastly.UpdateKinesisInput{
@@ -147,8 +149,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -162,39 +165,15 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		StreamName: "stream",
 		AccessKey:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
 		SecretKey:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandRequiredIAMRole() *CreateCommand {
@@ -206,8 +185,9 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -221,7 +201,10 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		StreamName: "stream",
 		IAMRole:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/KinesisAccess"},
@@ -237,8 +220,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -252,7 +236,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		StreamName:        "stream",
 		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
@@ -291,7 +278,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -316,7 +306,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		StreamName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/kinesis/kinesis_test.go
+++ b/pkg/logging/kinesis/kinesis_test.go
@@ -25,7 +25,7 @@ func TestCreateKinesisInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateKinesisInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				StreamName:     "stream",
 				AccessKey:      "access",
@@ -37,7 +37,7 @@ func TestCreateKinesisInput(t *testing.T) {
 			cmd:  createCommandRequiredIAMRole(),
 			want: &fastly.CreateKinesisInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				StreamName:     "stream",
 				IAMRole:        "arn:aws:iam::123456789012:role/KinesisAccess",
@@ -48,7 +48,7 @@ func TestCreateKinesisInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateKinesisInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "logs",
 				StreamName:        "stream",
 				Region:            "us-east-1",
@@ -87,14 +87,14 @@ func TestUpdateKinesisInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKinesisFn:   getKinesisOK,
 			},
 			want: &fastly.UpdateKinesisInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -102,14 +102,14 @@ func TestUpdateKinesisInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKinesisFn:   getKinesisOK,
 			},
 			want: &fastly.UpdateKinesisInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				StreamName:        fastly.String("new2"),
@@ -149,9 +149,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -185,9 +185,9 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -220,9 +220,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/kinesis/list.go
+++ b/pkg/logging/kinesis/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Amazon Kinesis logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListKinesisInput
+	manifest       manifest.Data
+	Input          fastly.ListKinesisInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Kinesis endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	kineses, err := c.Globals.Client.ListKinesis(&c.Input)
 	if err != nil {

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	StreamName        common.OptionalString
 	AccessKey         common.OptionalString
@@ -39,12 +40,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Kinesis logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Kinesis logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("stream-name", "Your Kinesis stream name").Action(c.StreamName.Set).StringVar(&c.StreamName.Value)
@@ -56,7 +55,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -67,9 +65,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateKinesisInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateKinesisInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/logentries/create.go
+++ b/pkg/logging/logentries/create.go
@@ -17,10 +17,11 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Port              common.OptionalUint
 	UseTLS            common.OptionalBool
 	Token             common.OptionalString
@@ -37,10 +38,7 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Logentries logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Logentries logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)
@@ -49,7 +47,8 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	return &c
 }
 
@@ -62,8 +61,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateLogentriesInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 
 	if c.Port.WasSet {

--- a/pkg/logging/logentries/delete.go
+++ b/pkg/logging/logentries/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Logentries logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteLogentriesInput
+	manifest       manifest.Data
+	Input          fastly.DeleteLogentriesInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Logentries logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteLogentries(&c.Input); err != nil {
 		return err

--- a/pkg/logging/logentries/describe.go
+++ b/pkg/logging/logentries/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Logentries logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetLogentriesInput
+	manifest       manifest.Data
+	Input          fastly.GetLogentriesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logentries logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	logentries, err := c.Globals.Client.GetLogentries(&c.Input)
 	if err != nil {

--- a/pkg/logging/logentries/list.go
+++ b/pkg/logging/logentries/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Logentries logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListLogentriesInput
+	manifest       manifest.Data
+	Input          fastly.ListLogentriesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Logentries endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	logentriess, err := c.Globals.Client.ListLogentries(&c.Input)
 	if err != nil {

--- a/pkg/logging/logentries/logentries_integration_test.go
+++ b/pkg/logging/logentries/logentries_integration_test.go
@@ -24,7 +24,7 @@ func TestLogentriesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000", "--autoclone"},
+			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -215,7 +215,7 @@ func TestLogentriesUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -266,7 +266,7 @@ func TestLogentriesDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,

--- a/pkg/logging/logentries/logentries_integration_test.go
+++ b/pkg/logging/logentries/logentries_integration_test.go
@@ -24,21 +24,21 @@ func TestLogentriesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "2", "--name", "log", "--port", "20000", "--autoclone"},
+			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateLogentriesFn: createLogentriesOK,
 			},
-			wantOutput: "Created Logentries logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Logentries logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "2", "--name", "log", "--port", "20000"},
+			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateLogentriesFn: createLogentriesError,
 			},
 			wantError: errTest.Error(),
@@ -71,55 +71,55 @@ func TestLogentriesList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesShortOutput,
 		},
 		{
-			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "logentries", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "logentries", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "logentries", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "logentries", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListLogentriesFn: listLogentriesError,
 			},
 			wantError: errTest.Error(),
@@ -152,23 +152,23 @@ func TestLogentriesDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetLogentriesFn: getLogentriesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetLogentriesFn: getLogentriesOK,
 			},
 			wantOutput: describeLogentriesOutput,
@@ -201,28 +201,28 @@ func TestLogentriesUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logentries", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateLogentriesFn: updateLogentriesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateLogentriesFn: updateLogentriesOK,
 			},
-			wantOutput: "Updated Logentries logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Logentries logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -252,28 +252,28 @@ func TestLogentriesDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteLogentriesFn: deleteLogentriesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteLogentriesFn: deleteLogentriesOK,
 			},
-			wantOutput: "Deleted Logentries logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Logentries logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -344,18 +344,18 @@ func listLogentriesError(i *fastly.ListLogentriesInput) ([]*fastly.Logentries, e
 
 var listLogentriesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listLogentriesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Logentries 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Port: 20000
 		Use TLS: true
@@ -366,7 +366,7 @@ Version: 2
 		Placement: none
 	Logentries 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Port: 20001
 		Use TLS: false
@@ -398,7 +398,7 @@ func getLogentriesError(i *fastly.GetLogentriesInput) (*fastly.Logentries, error
 
 var describeLogentriesOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Port: 20000
 Use TLS: true
@@ -434,35 +434,4 @@ func deleteLogentriesOK(i *fastly.DeleteLogentriesInput) error {
 
 func deleteLogentriesError(i *fastly.DeleteLogentriesInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/logentries/logentries_integration_test.go
+++ b/pkg/logging/logentries/logentries_integration_test.go
@@ -24,13 +24,23 @@ func TestLogentriesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
-			api:        mock.API{CreateLogentriesFn: createLogentriesOK},
-			wantOutput: "Created Logentries logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "2", "--name", "log", "--port", "20000", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateLogentriesFn: createLogentriesOK,
+			},
+			wantOutput: "Created Logentries logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
-			api:       mock.API{CreateLogentriesFn: createLogentriesError},
+			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "2", "--name", "log", "--port", "20000"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateLogentriesFn: createLogentriesError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -61,33 +71,57 @@ func TestLogentriesList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListLogentriesFn: listLogentriesOK,
+			},
 			wantOutput: listLogentriesShortOutput,
 		},
 		{
-			args:       []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListLogentriesFn: listLogentriesOK,
+			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListLogentriesFn: listLogentriesOK,
+			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "logentries", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			args: []string{"logging", "logentries", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListLogentriesFn: listLogentriesOK,
+			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "logentries", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogentriesFn: listLogentriesOK},
+			args: []string{"logging", "-v", "logentries", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListLogentriesFn: listLogentriesOK,
+			},
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListLogentriesFn: listLogentriesError},
+			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListLogentriesFn: listLogentriesError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -118,17 +152,25 @@ func TestLogentriesDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetLogentriesFn: getLogentriesError},
+			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetLogentriesFn: getLogentriesError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetLogentriesFn: getLogentriesOK},
+			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetLogentriesFn: getLogentriesOK,
+			},
 			wantOutput: describeLogentriesOutput,
 		},
 	} {
@@ -159,18 +201,28 @@ func TestLogentriesUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "logentries", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateLogentriesFn: updateLogentriesError},
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateLogentriesFn: updateLogentriesError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateLogentriesFn: updateLogentriesOK},
-			wantOutput: "Updated Logentries logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateLogentriesFn: updateLogentriesOK,
+			},
+			wantOutput: "Updated Logentries logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -200,18 +252,28 @@ func TestLogentriesDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteLogentriesFn: deleteLogentriesError},
+			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteLogentriesFn: deleteLogentriesError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteLogentriesFn: deleteLogentriesOK},
-			wantOutput: "Deleted Logentries logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteLogentriesFn: deleteLogentriesOK,
+			},
+			wantOutput: "Deleted Logentries logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -282,18 +344,18 @@ func listLogentriesError(i *fastly.ListLogentriesInput) ([]*fastly.Logentries, e
 
 var listLogentriesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listLogentriesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Logentries 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Port: 20000
 		Use TLS: true
@@ -304,7 +366,7 @@ Version: 1
 		Placement: none
 	Logentries 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Port: 20001
 		Use TLS: false
@@ -336,7 +398,7 @@ func getLogentriesError(i *fastly.GetLogentriesInput) (*fastly.Logentries, error
 
 var describeLogentriesOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Port: 20000
 Use TLS: true
@@ -372,4 +434,35 @@ func deleteLogentriesOK(i *fastly.DeleteLogentriesInput) error {
 
 func deleteLogentriesError(i *fastly.DeleteLogentriesInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/logentries/logentries_integration_test.go
+++ b/pkg/logging/logentries/logentries_integration_test.go
@@ -24,21 +24,21 @@ func TestLogentriesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
+			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateLogentriesFn: createLogentriesOK,
 			},
-			wantOutput: "Created Logentries logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Logentries logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000"},
+			args: []string{"logging", "logentries", "create", "--service-id", "123", "--version", "1", "--name", "log", "--port", "20000", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateLogentriesFn: createLogentriesError,
 			},
 			wantError: errTest.Error(),
@@ -73,8 +73,8 @@ func TestLogentriesList(t *testing.T) {
 		{
 			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesShortOutput,
@@ -82,8 +82,8 @@ func TestLogentriesList(t *testing.T) {
 		{
 			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
@@ -91,8 +91,8 @@ func TestLogentriesList(t *testing.T) {
 		{
 			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
@@ -100,8 +100,8 @@ func TestLogentriesList(t *testing.T) {
 		{
 			args: []string{"logging", "logentries", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
@@ -109,8 +109,8 @@ func TestLogentriesList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "logentries", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListLogentriesFn: listLogentriesOK,
 			},
 			wantOutput: listLogentriesVerboseOutput,
@@ -118,8 +118,8 @@ func TestLogentriesList(t *testing.T) {
 		{
 			args: []string{"logging", "logentries", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListLogentriesFn: listLogentriesError,
 			},
 			wantError: errTest.Error(),
@@ -158,8 +158,8 @@ func TestLogentriesDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetLogentriesFn: getLogentriesError,
 			},
 			wantError: errTest.Error(),
@@ -167,8 +167,8 @@ func TestLogentriesDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "logentries", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetLogentriesFn: getLogentriesOK,
 			},
 			wantOutput: describeLogentriesOutput,
@@ -205,24 +205,24 @@ func TestLogentriesUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateLogentriesFn: updateLogentriesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "logentries", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateLogentriesFn: updateLogentriesOK,
 			},
-			wantOutput: "Updated Logentries logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Logentries logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,24 +256,24 @@ func TestLogentriesDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteLogentriesFn: deleteLogentriesError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "logentries", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteLogentriesFn: deleteLogentriesOK,
 			},
-			wantOutput: "Deleted Logentries logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Logentries logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/logentries/logentries_test.go
+++ b/pkg/logging/logentries/logentries_test.go
@@ -25,7 +25,7 @@ func TestCreateLogentriesInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateLogentriesInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -34,7 +34,7 @@ func TestCreateLogentriesInput(t *testing.T) {
 			cmd:  createCommandOK(),
 			want: &fastly.CreateLogentriesInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Port:              22,
 				UseTLS:            fastly.Compatibool(true),
@@ -72,14 +72,14 @@ func TestUpdateLogentriesInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetLogentriesFn: getLogentriesOK,
 			},
 			want: &fastly.UpdateLogentriesInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -87,14 +87,14 @@ func TestUpdateLogentriesInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetLogentriesFn: getLogentriesOK,
 			},
 			want: &fastly.UpdateLogentriesInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Port:              fastly.Uint(23),
@@ -132,9 +132,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -172,9 +172,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/logentries/logentries_test.go
+++ b/pkg/logging/logentries/logentries_test.go
@@ -72,8 +72,9 @@ func TestUpdateLogentriesInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetLogentriesFn: getLogentriesOK,
 			},
 			want: &fastly.UpdateLogentriesInput{
@@ -86,8 +87,9 @@ func TestUpdateLogentriesInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetLogentriesFn: getLogentriesOK,
 			},
 			want: &fastly.UpdateLogentriesInput{
@@ -130,8 +132,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -145,7 +148,10 @@ func createCommandOK() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22},
 		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
@@ -166,8 +172,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -181,36 +188,12 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandMissingServiceID() *CreateCommand {
@@ -239,7 +222,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -264,7 +250,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},
 		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},

--- a/pkg/logging/logentries/logentries_test.go
+++ b/pkg/logging/logentries/logentries_test.go
@@ -1,6 +1,7 @@
 package logentries
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -70,7 +71,11 @@ func TestUpdateLogentriesInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetLogentriesFn: getLogentriesOK},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetLogentriesFn: getLogentriesOK,
+			},
 			want: &fastly.UpdateLogentriesInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -80,7 +85,11 @@ func TestUpdateLogentriesInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetLogentriesFn: getLogentriesOK},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetLogentriesFn: getLogentriesOK,
+			},
 			want: &fastly.UpdateLogentriesInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -113,10 +122,31 @@ func TestUpdateLogentriesInput(t *testing.T) {
 }
 
 func createCommandOK() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22},
 		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
 		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "tkn"},
@@ -128,11 +158,59 @@ func createCommandOK() *CreateCommand {
 }
 
 func createCommandRequired() *CreateCommand {
-	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName: "log",
-		Version:      2,
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
 	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
+	return &CreateCommand{
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+	}
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
 }
 
 func createCommandMissingServiceID() *CreateCommand {
@@ -142,20 +220,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},
 		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},

--- a/pkg/logging/loggly/create.go
+++ b/pkg/logging/loggly/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Token        string
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	Token          string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	ResponseCondition common.OptionalString
@@ -31,23 +32,19 @@ type CreateCommand struct {
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
-
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Loggly logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Loggly logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
-
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/)").Required().StringVar(&c.Token)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -60,8 +57,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateLogglyInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Token = c.Token
 

--- a/pkg/logging/loggly/delete.go
+++ b/pkg/logging/loggly/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Loggly logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteLogglyInput
+	manifest       manifest.Data
+	Input          fastly.DeleteLogglyInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Loggly logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Loggly logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteLoggly(&c.Input); err != nil {
 		return err

--- a/pkg/logging/loggly/describe.go
+++ b/pkg/logging/loggly/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Loggly logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetLogglyInput
+	manifest       manifest.Data
+	Input          fastly.GetLogglyInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Loggly logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Loggly logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	loggly, err := c.Globals.Client.GetLoggly(&c.Input)
 	if err != nil {

--- a/pkg/logging/loggly/list.go
+++ b/pkg/logging/loggly/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Loggly logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListLogglyInput
+	manifest       manifest.Data
+	Input          fastly.ListLogglyInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Loggly endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	logglys, err := c.Globals.Client.ListLoggly(&c.Input)
 	if err != nil {

--- a/pkg/logging/loggly/loggly_integration_test.go
+++ b/pkg/logging/loggly/loggly_integration_test.go
@@ -24,30 +24,30 @@ func TestLogglyCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateLogglyFn: createLogglyOK,
 			},
-			wantOutput: "Created Loggly logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Loggly logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateLogglyFn: createLogglyError,
 			},
 			wantError: errTest.Error(),
@@ -82,8 +82,8 @@ func TestLogglyList(t *testing.T) {
 		{
 			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysShortOutput,
@@ -91,8 +91,8 @@ func TestLogglyList(t *testing.T) {
 		{
 			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
@@ -100,8 +100,8 @@ func TestLogglyList(t *testing.T) {
 		{
 			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
@@ -109,8 +109,8 @@ func TestLogglyList(t *testing.T) {
 		{
 			args: []string{"logging", "loggly", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
@@ -118,8 +118,8 @@ func TestLogglyList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "loggly", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
@@ -127,8 +127,8 @@ func TestLogglyList(t *testing.T) {
 		{
 			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListLogglyFn:   listLogglysError,
 			},
 			wantError: errTest.Error(),
@@ -167,8 +167,8 @@ func TestLogglyDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetLogglyFn:    getLogglyError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestLogglyDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetLogglyFn:    getLogglyOK,
 			},
 			wantOutput: describeLogglyOutput,
@@ -214,24 +214,24 @@ func TestLogglyUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateLogglyFn: updateLogglyError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateLogglyFn: updateLogglyOK,
 			},
-			wantOutput: "Updated Loggly logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Loggly logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -265,24 +265,24 @@ func TestLogglyDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteLogglyFn: deleteLogglyError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteLogglyFn: deleteLogglyOK,
 			},
-			wantOutput: "Deleted Loggly logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Loggly logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/loggly/loggly_integration_test.go
+++ b/pkg/logging/loggly/loggly_integration_test.go
@@ -24,17 +24,27 @@ func TestLogglyCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "loggly", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:       []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
-			api:        mock.API{CreateLogglyFn: createLogglyOK},
-			wantOutput: "Created Loggly logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateLogglyFn: createLogglyOK,
+			},
+			wantOutput: "Created Loggly logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
-			api:       mock.API{CreateLogglyFn: createLogglyError},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateLogglyFn: createLogglyError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -65,33 +75,57 @@ func TestLogglyList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogglyFn: listLogglysOK},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListLogglyFn:   listLogglysOK,
+			},
 			wantOutput: listLogglysShortOutput,
 		},
 		{
-			args:       []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListLogglyFn: listLogglysOK},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListLogglyFn:   listLogglysOK,
+			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListLogglyFn: listLogglysOK},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListLogglyFn:   listLogglysOK,
+			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "loggly", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogglyFn: listLogglysOK},
+			args: []string{"logging", "loggly", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListLogglyFn:   listLogglysOK,
+			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "loggly", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogglyFn: listLogglysOK},
+			args: []string{"logging", "-v", "loggly", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListLogglyFn:   listLogglysOK,
+			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListLogglyFn: listLogglysError},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListLogglyFn:   listLogglysError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -122,17 +156,25 @@ func TestLogglyDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetLogglyFn: getLogglyError},
+			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetLogglyFn:    getLogglyError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetLogglyFn: getLogglyOK},
+			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetLogglyFn:    getLogglyOK,
+			},
 			wantOutput: describeLogglyOutput,
 		},
 	} {
@@ -163,18 +205,28 @@ func TestLogglyUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "loggly", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateLogglyFn: updateLogglyError},
+			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateLogglyFn: updateLogglyError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateLogglyFn: updateLogglyOK},
-			wantOutput: "Updated Loggly logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateLogglyFn: updateLogglyOK,
+			},
+			wantOutput: "Updated Loggly logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -204,18 +256,28 @@ func TestLogglyDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteLogglyFn: deleteLogglyError},
+			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteLogglyFn: deleteLogglyError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteLogglyFn: deleteLogglyOK},
-			wantOutput: "Deleted Loggly logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteLogglyFn: deleteLogglyOK,
+			},
+			wantOutput: "Deleted Loggly logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -287,18 +349,18 @@ func listLogglysError(i *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
 
 var listLogglysShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listLogglysVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Loggly 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Token: abc
 		Format: %h %l %u %t "%r" %>s %b
@@ -307,7 +369,7 @@ Version: 1
 		Placement: none
 	Loggly 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Token: abc
 		Format: %h %l %u %t "%r" %>s %b
@@ -335,7 +397,7 @@ func getLogglyError(i *fastly.GetLogglyInput) (*fastly.Loggly, error) {
 
 var describeLogglyOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Token: abc
 Format: %h %l %u %t "%r" %>s %b
@@ -366,4 +428,35 @@ func deleteLogglyOK(i *fastly.DeleteLogglyInput) error {
 
 func deleteLogglyError(i *fastly.DeleteLogglyInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/loggly/loggly_integration_test.go
+++ b/pkg/logging/loggly/loggly_integration_test.go
@@ -24,11 +24,16 @@ func TestLogglyCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -219,7 +224,7 @@ func TestLogglyUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -270,7 +275,7 @@ func TestLogglyDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/loggly/loggly_integration_test.go
+++ b/pkg/logging/loggly/loggly_integration_test.go
@@ -24,25 +24,25 @@ func TestLogglyCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateLogglyFn: createLogglyOK,
 			},
-			wantOutput: "Created Loggly logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Loggly logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "loggly", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateLogglyFn: createLogglyError,
 			},
 			wantError: errTest.Error(),
@@ -75,55 +75,55 @@ func TestLogglyList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysShortOutput,
 		},
 		{
-			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: []string{"logging", "loggly", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "loggly", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "loggly", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "loggly", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListLogglyFn:   listLogglysOK,
 			},
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "loggly", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListLogglyFn:   listLogglysError,
 			},
 			wantError: errTest.Error(),
@@ -156,23 +156,23 @@ func TestLogglyDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetLogglyFn:    getLogglyError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "loggly", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetLogglyFn:    getLogglyOK,
 			},
 			wantOutput: describeLogglyOutput,
@@ -205,28 +205,28 @@ func TestLogglyUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateLogglyFn: updateLogglyError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "loggly", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateLogglyFn: updateLogglyOK,
 			},
-			wantOutput: "Updated Loggly logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Loggly logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,28 +256,28 @@ func TestLogglyDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteLogglyFn: deleteLogglyError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "loggly", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteLogglyFn: deleteLogglyOK,
 			},
-			wantOutput: "Deleted Loggly logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Loggly logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -349,18 +349,18 @@ func listLogglysError(i *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
 
 var listLogglysShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listLogglysVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Loggly 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Token: abc
 		Format: %h %l %u %t "%r" %>s %b
@@ -369,7 +369,7 @@ Version: 2
 		Placement: none
 	Loggly 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Token: abc
 		Format: %h %l %u %t "%r" %>s %b
@@ -397,7 +397,7 @@ func getLogglyError(i *fastly.GetLogglyInput) (*fastly.Loggly, error) {
 
 var describeLogglyOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Token: abc
 Format: %h %l %u %t "%r" %>s %b
@@ -428,35 +428,4 @@ func deleteLogglyOK(i *fastly.DeleteLogglyInput) error {
 
 func deleteLogglyError(i *fastly.DeleteLogglyInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/loggly/loggly_test.go
+++ b/pkg/logging/loggly/loggly_test.go
@@ -25,7 +25,7 @@ func TestCreateLogglyInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateLogglyInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Token:          "tkn",
 			},
@@ -35,7 +35,7 @@ func TestCreateLogglyInput(t *testing.T) {
 			cmd:  createCommandOK(),
 			want: &fastly.CreateLogglyInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				FormatVersion:     2,
@@ -71,14 +71,14 @@ func TestUpdateLogglyInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetLogglyFn:    getLogglyOK,
 			},
 			want: &fastly.UpdateLogglyInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -86,14 +86,14 @@ func TestUpdateLogglyInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetLogglyFn:    getLogglyOK,
 			},
 			want: &fastly.UpdateLogglyInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Format:            fastly.String("new2"),
@@ -129,9 +129,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -167,9 +167,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/loggly/loggly_test.go
+++ b/pkg/logging/loggly/loggly_test.go
@@ -71,8 +71,9 @@ func TestUpdateLogglyInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetLogglyFn:    getLogglyOK,
 			},
 			want: &fastly.UpdateLogglyInput{
@@ -85,8 +86,9 @@ func TestUpdateLogglyInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetLogglyFn:    getLogglyOK,
 			},
 			want: &fastly.UpdateLogglyInput{
@@ -127,8 +129,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -143,7 +146,10 @@ func createCommandOK() *CreateCommand {
 		EndpointName: "log",
 		Token:        "tkn",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -161,8 +167,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -177,36 +184,12 @@ func createCommandRequired() *CreateCommand {
 		EndpointName: "log",
 		Token:        "tkn",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandMissingServiceID() *CreateCommand {
@@ -235,7 +218,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -260,7 +246,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/loggly/loggly_test.go
+++ b/pkg/logging/loggly/loggly_test.go
@@ -1,6 +1,7 @@
 package loggly
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -69,7 +70,11 @@ func TestUpdateLogglyInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetLogglyFn: getLogglyOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetLogglyFn:    getLogglyOK,
+			},
 			want: &fastly.UpdateLogglyInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -79,7 +84,11 @@ func TestUpdateLogglyInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetLogglyFn: getLogglyOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetLogglyFn:    getLogglyOK,
+			},
 			want: &fastly.UpdateLogglyInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -110,11 +119,32 @@ func TestUpdateLogglyInput(t *testing.T) {
 }
 
 func createCommandOK() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Token:             "tkn",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		Token:        "tkn",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
 		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
@@ -123,12 +153,60 @@ func createCommandOK() *CreateCommand {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		Token:        "tkn",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
 }
 
 func createCommandMissingServiceID() *CreateCommand {
@@ -138,20 +216,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},

--- a/pkg/logging/loggly/update.go
+++ b/pkg/logging/loggly/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
@@ -35,12 +36,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Loggly logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Loggly logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Loggly logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/)").Action(c.Token.Set).StringVar(&c.Token.Value)
@@ -48,7 +47,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -59,9 +57,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateLogglyInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateLogglyInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/logshuttle/create.go
+++ b/pkg/logging/logshuttle/create.go
@@ -17,12 +17,13 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Token        string
-	URL          string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Token          string
+	URL            string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
 	ResponseCondition common.OptionalString
@@ -32,23 +33,20 @@ type CreateCommand struct {
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
-
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Logshuttle logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Logshuttle logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("url", "Your Log Shuttle endpoint url").Required().StringVar(&c.URL)
 	c.CmdClause.Flag("auth-token", "The data authentication token associated with this endpoint").Required().StringVar(&c.Token)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,8 +59,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateLogshuttleInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Token = c.Token
 	input.URL = c.URL

--- a/pkg/logging/logshuttle/delete.go
+++ b/pkg/logging/logshuttle/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Logshuttle logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteLogshuttleInput
+	manifest       manifest.Data
+	Input          fastly.DeleteLogshuttleInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Logshuttle logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteLogshuttle(&c.Input); err != nil {
 		return err

--- a/pkg/logging/logshuttle/describe.go
+++ b/pkg/logging/logshuttle/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Logshuttle logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetLogshuttleInput
+	manifest       manifest.Data
+	Input          fastly.GetLogshuttleInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logshuttle logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	logshuttle, err := c.Globals.Client.GetLogshuttle(&c.Input)
 	if err != nil {

--- a/pkg/logging/logshuttle/list.go
+++ b/pkg/logging/logshuttle/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Logshuttle logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListLogshuttlesInput
+	manifest       manifest.Data
+	Input          fastly.ListLogshuttlesInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Logshuttle endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	logshuttles, err := c.Globals.Client.ListLogshuttles(&c.Input)
 	if err != nil {

--- a/pkg/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/logging/logshuttle/logshuttle_integration_test.go
@@ -24,37 +24,37 @@ func TestLogshuttleCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateLogshuttleFn: createLogshuttleOK,
 			},
-			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreateLogshuttleFn: createLogshuttleError,
 			},
 			wantError: errTest.Error(),
@@ -87,55 +87,55 @@ func TestLogshuttleList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesShortOutput,
 		},
 		{
-			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "logshuttle", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "logshuttle", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "logshuttle", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "logshuttle", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListLogshuttlesFn: listLogshuttlesError,
 			},
 			wantError: errTest.Error(),
@@ -168,23 +168,23 @@ func TestLogshuttleDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetLogshuttleFn: getLogshuttleError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetLogshuttleFn: getLogshuttleOK,
 			},
 			wantOutput: describeLogshuttleOutput,
@@ -217,28 +217,28 @@ func TestLogshuttleUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateLogshuttleFn: updateLogshuttleError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdateLogshuttleFn: updateLogshuttleOK,
 			},
-			wantOutput: "Updated Logshuttle logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Logshuttle logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -268,28 +268,28 @@ func TestLogshuttleDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteLogshuttleFn: deleteLogshuttleError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeleteLogshuttleFn: deleteLogshuttleOK,
 			},
-			wantOutput: "Deleted Logshuttle logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Logshuttle logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -363,18 +363,18 @@ func listLogshuttlesError(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle,
 
 var listLogshuttlesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listLogshuttlesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Logshuttle 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		URL: example.com
 		Token: abc
@@ -384,7 +384,7 @@ Version: 2
 		Placement: none
 	Logshuttle 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		URL: example.com
 		Token: abc
@@ -414,7 +414,7 @@ func getLogshuttleError(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error
 
 var describeLogshuttleOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 URL: example.com
 Token: abc
@@ -448,35 +448,4 @@ func deleteLogshuttleOK(i *fastly.DeleteLogshuttleInput) error {
 
 func deleteLogshuttleError(i *fastly.DeleteLogshuttleInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/logging/logshuttle/logshuttle_integration_test.go
@@ -28,6 +28,7 @@ func TestLogshuttleCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
@@ -36,11 +37,12 @@ func TestLogshuttleCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -231,7 +233,7 @@ func TestLogshuttleUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -282,7 +284,7 @@ func TestLogshuttleDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,

--- a/pkg/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/logging/logshuttle/logshuttle_integration_test.go
@@ -24,39 +24,39 @@ func TestLogshuttleCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateLogshuttleFn: createLogshuttleOK,
 			},
-			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateLogshuttleFn: createLogshuttleError,
 			},
 			wantError: errTest.Error(),
@@ -91,8 +91,8 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesShortOutput,
@@ -100,8 +100,8 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
@@ -109,8 +109,8 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
@@ -118,8 +118,8 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			args: []string{"logging", "logshuttle", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
@@ -127,8 +127,8 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "logshuttle", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			wantOutput: listLogshuttlesVerboseOutput,
@@ -136,8 +136,8 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListLogshuttlesFn: listLogshuttlesError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestLogshuttleDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetLogshuttleFn: getLogshuttleError,
 			},
 			wantError: errTest.Error(),
@@ -185,8 +185,8 @@ func TestLogshuttleDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetLogshuttleFn: getLogshuttleOK,
 			},
 			wantOutput: describeLogshuttleOutput,
@@ -223,24 +223,24 @@ func TestLogshuttleUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateLogshuttleFn: updateLogshuttleError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateLogshuttleFn: updateLogshuttleOK,
 			},
-			wantOutput: "Updated Logshuttle logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Logshuttle logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -274,24 +274,24 @@ func TestLogshuttleDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteLogshuttleFn: deleteLogshuttleError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteLogshuttleFn: deleteLogshuttleOK,
 			},
-			wantOutput: "Deleted Logshuttle logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Logshuttle logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/logging/logshuttle/logshuttle_integration_test.go
@@ -24,21 +24,39 @@ func TestLogshuttleCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:      []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:       []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
-			api:        mock.API{CreateLogshuttleFn: createLogshuttleOK},
-			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--auth-token", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateLogshuttleFn: createLogshuttleOK,
+			},
+			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
-			api:       mock.API{CreateLogshuttleFn: createLogshuttleError},
+			args: []string{"logging", "logshuttle", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreateLogshuttleFn: createLogshuttleError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -69,33 +87,57 @@ func TestLogshuttleList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListLogshuttlesFn: listLogshuttlesOK,
+			},
 			wantOutput: listLogshuttlesShortOutput,
 		},
 		{
-			args:       []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListLogshuttlesFn: listLogshuttlesOK,
+			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListLogshuttlesFn: listLogshuttlesOK,
+			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "logshuttle", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			args: []string{"logging", "logshuttle", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListLogshuttlesFn: listLogshuttlesOK,
+			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "logshuttle", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListLogshuttlesFn: listLogshuttlesOK},
+			args: []string{"logging", "-v", "logshuttle", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListLogshuttlesFn: listLogshuttlesOK,
+			},
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListLogshuttlesFn: listLogshuttlesError},
+			args: []string{"logging", "logshuttle", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListLogshuttlesFn: listLogshuttlesError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -126,17 +168,25 @@ func TestLogshuttleDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetLogshuttleFn: getLogshuttleError},
+			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetLogshuttleFn: getLogshuttleError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetLogshuttleFn: getLogshuttleOK},
+			args: []string{"logging", "logshuttle", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetLogshuttleFn: getLogshuttleOK,
+			},
 			wantOutput: describeLogshuttleOutput,
 		},
 	} {
@@ -167,18 +217,28 @@ func TestLogshuttleUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateLogshuttleFn: updateLogshuttleError},
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateLogshuttleFn: updateLogshuttleError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateLogshuttleFn: updateLogshuttleOK},
-			wantOutput: "Updated Logshuttle logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "logshuttle", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdateLogshuttleFn: updateLogshuttleOK,
+			},
+			wantOutput: "Updated Logshuttle logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -208,18 +268,28 @@ func TestLogshuttleDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteLogshuttleFn: deleteLogshuttleError},
+			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteLogshuttleFn: deleteLogshuttleError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteLogshuttleFn: deleteLogshuttleOK},
-			wantOutput: "Deleted Logshuttle logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "logshuttle", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeleteLogshuttleFn: deleteLogshuttleOK,
+			},
+			wantOutput: "Deleted Logshuttle logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -293,18 +363,18 @@ func listLogshuttlesError(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle,
 
 var listLogshuttlesShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listLogshuttlesVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Logshuttle 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		URL: example.com
 		Token: abc
@@ -314,7 +384,7 @@ Version: 1
 		Placement: none
 	Logshuttle 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		URL: example.com
 		Token: abc
@@ -344,7 +414,7 @@ func getLogshuttleError(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error
 
 var describeLogshuttleOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 URL: example.com
 Token: abc
@@ -378,4 +448,35 @@ func deleteLogshuttleOK(i *fastly.DeleteLogshuttleInput) error {
 
 func deleteLogshuttleError(i *fastly.DeleteLogshuttleInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/logshuttle/logshuttle_test.go
+++ b/pkg/logging/logshuttle/logshuttle_test.go
@@ -25,7 +25,7 @@ func TestCreateLogshuttleInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateLogshuttleInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Token:          "tkn",
 				URL:            "example.com",
@@ -36,7 +36,7 @@ func TestCreateLogshuttleInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateLogshuttleInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Format:            `%h %l %u %t "%r" %>s %b`,
 				FormatVersion:     2,
@@ -73,14 +73,14 @@ func TestUpdateLogshuttleInput(t *testing.T) {
 			name: "no update",
 			cmd:  updateCommandNoUpdate(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetLogshuttleFn: getLogshuttleOK,
 			},
 			want: &fastly.UpdateLogshuttleInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -88,14 +88,14 @@ func TestUpdateLogshuttleInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetLogshuttleFn: getLogshuttleOK,
 			},
 			want: &fastly.UpdateLogshuttleInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Format:            fastly.String("new2"),
@@ -132,9 +132,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -167,9 +167,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/logshuttle/logshuttle_test.go
+++ b/pkg/logging/logshuttle/logshuttle_test.go
@@ -73,8 +73,9 @@ func TestUpdateLogshuttleInput(t *testing.T) {
 			name: "no update",
 			cmd:  updateCommandNoUpdate(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetLogshuttleFn: getLogshuttleOK,
 			},
 			want: &fastly.UpdateLogshuttleInput{
@@ -87,8 +88,9 @@ func TestUpdateLogshuttleInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetLogshuttleFn: getLogshuttleOK,
 			},
 			want: &fastly.UpdateLogshuttleInput{
@@ -130,8 +132,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -147,36 +150,12 @@ func createCommandRequired() *CreateCommand {
 		Token:        "tkn",
 		URL:          "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -188,8 +167,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -205,7 +185,10 @@ func createCommandAll() *CreateCommand {
 		Token:        "tkn",
 		URL:          "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -240,7 +223,10 @@ func updateCommandNoUpdate() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -265,7 +251,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/openstack/delete.go
+++ b/pkg/logging/openstack/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an OpenStack logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteOpenstackInput
+	manifest       manifest.Data
+	Input          fastly.DeleteOpenstackInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an OpenStack logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the OpenStack logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteOpenstack(&c.Input); err != nil {
 		return err

--- a/pkg/logging/openstack/describe.go
+++ b/pkg/logging/openstack/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe an OpenStack logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetOpenstackInput
+	manifest       manifest.Data
+	Input          fastly.GetOpenstackInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an OpenStack logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the OpenStack logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	openstack, err := c.Globals.Client.GetOpenstack(&c.Input)
 	if err != nil {

--- a/pkg/logging/openstack/list.go
+++ b/pkg/logging/openstack/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list OpenStack logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListOpenstackInput
+	manifest       manifest.Data
+	Input          fastly.ListOpenstackInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List OpenStack logging endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	openstacks, err := c.Globals.Client.ListOpenstack(&c.Input)
 	if err != nil {

--- a/pkg/logging/openstack/openstack_integration_test.go
+++ b/pkg/logging/openstack/openstack_integration_test.go
@@ -28,6 +28,7 @@ func TestOpenstackCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
@@ -36,6 +37,7 @@ func TestOpenstackCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
@@ -44,6 +46,7 @@ func TestOpenstackCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
@@ -52,11 +55,12 @@ func TestOpenstackCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--autoclone"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,
@@ -80,6 +84,7 @@ func TestOpenstackCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -255,7 +260,7 @@ func TestOpenstackUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,
@@ -306,7 +311,7 @@ func TestOpenstackDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,

--- a/pkg/logging/openstack/openstack_integration_test.go
+++ b/pkg/logging/openstack/openstack_integration_test.go
@@ -24,33 +24,63 @@ func TestOpenstackCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "user", "--url", "https://example.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args:      []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--url", "https://example.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:       []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
-			api:        mock.API{CreateOpenstackFn: createOpenstackOK},
-			wantOutput: "Created OpenStack logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				CreateOpenstackFn: createOpenstackOK,
+			},
+			wantOutput: "Created OpenStack logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
-			api:       mock.API{CreateOpenstackFn: createOpenstackError},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				CreateOpenstackFn: createOpenstackError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -81,33 +111,57 @@ func TestOpenstackList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListOpenstacksFn: listOpenstacksOK},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListOpenstacksFn: listOpenstacksOK,
+			},
 			wantOutput: listOpenstacksShortOutput,
 		},
 		{
-			args:       []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListOpenstacksFn: listOpenstacksOK},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListOpenstacksFn: listOpenstacksOK,
+			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListOpenstacksFn: listOpenstacksOK},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListOpenstacksFn: listOpenstacksOK,
+			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "openstack", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListOpenstacksFn: listOpenstacksOK},
+			args: []string{"logging", "openstack", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListOpenstacksFn: listOpenstacksOK,
+			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "openstack", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListOpenstacksFn: listOpenstacksOK},
+			args: []string{"logging", "-v", "openstack", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListOpenstacksFn: listOpenstacksOK,
+			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListOpenstacksFn: listOpenstacksError},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListOpenstacksFn: listOpenstacksError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -138,17 +192,25 @@ func TestOpenstackDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetOpenstackFn: getOpenstackError},
+			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetOpenstackFn: getOpenstackError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetOpenstackFn: getOpenstackOK},
+			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetOpenstackFn: getOpenstackOK,
+			},
 			wantOutput: describeOpenstackOutput,
 		},
 	} {
@@ -179,18 +241,28 @@ func TestOpenstackUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "openstack", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateOpenstackFn: updateOpenstackError},
+			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				UpdateOpenstackFn: updateOpenstackError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateOpenstackFn: updateOpenstackOK},
-			wantOutput: "Updated OpenStack logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				UpdateOpenstackFn: updateOpenstackOK,
+			},
+			wantOutput: "Updated OpenStack logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -220,18 +292,28 @@ func TestOpenstackDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteOpenstackFn: deleteOpenstackError},
+			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				DeleteOpenstackFn: deleteOpenstackError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteOpenstackFn: deleteOpenstackOK},
-			wantOutput: "Deleted OpenStack logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				DeleteOpenstackFn: deleteOpenstackOK,
+			},
+			wantOutput: "Deleted OpenStack logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -323,18 +405,18 @@ func listOpenstacksError(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, err
 
 var listOpenstacksShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listOpenstacksVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Openstack 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Bucket: my-logs
 		Access key: 1234
@@ -353,7 +435,7 @@ Version: 1
 		Compression codec: zstd
 	Openstack 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Bucket: analytics
 		Access key: 1234
@@ -401,7 +483,7 @@ func getOpenstackError(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 
 var describeOpenstackOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Bucket: my-logs
 Access key: 1234
@@ -486,4 +568,35 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/openstack/openstack_integration_test.go
+++ b/pkg/logging/openstack/openstack_integration_test.go
@@ -24,67 +24,67 @@ func TestOpenstackCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "user", "--url", "https://example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--url", "https://example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateOpenstackFn: createOpenstackOK,
 			},
-			wantOutput: "Created OpenStack logging endpoint log (service 123 version 2)",
+			wantOutput: "Created OpenStack logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateOpenstackFn: createOpenstackError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -118,8 +118,8 @@ func TestOpenstackList(t *testing.T) {
 		{
 			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksShortOutput,
@@ -127,8 +127,8 @@ func TestOpenstackList(t *testing.T) {
 		{
 			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
@@ -136,8 +136,8 @@ func TestOpenstackList(t *testing.T) {
 		{
 			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
@@ -145,8 +145,8 @@ func TestOpenstackList(t *testing.T) {
 		{
 			args: []string{"logging", "openstack", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
@@ -154,8 +154,8 @@ func TestOpenstackList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "openstack", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
@@ -163,8 +163,8 @@ func TestOpenstackList(t *testing.T) {
 		{
 			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListOpenstacksFn: listOpenstacksError,
 			},
 			wantError: errTest.Error(),
@@ -203,8 +203,8 @@ func TestOpenstackDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetOpenstackFn: getOpenstackError,
 			},
 			wantError: errTest.Error(),
@@ -212,8 +212,8 @@ func TestOpenstackDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetOpenstackFn: getOpenstackOK,
 			},
 			wantOutput: describeOpenstackOutput,
@@ -250,24 +250,24 @@ func TestOpenstackUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateOpenstackFn: updateOpenstackError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateOpenstackFn: updateOpenstackOK,
 			},
-			wantOutput: "Updated OpenStack logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated OpenStack logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -301,24 +301,24 @@ func TestOpenstackDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteOpenstackFn: deleteOpenstackError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteOpenstackFn: deleteOpenstackOK,
 			},
-			wantOutput: "Deleted OpenStack logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted OpenStack logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/openstack/openstack_integration_test.go
+++ b/pkg/logging/openstack/openstack_integration_test.go
@@ -24,62 +24,62 @@ func TestOpenstackCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--user", "user", "--url", "https://example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--url", "https://example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--autoclone"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				CreateOpenstackFn: createOpenstackOK,
 			},
-			wantOutput: "Created OpenStack logging endpoint log (service 123 version 3)",
+			wantOutput: "Created OpenStack logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				CreateOpenstackFn: createOpenstackError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "openstack", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--user", "user", "--url", "https://example.com", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -111,55 +111,55 @@ func TestOpenstackList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksShortOutput,
 		},
 		{
-			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "openstack", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "openstack", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "openstack", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "openstack", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "openstack", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListOpenstacksFn: listOpenstacksError,
 			},
 			wantError: errTest.Error(),
@@ -192,23 +192,23 @@ func TestOpenstackDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetOpenstackFn: getOpenstackError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "openstack", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetOpenstackFn: getOpenstackOK,
 			},
 			wantOutput: describeOpenstackOutput,
@@ -241,28 +241,28 @@ func TestOpenstackUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "openstack", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				UpdateOpenstackFn: updateOpenstackError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "openstack", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				UpdateOpenstackFn: updateOpenstackOK,
 			},
-			wantOutput: "Updated OpenStack logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated OpenStack logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -292,28 +292,28 @@ func TestOpenstackDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				DeleteOpenstackFn: deleteOpenstackError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "openstack", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				DeleteOpenstackFn: deleteOpenstackOK,
 			},
-			wantOutput: "Deleted OpenStack logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted OpenStack logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -405,18 +405,18 @@ func listOpenstacksError(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, err
 
 var listOpenstacksShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listOpenstacksVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Openstack 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Bucket: my-logs
 		Access key: 1234
@@ -435,7 +435,7 @@ Version: 2
 		Compression codec: zstd
 	Openstack 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Bucket: analytics
 		Access key: 1234
@@ -483,7 +483,7 @@ func getOpenstackError(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 
 var describeOpenstackOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Bucket: my-logs
 Access key: 1234
@@ -568,35 +568,4 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/openstack/openstack_test.go
+++ b/pkg/logging/openstack/openstack_test.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -82,7 +83,11 @@ func TestUpdateOpenstackInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetOpenstackFn: getOpenstackOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetOpenstackFn: getOpenstackOK,
+			},
 			want: &fastly.UpdateOpenstackInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -108,7 +113,11 @@ func TestUpdateOpenstackInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetOpenstackFn: getOpenstackOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetOpenstackFn: getOpenstackOK,
+			},
 			want: &fastly.UpdateOpenstackInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -133,22 +142,91 @@ func TestUpdateOpenstackInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		BucketName:   "bucket",
-		AccessKey:    "access",
-		User:         "user",
-		URL:          "https://example.com",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		BucketName: "bucket",
+		AccessKey:  "access",
+		User:       "user",
+		URL:        "https://example.com",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		BucketName:        "bucket",
 		AccessKey:         "access",
 		User:              "user",
@@ -173,20 +251,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		BucketName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/openstack/openstack_test.go
+++ b/pkg/logging/openstack/openstack_test.go
@@ -84,8 +84,9 @@ func TestUpdateOpenstackInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetOpenstackFn: getOpenstackOK,
 			},
 			want: &fastly.UpdateOpenstackInput{
@@ -114,8 +115,9 @@ func TestUpdateOpenstackInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetOpenstackFn: getOpenstackOK,
 			},
 			want: &fastly.UpdateOpenstackInput{
@@ -150,8 +152,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -165,40 +168,16 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		BucketName: "bucket",
 		AccessKey:  "access",
 		User:       "user",
 		URL:        "https://example.com",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -210,8 +189,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -225,7 +205,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		BucketName:        "bucket",
 		AccessKey:         "access",
@@ -270,7 +253,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -295,7 +281,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		BucketName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/openstack/openstack_test.go
+++ b/pkg/logging/openstack/openstack_test.go
@@ -26,7 +26,7 @@ func TestCreateOpenstackInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateOpenstackInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				BucketName:     "bucket",
 				AccessKey:      "access",
@@ -39,7 +39,7 @@ func TestCreateOpenstackInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateOpenstackInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				BucketName:        "bucket",
 				AccessKey:         "access",
@@ -84,14 +84,14 @@ func TestUpdateOpenstackInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetOpenstackFn: getOpenstackOK,
 			},
 			want: &fastly.UpdateOpenstackInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				BucketName:        fastly.String("new2"),
@@ -115,14 +115,14 @@ func TestUpdateOpenstackInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetOpenstackFn: getOpenstackOK,
 			},
 			want: &fastly.UpdateOpenstackInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -152,9 +152,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -189,9 +189,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/openstack/update.go
+++ b/pkg/logging/openstack/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	//required
-	EndpointName string
-	Version      int
+	EndpointName   string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	BucketName        common.OptionalString
 	AccessKey         common.OptionalString
@@ -48,7 +49,8 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 
 	c.CmdClause = parent.Command("update", "Update an OpenStack logging endpoint on a Fastly service version")
 
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the OpenStack logging object").Short('n').Required().StringVar(&c.EndpointName)
 
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
@@ -79,9 +81,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateOpenstackInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateOpenstackInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/papertrail/create.go
+++ b/pkg/logging/papertrail/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Address      string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Address        string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Port              common.OptionalUint
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
@@ -36,18 +37,16 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Papertrail logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Papertrail logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Required().StringVar(&c.Address)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -60,9 +59,18 @@ func (c *CreateCommand) createInput() (*fastly.CreatePapertrailInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
 	input.Name = c.EndpointName
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Address = c.Address
 
 	if c.Port.WasSet {

--- a/pkg/logging/papertrail/delete.go
+++ b/pkg/logging/papertrail/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Papertrail logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeletePapertrailInput
+	manifest       manifest.Data
+	Input          fastly.DeletePapertrailInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Papertrail logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeletePapertrail(&c.Input); err != nil {
 		return err

--- a/pkg/logging/papertrail/describe.go
+++ b/pkg/logging/papertrail/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Papertrail logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetPapertrailInput
+	manifest       manifest.Data
+	Input          fastly.GetPapertrailInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Papertrail logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	papertrail, err := c.Globals.Client.GetPapertrail(&c.Input)
 	if err != nil {

--- a/pkg/logging/papertrail/list.go
+++ b/pkg/logging/papertrail/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Papertrail logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListPapertrailsInput
+	manifest       manifest.Data
+	Input          fastly.ListPapertrailsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Papertrail endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	papertrails, err := c.Globals.Client.ListPapertrails(&c.Input)
 	if err != nil {

--- a/pkg/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/logging/papertrail/papertrail_integration_test.go
@@ -24,17 +24,27 @@ func TestPapertrailCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args:       []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
-			api:        mock.API{CreatePapertrailFn: createPapertrailOK},
-			wantOutput: "Created Papertrail logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com:123", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreatePapertrailFn: createPapertrailOK,
+			},
+			wantOutput: "Created Papertrail logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
-			api:       mock.API{CreatePapertrailFn: createPapertrailError},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com:123"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				CreatePapertrailFn: createPapertrailError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -65,33 +75,57 @@ func TestPapertrailList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListPapertrailsFn: listPapertrailsOK,
+			},
 			wantOutput: listPapertrailsShortOutput,
 		},
 		{
-			args:       []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListPapertrailsFn: listPapertrailsOK,
+			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListPapertrailsFn: listPapertrailsOK,
+			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "papertrail", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			args: []string{"logging", "papertrail", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListPapertrailsFn: listPapertrailsOK,
+			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "papertrail", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListPapertrailsFn: listPapertrailsOK},
+			args: []string{"logging", "-v", "papertrail", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListPapertrailsFn: listPapertrailsOK,
+			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListPapertrailsFn: listPapertrailsError},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				ListPapertrailsFn: listPapertrailsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -122,17 +156,25 @@ func TestPapertrailDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetPapertrailFn: getPapertrailError},
+			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetPapertrailFn: getPapertrailError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetPapertrailFn: getPapertrailOK},
+			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetPapertrailFn: getPapertrailOK,
+			},
 			wantOutput: describePapertrailOutput,
 		},
 	} {
@@ -163,18 +205,28 @@ func TestPapertrailUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdatePapertrailFn: updatePapertrailError},
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdatePapertrailFn: updatePapertrailError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdatePapertrailFn: updatePapertrailOK},
-			wantOutput: "Updated Papertrail logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				UpdatePapertrailFn: updatePapertrailOK,
+			},
+			wantOutput: "Updated Papertrail logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -204,18 +256,28 @@ func TestPapertrailDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeletePapertrailFn: deletePapertrailError},
+			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeletePapertrailFn: deletePapertrailError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeletePapertrailFn: deletePapertrailOK},
-			wantOutput: "Deleted Papertrail logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:     listVersionsOK,
+				GetVersionFn:       getVersionOK,
+				CloneVersionFn:     cloneVersionOK,
+				DeletePapertrailFn: deletePapertrailOK,
+			},
+			wantOutput: "Deleted Papertrail logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -284,18 +346,18 @@ func listPapertrailsError(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail,
 
 var listPapertrailsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listPapertrailsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Papertrail 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Address: example.com:123
 		Port: 123
@@ -305,7 +367,7 @@ Version: 1
 		Placement: none
 	Papertrail 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Address: 127.0.0.1:456
 		Port: 456
@@ -335,7 +397,7 @@ func getPapertrailError(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error
 
 var describePapertrailOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Address: example.com:123
 Port: 123
@@ -369,4 +431,35 @@ func deletePapertrailOK(i *fastly.DeletePapertrailInput) error {
 
 func deletePapertrailError(i *fastly.DeletePapertrailInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/logging/papertrail/papertrail_integration_test.go
@@ -24,25 +24,25 @@ func TestPapertrailCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com:123", "--autoclone"},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreatePapertrailFn: createPapertrailOK,
 			},
-			wantOutput: "Created Papertrail logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Papertrail logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com:123"},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				CreatePapertrailFn: createPapertrailError,
 			},
 			wantError: errTest.Error(),
@@ -75,55 +75,55 @@ func TestPapertrailList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsShortOutput,
 		},
 		{
-			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "papertrail", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "papertrail", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "papertrail", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "papertrail", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
 				ListPapertrailsFn: listPapertrailsError,
 			},
 			wantError: errTest.Error(),
@@ -156,23 +156,23 @@ func TestPapertrailDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetPapertrailFn: getPapertrailError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
 				GetPapertrailFn: getPapertrailOK,
 			},
 			wantOutput: describePapertrailOutput,
@@ -205,28 +205,28 @@ func TestPapertrailUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdatePapertrailFn: updatePapertrailError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				UpdatePapertrailFn: updatePapertrailOK,
 			},
-			wantOutput: "Updated Papertrail logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Papertrail logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,28 +256,28 @@ func TestPapertrailDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeletePapertrailFn: deletePapertrailError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     listVersionsOK,
-				GetVersionFn:       getVersionOK,
-				CloneVersionFn:     cloneVersionOK,
+				ListVersionsFn:     testutil.ListVersionsOk,
+				GetVersionFn:       testutil.GetActiveVersionOK,
+				CloneVersionFn:     testutil.CloneVersionOK,
 				DeletePapertrailFn: deletePapertrailOK,
 			},
-			wantOutput: "Deleted Papertrail logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Papertrail logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -346,18 +346,18 @@ func listPapertrailsError(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail,
 
 var listPapertrailsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listPapertrailsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Papertrail 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Address: example.com:123
 		Port: 123
@@ -367,7 +367,7 @@ Version: 2
 		Placement: none
 	Papertrail 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Address: 127.0.0.1:456
 		Port: 456
@@ -397,7 +397,7 @@ func getPapertrailError(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error
 
 var describePapertrailOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Address: example.com:123
 Port: 123
@@ -431,35 +431,4 @@ func deletePapertrailOK(i *fastly.DeletePapertrailInput) error {
 
 func deletePapertrailError(i *fastly.DeletePapertrailInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/logging/papertrail/papertrail_integration_test.go
@@ -24,11 +24,16 @@ func TestPapertrailCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123", "--autoclone"},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -219,7 +224,7 @@ func TestPapertrailUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,
@@ -270,7 +275,7 @@ func TestPapertrailDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersionsOk,
 				GetVersionFn:       testutil.GetActiveVersionOK,

--- a/pkg/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/logging/papertrail/papertrail_integration_test.go
@@ -24,30 +24,30 @@ func TestPapertrailCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreatePapertrailFn: createPapertrailOK,
 			},
-			wantOutput: "Created Papertrail logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Papertrail logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123"},
+			args: []string{"logging", "papertrail", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com:123", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreatePapertrailFn: createPapertrailError,
 			},
 			wantError: errTest.Error(),
@@ -82,8 +82,8 @@ func TestPapertrailList(t *testing.T) {
 		{
 			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsShortOutput,
@@ -91,8 +91,8 @@ func TestPapertrailList(t *testing.T) {
 		{
 			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
@@ -100,8 +100,8 @@ func TestPapertrailList(t *testing.T) {
 		{
 			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
@@ -109,8 +109,8 @@ func TestPapertrailList(t *testing.T) {
 		{
 			args: []string{"logging", "papertrail", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
@@ -118,8 +118,8 @@ func TestPapertrailList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "papertrail", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			wantOutput: listPapertrailsVerboseOutput,
@@ -127,8 +127,8 @@ func TestPapertrailList(t *testing.T) {
 		{
 			args: []string{"logging", "papertrail", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
 				ListPapertrailsFn: listPapertrailsError,
 			},
 			wantError: errTest.Error(),
@@ -167,8 +167,8 @@ func TestPapertrailDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetPapertrailFn: getPapertrailError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestPapertrailDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "papertrail", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
 				GetPapertrailFn: getPapertrailOK,
 			},
 			wantOutput: describePapertrailOutput,
@@ -214,24 +214,24 @@ func TestPapertrailUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdatePapertrailFn: updatePapertrailError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "papertrail", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdatePapertrailFn: updatePapertrailOK,
 			},
-			wantOutput: "Updated Papertrail logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Papertrail logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -265,24 +265,24 @@ func TestPapertrailDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeletePapertrailFn: deletePapertrailError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "papertrail", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersionsOk,
-				GetVersionFn:       testutil.GetActiveVersionOK,
-				CloneVersionFn:     testutil.CloneVersionOK,
+				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetActiveVersion(1),
+				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeletePapertrailFn: deletePapertrailOK,
 			},
-			wantOutput: "Deleted Papertrail logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Papertrail logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/papertrail/papertrail_test.go
+++ b/pkg/logging/papertrail/papertrail_test.go
@@ -1,6 +1,7 @@
 package papertrail
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -70,7 +71,11 @@ func TestUpdatePapertrailInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetPapertrailFn: getPapertrailOK},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetPapertrailFn: getPapertrailOK,
+			},
 			want: &fastly.UpdatePapertrailInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -80,7 +85,11 @@ func TestUpdatePapertrailInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetPapertrailFn: getPapertrailOK},
+			api: mock.API{
+				ListVersionsFn:  listVersionsOK,
+				GetVersionFn:    getVersionOK,
+				GetPapertrailFn: getPapertrailOK,
+			},
 			want: &fastly.UpdatePapertrailInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -112,19 +121,88 @@ func TestUpdatePapertrailInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		Address:      "example.com",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Address:           "example.com",
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -141,20 +219,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},

--- a/pkg/logging/papertrail/papertrail_test.go
+++ b/pkg/logging/papertrail/papertrail_test.go
@@ -25,7 +25,7 @@ func TestCreatePapertrailInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreatePapertrailInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Address:        "example.com",
 			},
@@ -35,7 +35,7 @@ func TestCreatePapertrailInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreatePapertrailInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Address:           "example.com",
 				Port:              22,
@@ -72,14 +72,14 @@ func TestUpdatePapertrailInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetPapertrailFn: getPapertrailOK,
 			},
 			want: &fastly.UpdatePapertrailInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -87,14 +87,14 @@ func TestUpdatePapertrailInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersionsOk,
-				GetVersionFn:    testutil.GetActiveVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetPapertrailFn: getPapertrailOK,
 			},
 			want: &fastly.UpdatePapertrailInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Address:           fastly.String("new2"),
@@ -131,9 +131,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -165,9 +165,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/papertrail/papertrail_test.go
+++ b/pkg/logging/papertrail/papertrail_test.go
@@ -72,8 +72,9 @@ func TestUpdatePapertrailInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetPapertrailFn: getPapertrailOK,
 			},
 			want: &fastly.UpdatePapertrailInput{
@@ -86,8 +87,9 @@ func TestUpdatePapertrailInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
+				ListVersionsFn:  testutil.ListVersionsOk,
+				GetVersionFn:    testutil.GetActiveVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				GetPapertrailFn: getPapertrailOK,
 			},
 			want: &fastly.UpdatePapertrailInput{
@@ -129,8 +131,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -145,36 +148,12 @@ func createCommandRequired() *CreateCommand {
 		EndpointName: "log",
 		Address:      "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -186,8 +165,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -201,7 +181,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Address:           "example.com",
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
@@ -238,7 +221,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -263,7 +249,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/papertrail/update.go
+++ b/pkg/logging/papertrail/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string
-	Version      int
+	EndpointName   string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Address           common.OptionalString
 	Port              common.OptionalUint
@@ -36,12 +37,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Papertrail logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Papertrail logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
@@ -50,7 +49,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,9 +59,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdatePapertrailInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdatePapertrailInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/s3/delete.go
+++ b/pkg/logging/s3/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an Amazon S3 logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteS3Input
+	manifest       manifest.Data
+	Input          fastly.DeleteS3Input
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,11 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a S3 logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the S3 logging object").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -40,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteS3(&c.Input); err != nil {
 		return err

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe an Amazon S3 logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetS3Input
+	manifest       manifest.Data
+	Input          fastly.GetS3Input
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a S3 logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the S3 logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	s3, err := c.Globals.Client.GetS3(&c.Input)
 	if err != nil {

--- a/pkg/logging/s3/list.go
+++ b/pkg/logging/s3/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Amazon S3 logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListS3sInput
+	manifest       manifest.Data
+	Input          fastly.ListS3sInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List S3 endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	s3s, err := c.Globals.Client.ListS3s(&c.Input)
 	if err != nil {

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -24,51 +24,99 @@ func TestS3Create(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags or the --iam-role flag must be provided",
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "bar"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args:       []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
-			api:        mock.API{CreateS3Fn: createS3OK},
-			wantOutput: "Created S3 logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateS3Fn:     createS3OK,
+			},
+			wantOutput: "Created S3 logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
-			api:       mock.API{CreateS3Fn: createS3Error},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateS3Fn:     createS3Error,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
-			api:        mock.API{CreateS3Fn: createS3OK},
-			wantOutput: "Created S3 logging endpoint log2 (service 123 version 1)",
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateS3Fn:     createS3OK,
+			},
+			wantOutput: "Created S3 logging endpoint log2 (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
-			api:       mock.API{CreateS3Fn: createS3Error},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateS3Fn:     createS3Error,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--compression-codec", "zstd", "--gzip-level", "9"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -99,33 +147,57 @@ func TestS3List(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListS3sFn: listS3sOK},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListS3sFn:      listS3sOK,
+			},
 			wantOutput: listS3sShortOutput,
 		},
 		{
-			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListS3sFn: listS3sOK},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListS3sFn:      listS3sOK,
+			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListS3sFn: listS3sOK},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListS3sFn:      listS3sOK,
+			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "s3", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListS3sFn: listS3sOK},
+			args: []string{"logging", "s3", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListS3sFn:      listS3sOK,
+			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "s3", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListS3sFn: listS3sOK},
+			args: []string{"logging", "-v", "s3", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListS3sFn:      listS3sOK,
+			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListS3sFn: listS3sError},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListS3sFn:      listS3sError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -156,17 +228,25 @@ func TestS3Describe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetS3Fn: getS3Error},
+			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetS3Fn:        getS3Error,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetS3Fn: getS3OK},
+			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetS3Fn:        getS3OK,
+			},
 			wantOutput: describeS3Output,
 		},
 	} {
@@ -197,23 +277,38 @@ func TestS3Update(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateS3Fn: updateS3Error},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateS3Fn:     updateS3Error,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateS3Fn: updateS3OK},
-			wantOutput: "Updated S3 logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateS3Fn:     updateS3OK,
+			},
+			wantOutput: "Updated S3 logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:       []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", ""},
-			api:        mock.API{UpdateS3Fn: updateS3OK},
-			wantOutput: "Updated S3 logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateS3Fn:     updateS3OK,
+			},
+			wantOutput: "Updated S3 logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -243,18 +338,28 @@ func TestS3Delete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteS3Fn: deleteS3Error},
+			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteS3Fn:     deleteS3Error,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteS3Fn: deleteS3OK},
-			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteS3Fn:     deleteS3OK,
+			},
+			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -347,18 +452,18 @@ func listS3sError(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 
 var listS3sShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listS3sVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	S3 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Bucket: my-logs
 		Access key: 1234
@@ -379,7 +484,7 @@ Version: 1
 		Compression codec: zstd
 	S3 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Bucket: analytics
 		Access key: 1234
@@ -431,7 +536,7 @@ func getS3Error(i *fastly.GetS3Input) (*fastly.S3, error) {
 
 var describeS3Output = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Bucket: my-logs
 Access key: 1234
@@ -521,4 +626,35 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -24,98 +24,98 @@ func TestS3Create(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags or the --iam-role flag must be provided",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "bar"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--autoclone"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateS3Fn:     createS3OK,
 			},
-			wantOutput: "Created S3 logging endpoint log (service 123 version 3)",
+			wantOutput: "Created S3 logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateS3Fn:     createS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateS3Fn:     createS3OK,
 			},
-			wantOutput: "Created S3 logging endpoint log2 (service 123 version 3)",
+			wantOutput: "Created S3 logging endpoint log2 (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateS3Fn:     createS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "2", "--name", "log", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -147,55 +147,55 @@ func TestS3List(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sShortOutput,
 		},
 		{
-			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: []string{"logging", "s3", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "s3", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "s3", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "s3", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListS3sFn:      listS3sError,
 			},
 			wantError: errTest.Error(),
@@ -228,23 +228,23 @@ func TestS3Describe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetS3Fn:        getS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetS3Fn:        getS3OK,
 			},
 			wantOutput: describeS3Output,
@@ -277,38 +277,38 @@ func TestS3Update(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateS3Fn:     updateS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateS3Fn:     updateS3OK,
 			},
-			wantOutput: "Updated S3 logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated S3 logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "", "--autoclone"},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateS3Fn:     updateS3OK,
 			},
-			wantOutput: "Updated S3 logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated S3 logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -338,28 +338,28 @@ func TestS3Delete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteS3Fn:     deleteS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteS3Fn:     deleteS3OK,
 			},
-			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -452,18 +452,18 @@ func listS3sError(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 
 var listS3sShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listS3sVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	S3 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Bucket: my-logs
 		Access key: 1234
@@ -484,7 +484,7 @@ Version: 2
 		Compression codec: zstd
 	S3 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Bucket: analytics
 		Access key: 1234
@@ -536,7 +536,7 @@ func getS3Error(i *fastly.GetS3Input) (*fastly.S3, error) {
 
 var describeS3Output = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Bucket: my-logs
 Access key: 1234
@@ -626,35 +626,4 @@ wMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N
 =28dr
 -----END PGP PUBLIC KEY BLOCK-----
 `)
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -24,105 +24,105 @@ func TestS3Create(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags or the --iam-role flag must be provided",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3OK,
 			},
-			wantOutput: "Created S3 logging endpoint log (service 123 version 2)",
+			wantOutput: "Created S3 logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3OK,
 			},
-			wantOutput: "Created S3 logging endpoint log2 (service 123 version 2)",
+			wantOutput: "Created S3 logging endpoint log2 (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -156,8 +156,8 @@ func TestS3List(t *testing.T) {
 		{
 			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sShortOutput,
@@ -165,8 +165,8 @@ func TestS3List(t *testing.T) {
 		{
 			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
@@ -174,8 +174,8 @@ func TestS3List(t *testing.T) {
 		{
 			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
@@ -183,8 +183,8 @@ func TestS3List(t *testing.T) {
 		{
 			args: []string{"logging", "s3", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
@@ -192,8 +192,8 @@ func TestS3List(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "s3", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListS3sFn:      listS3sOK,
 			},
 			wantOutput: listS3sVerboseOutput,
@@ -201,8 +201,8 @@ func TestS3List(t *testing.T) {
 		{
 			args: []string{"logging", "s3", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListS3sFn:      listS3sError,
 			},
 			wantError: errTest.Error(),
@@ -241,8 +241,8 @@ func TestS3Describe(t *testing.T) {
 		{
 			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetS3Fn:        getS3Error,
 			},
 			wantError: errTest.Error(),
@@ -250,8 +250,8 @@ func TestS3Describe(t *testing.T) {
 		{
 			args: []string{"logging", "s3", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetS3Fn:        getS3OK,
 			},
 			wantOutput: describeS3Output,
@@ -288,34 +288,34 @@ func TestS3Update(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateS3Fn:     updateS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateS3Fn:     updateS3OK,
 			},
-			wantOutput: "Updated S3 logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated S3 logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", ""},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateS3Fn:     updateS3OK,
 			},
-			wantOutput: "Updated S3 logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated S3 logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -349,24 +349,24 @@ func TestS3Delete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteS3Fn:     deleteS3Error,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteS3Fn:     deleteS3OK,
 			},
-			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted S3 logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/s3/s3_integration_test.go
+++ b/pkg/logging/s3/s3_integration_test.go
@@ -28,6 +28,7 @@ func TestS3Create(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags or the --iam-role flag must be provided",
 		},
@@ -36,6 +37,7 @@ func TestS3Create(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
@@ -44,6 +46,7 @@ func TestS3Create(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
@@ -52,6 +55,7 @@ func TestS3Create(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
@@ -60,6 +64,7 @@ func TestS3Create(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
@@ -68,11 +73,12 @@ func TestS3Create(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar", "--autoclone"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log", "--bucket", "log", "--access-key", "foo", "--secret-key", "bar"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -92,7 +98,7 @@ func TestS3Create(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access", "--autoclone"},
+			args: []string{"logging", "s3", "create", "--service-id", "123", "--version", "1", "--name", "log2", "--bucket", "log", "--iam-role", "arn:aws:iam::123456789012:role/S3Access"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -116,6 +122,7 @@ func TestS3Create(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -291,7 +298,7 @@ func TestS3Update(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -301,7 +308,7 @@ func TestS3Update(t *testing.T) {
 			wantOutput: "Updated S3 logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", "", "--autoclone"},
+			args: []string{"logging", "s3", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--access-key", "foo", "--secret-key", "bar", "--iam-role", ""},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -352,7 +359,7 @@ func TestS3Delete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "s3", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -26,7 +26,7 @@ func TestCreateS3Input(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateS3Input{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				BucketName:     "bucket",
 				AccessKey:      "access",
@@ -38,7 +38,7 @@ func TestCreateS3Input(t *testing.T) {
 			cmd:  createCommandRequiredIAMRole(),
 			want: &fastly.CreateS3Input{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				BucketName:     "bucket",
 				IAMRole:        "arn:aws:iam::123456789012:role/S3Access",
@@ -49,7 +49,7 @@ func TestCreateS3Input(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateS3Input{
 				ServiceID:                    "123",
-				ServiceVersion:               2,
+				ServiceVersion:               4,
 				Name:                         "logs",
 				BucketName:                   "bucket",
 				Domain:                       "domain",
@@ -97,14 +97,14 @@ func TestUpdateS3Input(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetS3Fn:        getS3OK,
 			},
 			want: &fastly.UpdateS3Input{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -112,14 +112,14 @@ func TestUpdateS3Input(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetS3Fn:        getS3OK,
 			},
 			want: &fastly.UpdateS3Input{
 				ServiceID:                    "123",
-				ServiceVersion:               2,
+				ServiceVersion:               4,
 				Name:                         "log",
 				NewName:                      fastly.String("new1"),
 				BucketName:                   fastly.String("new2"),
@@ -169,9 +169,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -205,9 +205,9 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -240,9 +240,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -97,8 +97,9 @@ func TestUpdateS3Input(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetS3Fn:        getS3OK,
 			},
 			want: &fastly.UpdateS3Input{
@@ -111,8 +112,9 @@ func TestUpdateS3Input(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetS3Fn:        getS3OK,
 			},
 			want: &fastly.UpdateS3Input{
@@ -167,8 +169,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -182,39 +185,15 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		BucketName: "bucket",
 		AccessKey:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
 		SecretKey:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandRequiredIAMRole() *CreateCommand {
@@ -226,8 +205,9 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -241,7 +221,10 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		BucketName: "bucket",
 		IAMRole:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/S3Access"},
@@ -257,8 +240,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -272,7 +256,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "logs",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		BucketName:                   "bucket",
 		AccessKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
@@ -320,7 +307,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -345,7 +335,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:                      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		BucketName:                   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -95,7 +96,11 @@ func TestUpdateS3Input(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetS3Fn: getS3OK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetS3Fn:        getS3OK,
+			},
 			want: &fastly.UpdateS3Input{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -105,7 +110,11 @@ func TestUpdateS3Input(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetS3Fn: getS3OK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetS3Fn:        getS3OK,
+			},
 			want: &fastly.UpdateS3Input{
 				ServiceID:                    "123",
 				ServiceVersion:               2,
@@ -150,31 +159,121 @@ func TestUpdateS3Input(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		BucketName:   "bucket",
-		AccessKey:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
-		SecretKey:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		BucketName: "bucket",
+		AccessKey:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
+		SecretKey:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandRequiredIAMRole() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		BucketName:   "bucket",
-		IAMRole:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/S3Access"},
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		BucketName: "bucket",
+		IAMRole:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/S3Access"},
 	}
 }
 
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:                     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:                 "logs",
-		Version:                      2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "logs",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		BucketName:                   "bucket",
 		AccessKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
 		SecretKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
@@ -202,20 +301,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:                         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:                     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:                 "log",
-		Version:                      2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:                      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		BucketName:                   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		AccessKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone                    common.OptionalAutoClone
 	NewName                      common.OptionalString
 	Address                      common.OptionalString
 	BucketName                   common.OptionalString
@@ -50,12 +51,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a S3 logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the S3 logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the S3 logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("bucket", "Your S3 bucket name").Action(c.BucketName.Set).StringVar(&c.BucketName.Value)
@@ -77,7 +76,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("server-side-encryption", "Set to enable S3 Server Side Encryption. Can be either AES256 or aws:kms").Action(c.ServerSideEncryption.Set).EnumVar(&c.ServerSideEncryption.Value, string(fastly.S3ServerSideEncryptionAES), string(fastly.S3ServerSideEncryptionKMS))
 	c.CmdClause.Flag("server-side-encryption-kms-key-id", "Server-side KMS Key ID. Must be set if server-side-encryption is set to aws:kms").Action(c.ServerSideEncryptionKMSKeyID.Set).StringVar(&c.ServerSideEncryptionKMSKeyID.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -88,9 +86,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateS3Input, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateS3Input{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/scalyr/create.go
+++ b/pkg/logging/scalyr/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Token        string
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	Token          string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Region            common.OptionalString
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
@@ -32,23 +33,20 @@ type CreateCommand struct {
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
-
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Scalyr logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Scalyr logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.scalyr.com/keys)").Required().StringVar(&c.Token)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,8 +59,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateScalyrInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Token = c.Token
 

--- a/pkg/logging/scalyr/delete.go
+++ b/pkg/logging/scalyr/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Scalyr logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteScalyrInput
+	manifest       manifest.Data
+	Input          fastly.DeleteScalyrInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Scalyr logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteScalyr(&c.Input); err != nil {
 		return err

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Scalyr logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetScalyrInput
+	manifest       manifest.Data
+	Input          fastly.GetScalyrInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Scalyr logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	scalyr, err := c.Globals.Client.GetScalyr(&c.Input)
 	if err != nil {

--- a/pkg/logging/scalyr/list.go
+++ b/pkg/logging/scalyr/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Scalyr logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListScalyrsInput
+	manifest       manifest.Data
+	Input          fastly.ListScalyrsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Scalyr endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	scalyrs, err := c.Globals.Client.ListScalyrs(&c.Input)
 	if err != nil {

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -25,33 +25,33 @@ func TestScalyrCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--auth-token", "abc"},
+			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--auth-token", "abc"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "2", "--auth-token", "abc"},
+			args:      []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "1", "--auth-token", "abc"},
 			wantError: fsterrs.ErrNoServiceID.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateScalyrFn: createScalyrOK,
 			},
-			wantOutput: "Created Scalyr logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Scalyr logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateScalyrFn: createScalyrError,
 			},
 			wantError: errTest.Error(),
@@ -84,55 +84,55 @@ func TestScalyrList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsShortOutput,
 		},
 		{
-			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "scalyr", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "scalyr", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "scalyr", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "scalyr", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListScalyrsFn:  listScalyrsError,
 			},
 			wantError: errTest.Error(),
@@ -165,23 +165,23 @@ func TestScalyrDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetScalyrFn:    getScalyrError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetScalyrFn:    getScalyrOK,
 			},
 			wantOutput: describeScalyrOutput,
@@ -214,28 +214,28 @@ func TestScalyrUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateScalyrFn: updateScalyrError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateScalyrFn: updateScalyrOK,
 			},
-			wantOutput: "Updated Scalyr logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Scalyr logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -265,28 +265,28 @@ func TestScalyrDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteScalyrFn: deleteScalyrError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteScalyrFn: deleteScalyrOK,
 			},
-			wantOutput: "Deleted Scalyr logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Scalyr logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -382,18 +382,18 @@ func listScalyrsError(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
 
 var listScalyrsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listScalyrsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Scalyr 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Token: abc
 		Region: US
@@ -403,7 +403,7 @@ Version: 2
 		Placement: none
 	Scalyr 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Token: abc
 		Region: US
@@ -433,7 +433,7 @@ func getScalyrError(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
 
 var describeScalyrOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Token: abc
 Region: US
@@ -467,35 +467,4 @@ func deleteScalyrOK(i *fastly.DeleteScalyrInput) error {
 
 func deleteScalyrError(i *fastly.DeleteScalyrInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -25,19 +25,34 @@ func TestScalyrCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--auth-token", "abc"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "1", "--auth-token", "abc"},
+			args: []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "1", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: fsterrs.ErrNoServiceID.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -228,7 +243,7 @@ func TestScalyrUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -279,7 +294,7 @@ func TestScalyrDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -25,48 +25,48 @@ func TestScalyrCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--auth-token", "abc"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "1", "--auth-token", "abc"},
+			args: []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "1", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: fsterrs.ErrNoServiceID.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateScalyrFn: createScalyrOK,
 			},
-			wantOutput: "Created Scalyr logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Scalyr logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateScalyrFn: createScalyrError,
 			},
 			wantError: errTest.Error(),
@@ -101,8 +101,8 @@ func TestScalyrList(t *testing.T) {
 		{
 			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsShortOutput,
@@ -110,8 +110,8 @@ func TestScalyrList(t *testing.T) {
 		{
 			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
@@ -119,8 +119,8 @@ func TestScalyrList(t *testing.T) {
 		{
 			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
@@ -128,8 +128,8 @@ func TestScalyrList(t *testing.T) {
 		{
 			args: []string{"logging", "scalyr", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
@@ -137,8 +137,8 @@ func TestScalyrList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "scalyr", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListScalyrsFn:  listScalyrsOK,
 			},
 			wantOutput: listScalyrsVerboseOutput,
@@ -146,8 +146,8 @@ func TestScalyrList(t *testing.T) {
 		{
 			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListScalyrsFn:  listScalyrsError,
 			},
 			wantError: errTest.Error(),
@@ -186,8 +186,8 @@ func TestScalyrDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetScalyrFn:    getScalyrError,
 			},
 			wantError: errTest.Error(),
@@ -195,8 +195,8 @@ func TestScalyrDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetScalyrFn:    getScalyrOK,
 			},
 			wantOutput: describeScalyrOutput,
@@ -233,24 +233,24 @@ func TestScalyrUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateScalyrFn: updateScalyrError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateScalyrFn: updateScalyrOK,
 			},
-			wantOutput: "Updated Scalyr logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Scalyr logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -284,24 +284,24 @@ func TestScalyrDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteScalyrFn: deleteScalyrError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteScalyrFn: deleteScalyrOK,
 			},
-			wantOutput: "Deleted Scalyr logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Scalyr logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/logging/scalyr/scalyr_integration_test.go
@@ -25,25 +25,35 @@ func TestScalyrCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--auth-token", "abc"},
+			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--auth-token", "abc"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "1", "--auth-token", "abc"},
+			args:      []string{"logging", "scalyr", "create", "--name", "log", "--service-id", "", "--version", "2", "--auth-token", "abc"},
 			wantError: fsterrs.ErrNoServiceID.Error(),
 		},
 		{
-			args:       []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
-			api:        mock.API{CreateScalyrFn: createScalyrOK},
-			wantOutput: "Created Scalyr logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateScalyrFn: createScalyrOK,
+			},
+			wantOutput: "Created Scalyr logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "1", "--name", "log", "--auth-token", "abc"},
-			api:       mock.API{CreateScalyrFn: createScalyrError},
+			args: []string{"logging", "scalyr", "create", "--service-id", "123", "--version", "2", "--name", "log", "--auth-token", "abc"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateScalyrFn: createScalyrError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -74,33 +84,57 @@ func TestScalyrList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListScalyrsFn:  listScalyrsOK,
+			},
 			wantOutput: listScalyrsShortOutput,
 		},
 		{
-			args:       []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListScalyrsFn:  listScalyrsOK,
+			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListScalyrsFn:  listScalyrsOK,
+			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "scalyr", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			args: []string{"logging", "scalyr", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListScalyrsFn:  listScalyrsOK,
+			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "scalyr", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListScalyrsFn: listScalyrsOK},
+			args: []string{"logging", "-v", "scalyr", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListScalyrsFn:  listScalyrsOK,
+			},
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListScalyrsFn: listScalyrsError},
+			args: []string{"logging", "scalyr", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListScalyrsFn:  listScalyrsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -131,17 +165,25 @@ func TestScalyrDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetScalyrFn: getScalyrError},
+			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetScalyrFn:    getScalyrError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetScalyrFn: getScalyrOK},
+			args: []string{"logging", "scalyr", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetScalyrFn:    getScalyrOK,
+			},
 			wantOutput: describeScalyrOutput,
 		},
 	} {
@@ -172,18 +214,28 @@ func TestScalyrUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateScalyrFn: updateScalyrError},
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateScalyrFn: updateScalyrError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateScalyrFn: updateScalyrOK},
-			wantOutput: "Updated Scalyr logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "scalyr", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateScalyrFn: updateScalyrOK,
+			},
+			wantOutput: "Updated Scalyr logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -213,18 +265,28 @@ func TestScalyrDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteScalyrFn: deleteScalyrError},
+			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteScalyrFn: deleteScalyrError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteScalyrFn: deleteScalyrOK},
-			wantOutput: "Deleted Scalyr logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "scalyr", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteScalyrFn: deleteScalyrOK,
+			},
+			wantOutput: "Deleted Scalyr logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -320,18 +382,18 @@ func listScalyrsError(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
 
 var listScalyrsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listScalyrsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Scalyr 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Token: abc
 		Region: US
@@ -341,7 +403,7 @@ Version: 1
 		Placement: none
 	Scalyr 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Token: abc
 		Region: US
@@ -371,7 +433,7 @@ func getScalyrError(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
 
 var describeScalyrOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Token: abc
 Region: US
@@ -405,4 +467,35 @@ func deleteScalyrOK(i *fastly.DeleteScalyrInput) error {
 
 func deleteScalyrError(i *fastly.DeleteScalyrInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/scalyr/scalyr_test.go
+++ b/pkg/logging/scalyr/scalyr_test.go
@@ -25,7 +25,7 @@ func TestCreateScalyrInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateScalyrInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Token:          "tkn",
 			},
@@ -35,7 +35,7 @@ func TestCreateScalyrInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateScalyrInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Token:             "tkn",
 				Region:            "US",
@@ -72,14 +72,14 @@ func TestUpdateScalyrInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetScalyrFn:    getScalyrOK,
 			},
 			want: &fastly.UpdateScalyrInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -87,14 +87,14 @@ func TestUpdateScalyrInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetScalyrFn:    getScalyrOK,
 			},
 			want: &fastly.UpdateScalyrInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Token:             fastly.String("new2"),
@@ -131,9 +131,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -165,9 +165,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/scalyr/scalyr_test.go
+++ b/pkg/logging/scalyr/scalyr_test.go
@@ -72,8 +72,9 @@ func TestUpdateScalyrInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetScalyrFn:    getScalyrOK,
 			},
 			want: &fastly.UpdateScalyrInput{
@@ -86,8 +87,9 @@ func TestUpdateScalyrInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetScalyrFn:    getScalyrOK,
 			},
 			want: &fastly.UpdateScalyrInput{
@@ -129,8 +131,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -144,37 +147,13 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Token: "tkn",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -186,8 +165,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -201,7 +181,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Token:             "tkn",
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "US"},
@@ -238,7 +221,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -263,7 +249,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/scalyr/scalyr_test.go
+++ b/pkg/logging/scalyr/scalyr_test.go
@@ -1,6 +1,7 @@
 package scalyr
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -70,7 +71,11 @@ func TestUpdateScalyrInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetScalyrFn: getScalyrOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetScalyrFn:    getScalyrOK,
+			},
 			want: &fastly.UpdateScalyrInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -80,7 +85,11 @@ func TestUpdateScalyrInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetScalyrFn: getScalyrOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetScalyrFn:    getScalyrOK,
+			},
 			want: &fastly.UpdateScalyrInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -112,19 +121,88 @@ func TestUpdateScalyrInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		Token:        "tkn",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		Token: "tkn",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Token:             "tkn",
 		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "US"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
@@ -141,20 +219,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/scalyr/update.go
+++ b/pkg/logging/scalyr/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Format            common.OptionalString
 	FormatVersion     common.OptionalUint
@@ -36,12 +37,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Scalyr logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Scalyr logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
@@ -50,7 +49,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,9 +59,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateScalyrInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateScalyrInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/sftp/create.go
+++ b/pkg/logging/sftp/create.go
@@ -18,13 +18,14 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName  string // Can't shadow common.Base method Name().
-	Version       int
-	Address       string
-	User          string
-	SSHKnownHosts string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Address        string
+	User           string
+	SSHKnownHosts  string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Port              common.OptionalUint
 	Password          common.OptionalString
 	PublicKey         common.OptionalString
@@ -44,19 +45,16 @@ type CreateCommand struct {
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
-
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create an SFTP logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the SFTP logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("address", "The hostname or IPv4 addres").Required().StringVar(&c.Address)
 	c.CmdClause.Flag("user", "The username for the server").Required().StringVar(&c.User)
 	c.CmdClause.Flag("ssh-known-hosts", "A list of host keys for all hosts we can connect to over SFTP").Required().StringVar(&c.SSHKnownHosts)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("password", "The password for the server. If both password and secret_key are passed, secret_key will be used in preference").Action(c.Password.Set).StringVar(&c.Password.Value)
@@ -72,7 +70,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -85,8 +82,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateSFTPInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.Address = c.Address
 	input.User = c.User

--- a/pkg/logging/sftp/delete.go
+++ b/pkg/logging/sftp/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete an SFTP logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteSFTPInput
+	manifest       manifest.Data
+	Input          fastly.DeleteSFTPInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an SFTP logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the SFTP logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteSFTP(&c.Input); err != nil {
 		return err

--- a/pkg/logging/sftp/list.go
+++ b/pkg/logging/sftp/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list SFTP logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListSFTPsInput
+	manifest       manifest.Data
+	Input          fastly.ListSFTPsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List SFTP endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	sftps, err := c.Globals.Client.ListSFTPs(&c.Input)
 	if err != nil {

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -24,29 +24,55 @@ func TestSFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args:      []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "user", "--port", "80"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --ssh-known-hosts not provided",
 		},
 		{
-			args:       []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
-			api:        mock.API{CreateSFTPFn: createSFTPOK},
-			wantOutput: "Created SFTP logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateSFTPFn:   createSFTPOK,
+			},
+			wantOutput: "Created SFTP logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
-			api:       mock.API{CreateSFTPFn: createSFTPError},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateSFTPFn:   createSFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:      []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--ssh-known-hosts", knownHosts(), "--port", "80", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--ssh-known-hosts", knownHosts(), "--port", "80", "--compression-codec", "zstd", "--gzip-level", "9"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
 	} {
@@ -77,33 +103,57 @@ func TestSFTPList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSFTPsFn: listSFTPsOK},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSFTPsFn:    listSFTPsOK,
+			},
 			wantOutput: listSFTPsShortOutput,
 		},
 		{
-			args:       []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListSFTPsFn: listSFTPsOK},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSFTPsFn:    listSFTPsOK,
+			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListSFTPsFn: listSFTPsOK},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSFTPsFn:    listSFTPsOK,
+			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "sftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSFTPsFn: listSFTPsOK},
+			args: []string{"logging", "sftp", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSFTPsFn:    listSFTPsOK,
+			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "sftp", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSFTPsFn: listSFTPsOK},
+			args: []string{"logging", "-v", "sftp", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSFTPsFn:    listSFTPsOK,
+			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListSFTPsFn: listSFTPsError},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSFTPsFn:    listSFTPsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -134,17 +184,25 @@ func TestSFTPDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetSFTPFn: getSFTPError},
+			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSFTPFn:      getSFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetSFTPFn: getSFTPOK},
+			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSFTPFn:      getSFTPOK,
+			},
 			wantOutput: describeSFTPOutput,
 		},
 	} {
@@ -175,18 +233,28 @@ func TestSFTPUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "sftp", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateSFTPFn: updateSFTPError},
+			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateSFTPFn:   updateSFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateSFTPFn: updateSFTPOK},
-			wantOutput: "Updated SFTP logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateSFTPFn:   updateSFTPOK,
+			},
+			wantOutput: "Updated SFTP logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -216,18 +284,28 @@ func TestSFTPDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteSFTPFn: deleteSFTPError},
+			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteSFTPFn:   deleteSFTPError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteSFTPFn: deleteSFTPOK},
-			wantOutput: "Deleted SFTP logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteSFTPFn:   deleteSFTPOK,
+			},
+			wantOutput: "Deleted SFTP logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -322,18 +400,18 @@ func listSFTPsError(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 
 var listSFTPsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listSFTPsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	SFTP 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Address: 127.0.0.1
 		Port: 514
@@ -354,7 +432,7 @@ Version: 1
 		Compression codec: zstd
 	SFTP 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Address: example.com
 		Port: 123
@@ -406,7 +484,7 @@ func getSFTPError(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 
 var describeSFTPOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Address: example.com
 Port: 514
@@ -522,4 +600,35 @@ Wzi0vI/Nnxas5YayGJaf3XSFpj70QnsJUWUJagFRXjTmZyYohsELPpYT9eqIvXUm
 o0BQBImvAhu9whtRia0CQCFdDHdNnyyzKH8vC0NsEN65h3Bp2KEPkv8SOV27ZRR2
 xIGqLusk3y+yzbueLZJ117osdB1Owr19fvAHR7vq6Mw=
 -----END RSA PRIVATE KEY-----`)
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -24,54 +24,54 @@ func TestSFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--ssh-known-hosts", knownHosts(), "--port", "80"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "user", "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--port", "80"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --ssh-known-hosts not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateSFTPFn:   createSFTPOK,
 			},
-			wantOutput: "Created SFTP logging endpoint log (service 123 version 3)",
+			wantOutput: "Created SFTP logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateSFTPFn:   createSFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "example.com", "--user", "anonymous", "--ssh-known-hosts", knownHosts(), "--port", "80", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--ssh-known-hosts", knownHosts(), "--port", "80", "--compression-codec", "zstd", "--gzip-level", "9"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -103,55 +103,55 @@ func TestSFTPList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsShortOutput,
 		},
 		{
-			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "sftp", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "sftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "sftp", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "sftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSFTPsFn:    listSFTPsError,
 			},
 			wantError: errTest.Error(),
@@ -184,23 +184,23 @@ func TestSFTPDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSFTPFn:      getSFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSFTPFn:      getSFTPOK,
 			},
 			wantOutput: describeSFTPOutput,
@@ -233,28 +233,28 @@ func TestSFTPUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sftp", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateSFTPFn:   updateSFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateSFTPFn:   updateSFTPOK,
 			},
-			wantOutput: "Updated SFTP logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated SFTP logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -284,28 +284,28 @@ func TestSFTPDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteSFTPFn:   deleteSFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteSFTPFn:   deleteSFTPOK,
 			},
-			wantOutput: "Deleted SFTP logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted SFTP logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -400,18 +400,18 @@ func listSFTPsError(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 
 var listSFTPsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listSFTPsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	SFTP 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Address: 127.0.0.1
 		Port: 514
@@ -432,7 +432,7 @@ Version: 2
 		Compression codec: zstd
 	SFTP 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Address: example.com
 		Port: 123
@@ -484,7 +484,7 @@ func getSFTPError(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 
 var describeSFTPOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Address: example.com
 Port: 514
@@ -600,35 +600,4 @@ Wzi0vI/Nnxas5YayGJaf3XSFpj70QnsJUWUJagFRXjTmZyYohsELPpYT9eqIvXUm
 o0BQBImvAhu9whtRia0CQCFdDHdNnyyzKH8vC0NsEN65h3Bp2KEPkv8SOV27ZRR2
 xIGqLusk3y+yzbueLZJ117osdB1Owr19fvAHR7vq6Mw=
 -----END RSA PRIVATE KEY-----`)
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -28,6 +28,7 @@ func TestSFTPCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
@@ -36,6 +37,7 @@ func TestSFTPCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
@@ -44,11 +46,12 @@ func TestSFTPCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --ssh-known-hosts not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -72,6 +75,7 @@ func TestSFTPCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -247,7 +251,7 @@ func TestSFTPUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -298,7 +302,7 @@ func TestSFTPDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/sftp/sftp_integration_test.go
+++ b/pkg/logging/sftp/sftp_integration_test.go
@@ -24,58 +24,58 @@ func TestSFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--port", "80", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --ssh-known-hosts not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSFTPFn:   createSFTPOK,
 			},
-			wantOutput: "Created SFTP logging endpoint log (service 123 version 2)",
+			wantOutput: "Created SFTP logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "user", "--ssh-known-hosts", knownHosts(), "--port", "80", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSFTPFn:   createSFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--ssh-known-hosts", knownHosts(), "--port", "80", "--compression-codec", "zstd", "--gzip-level", "9"},
+			args: []string{"logging", "sftp", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "example.com", "--user", "anonymous", "--ssh-known-hosts", knownHosts(), "--port", "80", "--compression-codec", "zstd", "--gzip-level", "9", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
 		},
@@ -109,8 +109,8 @@ func TestSFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsShortOutput,
@@ -118,8 +118,8 @@ func TestSFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
@@ -127,8 +127,8 @@ func TestSFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
@@ -136,8 +136,8 @@ func TestSFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "sftp", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
@@ -145,8 +145,8 @@ func TestSFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "sftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSFTPsFn:    listSFTPsOK,
 			},
 			wantOutput: listSFTPsVerboseOutput,
@@ -154,8 +154,8 @@ func TestSFTPList(t *testing.T) {
 		{
 			args: []string{"logging", "sftp", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSFTPsFn:    listSFTPsError,
 			},
 			wantError: errTest.Error(),
@@ -194,8 +194,8 @@ func TestSFTPDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSFTPFn:      getSFTPError,
 			},
 			wantError: errTest.Error(),
@@ -203,8 +203,8 @@ func TestSFTPDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "sftp", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSFTPFn:      getSFTPOK,
 			},
 			wantOutput: describeSFTPOutput,
@@ -241,24 +241,24 @@ func TestSFTPUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSFTPFn:   updateSFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "sftp", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSFTPFn:   updateSFTPOK,
 			},
-			wantOutput: "Updated SFTP logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated SFTP logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -292,24 +292,24 @@ func TestSFTPDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSFTPFn:   deleteSFTPError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "sftp", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSFTPFn:   deleteSFTPOK,
 			},
-			wantOutput: "Deleted SFTP logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted SFTP logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/sftp/sftp_test.go
+++ b/pkg/logging/sftp/sftp_test.go
@@ -85,8 +85,9 @@ func TestUpdateSFTPInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSFTPFn:      getSFTPOK,
 			},
 			want: &fastly.UpdateSFTPInput{
@@ -117,8 +118,9 @@ func TestUpdateSFTPInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSFTPFn:      getSFTPOK,
 			},
 			want: &fastly.UpdateSFTPInput{
@@ -153,8 +155,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -168,39 +171,15 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Address:       "127.0.0.1",
 		User:          "user",
 		SSHKnownHosts: knownHosts(),
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -212,8 +191,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -227,7 +207,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Address:           "127.0.0.1",
 		User:              "user",
@@ -274,7 +257,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -299,7 +285,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/sftp/sftp_test.go
+++ b/pkg/logging/sftp/sftp_test.go
@@ -1,6 +1,7 @@
 package sftp
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -83,7 +84,11 @@ func TestUpdateSFTPInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetSFTPFn: getSFTPOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSFTPFn:      getSFTPOK,
+			},
 			want: &fastly.UpdateSFTPInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -111,7 +116,11 @@ func TestUpdateSFTPInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetSFTPFn: getSFTPOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSFTPFn:      getSFTPOK,
+			},
 			want: &fastly.UpdateSFTPInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -136,21 +145,90 @@ func TestUpdateSFTPInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:      manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:  "log",
-		Version:       2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Address:       "127.0.0.1",
 		User:          "user",
 		SSHKnownHosts: knownHosts(),
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Address:           "127.0.0.1",
 		User:              "user",
 		SSHKnownHosts:     knownHosts(),
@@ -177,20 +255,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/sftp/sftp_test.go
+++ b/pkg/logging/sftp/sftp_test.go
@@ -26,7 +26,7 @@ func TestCreateSFTPInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateSFTPInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Address:        "127.0.0.1",
 				User:           "user",
@@ -38,7 +38,7 @@ func TestCreateSFTPInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateSFTPInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Address:           "127.0.0.1",
 				Port:              80,
@@ -85,14 +85,14 @@ func TestUpdateSFTPInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSFTPFn:      getSFTPOK,
 			},
 			want: &fastly.UpdateSFTPInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Address:           fastly.String("new2"),
@@ -118,14 +118,14 @@ func TestUpdateSFTPInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSFTPFn:      getSFTPOK,
 			},
 			want: &fastly.UpdateSFTPInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -155,9 +155,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -191,9 +191,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/sftp/update.go
+++ b/pkg/logging/sftp/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string
-	Version      int
+	EndpointName   string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Address           common.OptionalString
 	Port              common.OptionalUint
@@ -47,12 +48,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update an SFTP logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the SFTP logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the SFTP logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "The hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
@@ -72,7 +71,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("timestamp-format", `strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000")`).Action(c.TimestampFormat.Set).StringVar(&c.TimestampFormat.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("compression-codec", `The codec used for compression of your logs. Valid values are zstd, snappy, and gzip. If the specified codec is "gzip", gzip_level will default to 3. To specify a different level, leave compression_codec blank and explicitly set the level using gzip_level. Specifying both compression_codec and gzip_level in the same API request will result in an error.`).Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
-
 	return &c
 }
 
@@ -83,9 +81,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSFTPInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateSFTPInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/splunk/create.go
+++ b/pkg/logging/splunk/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	URL          string
+	EndpointName   string // Can't shadow common.Base method Name().
+	URL            string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	TLSHostname       common.OptionalString
 	TLSCACert         common.OptionalString
 	TLSClientCert     common.OptionalString
@@ -41,11 +42,10 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Splunk logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Splunk logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.URL)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
 	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
@@ -56,7 +56,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("auth-token", "A Splunk token for use in posting logs over HTTP to your collector").Action(c.Token.Set).StringVar(&c.Token.Value)
-
 	return &c
 }
 
@@ -69,8 +68,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateSplunkInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.URL = c.URL
 

--- a/pkg/logging/splunk/delete.go
+++ b/pkg/logging/splunk/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Splunk logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteSplunkInput
+	manifest       manifest.Data
+	Input          fastly.DeleteSplunkInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Splunk logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteSplunk(&c.Input); err != nil {
 		return err

--- a/pkg/logging/splunk/describe.go
+++ b/pkg/logging/splunk/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Splunk logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetSplunkInput
+	manifest       manifest.Data
+	Input          fastly.GetSplunkInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Splunk logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	splunk, err := c.Globals.Client.GetSplunk(&c.Input)
 	if err != nil {

--- a/pkg/logging/splunk/list.go
+++ b/pkg/logging/splunk/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Splunk logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListSplunksInput
+	manifest       manifest.Data
+	Input          fastly.ListSplunksInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Splunk endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	splunks, err := c.Globals.Client.ListSplunks(&c.Input)
 	if err != nil {

--- a/pkg/logging/splunk/splunk_integration_test.go
+++ b/pkg/logging/splunk/splunk_integration_test.go
@@ -24,25 +24,25 @@ func TestSplunkCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateSplunkFn: createSplunkOK,
 			},
-			wantOutput: "Created Splunk logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Splunk logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateSplunkFn: createSplunkError,
 			},
 			wantError: errTest.Error(),
@@ -75,55 +75,55 @@ func TestSplunkList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksShortOutput,
 		},
 		{
-			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "splunk", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "splunk", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "splunk", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "splunk", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSplunksFn:  listSplunksError,
 			},
 			wantError: errTest.Error(),
@@ -156,23 +156,23 @@ func TestSplunkDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSplunkFn:    getSplunkError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSplunkFn:    getSplunkOK,
 			},
 			wantOutput: describeSplunkOutput,
@@ -205,28 +205,28 @@ func TestSplunkUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateSplunkFn: updateSplunkError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateSplunkFn: updateSplunkOK,
 			},
-			wantOutput: "Updated Splunk logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Splunk logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,28 +256,28 @@ func TestSplunkDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteSplunkFn: deleteSplunkError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteSplunkFn: deleteSplunkOK,
 			},
-			wantOutput: "Deleted Splunk logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Splunk logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -354,18 +354,18 @@ func listSplunksError(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
 
 var listSplunksShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listSplunksVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Splunk 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		URL: example.com
 		Token: tkn
@@ -379,7 +379,7 @@ Version: 2
 		Placement: none
 	Splunk 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		URL: 127.0.0.1
 		Token: tkn1
@@ -417,7 +417,7 @@ func getSplunkError(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
 
 var describeSplunkOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 URL: example.com
 Token: tkn
@@ -459,35 +459,4 @@ func deleteSplunkOK(i *fastly.DeleteSplunkInput) error {
 
 func deleteSplunkError(i *fastly.DeleteSplunkInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/splunk/splunk_integration_test.go
+++ b/pkg/logging/splunk/splunk_integration_test.go
@@ -24,11 +24,16 @@ func TestSplunkCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -219,7 +224,7 @@ func TestSplunkUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -270,7 +275,7 @@ func TestSplunkDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/splunk/splunk_integration_test.go
+++ b/pkg/logging/splunk/splunk_integration_test.go
@@ -24,30 +24,30 @@ func TestSplunkCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSplunkFn: createSplunkOK,
 			},
-			wantOutput: "Created Splunk logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Splunk logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSplunkFn: createSplunkError,
 			},
 			wantError: errTest.Error(),
@@ -82,8 +82,8 @@ func TestSplunkList(t *testing.T) {
 		{
 			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksShortOutput,
@@ -91,8 +91,8 @@ func TestSplunkList(t *testing.T) {
 		{
 			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
@@ -100,8 +100,8 @@ func TestSplunkList(t *testing.T) {
 		{
 			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
@@ -109,8 +109,8 @@ func TestSplunkList(t *testing.T) {
 		{
 			args: []string{"logging", "splunk", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
@@ -118,8 +118,8 @@ func TestSplunkList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "splunk", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSplunksFn:  listSplunksOK,
 			},
 			wantOutput: listSplunksVerboseOutput,
@@ -127,8 +127,8 @@ func TestSplunkList(t *testing.T) {
 		{
 			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSplunksFn:  listSplunksError,
 			},
 			wantError: errTest.Error(),
@@ -167,8 +167,8 @@ func TestSplunkDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSplunkFn:    getSplunkError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestSplunkDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSplunkFn:    getSplunkOK,
 			},
 			wantOutput: describeSplunkOutput,
@@ -214,24 +214,24 @@ func TestSplunkUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSplunkFn: updateSplunkError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSplunkFn: updateSplunkOK,
 			},
-			wantOutput: "Updated Splunk logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Splunk logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -265,24 +265,24 @@ func TestSplunkDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSplunkFn: deleteSplunkError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSplunkFn: deleteSplunkOK,
 			},
-			wantOutput: "Deleted Splunk logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Splunk logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/splunk/splunk_integration_test.go
+++ b/pkg/logging/splunk/splunk_integration_test.go
@@ -24,17 +24,27 @@ func TestSplunkCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:       []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
-			api:        mock.API{CreateSplunkFn: createSplunkOK},
-			wantOutput: "Created Splunk logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateSplunkFn: createSplunkOK,
+			},
+			wantOutput: "Created Splunk logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "splunk", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
-			api:       mock.API{CreateSplunkFn: createSplunkError},
+			args: []string{"logging", "splunk", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateSplunkFn: createSplunkError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -65,33 +75,57 @@ func TestSplunkList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSplunksFn: listSplunksOK},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSplunksFn:  listSplunksOK,
+			},
 			wantOutput: listSplunksShortOutput,
 		},
 		{
-			args:       []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListSplunksFn: listSplunksOK},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSplunksFn:  listSplunksOK,
+			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListSplunksFn: listSplunksOK},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSplunksFn:  listSplunksOK,
+			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "splunk", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSplunksFn: listSplunksOK},
+			args: []string{"logging", "splunk", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSplunksFn:  listSplunksOK,
+			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "splunk", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSplunksFn: listSplunksOK},
+			args: []string{"logging", "-v", "splunk", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSplunksFn:  listSplunksOK,
+			},
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "splunk", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListSplunksFn: listSplunksError},
+			args: []string{"logging", "splunk", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				ListSplunksFn:  listSplunksError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -122,17 +156,25 @@ func TestSplunkDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetSplunkFn: getSplunkError},
+			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSplunkFn:    getSplunkError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetSplunkFn: getSplunkOK},
+			args: []string{"logging", "splunk", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSplunkFn:    getSplunkOK,
+			},
 			wantOutput: describeSplunkOutput,
 		},
 	} {
@@ -163,18 +205,28 @@ func TestSplunkUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "splunk", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateSplunkFn: updateSplunkError},
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateSplunkFn: updateSplunkError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "splunk", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateSplunkFn: updateSplunkOK},
-			wantOutput: "Updated Splunk logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "splunk", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateSplunkFn: updateSplunkOK,
+			},
+			wantOutput: "Updated Splunk logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -204,18 +256,28 @@ func TestSplunkDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteSplunkFn: deleteSplunkError},
+			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteSplunkFn: deleteSplunkError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteSplunkFn: deleteSplunkOK},
-			wantOutput: "Deleted Splunk logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "splunk", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteSplunkFn: deleteSplunkOK,
+			},
+			wantOutput: "Deleted Splunk logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -292,18 +354,18 @@ func listSplunksError(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
 
 var listSplunksShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listSplunksVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Splunk 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		URL: example.com
 		Token: tkn
@@ -317,7 +379,7 @@ Version: 1
 		Placement: none
 	Splunk 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		URL: 127.0.0.1
 		Token: tkn1
@@ -355,7 +417,7 @@ func getSplunkError(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
 
 var describeSplunkOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 URL: example.com
 Token: tkn
@@ -397,4 +459,35 @@ func deleteSplunkOK(i *fastly.DeleteSplunkInput) error {
 
 func deleteSplunkError(i *fastly.DeleteSplunkInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/splunk/splunk_test.go
+++ b/pkg/logging/splunk/splunk_test.go
@@ -76,8 +76,9 @@ func TestUpdateSplunkInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSplunkFn:    getSplunkOK,
 			},
 			want: &fastly.UpdateSplunkInput{
@@ -90,8 +91,9 @@ func TestUpdateSplunkInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSplunkFn:    getSplunkOK,
 			},
 			want: &fastly.UpdateSplunkInput{
@@ -137,8 +139,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -152,37 +155,13 @@ func createCommandRequired() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		URL: "example.com",
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -194,8 +173,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -209,7 +189,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		URL:               "example.com",
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
@@ -251,7 +234,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -276,7 +262,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/splunk/splunk_test.go
+++ b/pkg/logging/splunk/splunk_test.go
@@ -25,7 +25,7 @@ func TestCreateSplunkInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateSplunkInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				URL:            "example.com",
 			},
@@ -35,7 +35,7 @@ func TestCreateSplunkInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateSplunkInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				URL:               "example.com",
 				Format:            `%h %l %u %t "%r" %>s %b`,
@@ -76,14 +76,14 @@ func TestUpdateSplunkInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSplunkFn:    getSplunkOK,
 			},
 			want: &fastly.UpdateSplunkInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -91,14 +91,14 @@ func TestUpdateSplunkInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSplunkFn:    getSplunkOK,
 			},
 			want: &fastly.UpdateSplunkInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				URL:               fastly.String("new2"),
@@ -139,9 +139,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -173,9 +173,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/splunk/splunk_test.go
+++ b/pkg/logging/splunk/splunk_test.go
@@ -1,6 +1,7 @@
 package splunk
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -74,7 +75,11 @@ func TestUpdateSplunkInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetSplunkFn: getSplunkOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSplunkFn:    getSplunkOK,
+			},
 			want: &fastly.UpdateSplunkInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -84,7 +89,11 @@ func TestUpdateSplunkInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetSplunkFn: getSplunkOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSplunkFn:    getSplunkOK,
+			},
 			want: &fastly.UpdateSplunkInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -120,19 +129,88 @@ func TestUpdateSplunkInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
-		URL:          "example.com",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
+		URL: "example.com",
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		URL:               "example.com",
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -154,20 +232,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},

--- a/pkg/logging/splunk/update.go
+++ b/pkg/logging/splunk/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	URL               common.OptionalString
 	Format            common.OptionalString
@@ -40,12 +41,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Splunk logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Splunk logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("url", "The URL to POST to.").Action(c.URL.Set).StringVar(&c.URL.Value)
@@ -58,7 +57,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "	Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("auth-token", "").Action(c.Token.Set).StringVar(&c.Token.Value)
-
 	return &c
 }
 
@@ -69,9 +67,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSplunkInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateSplunkInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/sumologic/create.go
+++ b/pkg/logging/sumologic/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	URL          string
+	EndpointName   string // Can't shadow common.Base method Name().
+	URL            string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Format            common.OptionalString
 	FormatVersion     common.OptionalInt
 	ResponseCondition common.OptionalString
@@ -36,18 +37,16 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Sumologic logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Sumologic logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.URL)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).IntVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -60,8 +59,17 @@ func (c *CreateCommand) createInput() (*fastly.CreateSumologicInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Name = c.EndpointName
 	input.URL = c.URL
 

--- a/pkg/logging/sumologic/delete.go
+++ b/pkg/logging/sumologic/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Sumologic logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteSumologicInput
+	manifest       manifest.Data
+	Input          fastly.DeleteSumologicInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,12 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Sumologic logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.Input.Name)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -41,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteSumologic(&c.Input); err != nil {
 		return err

--- a/pkg/logging/sumologic/describe.go
+++ b/pkg/logging/sumologic/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Sumologic logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetSumologicInput
+	manifest       manifest.Data
+	Input          fastly.GetSumologicInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Sumologic logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	sumologic, err := c.Globals.Client.GetSumologic(&c.Input)
 	if err != nil {

--- a/pkg/logging/sumologic/list.go
+++ b/pkg/logging/sumologic/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Sumologic logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListSumologicsInput
+	manifest       manifest.Data
+	Input          fastly.ListSumologicsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Sumologic endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	sumologics, err := c.Globals.Client.ListSumologics(&c.Input)
 	if err != nil {

--- a/pkg/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/logging/sumologic/sumologic_integration_test.go
@@ -24,17 +24,27 @@ func TestSumologicCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args:       []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
-			api:        mock.API{CreateSumologicFn: createSumologicOK},
-			wantOutput: "Created Sumologic logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				CreateSumologicFn: createSumologicOK,
+			},
+			wantOutput: "Created Sumologic logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
-			api:       mock.API{CreateSumologicFn: createSumologicError},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				CreateSumologicFn: createSumologicError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -65,33 +75,57 @@ func TestSumologicList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListSumologicsFn: listSumologicsOK,
+			},
 			wantOutput: listSumologicsShortOutput,
 		},
 		{
-			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListSumologicsFn: listSumologicsOK,
+			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListSumologicsFn: listSumologicsOK,
+			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "sumologic", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			args: []string{"logging", "sumologic", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListSumologicsFn: listSumologicsOK,
+			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "sumologic", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSumologicsFn: listSumologicsOK},
+			args: []string{"logging", "-v", "sumologic", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListSumologicsFn: listSumologicsOK,
+			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListSumologicsFn: listSumologicsError},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn:   listVersionsOK,
+				GetVersionFn:     getVersionOK,
+				ListSumologicsFn: listSumologicsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -122,17 +156,25 @@ func TestSumologicDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetSumologicFn: getSumologicError},
+			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSumologicFn: getSumologicError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetSumologicFn: getSumologicOK},
+			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSumologicFn: getSumologicOK,
+			},
 			wantOutput: describeSumologicOutput,
 		},
 	} {
@@ -163,18 +205,28 @@ func TestSumologicUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateSumologicFn: updateSumologicError},
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				UpdateSumologicFn: updateSumologicError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateSumologicFn: updateSumologicOK},
-			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				UpdateSumologicFn: updateSumologicOK,
+			},
+			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -204,18 +256,28 @@ func TestSumologicDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteSumologicFn: deleteSumologicError},
+			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				DeleteSumologicFn: deleteSumologicError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteSumologicFn: deleteSumologicOK},
-			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    listVersionsOK,
+				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    cloneVersionOK,
+				DeleteSumologicFn: deleteSumologicOK,
+			},
+			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -284,18 +346,18 @@ func listSumologicsError(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, er
 
 var listSumologicsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listSumologicsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Sumologic 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		URL: example.com
 		Format: %h %l %u %t "%r" %>s %b
@@ -305,7 +367,7 @@ Version: 1
 		Placement: none
 	Sumologic 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		URL: bar.com
 		Format: %h %l %u %t "%r" %>s %b
@@ -335,7 +397,7 @@ func getSumologicError(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
 
 var describeSumologicOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 URL: example.com
 Format: %h %l %u %t "%r" %>s %b
@@ -369,4 +431,35 @@ func deleteSumologicOK(i *fastly.DeleteSumologicInput) error {
 
 func deleteSumologicError(i *fastly.DeleteSumologicInput) error {
 	return errTest
+}
+
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/logging/sumologic/sumologic_integration_test.go
@@ -24,30 +24,30 @@ func TestSumologicCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateSumologicFn: createSumologicOK,
 			},
-			wantOutput: "Created Sumologic logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Sumologic logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetInactiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetInactiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateSumologicFn: createSumologicError,
 			},
 			wantError: errTest.Error(),
@@ -82,8 +82,8 @@ func TestSumologicList(t *testing.T) {
 		{
 			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsShortOutput,
@@ -91,8 +91,8 @@ func TestSumologicList(t *testing.T) {
 		{
 			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
@@ -100,8 +100,8 @@ func TestSumologicList(t *testing.T) {
 		{
 			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
@@ -109,8 +109,8 @@ func TestSumologicList(t *testing.T) {
 		{
 			args: []string{"logging", "sumologic", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
@@ -118,8 +118,8 @@ func TestSumologicList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "sumologic", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
@@ -127,8 +127,8 @@ func TestSumologicList(t *testing.T) {
 		{
 			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersionsOk,
-				GetVersionFn:     testutil.GetActiveVersionOK,
+				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetActiveVersion(1),
 				ListSumologicsFn: listSumologicsError,
 			},
 			wantError: errTest.Error(),
@@ -167,8 +167,8 @@ func TestSumologicDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSumologicFn: getSumologicError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestSumologicDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSumologicFn: getSumologicOK,
 			},
 			wantOutput: describeSumologicOutput,
@@ -214,24 +214,24 @@ func TestSumologicUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateSumologicFn: updateSumologicError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateSumologicFn: updateSumologicOK,
 			},
-			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -265,24 +265,24 @@ func TestSumologicDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteSumologicFn: deleteSumologicError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersionsOk,
-				GetVersionFn:      testutil.GetActiveVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteSumologicFn: deleteSumologicOK,
 			},
-			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/logging/sumologic/sumologic_integration_test.go
@@ -24,25 +24,25 @@ func TestSumologicCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				CreateSumologicFn: createSumologicOK,
 			},
-			wantOutput: "Created Sumologic logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Sumologic logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "2", "--name", "log", "--url", "example.com"},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetInactiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				CreateSumologicFn: createSumologicError,
 			},
 			wantError: errTest.Error(),
@@ -75,55 +75,55 @@ func TestSumologicList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsShortOutput,
 		},
 		{
-			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "sumologic", "--verbose", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "sumologic", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "sumologic", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "sumologic", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "sumologic", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:   listVersionsOK,
-				GetVersionFn:     getVersionOK,
+				ListVersionsFn:   testutil.ListVersionsOk,
+				GetVersionFn:     testutil.GetActiveVersionOK,
 				ListSumologicsFn: listSumologicsError,
 			},
 			wantError: errTest.Error(),
@@ -156,23 +156,23 @@ func TestSumologicDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSumologicFn: getSumologicError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "sumologic", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSumologicFn: getSumologicOK,
 			},
 			wantOutput: describeSumologicOutput,
@@ -205,28 +205,28 @@ func TestSumologicUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				UpdateSumologicFn: updateSumologicError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				UpdateSumologicFn: updateSumologicOK,
 			},
-			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Sumologic logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -256,28 +256,28 @@ func TestSumologicDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				DeleteSumologicFn: deleteSumologicError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersionsOk,
+				GetVersionFn:      testutil.GetActiveVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				DeleteSumologicFn: deleteSumologicOK,
 			},
-			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Sumologic logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -346,18 +346,18 @@ func listSumologicsError(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, er
 
 var listSumologicsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listSumologicsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Sumologic 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		URL: example.com
 		Format: %h %l %u %t "%r" %>s %b
@@ -367,7 +367,7 @@ Version: 2
 		Placement: none
 	Sumologic 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		URL: bar.com
 		Format: %h %l %u %t "%r" %>s %b
@@ -397,7 +397,7 @@ func getSumologicError(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
 
 var describeSumologicOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 URL: example.com
 Format: %h %l %u %t "%r" %>s %b
@@ -431,35 +431,4 @@ func deleteSumologicOK(i *fastly.DeleteSumologicInput) error {
 
 func deleteSumologicError(i *fastly.DeleteSumologicInput) error {
 	return errTest
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/logging/sumologic/sumologic_integration_test.go
@@ -24,11 +24,16 @@ func TestSumologicCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com", "--autoclone"},
+			args: []string{"logging", "sumologic", "create", "--service-id", "123", "--version", "1", "--name", "log", "--url", "example.com"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,
@@ -219,7 +224,7 @@ func TestSumologicUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "sumologic", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,
@@ -270,7 +275,7 @@ func TestSumologicDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "sumologic", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersionsOk,
 				GetVersionFn:      testutil.GetActiveVersionOK,

--- a/pkg/logging/sumologic/sumologic_test.go
+++ b/pkg/logging/sumologic/sumologic_test.go
@@ -72,8 +72,9 @@ func TestUpdateSumologicInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSumologicFn: getSumologicOK,
 			},
 			want: &fastly.UpdateSumologicInput{
@@ -86,8 +87,9 @@ func TestUpdateSumologicInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSumologicFn: getSumologicOK,
 			},
 			want: &fastly.UpdateSumologicInput{
@@ -129,8 +131,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -145,7 +148,10 @@ func createCommandOK() *CreateCommand {
 		EndpointName: "log",
 		URL:          "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalInt{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -164,8 +170,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -180,36 +187,12 @@ func createCommandRequired() *CreateCommand {
 		EndpointName: "log",
 		URL:          "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandMissingServiceID() *CreateCommand {
@@ -238,7 +221,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -263,7 +249,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/sumologic/sumologic_test.go
+++ b/pkg/logging/sumologic/sumologic_test.go
@@ -25,7 +25,7 @@ func TestCreateSumologicInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateSumologicInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				URL:            "example.com",
 			},
@@ -35,7 +35,7 @@ func TestCreateSumologicInput(t *testing.T) {
 			cmd:  createCommandOK(),
 			want: &fastly.CreateSumologicInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				URL:               "example.com",
 				Format:            `%h %l %u %t "%r" %>s %b`,
@@ -72,14 +72,14 @@ func TestUpdateSumologicInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSumologicFn: getSumologicOK,
 			},
 			want: &fastly.UpdateSumologicInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -87,14 +87,14 @@ func TestUpdateSumologicInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSumologicFn: getSumologicOK,
 			},
 			want: &fastly.UpdateSumologicInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				URL:               fastly.String("new2"),
@@ -131,9 +131,9 @@ func createCommandOK() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -170,9 +170,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
+	EndpointName   string // Can't shadow common.Base method Name().
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	URL               common.OptionalString
 	Format            common.OptionalString
@@ -36,12 +37,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Sumologic logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Sumologic logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("url", "The URL to POST to").Action(c.URL.Set).StringVar(&c.URL.Value)
@@ -50,7 +49,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -61,9 +59,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSumologicInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateSumologicInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/logging/syslog/create.go
+++ b/pkg/logging/syslog/create.go
@@ -17,11 +17,12 @@ type CreateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
-	Version      int
-	Address      string
+	EndpointName   string // Can't shadow common.Base method Name().
+	Address        string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	Port              common.OptionalUint
 	UseTLS            common.OptionalBool
 	Token             common.OptionalString
@@ -43,11 +44,10 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Syslog logging endpoint on a Fastly service version").Alias("add")
-
 	c.CmdClause.Flag("name", "The name of the Syslog logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Required().StringVar(&c.Address)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)
@@ -61,7 +61,6 @@ func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCom
 	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -74,9 +73,18 @@ func (c *CreateCommand) createInput() (*fastly.CreateSyslogInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input.ServiceID = serviceID
 	input.Name = c.EndpointName
-	input.ServiceVersion = c.Version
+	input.ServiceVersion = v.Number
 	input.Address = c.Address
 
 	if c.Port.WasSet {

--- a/pkg/logging/syslog/delete.go
+++ b/pkg/logging/syslog/delete.go
@@ -14,8 +14,10 @@ import (
 // DeleteCommand calls the Fastly API to delete a Syslog logging endpoint.
 type DeleteCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeleteSyslogInput
+	manifest       manifest.Data
+	Input          fastly.DeleteSyslogInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,11 +27,10 @@ func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCom
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Syslog logging endpoint on a Fastly service version").Alias("remove")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-
 	return &c
 }
 
@@ -40,6 +41,16 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	if err := c.Globals.Client.DeleteSyslog(&c.Input); err != nil {
 		return err

--- a/pkg/logging/syslog/describe.go
+++ b/pkg/logging/syslog/describe.go
@@ -14,8 +14,9 @@ import (
 // DescribeCommand calls the Fastly API to describe a Syslog logging endpoint.
 type DescribeCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.GetSyslogInput
+	manifest       manifest.Data
+	Input          fastly.GetSyslogInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDescribeCommand(parent common.Registerer, globals *config.Data) *Describ
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Syslog logging endpoint on a Fastly service version").Alias("get")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
@@ -38,6 +39,12 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	syslog, err := c.Globals.Client.GetSyslog(&c.Input)
 	if err != nil {

--- a/pkg/logging/syslog/list.go
+++ b/pkg/logging/syslog/list.go
@@ -15,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list Syslog logging endpoints.
 type ListCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ListSyslogsInput
+	manifest       manifest.Data
+	Input          fastly.ListSyslogsInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -27,7 +28,7 @@ func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Syslog endpoints on a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,6 +39,12 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return errors.ErrNoServiceID
 	}
 	c.Input.ServiceID = serviceID
+
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
 
 	syslogs, err := c.Globals.Client.ListSyslogs(&c.Input)
 	if err != nil {

--- a/pkg/logging/syslog/syslog_integration_test.go
+++ b/pkg/logging/syslog/syslog_integration_test.go
@@ -24,17 +24,26 @@ func TestSyslogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "2", "--name", "log"},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args:       []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
-			api:        mock.API{CreateSyslogFn: createSyslogOK},
-			wantOutput: "Created Syslog logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "127.0.0.1", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				CreateSyslogFn: createSyslogOK,
+			},
+			wantOutput: "Created Syslog logging endpoint log (service 123 version 3)",
 		},
 		{
-			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
-			api:       mock.API{CreateSyslogFn: createSyslogError},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "127.0.0.1"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				CreateSyslogFn: createSyslogError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -65,33 +74,57 @@ func TestSyslogList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				ListSyslogsFn:  listSyslogsOK,
+			},
 			wantOutput: listSyslogsShortOutput,
 		},
 		{
-			args:       []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "--verbose"},
-			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				ListSyslogsFn:  listSyslogsOK,
+			},
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "-v"},
-			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2", "-v"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				ListSyslogsFn:  listSyslogsOK,
+			},
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "syslog", "--verbose", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			args: []string{"logging", "syslog", "--verbose", "list", "--service-id", "123", "--version", "1"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				ListSyslogsFn:  listSyslogsOK,
+			},
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args:       []string{"logging", "-v", "syslog", "list", "--service-id", "123", "--version", "1"},
-			api:        mock.API{ListSyslogsFn: listSyslogsOK},
+			args: []string{"logging", "-v", "syslog", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				ListSyslogsFn:  listSyslogsOK,
+			},
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args:      []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
-			api:       mock.API{ListSyslogsFn: listSyslogsError},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				ListSyslogsFn:  listSyslogsError,
+			},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -126,13 +159,21 @@ func TestSyslogDescribe(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{GetSyslogFn: getSyslogError},
+			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				GetSyslogFn:    getSyslogError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{GetSyslogFn: getSyslogOK},
+			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				GetSyslogFn:    getSyslogOK,
+			},
 			wantOutput: describeSyslogOutput,
 		},
 	} {
@@ -163,18 +204,27 @@ func TestSyslogUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
+			args:      []string{"logging", "syslog", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:       mock.API{UpdateSyslogFn: updateSyslogError},
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				UpdateSyslogFn: updateSyslogError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
-			api:        mock.API{UpdateSyslogFn: updateSyslogOK},
-			wantOutput: "Updated Syslog logging endpoint log (service 123 version 1)",
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				UpdateSyslogFn: updateSyslogOK,
+			},
+			wantOutput: "Updated Syslog logging endpoint log (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -204,18 +254,27 @@ func TestSyslogDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1"},
+			args:      []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "2"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:      []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:       mock.API{DeleteSyslogFn: deleteSyslogError},
+			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				DeleteSyslogFn: deleteSyslogError,
+			},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
-			api:        mock.API{DeleteSyslogFn: deleteSyslogOK},
-			wantOutput: "Deleted Syslog logging endpoint logs (service 123 version 1)",
+			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn: listVersionsActiveOk,
+				GetVersionFn:   getVersionOK,
+				CloneVersionFn: cloneVersionOK,
+				DeleteSyslogFn: deleteSyslogOK,
+			},
+			wantOutput: "Deleted Syslog logging endpoint logs (service 123 version 3)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -302,18 +361,18 @@ func listSyslogsError(i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
 
 var listSyslogsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      1        logs
-123      1        analytics
+123      2        logs
+123      2        analytics
 `) + "\n"
 
 var listSyslogsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 1
+Version: 2
 	Syslog 1/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: logs
 		Address: 127.0.0.1
 		Hostname: 
@@ -332,7 +391,7 @@ Version: 1
 		Placement: none
 	Syslog 2/2
 		Service ID: 123
-		Version: 1
+		Version: 2
 		Name: analytics
 		Address: example.com
 		Hostname: example.com
@@ -380,7 +439,7 @@ func getSyslogError(i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
 
 var describeSyslogOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 1
+Version: 2
 Name: logs
 Address: example.com
 Hostname: example.com
@@ -432,4 +491,35 @@ func deleteSyslogOK(i *fastly.DeleteSyslogInput) error {
 
 func deleteSyslogError(i *fastly.DeleteSyslogInput) error {
 	return errTest
+}
+
+func listVersionsActiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/syslog/syslog_integration_test.go
+++ b/pkg/logging/syslog/syslog_integration_test.go
@@ -24,30 +24,30 @@ func TestSyslogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSyslogFn: createSyslogOK,
 			},
-			wantOutput: "Created Syslog logging endpoint log (service 123 version 2)",
+			wantOutput: "Created Syslog logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSyslogFn: createSyslogError,
 			},
 			wantError: errTest.Error(),
@@ -82,8 +82,8 @@ func TestSyslogList(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsShortOutput,
@@ -91,8 +91,8 @@ func TestSyslogList(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
@@ -100,8 +100,8 @@ func TestSyslogList(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
@@ -109,8 +109,8 @@ func TestSyslogList(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
@@ -118,8 +118,8 @@ func TestSyslogList(t *testing.T) {
 		{
 			args: []string{"logging", "-v", "syslog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
@@ -127,8 +127,8 @@ func TestSyslogList(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				ListSyslogsFn:  listSyslogsError,
 			},
 			wantError: errTest.Error(),
@@ -167,8 +167,8 @@ func TestSyslogDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSyslogFn:    getSyslogError,
 			},
 			wantError: errTest.Error(),
@@ -176,8 +176,8 @@ func TestSyslogDescribe(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				GetSyslogFn:    getSyslogOK,
 			},
 			wantOutput: describeSyslogOutput,
@@ -214,24 +214,24 @@ func TestSyslogUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSyslogFn: updateSyslogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSyslogFn: updateSyslogOK,
 			},
-			wantOutput: "Updated Syslog logging endpoint log (service 123 version 2)",
+			wantOutput: "Updated Syslog logging endpoint log (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -265,24 +265,24 @@ func TestSyslogDelete(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSyslogFn: deleteSyslogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
+			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSyslogFn: deleteSyslogOK,
 			},
-			wantOutput: "Deleted Syslog logging endpoint logs (service 123 version 2)",
+			wantOutput: "Deleted Syslog logging endpoint logs (service 123 version 4)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {

--- a/pkg/logging/syslog/syslog_integration_test.go
+++ b/pkg/logging/syslog/syslog_integration_test.go
@@ -24,24 +24,24 @@ func TestSyslogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "2", "--name", "log"},
+			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "127.0.0.1", "--autoclone"},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateSyslogFn: createSyslogOK,
 			},
-			wantOutput: "Created Syslog logging endpoint log (service 123 version 3)",
+			wantOutput: "Created Syslog logging endpoint log (service 123 version 2)",
 		},
 		{
-			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "2", "--name", "log", "--address", "127.0.0.1"},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				CreateSyslogFn: createSyslogError,
 			},
 			wantError: errTest.Error(),
@@ -74,28 +74,28 @@ func TestSyslogList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsShortOutput,
 		},
 		{
-			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2", "--verbose"},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "--verbose"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2", "-v"},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1", "-v"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
@@ -103,26 +103,26 @@ func TestSyslogList(t *testing.T) {
 		{
 			args: []string{"logging", "syslog", "--verbose", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "-v", "syslog", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "-v", "syslog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSyslogsFn:  listSyslogsOK,
 			},
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "2"},
+			args: []string{"logging", "syslog", "list", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				ListSyslogsFn:  listSyslogsError,
 			},
 			wantError: errTest.Error(),
@@ -159,19 +159,19 @@ func TestSyslogDescribe(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSyslogFn:    getSyslogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "syslog", "describe", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				GetSyslogFn:    getSyslogOK,
 			},
 			wantOutput: describeSyslogOutput,
@@ -204,27 +204,27 @@ func TestSyslogUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "syslog", "update", "--service-id", "123", "--version", "2", "--new-name", "log"},
+			args:      []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--new-name", "log"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log"},
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				UpdateSyslogFn: updateSyslogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "2", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateSyslogFn: updateSyslogOK,
 			},
-			wantOutput: "Updated Syslog logging endpoint log (service 123 version 3)",
+			wantOutput: "Updated Syslog logging endpoint log (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -254,27 +254,27 @@ func TestSyslogDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "2"},
+			args:      []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1"},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "2", "--name", "logs"},
+			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
 				DeleteSyslogFn: deleteSyslogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "2", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsActiveOk,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteSyslogFn: deleteSyslogOK,
 			},
-			wantOutput: "Deleted Syslog logging endpoint logs (service 123 version 3)",
+			wantOutput: "Deleted Syslog logging endpoint logs (service 123 version 2)",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -361,18 +361,18 @@ func listSyslogsError(i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
 
 var listSyslogsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME
-123      2        logs
-123      2        analytics
+123      1        logs
+123      1        analytics
 `) + "\n"
 
 var listSyslogsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
 Service ID: 123
-Version: 2
+Version: 1
 	Syslog 1/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: logs
 		Address: 127.0.0.1
 		Hostname: 
@@ -391,7 +391,7 @@ Version: 2
 		Placement: none
 	Syslog 2/2
 		Service ID: 123
-		Version: 2
+		Version: 1
 		Name: analytics
 		Address: example.com
 		Hostname: example.com
@@ -439,7 +439,7 @@ func getSyslogError(i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
 
 var describeSyslogOutput = strings.TrimSpace(`
 Service ID: 123
-Version: 2
+Version: 1
 Name: logs
 Address: example.com
 Hostname: example.com
@@ -491,35 +491,4 @@ func deleteSyslogOK(i *fastly.DeleteSyslogInput) error {
 
 func deleteSyslogError(i *fastly.DeleteSyslogInput) error {
 	return errTest
-}
-
-func listVersionsActiveOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
 }

--- a/pkg/logging/syslog/syslog_integration_test.go
+++ b/pkg/logging/syslog/syslog_integration_test.go
@@ -24,11 +24,16 @@ func TestSyslogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log"},
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
+			},
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1", "--autoclone"},
+			args: []string{"logging", "syslog", "create", "--service-id", "123", "--version", "1", "--name", "log", "--address", "127.0.0.1"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -42,6 +47,7 @@ func TestSyslogCreate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				CreateSyslogFn: createSyslogError,
 			},
 			wantError: errTest.Error(),
@@ -212,12 +218,13 @@ func TestSyslogUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				UpdateSyslogFn: updateSyslogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log", "--autoclone"},
+			args: []string{"logging", "syslog", "update", "--service-id", "123", "--version", "1", "--name", "logs", "--new-name", "log"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
@@ -262,12 +269,13 @@ func TestSyslogDelete(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				DeleteSyslogFn: deleteSyslogError,
 			},
 			wantError: errTest.Error(),
 		},
 		{
-			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs", "--autoclone"},
+			args: []string{"logging", "syslog", "delete", "--service-id", "123", "--version", "1", "--name", "logs"},
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersionsOk,
 				GetVersionFn:   testutil.GetActiveVersionOK,

--- a/pkg/logging/syslog/syslog_test.go
+++ b/pkg/logging/syslog/syslog_test.go
@@ -79,8 +79,9 @@ func TestUpdateSyslogInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSyslogFn:    getSyslogOK,
 			},
 			want: &fastly.UpdateSyslogInput{
@@ -93,8 +94,9 @@ func TestUpdateSyslogInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
+				ListVersionsFn: testutil.ListVersionsOk,
+				GetVersionFn:   testutil.GetActiveVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				GetSyslogFn:    getSyslogOK,
 			},
 			want: &fastly.UpdateSyslogInput{
@@ -143,8 +145,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -159,36 +162,12 @@ func createCommandRequired() *CreateCommand {
 		EndpointName: "log",
 		Address:      "example.com",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			ServiceID: i.ServiceID,
-			Number:    1,
-			Active:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-		},
-		{
-			ServiceID: i.ServiceID,
-			Number:    2,
-			Active:    false,
-			Locked:    true,
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
-		},
-	}, nil
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    2,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
 }
 
 func createCommandAll() *CreateCommand {
@@ -200,8 +179,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: listVersionsOK,
-		GetVersionFn:   getVersionOK,
+		ListVersionsFn: testutil.ListVersionsOk,
+		GetVersionFn:   testutil.GetActiveVersionOK,
+		CloneVersionFn: testutil.CloneVersionOK,
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -215,7 +195,10 @@ func createCommandAll() *CreateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		Address:           "example.com",
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
@@ -259,7 +242,10 @@ func updateCommandNoUpdates() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 	}
 }
@@ -284,7 +270,10 @@ func updateCommandAll() *UpdateCommand {
 		},
 		EndpointName: "log",
 		serviceVersion: common.OptionalServiceVersion{
-			OptionalString: common.OptionalString{Value: "2"},
+			OptionalString: common.OptionalString{Value: "1"},
+		},
+		autoClone: common.OptionalAutoClone{
+			OptionalBool: common.OptionalBool{Value: true},
 		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},

--- a/pkg/logging/syslog/syslog_test.go
+++ b/pkg/logging/syslog/syslog_test.go
@@ -1,6 +1,7 @@
 package syslog
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fastly/cli/pkg/common"
@@ -77,7 +78,11 @@ func TestUpdateSyslogInput(t *testing.T) {
 		{
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
-			api:  mock.API{GetSyslogFn: getSyslogOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSyslogFn:    getSyslogOK,
+			},
 			want: &fastly.UpdateSyslogInput{
 				ServiceID:      "123",
 				ServiceVersion: 2,
@@ -87,7 +92,11 @@ func TestUpdateSyslogInput(t *testing.T) {
 		{
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
-			api:  mock.API{GetSyslogFn: getSyslogOK},
+			api: mock.API{
+				ListVersionsFn: listVersionsOK,
+				GetVersionFn:   getVersionOK,
+				GetSyslogFn:    getSyslogOK,
+			},
 			want: &fastly.UpdateSyslogInput{
 				ServiceID:         "123",
 				ServiceVersion:    2,
@@ -126,19 +135,88 @@ func TestUpdateSyslogInput(t *testing.T) {
 }
 
 func createCommandRequired() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
 		Address:      "example.com",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
+func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    2,
+		Active:    true,
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 func createCommandAll() *CreateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+	globals.Client, _ = mock.APIClient(mock.API{
+		ListVersionsFn: listVersionsOK,
+		GetVersionFn:   getVersionOK,
+	})("token", "endpoint")
+
 	return &CreateCommand{
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		Address:           "example.com",
 		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
 		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
@@ -162,20 +240,52 @@ func createCommandMissingServiceID() *CreateCommand {
 }
 
 func updateCommandNoUpdates() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
-		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
 		EndpointName: "log",
-		Version:      2,
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 	}
 }
 
 func updateCommandAll() *UpdateCommand {
+	var b bytes.Buffer
+
+	globals := config.Data{
+		File:   config.File{},
+		Env:    config.Environment{},
+		Output: &b,
+	}
+
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
-		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
-		EndpointName:      "log",
-		Version:           2,
+		Base: common.Base{
+			Globals: &globals,
+		},
+		manifest: manifest.Data{
+			Flag: manifest.Flag{
+				ServiceID: "123",
+			},
+		},
+		EndpointName: "log",
+		serviceVersion: common.OptionalServiceVersion{
+			OptionalString: common.OptionalString{Value: "2"},
+		},
 		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
 		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
 		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},

--- a/pkg/logging/syslog/syslog_test.go
+++ b/pkg/logging/syslog/syslog_test.go
@@ -25,7 +25,7 @@ func TestCreateSyslogInput(t *testing.T) {
 			cmd:  createCommandRequired(),
 			want: &fastly.CreateSyslogInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 				Address:        "example.com",
 			},
@@ -35,7 +35,7 @@ func TestCreateSyslogInput(t *testing.T) {
 			cmd:  createCommandAll(),
 			want: &fastly.CreateSyslogInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				Address:           "example.com",
 				Port:              22,
@@ -79,14 +79,14 @@ func TestUpdateSyslogInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSyslogFn:    getSyslogOK,
 			},
 			want: &fastly.UpdateSyslogInput{
 				ServiceID:      "123",
-				ServiceVersion: 2,
+				ServiceVersion: 4,
 				Name:           "log",
 			},
 		},
@@ -94,14 +94,14 @@ func TestUpdateSyslogInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersionsOk,
-				GetVersionFn:   testutil.GetActiveVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSyslogFn:    getSyslogOK,
 			},
 			want: &fastly.UpdateSyslogInput{
 				ServiceID:         "123",
-				ServiceVersion:    2,
+				ServiceVersion:    4,
 				Name:              "log",
 				NewName:           fastly.String("new1"),
 				Address:           fastly.String("new2"),
@@ -145,9 +145,9 @@ func createCommandRequired() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{
@@ -179,9 +179,9 @@ func createCommandAll() *CreateCommand {
 		Output: &b,
 	}
 	globals.Client, _ = mock.APIClient(mock.API{
-		ListVersionsFn: testutil.ListVersionsOk,
-		GetVersionFn:   testutil.GetActiveVersionOK,
-		CloneVersionFn: testutil.CloneVersionOK,
+		ListVersionsFn: testutil.ListVersions,
+		GetVersionFn:   testutil.GetActiveVersion(1),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
 
 	return &CreateCommand{

--- a/pkg/logging/syslog/update.go
+++ b/pkg/logging/syslog/update.go
@@ -17,10 +17,11 @@ type UpdateCommand struct {
 	manifest manifest.Data
 
 	// required
-	EndpointName string
-	Version      int
+	EndpointName   string
+	serviceVersion common.OptionalServiceVersion
 
 	// optional
+	autoClone         common.OptionalAutoClone
 	NewName           common.OptionalString
 	Address           common.OptionalString
 	Port              common.OptionalUint
@@ -43,12 +44,10 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
-
 	c.CmdClause = parent.Command("update", "Update a Syslog logging endpoint on a Fastly service version")
-
-	c.CmdClause.Flag("version", "Number of service version").Required().IntVar(&c.Version)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.EndpointName)
-
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Syslog logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
@@ -64,7 +63,6 @@ func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCom
 	c.CmdClause.Flag("message-type", "How the message should be formatted. One of: classic (default), loggly, logplex or blank").Action(c.MessageType.Set).StringVar(&c.MessageType.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
-
 	return &c
 }
 
@@ -75,9 +73,18 @@ func (c *UpdateCommand) createInput() (*fastly.UpdateSyslogInput, error) {
 		return nil, errors.ErrNoServiceID
 	}
 
+	v, err := c.serviceVersion.Parse(serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+	v, err = c.autoClone.Parse(v, serviceID, c.Globals.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	input := fastly.UpdateSyslogInput{
 		ServiceID:      serviceID,
-		ServiceVersion: c.Version,
+		ServiceVersion: v.Number,
 		Name:           c.EndpointName,
 	}
 

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -19,6 +19,7 @@ type API struct {
 	SearchServiceFn     func(*fastly.SearchServiceInput) (*fastly.Service, error)
 
 	CloneVersionFn      func(*fastly.CloneVersionInput) (*fastly.Version, error)
+	GetVersionFn        func(*fastly.GetVersionInput) (*fastly.Version, error)
 	ListVersionsFn      func(*fastly.ListVersionsInput) ([]*fastly.Version, error)
 	UpdateVersionFn     func(*fastly.UpdateVersionInput) (*fastly.Version, error)
 	ActivateVersionFn   func(*fastly.ActivateVersionInput) (*fastly.Version, error)
@@ -263,6 +264,11 @@ func (m API) DeleteService(i *fastly.DeleteServiceInput) error {
 // CloneVersion implements Interface.
 func (m API) CloneVersion(i *fastly.CloneVersionInput) (*fastly.Version, error) {
 	return m.CloneVersionFn(i)
+}
+
+// GetVersion implements Interface.
+func (m API) GetVersion(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return m.GetVersionFn(i)
 }
 
 // ListVersions implements Interface.

--- a/pkg/serviceversion/activate.go
+++ b/pkg/serviceversion/activate.go
@@ -14,8 +14,10 @@ import (
 // ActivateCommand calls the Fastly API to activate a service version.
 type ActivateCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.ActivateVersionInput
+	manifest       manifest.Data
+	Input          fastly.ActivateVersionInput
+	serviceVersion common.OptionalServiceVersion
+	autoClone      common.OptionalAutoClone
 }
 
 // NewActivateCommand returns a usable command registered under the parent.
@@ -26,7 +28,8 @@ func NewActivateCommand(parent common.Registerer, globals *config.Data) *Activat
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("activate", "Activate a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of version you wish to activate").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
+	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	return &c
 }
 
@@ -38,11 +41,21 @@ func (c *ActivateCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 	c.Input.ServiceID = serviceID
 
-	v, err := c.Globals.Client.ActivateVersion(&c.Input)
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
+
+	ver, err := c.Globals.Client.ActivateVersion(&c.Input)
 	if err != nil {
 		return err
 	}
 
-	text.Success(out, "Activated service %s version %d", v.ServiceID, c.Input.ServiceVersion)
+	text.Success(out, "Activated service %s version %d", ver.ServiceID, c.Input.ServiceVersion)
 	return nil
 }

--- a/pkg/serviceversion/deactivate.go
+++ b/pkg/serviceversion/deactivate.go
@@ -14,8 +14,9 @@ import (
 // DeactivateCommand calls the Fastly API to deactivate a service version.
 type DeactivateCommand struct {
 	common.Base
-	manifest manifest.Data
-	Input    fastly.DeactivateVersionInput
+	manifest       manifest.Data
+	Input          fastly.DeactivateVersionInput
+	serviceVersion common.OptionalServiceVersion
 }
 
 // NewDeactivateCommand returns a usable command registered under the parent.
@@ -26,7 +27,7 @@ func NewDeactivateCommand(parent common.Registerer, globals *config.Data) *Deact
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("deactivate", "Deactivate a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
-	c.CmdClause.Flag("version", "Number of version you wish to deactivate").Required().IntVar(&c.Input.ServiceVersion)
+	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
 	return &c
 }
 
@@ -38,11 +39,17 @@ func (c *DeactivateCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 	c.Input.ServiceID = serviceID
 
-	v, err := c.Globals.Client.DeactivateVersion(&c.Input)
+	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
+	if err != nil {
+		return err
+	}
+	c.Input.ServiceVersion = v.Number
+
+	ver, err := c.Globals.Client.DeactivateVersion(&c.Input)
 	if err != nil {
 		return err
 	}
 
-	text.Success(out, "Deactivated service %s version %d", v.ServiceID, c.Input.ServiceVersion)
+	text.Success(out, "Deactivated service %s version %d", ver.ServiceID, c.Input.ServiceVersion)
 	return nil
 }

--- a/pkg/serviceversion/lock.go
+++ b/pkg/serviceversion/lock.go
@@ -17,7 +17,6 @@ type LockCommand struct {
 	manifest       manifest.Data
 	Input          fastly.LockVersionInput
 	serviceVersion common.OptionalServiceVersion
-	autoClone      common.OptionalAutoClone
 }
 
 // NewLockCommand returns a usable command registered under the parent.
@@ -29,7 +28,6 @@ func NewLockCommand(parent common.Registerer, globals *config.Data) *LockCommand
 	c.CmdClause = parent.Command("lock", "Lock a Fastly service version")
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.NewServiceVersionFlag(common.ServiceVersionFlagOpts{Dst: &c.serviceVersion.Value})
-	c.NewAutoCloneFlag(c.autoClone.Set, &c.autoClone.Value)
 	return &c
 }
 
@@ -42,10 +40,6 @@ func (c *LockCommand) Exec(in io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 
 	v, err := c.serviceVersion.Parse(c.Input.ServiceID, c.Globals.Client)
-	if err != nil {
-		return err
-	}
-	v, err = c.autoClone.Parse(v, c.Input.ServiceID, c.Globals.Client)
 	if err != nil {
 		return err
 	}

--- a/pkg/serviceversion/serviceversion_test.go
+++ b/pkg/serviceversion/serviceversion_test.go
@@ -34,18 +34,18 @@ func TestVersionClone(t *testing.T) {
 		{
 			args: []string{"service-version", "clone", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
-			wantOutput: "Cloned service 123 version 1 to version 2",
+			wantOutput: "Cloned service 123 version 1 to version 4",
 		},
 		{
 			args: []string{"service-version", "clone", "--service-id", "456", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: cloneVersionError,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionError,
 			},
 			wantError: errTest.Error(),
 		},
@@ -78,32 +78,32 @@ func TestVersionList(t *testing.T) {
 	}{
 		{
 			args:       []string{"service-version", "list", "--service-id", "123"},
-			api:        mock.API{ListVersionsFn: listVersionsOK},
+			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsShortOutput,
 		},
 		{
 			args:       []string{"service-version", "list", "--service-id", "123", "--verbose"},
-			api:        mock.API{ListVersionsFn: listVersionsOK},
+			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
 			args:       []string{"service-version", "list", "--service-id", "123", "-v"},
-			api:        mock.API{ListVersionsFn: listVersionsOK},
+			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
 			args:       []string{"service-version", "--verbose", "list", "--service-id", "123"},
-			api:        mock.API{ListVersionsFn: listVersionsOK},
+			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
 			args:       []string{"-v", "service-version", "list", "--service-id", "123"},
-			api:        mock.API{ListVersionsFn: listVersionsOK},
+			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
 			args:      []string{"service-version", "list", "--service-id", "123"},
-			api:       mock.API{ListVersionsFn: listVersionsError},
+			api:       mock.API{ListVersionsFn: testutil.ListVersionsError},
 			wantError: errTest.Error(),
 		},
 	} {
@@ -134,30 +134,30 @@ func TestVersionUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: []string{"service-version", "update", "--service-id", "123", "--version", "1", "--comment", "foo"},
+			args: []string{"service-version", "update", "--service-id", "123", "--version", "1", "--comment", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateVersionFn: updateVersionOK,
 			},
-			wantOutput: "Updated service 123 version 2",
+			wantOutput: "Updated service 123 version 4",
 		},
 		{
-			args: []string{"service-version", "update", "--service-id", "123", "--version", "1"},
+			args: []string{"service-version", "update", "--service-id", "123", "--version", "1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			wantError: "error parsing arguments: required flag --comment not provided",
 		},
 		{
-			args: []string{"service-version", "update", "--service-id", "123", "--version", "1", "--comment", "foo"},
+			args: []string{"service-version", "update", "--service-id", "123", "--version", "1", "--comment", "foo", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:  listVersionsOK,
-				GetVersionFn:    getVersionOK,
-				CloneVersionFn:  testutil.CloneVersionOK,
+				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetActiveVersion(1),
+				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateVersionFn: updateVersionError,
 			},
 			wantError: errTest.Error(),
@@ -194,26 +194,33 @@ func TestVersionActivate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args: []string{"service-version", "activate", "--service-id", "123", "--version", "1"},
+			args: []string{"service-version", "activate", "--service-id", "123", "--version", "1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    testutil.CloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				ActivateVersionFn: activateVersionError,
 			},
 			wantError: errTest.Error(),
 		},
-		// The following test validates that the autoclone logic causes the
-		// returned service version 1, which is 'activated', to be cloned.
 		{
-			args: []string{"service-version", "activate", "--service-id", "123", "--version", "1"},
+			args: []string{"service-version", "activate", "--service-id", "123", "--version", "1", "--autoclone"},
 			api: mock.API{
-				ListVersionsFn:    listVersionsOK,
-				GetVersionFn:      getVersionOK,
-				CloneVersionFn:    cloneVersionOK,
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetActiveVersion(1),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				ActivateVersionFn: activateVersionOK,
 			},
-			wantOutput: "Activated service 123 version 2",
+			wantOutput: "Activated service 123 version 4",
+		},
+		{
+			args: []string{"service-version", "activate", "--service-id", "123", "--version", "3", "--autoclone"},
+			api: mock.API{
+				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetInactiveVersion(3),
+				ActivateVersionFn: activateVersionOK,
+			},
+			wantOutput: "Activated service 123 version 3",
 		},
 	} {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
@@ -249,17 +256,26 @@ func TestVersionDeactivate(t *testing.T) {
 		{
 			args: []string{"service-version", "deactivate", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetActiveVersion(1),
 				DeactivateVersionFn: deactivateVersionOK,
 			},
 			wantOutput: "Deactivated service 123 version 1",
 		},
 		{
-			args: []string{"service-version", "deactivate", "--service-id", "123", "--version", "1"},
+			args: []string{"service-version", "deactivate", "--service-id", "123", "--version", "3"},
 			api: mock.API{
-				ListVersionsFn:      listVersionsOK,
-				GetVersionFn:        getVersionOK,
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetInactiveVersion(3),
+				DeactivateVersionFn: deactivateVersionOK,
+			},
+			wantOutput: "Deactivated service 123 version 3",
+		},
+		{
+			args: []string{"service-version", "deactivate", "--service-id", "123", "--version", "3"},
+			api: mock.API{
+				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetInactiveVersion(3),
 				DeactivateVersionFn: deactivateVersionError,
 			},
 			wantError: errTest.Error(),
@@ -298,19 +314,17 @@ func TestVersionLock(t *testing.T) {
 		{
 			args: []string{"service-version", "lock", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				LockVersionFn:  lockVersionOK,
 			},
-			wantOutput: "Locked service 123 version 2",
+			wantOutput: "Locked service 123 version 1",
 		},
 		{
 			args: []string{"service-version", "lock", "--service-id", "123", "--version", "1"},
 			api: mock.API{
-				ListVersionsFn: listVersionsOK,
-				GetVersionFn:   getVersionOK,
-				CloneVersionFn: testutil.CloneVersionOK,
+				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetActiveVersion(1),
 				LockVersionFn:  lockVersionError,
 			},
 			wantError: errTest.Error(),
@@ -337,86 +351,44 @@ func TestVersionLock(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func cloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		Number:    i.ServiceVersion + 1,
-		ServiceID: "123",
-		Active:    true,
-		Deployed:  true,
-		CreatedAt: testutil.MustParseTimeRFC3339("2010-11-15T19:01:02Z"),
-	}, nil
-}
-
-func cloneVersionError(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return nil, errTest
-}
-
-func getVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    1,
-		Active:    true,
-		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
-}
-
-func listVersionsOK(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return []*fastly.Version{
-		{
-			Number:    1,
-			Comment:   "a",
-			ServiceID: "b",
-			CreatedAt: testutil.MustParseTimeRFC3339("2001-02-03T04:05:06Z"),
-			UpdatedAt: testutil.MustParseTimeRFC3339("2010-11-15T19:01:02Z"),
-		},
-		{
-			Number:    2,
-			Comment:   "c",
-			ServiceID: "b",
-			Active:    true,
-			Deployed:  true,
-			CreatedAt: testutil.MustParseTimeRFC3339("2001-03-03T04:05:06Z"),
-			UpdatedAt: testutil.MustParseTimeRFC3339("2015-03-14T12:59:59Z"),
-		},
-	}, nil
-}
-
-func listVersionsError(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return nil, errTest
-}
-
 var listVersionsShortOutput = strings.TrimSpace(`
 NUMBER  ACTIVE  LAST EDITED (UTC)
-1       false   2010-11-15 19:01
-2       true    2015-03-14 12:59
+1       true    2000-01-01 01:00
+2       false   2000-01-02 01:00
+3       false   2000-01-03 01:00
 `) + "\n"
 
 var listVersionsVerboseOutput = strings.TrimSpace(`
 Fastly API token not provided
 Fastly API endpoint: https://api.fastly.com
-Versions: 2
-	Version 1/2
+Versions: 3
+	Version 1/3
 		Number: 1
-		Comment: a
-		Service ID: b
+		Service ID: 123
+		Active: true
+		Locked: false
+		Deployed: false
+		Staging: false
+		Testing: false
+		Last edited (UTC): 2000-01-01 01:00
+	Version 2/3
+		Number: 2
+		Service ID: 123
+		Active: false
+		Locked: true
+		Deployed: false
+		Staging: false
+		Testing: false
+		Last edited (UTC): 2000-01-02 01:00
+	Version 3/3
+		Number: 3
+		Service ID: 123
 		Active: false
 		Locked: false
 		Deployed: false
 		Staging: false
 		Testing: false
-		Created (UTC): 2001-02-03 04:05
-		Last edited (UTC): 2010-11-15 19:01
-	Version 2/2
-		Number: 2
-		Comment: c
-		Service ID: b
-		Active: true
-		Locked: false
-		Deployed: true
-		Staging: false
-		Testing: false
-		Created (UTC): 2001-03-03 04:05
-		Last edited (UTC): 2015-03-14 12:59
+		Last edited (UTC): 2000-01-03 01:00
 `) + "\n\n"
 
 func updateVersionOK(i *fastly.UpdateVersionInput) (*fastly.Version, error) {

--- a/pkg/serviceversion/serviceversion_test.go
+++ b/pkg/serviceversion/serviceversion_test.go
@@ -138,15 +138,17 @@ func TestVersionUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  listVersionsOK,
 				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				UpdateVersionFn: updateVersionOK,
 			},
-			wantOutput: "Updated service 123 version 1",
+			wantOutput: "Updated service 123 version 2",
 		},
 		{
-			args: []string{"service-version", "update", "--service-id", "123", "--version", "2"},
+			args: []string{"service-version", "update", "--service-id", "123", "--version", "1"},
 			api: mock.API{
 				ListVersionsFn: listVersionsOK,
 				GetVersionFn:   getVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 			},
 			wantError: "error parsing arguments: required flag --comment not provided",
 		},
@@ -155,6 +157,7 @@ func TestVersionUpdate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:  listVersionsOK,
 				GetVersionFn:    getVersionOK,
+				CloneVersionFn:  testutil.CloneVersionOK,
 				UpdateVersionFn: updateVersionError,
 			},
 			wantError: errTest.Error(),
@@ -195,14 +198,15 @@ func TestVersionActivate(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn:    listVersionsOK,
 				GetVersionFn:      getVersionOK,
+				CloneVersionFn:    testutil.CloneVersionOK,
 				ActivateVersionFn: activateVersionError,
 			},
 			wantError: errTest.Error(),
 		},
-		// The following test validates that the --autoclone flag causes the
+		// The following test validates that the autoclone logic causes the
 		// returned service version 1, which is 'activated', to be cloned.
 		{
-			args: []string{"service-version", "activate", "--service-id", "123", "--version", "1", "--autoclone"},
+			args: []string{"service-version", "activate", "--service-id", "123", "--version", "1"},
 			api: mock.API{
 				ListVersionsFn:    listVersionsOK,
 				GetVersionFn:      getVersionOK,
@@ -296,15 +300,17 @@ func TestVersionLock(t *testing.T) {
 			api: mock.API{
 				ListVersionsFn: listVersionsOK,
 				GetVersionFn:   getVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				LockVersionFn:  lockVersionOK,
 			},
-			wantOutput: "Locked service 123 version 1",
+			wantOutput: "Locked service 123 version 2",
 		},
 		{
 			args: []string{"service-version", "lock", "--service-id", "123", "--version", "1"},
 			api: mock.API{
 				ListVersionsFn: listVersionsOK,
 				GetVersionFn:   getVersionOK,
+				CloneVersionFn: testutil.CloneVersionOK,
 				LockVersionFn:  lockVersionError,
 			},
 			wantError: errTest.Error(),

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -1,13 +1,19 @@
 package testutil
 
 import (
+	"errors"
+
 	"github.com/fastly/go-fastly/v3/fastly"
 )
 
-// ListVersionsOk returns a list of service versions in different states.
+// ListVersions returns a list of service versions in different states.
 //
 // The first element is active, the second is locked, the third is editable.
-func ListVersionsOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+//
+// NOTE: consult the entire test suite before adding any new entries to the
+// returned type as the tests currently use testutil.CloneVersionResult() as a
+// way of making the test output and expectations as accurate as possible.
+func ListVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
 		{
 			ServiceID: i.ServiceID,
@@ -26,32 +32,53 @@ func ListVersionsOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 			ServiceID: i.ServiceID,
 			Number:    3,
 			Active:    false,
-			UpdatedAt: MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
 		},
 	}, nil
 }
 
-// GetActiveVersionOK returns an active service version (Number: 1).
-func GetActiveVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    1,
-		Active:    true,
-		UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
+// ListVersionsError returns a generic error message when attempting to list
+// service versions.
+func ListVersionsError(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return nil, errors.New("fixture error")
 }
 
-// GetInactiveVersionOK returns an inactive service version (Number: 1).
-func GetInactiveVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{
-		ServiceID: i.ServiceID,
-		Number:    1,
-		Active:    false,
-		UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
-	}, nil
+// GetActiveVersion returns a function which returns an active service version.
+func GetActiveVersion(version int) func(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return func(i *fastly.GetVersionInput) (*fastly.Version, error) {
+		return &fastly.Version{
+			ServiceID: i.ServiceID,
+			Number:    version,
+			Active:    true,
+			UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		}, nil
+	}
 }
 
-// CloneVersionOK returns an incremented service version.
-func CloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
+// GetInactiveVersion returns a function which returns an inactive service version.
+func GetInactiveVersion(version int) func(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return func(i *fastly.GetVersionInput) (*fastly.Version, error) {
+		return &fastly.Version{
+			ServiceID: i.ServiceID,
+			Number:    version,
+			Active:    false,
+			UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		}, nil
+	}
+}
+
+// CloneVersionResult returns a function which returns a specific cloned version.
+func CloneVersionResult(version int) func(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return func(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+		return &fastly.Version{
+			ServiceID: i.ServiceID,
+			Number:    version,
+		}, nil
+	}
+}
+
+// CloneVersionError returns a generic error message when attempting to clone a
+// service version.
+func CloneVersionError(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return nil, errors.New("fixture error")
 }

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -41,6 +41,16 @@ func GetActiveVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
 	}, nil
 }
 
+// GetInactiveVersionOK returns an inactive service version (Number: 1).
+func GetInactiveVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    1,
+		Active:    false,
+		UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
 // CloneVersionOK returns an incremented service version.
 func CloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -1,0 +1,47 @@
+package testutil
+
+import (
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+// ListVersionsOk returns a list of service versions in different states.
+//
+// The first element is active, the second is locked, the third is editable.
+func ListVersionsOk(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    3,
+			Active:    false,
+			UpdatedAt: MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+	}, nil
+}
+
+// GetActiveVersionOK returns an active service version (Number: 1).
+func GetActiveVersionOK(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{
+		ServiceID: i.ServiceID,
+		Number:    1,
+		Active:    true,
+		UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}, nil
+}
+
+// CloneVersionOK returns an incremented service version.
+func CloneVersionOK(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion + 1}, nil
+}

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ServiceType is a utility function which returns the given type string if
-// non-empty otherwise returns the default `vcl`. This should be used unitl the
+// non-empty otherwise returns the default `vcl`. This should be used until the
 // API properly returns Service.Type for non-wasm services.
 // TODO(phamann): remove once API returns correct type.
 func ServiceType(t string) string {


### PR DESCRIPTION
**Problem**: identifying the correct service version to use is a manual process which slows down a user's workflow.
**Solution**: overload the `--version` flag and implement a new `--autoclone` flag (fixes: https://github.com/fastly/cli/issues/141).
**Notes**: the implementation can be summarised as follows:

```
--version=VERSION   Number of service version, 'latest', 'active'
                    or 'editable'
--autoclone         Automatically clone the identified service
                    version if it's 'locked' or 'active'
```

- Every command that implements `--version` will call a `serviceVersion.Parse` function.
  - This function makes an API call for a list of all available service versions.
  - The returned list is sorted in descending order (i.e. newest versions first).
  - If the `--version` flag is set with the value `latest`:
    - We consider the selected version to be the latest version available.
    - The version _could_ be 'active' or 'locked', so `--autoclone` might need to be specified too.
    - We do not expect the returned version to be older than the last active version.
  - If the `--version` flag is set with the value `active`:
    - We consider the selected version to be the latest 'active' version.
  - If the `--version` flag is set with a numerical value (e.g. `1`, `2`, `3` etc):
    - We consider the selected version to be the given version.
  - If the `--version` flag is set with the value `editable`:
    - We consider the selected version to be the latest _editable_ version.
    - If we find an active version before an editable version, then we return an error.
  - If the `--version` flag is _not_ set (or an empty value is provided):
    - We consider the selected version to be the latest _editable_ version.
    - If we find an active version before an editable version, then we return an error.
- Once the version has been identified, if `--autoclone` is defined, we call a `autoclone.Parse` function.
  - This function checks if the version is 'active' or 'locked' and will clone it if necessary.
  - The `autoclone.Parse` function should only be called inside of commands where an 'editable' version is required.
  - The `--autoclone` flag should only be defined on commands where an 'editable' version is required.

## Example Scenarios

### Version not set, no editable versions available

The user has a service with a single version that is 'active'. They execute `backend create` without passing the `--version` flag. 

In this scenario the CLI would internally call `getLatestEditableVersion` and, because there are no editable versions available, it would return an error message such as "error retrieving an editable service version".

The resolution for the user would be to pass both the `--version` flag and the `--autoclone` flag. The value of the `--version` flag could be either `latest`, `active` or `1`. With `--autoclone` also specified this would cause a new editable service version `2` to be created, and the backend created within that new version.

On subsequent calls to `backend create` the user could then omit the `--version` and `--autoclone` flags as the CLI would infer calling `getLatestEditableVersion` and (unless the user had 'activated' the newly cloned version) would result in the newly cloned/editable version being identified and the new backend resource created within it.

Alternatively, on subsequent calls the user could specify either `--version=latest` or `--version=editable`. Because each CLI invocation will acquire an updated versions list, which is then sorted in descending order, this should ensure (regardless of whether the value `latest` or `editable` was provided) the version returned was the newly cloned/editable version and thus `--autoclone` wouldn't be needed on the subsequent calls.

### Version not set, editable version available

The user has a service with a single version that is editable (i.e. it is neither 'locked' nor 'active'). They execute `backend create` multiple times without passing the `--version` flag.

In this scenario the CLI would internally call `getLatestEditableVersion` on each CLI invocation (resulting in the editable version `1` being identified each time), which means the three backends would be created within the same editable version.

Alternatively, the user could prefer to be _explicit_ about their intention and for each CLI invocation they could pass either `--version=editable`, which also would internally call `getLatestEditableVersion`, or `--version=latest`. Both would result in the editable version `1` being identified each time.