### PR TITLE
Move time behaviour from common to own package

### DIFF
--- a/pkg/common/time.go
+++ b/pkg/common/time.go
@@ -1,5 +1,0 @@
-package common
-
-// TimeFormat is a format string for time.Format that reflects what the Fastly
-// web UI uses.
-const TimeFormat = "2006-01-02 15:04"

--- a/pkg/service/list.go
+++ b/pkg/service/list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/cli/pkg/time"
 	"github.com/fastly/go-fastly/v3/fastly"
 )
 
@@ -38,7 +39,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		for _, service := range services {
 			updatedAt := "n/a"
 			if service.UpdatedAt != nil {
-				updatedAt = service.UpdatedAt.UTC().Format(common.TimeFormat)
+				updatedAt = service.UpdatedAt.UTC().Format(time.Format)
 			}
 
 			activeVersion := fmt.Sprint(service.ActiveVersion)

--- a/pkg/serviceversion/list.go
+++ b/pkg/serviceversion/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/cli/pkg/time"
 	"github.com/fastly/go-fastly/v3/fastly"
 )
 
@@ -47,7 +48,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		tw := text.NewTable(out)
 		tw.AddHeader("NUMBER", "ACTIVE", "LAST EDITED (UTC)")
 		for _, version := range versions {
-			tw.AddLine(version.Number, version.Active, version.UpdatedAt.UTC().Format(common.TimeFormat))
+			tw.AddLine(version.Number, version.Active, version.UpdatedAt.UTC().Format(time.Format))
 		}
 		tw.Print()
 		return nil

--- a/pkg/text/dictionary.go
+++ b/pkg/text/dictionary.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/time"
 	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
@@ -18,9 +18,9 @@ func PrintDictionary(out io.Writer, prefix string, d *fastly.Dictionary) {
 	fmt.Fprintf(out, "ID: %s\n", d.ID)
 	fmt.Fprintf(out, "Name: %s\n", d.Name)
 	fmt.Fprintf(out, "Write Only: %t\n", d.WriteOnly)
-	fmt.Fprintf(out, "Created (UTC): %s\n", d.CreatedAt.UTC().Format(common.TimeFormat))
-	fmt.Fprintf(out, "Last edited (UTC): %s\n", d.UpdatedAt.UTC().Format(common.TimeFormat))
+	fmt.Fprintf(out, "Created (UTC): %s\n", d.CreatedAt.UTC().Format(time.Format))
+	fmt.Fprintf(out, "Last edited (UTC): %s\n", d.UpdatedAt.UTC().Format(time.Format))
 	if d.DeletedAt != nil {
-		fmt.Fprintf(out, "Deleted (UTC): %s\n", d.DeletedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Deleted (UTC): %s\n", d.DeletedAt.UTC().Format(time.Format))
 	}
 }

--- a/pkg/text/dictionaryitem.go
+++ b/pkg/text/dictionaryitem.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/time"
 	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
@@ -19,13 +19,13 @@ func PrintDictionaryItem(out io.Writer, prefix string, d *fastly.DictionaryItem)
 	fmt.Fprintf(out, "Item Key: %s\n", d.ItemKey)
 	fmt.Fprintf(out, "Item Value: %s\n", d.ItemValue)
 	if d.CreatedAt != nil {
-		fmt.Fprintf(out, "Created (UTC): %s\n", d.CreatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Created (UTC): %s\n", d.CreatedAt.UTC().Format(time.Format))
 	}
 	if d.UpdatedAt != nil {
-		fmt.Fprintf(out, "Last edited (UTC): %s\n", d.UpdatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Last edited (UTC): %s\n", d.UpdatedAt.UTC().Format(time.Format))
 	}
 	if d.DeletedAt != nil {
-		fmt.Fprintf(out, "Deleted (UTC): %s\n", d.DeletedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Deleted (UTC): %s\n", d.DeletedAt.UTC().Format(time.Format))
 	}
 }
 

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/time"
 	"github.com/fastly/go-fastly/v3/fastly"
 	"github.com/segmentio/textio"
 )
@@ -35,13 +35,13 @@ func PrintService(out io.Writer, prefix string, s *fastly.Service) {
 	}
 	fmt.Fprintf(out, "Customer ID: %s\n", s.CustomerID)
 	if s.CreatedAt != nil {
-		fmt.Fprintf(out, "Created (UTC): %s\n", s.CreatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Created (UTC): %s\n", s.CreatedAt.UTC().Format(time.Format))
 	}
 	if s.UpdatedAt != nil {
-		fmt.Fprintf(out, "Last edited (UTC): %s\n", s.UpdatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Last edited (UTC): %s\n", s.UpdatedAt.UTC().Format(time.Format))
 	}
 	if s.DeletedAt != nil {
-		fmt.Fprintf(out, "Deleted (UTC): %s\n", s.DeletedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Deleted (UTC): %s\n", s.DeletedAt.UTC().Format(time.Format))
 	}
 	fmt.Fprintf(out, "Active version: %d\n", s.ActiveVersion)
 	fmt.Fprintf(out, "Versions: %d\n", len(s.Versions))
@@ -73,13 +73,13 @@ func PrintServiceDetail(out io.Writer, indent string, s *fastly.ServiceDetail) {
 	}
 	fmt.Fprintf(out, "Customer ID: %s\n", s.CustomerID)
 	if s.CreatedAt != nil {
-		fmt.Fprintf(out, "Created (UTC): %s\n", s.CreatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Created (UTC): %s\n", s.CreatedAt.UTC().Format(time.Format))
 	}
 	if s.UpdatedAt != nil {
-		fmt.Fprintf(out, "Last edited (UTC): %s\n", s.UpdatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Last edited (UTC): %s\n", s.UpdatedAt.UTC().Format(time.Format))
 	}
 	if s.DeletedAt != nil {
-		fmt.Fprintf(out, "Deleted (UTC): %s\n", s.DeletedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Deleted (UTC): %s\n", s.DeletedAt.UTC().Format(time.Format))
 	}
 	if s.ActiveVersion.Active {
 		fmt.Fprintf(out, "Active version:\n")
@@ -111,12 +111,12 @@ func PrintVersion(out io.Writer, indent string, v *fastly.Version) {
 	fmt.Fprintf(out, "Staging: %v\n", v.Staging)
 	fmt.Fprintf(out, "Testing: %v\n", v.Testing)
 	if v.CreatedAt != nil {
-		fmt.Fprintf(out, "Created (UTC): %s\n", v.CreatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Created (UTC): %s\n", v.CreatedAt.UTC().Format(time.Format))
 	}
 	if v.UpdatedAt != nil {
-		fmt.Fprintf(out, "Last edited (UTC): %s\n", v.UpdatedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Last edited (UTC): %s\n", v.UpdatedAt.UTC().Format(time.Format))
 	}
 	if v.DeletedAt != nil {
-		fmt.Fprintf(out, "Deleted (UTC): %s\n", v.DeletedAt.UTC().Format(common.TimeFormat))
+		fmt.Fprintf(out, "Deleted (UTC): %s\n", v.DeletedAt.UTC().Format(time.Format))
 	}
 }

--- a/pkg/time/doc.go
+++ b/pkg/time/doc.go
@@ -1,0 +1,2 @@
+// Package time contains helper abstractions for working with time formats.
+package time

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -1,0 +1,5 @@
+package time
+
+// Format is a format string for time.Format that reflects what the Fastly web
+// UI uses.
+const Format = "2006-01-02 15:04"


### PR DESCRIPTION
**Problem**: I'm increasingly stumbling into issues with the `common` package being too broad/generic. This materialises as an "import cycle error". It is also considered bad practice to have folders named `common` or `utils` etc.
**Solution**: Move these behaviours into their own packages.
**Example**: I would like to add a remediation error type to some code in our `config` package. This isn't possible because importing the `errors` package will import `text` which will import `common` and the common package has already been imported earlier in the import cycle:

```
package github.com/fastly/cli/cmd/fastly
        imports github.com/fastly/cli/pkg/app
        imports github.com/fastly/cli/pkg/backend
        imports github.com/fastly/cli/pkg/common << command stuff like: Base/Register/StreamingExec + lots more other misc stuff.
        imports github.com/fastly/cli/pkg/config
        imports github.com/fastly/cli/pkg/errors
        imports github.com/fastly/cli/pkg/text
        imports github.com/fastly/cli/pkg/common: import cycle not allowed
```