### PR TITLE
fix bug in `publish` command caused by lack of flag override

### DIFF
--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -102,6 +102,7 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if c.backendPort.WasSet {
 		c.deploy.BackendPort = c.backendPort.Value
 	}
+	c.deploy.Manifest = c.manifest
 
 	err = c.deploy.Exec(in, out)
 	if err != nil {


### PR DESCRIPTION
**Problem**: A report came in to say that using `publish` with the `--service-id` flag was causing an error stating the relevant service could not be found, while switching to the `deploy` command (which publish proxies to) the flag would work as expected. 

This was caused by the `publish` command not overriding the manifest field used by the `deploy` command it was proxying to.