### PR TITLE
Fix bug in parsing port number for backend

### DIFF
--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -545,10 +545,13 @@ func cfgBackend(backend string, backendPort uint, out io.Writer, in io.Reader, f
 			return "", 0, fmt.Errorf("error reading input %w", err)
 		}
 
-		portnumber, err := strconv.Atoi(input)
-		if err != nil {
-			text.Warning(out, "error converting input: %v. We'll use the default port number: [80].", err)
-			portnumber = 80
+		portnumber := 80
+		if input != "" {
+			portnumber, err = strconv.Atoi(input)
+			if err != nil {
+				text.Warning(out, "error converting input. We'll use the default port number: [80].")
+				portnumber = 80
+			}
 		}
 
 		backendPort = uint(portnumber)


### PR DESCRIPTION
When prompting the user for a backend port, we incorrectly try to convert an empty string into an integer.