### PR TITLE
Move command behaviour from common to own package

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/backend"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/configure"
@@ -363,7 +363,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	statsHistorical := stats.NewHistoricalCommand(statsRoot.CmdClause, &globals)
 	statsRealtime := stats.NewRealtimeCommand(statsRoot.CmdClause, &globals)
 
-	commands := []common.Command{
+	commands := []cmd.Command{
 		configureRoot,
 		whoamiRoot,
 		versionRoot,
@@ -723,7 +723,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		return fmt.Errorf("error constructing Fastly realtime stats client: %w", err)
 	}
 
-	command, found := common.SelectCommand(name, commands)
+	command, found := cmd.Select(name, commands)
 	if !found {
 		usage := Usage(args, app, out, io.Discard)
 		return errors.RemediationError{Prefix: usage, Inner: fmt.Errorf("command not found")}

--- a/pkg/backend/create.go
+++ b/pkg/backend/create.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -11,7 +11,7 @@ import (
 
 // CreateCommand calls the Fastly API to create backends.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	Input fastly.CreateBackendInput
 
 	// We must store all of the boolean flags separately to the input structure
@@ -22,7 +22,7 @@ type CreateCommand struct {
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("create", "Create a backend on a Fastly service version").Alias("add")

--- a/pkg/backend/delete.go
+++ b/pkg/backend/delete.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -11,12 +11,12 @@ import (
 
 // DeleteCommand calls the Fastly API to delete backends.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	Input fastly.DeleteBackendInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("delete", "Delete a backend on a Fastly service version").Alias("remove")

--- a/pkg/backend/describe.go
+++ b/pkg/backend/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -12,12 +12,12 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a backend.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	Input fastly.GetBackendInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("describe", "Show detailed information about a backend on a Fastly service version").Alias("get")

--- a/pkg/backend/list.go
+++ b/pkg/backend/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -12,12 +12,12 @@ import (
 
 // ListCommand calls the Fastly API to list backends.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	Input fastly.ListBackendsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("list", "List backends on a Fastly service version")

--- a/pkg/backend/root.go
+++ b/pkg/backend/root.go
@@ -3,19 +3,19 @@ package backend
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("backend", "Manipulate Fastly service version backends")

--- a/pkg/backend/update.go
+++ b/pkg/backend/update.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -11,38 +11,38 @@ import (
 
 // UpdateCommand calls the Fastly API to update backends.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	Input fastly.GetBackendInput
 
-	NewName             common.OptionalString
-	Comment             common.OptionalString
-	Address             common.OptionalString
-	Port                common.OptionalUint
-	OverrideHost        common.OptionalString
-	ConnectTimeout      common.OptionalUint
-	MaxConn             common.OptionalUint
-	FirstByteTimeout    common.OptionalUint
-	BetweenBytesTimeout common.OptionalUint
-	AutoLoadbalance     common.OptionalBool
-	Weight              common.OptionalUint
-	RequestCondition    common.OptionalString
-	HealthCheck         common.OptionalString
-	Hostname            common.OptionalString
-	Shield              common.OptionalString
-	UseSSL              common.OptionalBool
-	SSLCheckCert        common.OptionalBool
-	SSLCACert           common.OptionalString
-	SSLClientCert       common.OptionalString
-	SSLClientKey        common.OptionalString
-	SSLCertHostname     common.OptionalString
-	SSLSNIHostname      common.OptionalString
-	MinTLSVersion       common.OptionalString
-	MaxTLSVersion       common.OptionalString
-	SSLCiphers          common.OptionalStringSlice
+	NewName             cmd.OptionalString
+	Comment             cmd.OptionalString
+	Address             cmd.OptionalString
+	Port                cmd.OptionalUint
+	OverrideHost        cmd.OptionalString
+	ConnectTimeout      cmd.OptionalUint
+	MaxConn             cmd.OptionalUint
+	FirstByteTimeout    cmd.OptionalUint
+	BetweenBytesTimeout cmd.OptionalUint
+	AutoLoadbalance     cmd.OptionalBool
+	Weight              cmd.OptionalUint
+	RequestCondition    cmd.OptionalString
+	HealthCheck         cmd.OptionalString
+	Hostname            cmd.OptionalString
+	Shield              cmd.OptionalString
+	UseSSL              cmd.OptionalBool
+	SSLCheckCert        cmd.OptionalBool
+	SSLCACert           cmd.OptionalString
+	SSLClientCert       cmd.OptionalString
+	SSLClientKey        cmd.OptionalString
+	SSLCertHostname     cmd.OptionalString
+	SSLSNIHostname      cmd.OptionalString
+	MinTLSVersion       cmd.OptionalString
+	MaxTLSVersion       cmd.OptionalString
+	SSLCiphers          cmd.OptionalStringSlice
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("update", "Update a backend on a Fastly service version")

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -1,4 +1,4 @@
-package common
+package cmd
 
 import (
 	"io"
@@ -16,8 +16,8 @@ type Command interface {
 	Exec(in io.Reader, out io.Writer) error
 }
 
-// SelectCommand chooses the command matching name, if it exists.
-func SelectCommand(name string, commands []Command) (Command, bool) {
+// Select chooses the command matching name, if it exists.
+func Select(name string, commands []Command) (Command, bool) {
 	for _, command := range commands {
 		if command.Name() == name {
 			return command, true

--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,0 +1,2 @@
+// Package cmd contains helper abstractions for working with the CLI parser.
+package cmd

--- a/pkg/compute/build.go
+++ b/pkg/compute/build.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/filesystem"
@@ -64,7 +64,7 @@ func NewLanguage(options *LanguageOptions) *Language {
 
 // BuildCommand produces a deployable artifact from files on the local disk.
 type BuildCommand struct {
-	common.Base
+	cmd.Base
 	client api.HTTPClient
 
 	// NOTE: these are public so that the "publish" composite command can set the
@@ -76,7 +76,7 @@ type BuildCommand struct {
 }
 
 // NewBuildCommand returns a usable command registered under the parent.
-func NewBuildCommand(parent common.Registerer, client api.HTTPClient, globals *config.Data) *BuildCommand {
+func NewBuildCommand(parent cmd.Registerer, client api.HTTPClient, globals *config.Data) *BuildCommand {
 	var c BuildCommand
 	c.Globals = globals
 	c.client = client

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -15,7 +15,7 @@ import (
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -38,20 +38,20 @@ const (
 
 // DeployCommand deploys an artifact previously produced by build.
 type DeployCommand struct {
-	common.Base
+	cmd.Base
 
 	// NOTE: these are public so that the "publish" composite command can set the
 	// values appropriately before calling the Exec() function.
 	Manifest    manifest.Data
 	Path        string
-	Version     common.OptionalInt
+	Version     cmd.OptionalInt
 	Domain      string
 	Backend     string
 	BackendPort uint
 }
 
 // NewDeployCommand returns a usable command registered under the parent.
-func NewDeployCommand(parent common.Registerer, client api.HTTPClient, globals *config.Data) *DeployCommand {
+func NewDeployCommand(parent cmd.Registerer, client api.HTTPClient, globals *config.Data) *DeployCommand {
 	var c DeployCommand
 	c.Globals = globals
 	c.Manifest.File.SetOutput(c.Globals.Output)
@@ -321,7 +321,7 @@ func pkgPath(path string, name string, source manifest.Source) (string, error) {
 
 // validateService checks if the service version has a domain and backend
 // defined.
-func validateService(serviceID string, client api.Interface, version common.OptionalInt) (*fastly.Version, bool, invalidResource, error) {
+func validateService(serviceID string, client api.Interface, version cmd.OptionalInt) (*fastly.Version, bool, invalidResource, error) {
 	v, err := serviceVersion(serviceID, client, version)
 	if err != nil {
 		return nil, false, resourceNone, err
@@ -360,7 +360,7 @@ func validateService(serviceID string, client api.Interface, version common.Opti
 }
 
 // serviceVersion returns the version for the given service.
-func serviceVersion(serviceID string, client api.Interface, versionFlag common.OptionalInt) (*fastly.Version, error) {
+func serviceVersion(serviceID string, client api.Interface, versionFlag cmd.OptionalInt) (*fastly.Version, error) {
 	_, err := client.GetService(&fastly.GetServiceInput{
 		ID: serviceID,
 	})

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -30,7 +30,7 @@ var (
 
 // InitCommand initializes a Compute@Edge project package on the local machine.
 type InitCommand struct {
-	common.Base
+	cmd.Base
 	client        api.HTTPClient
 	manifest      manifest.Data
 	language      string
@@ -42,7 +42,7 @@ type InitCommand struct {
 }
 
 // NewInitCommand returns a usable command registered under the parent.
-func NewInitCommand(parent common.Registerer, client api.HTTPClient, globals *config.Data) *InitCommand {
+func NewInitCommand(parent cmd.Registerer, client api.HTTPClient, globals *config.Data) *InitCommand {
 	var c InitCommand
 	c.Globals = globals
 	c.client = client

--- a/pkg/compute/pack.go
+++ b/pkg/compute/pack.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -16,13 +16,13 @@ import (
 
 // PackCommand takes a .wasm and builds the required tar/gzip package ready to be uploaded.
 type PackCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	path     string
 }
 
 // NewPackCommand returns a usable command registered under the parent.
-func NewPackCommand(parent common.Registerer, globals *config.Data) *PackCommand {
+func NewPackCommand(parent cmd.Registerer, globals *config.Data) *PackCommand {
 	var c PackCommand
 	c.Globals = globals
 

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -3,7 +3,7 @@ package compute
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
@@ -11,27 +11,27 @@ import (
 
 // PublishCommand produces and deploys an artifact from files on the local disk.
 type PublishCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	build    *BuildCommand
 	deploy   *DeployCommand
 
 	// Deploy fields
-	path        common.OptionalString
-	version     common.OptionalInt
-	domain      common.OptionalString
-	backend     common.OptionalString
-	backendPort common.OptionalUint
+	path        cmd.OptionalString
+	version     cmd.OptionalInt
+	domain      cmd.OptionalString
+	backend     cmd.OptionalString
+	backendPort cmd.OptionalUint
 
 	// Build fields
-	name       common.OptionalString
-	lang       common.OptionalString
-	includeSrc common.OptionalBool
-	force      common.OptionalBool
+	name       cmd.OptionalString
+	lang       cmd.OptionalString
+	includeSrc cmd.OptionalBool
+	force      cmd.OptionalBool
 }
 
 // NewPublishCommand returns a usable command registered under the parent.
-func NewPublishCommand(parent common.Registerer, globals *config.Data, build *BuildCommand, deploy *DeployCommand) *PublishCommand {
+func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *BuildCommand, deploy *DeployCommand) *PublishCommand {
 	var c PublishCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
@@ -91,7 +91,7 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		c.deploy.Path = c.path.Value
 	}
 	if c.version.WasSet {
-		c.deploy.Version = c.version // deploy's field is a common.OptionalInt
+		c.deploy.Version = c.version // deploy's field is a cmd.OptionalInt
 	}
 	if c.domain.WasSet {
 		c.deploy.Domain = c.domain.Value

--- a/pkg/compute/root.go
+++ b/pkg/compute/root.go
@@ -3,7 +3,7 @@ package compute
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
@@ -13,12 +13,12 @@ const ManifestFilename = "fastly.toml"
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("compute", "Manage Compute@Edge packages")

--- a/pkg/compute/update.go
+++ b/pkg/compute/update.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
@@ -14,14 +14,14 @@ import (
 
 // UpdateCommand calls the Fastly API to update packages.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	serviceID string
 	version   int
 	path      string
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, client api.HTTPClient, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, client api.HTTPClient, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("update", "Update a package on a Fastly Compute@Edge service version")

--- a/pkg/compute/validate.go
+++ b/pkg/compute/validate.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/mholt/archiver/v3"
@@ -68,12 +68,12 @@ func validate(path string) error {
 
 // ValidateCommand validates a package archive.
 type ValidateCommand struct {
-	common.Base
+	cmd.Base
 	path string
 }
 
 // NewValidateCommand returns a usable command registered under the parent.
-func NewValidateCommand(parent common.Registerer, globals *config.Data) *ValidateCommand {
+func NewValidateCommand(parent cmd.Registerer, globals *config.Data) *ValidateCommand {
 	var c ValidateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("validate", "Validate a Compute@Edge package")

--- a/pkg/configure/root.go
+++ b/pkg/configure/root.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -23,13 +23,13 @@ type APIClientFactory func(token, endpoint string) (api.Interface, error)
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	configFilePath string
 	clientFactory  APIClientFactory
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, configFilePath string, cf APIClientFactory, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, configFilePath string, cf APIClientFactory, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("configure", "Configure the Fastly CLI")

--- a/pkg/domain/create.go
+++ b/pkg/domain/create.go
@@ -3,7 +3,7 @@ package domain
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // CreateCommand calls the Fastly API to create domains.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.CreateDomainInput
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/domain/delete.go
+++ b/pkg/domain/delete.go
@@ -3,7 +3,7 @@ package domain
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete domains.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteDomainInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/domain/describe.go
+++ b/pkg/domain/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a domain.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetDomainInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/domain/list.go
+++ b/pkg/domain/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list domains.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListDomainsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/domain/root.go
+++ b/pkg/domain/root.go
@@ -3,19 +3,19 @@ package domain
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("domain", "Manipulate Fastly service version domains")

--- a/pkg/domain/update.go
+++ b/pkg/domain/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,16 +14,16 @@ import (
 
 // UpdateCommand calls the Fastly API to update domains.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	input    fastly.UpdateDomainInput
 
-	NewName common.OptionalString
-	Comment common.OptionalString
+	NewName cmd.OptionalString
+	Comment cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("update", "Update a domain on a Fastly service version")

--- a/pkg/edgedictionary/create.go
+++ b/pkg/edgedictionary/create.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,15 +14,15 @@ import (
 
 // CreateCommand calls the Fastly API to create a service.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.CreateDictionaryInput
 
-	writeOnly common.OptionalString
+	writeOnly cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionary/delete.go
+++ b/pkg/edgedictionary/delete.go
@@ -3,7 +3,7 @@ package edgedictionary
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a service.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteDictionaryInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionary/describe.go
+++ b/pkg/edgedictionary/describe.go
@@ -3,7 +3,7 @@ package edgedictionary
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a dictionary.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetDictionaryInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionary/list.go
+++ b/pkg/edgedictionary/list.go
@@ -3,7 +3,7 @@ package edgedictionary
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // ListCommand calls the Fastly API to list dictionaries
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListDictionariesInput
 }
 
 // NewListCommand returns a usable command registered under the parent
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionary/root.go
+++ b/pkg/edgedictionary/root.go
@@ -3,19 +3,19 @@ package edgedictionary
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("dictionary", "Manipulate Fastly edge dictionaries")

--- a/pkg/edgedictionary/update.go
+++ b/pkg/edgedictionary/update.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -15,16 +15,16 @@ import (
 
 // UpdateCommand calls the Fastly API to update a dictionary.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	input    fastly.UpdateDictionaryInput
 
-	newname   common.OptionalString
-	writeOnly common.OptionalString
+	newname   cmd.OptionalString
+	writeOnly cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionaryitem/batch.go
+++ b/pkg/edgedictionaryitem/batch.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -16,15 +16,15 @@ import (
 
 // BatchCommand calls the Fastly API to batch update a dictionary.
 type BatchCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.BatchModifyDictionaryItemsInput
 
-	file common.OptionalString
+	file cmd.OptionalString
 }
 
 // NewBatchCommand returns a usable command registered under the parent.
-func NewBatchCommand(parent common.Registerer, globals *config.Data) *BatchCommand {
+func NewBatchCommand(parent cmd.Registerer, globals *config.Data) *BatchCommand {
 	var c BatchCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionaryitem/create.go
+++ b/pkg/edgedictionaryitem/create.go
@@ -3,7 +3,7 @@ package edgedictionaryitem
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // CreateCommand calls the Fastly API to create a dictionary item.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.CreateDictionaryItemInput
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionaryitem/delete.go
+++ b/pkg/edgedictionaryitem/delete.go
@@ -3,7 +3,7 @@ package edgedictionaryitem
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a service.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteDictionaryItemInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionaryitem/describe.go
+++ b/pkg/edgedictionaryitem/describe.go
@@ -3,7 +3,7 @@ package edgedictionaryitem
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a dictionary item.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetDictionaryItemInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionaryitem/list.go
+++ b/pkg/edgedictionaryitem/list.go
@@ -3,7 +3,7 @@ package edgedictionaryitem
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // ListCommand calls the Fastly API to list dictionary items.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListDictionaryItemsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/edgedictionaryitem/root.go
+++ b/pkg/edgedictionaryitem/root.go
@@ -3,19 +3,19 @@ package edgedictionaryitem
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("dictionaryitem", "Manipulate Fastly edge dictionary items")

--- a/pkg/edgedictionaryitem/update.go
+++ b/pkg/edgedictionaryitem/update.go
@@ -3,7 +3,7 @@ package edgedictionaryitem
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,17 +13,17 @@ import (
 
 // UpdateCommand calls the Fastly API to update a dictionary item.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.UpdateDictionaryItemInput
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
 //
-// TODO(integralist) update to not use common.OptionalString once we have a
+// TODO(integralist) update to not use cmd.OptionalString once we have a
 // new Go-Fastly release that modifies UpdateDictionaryItemInput so that the
 // ItemValue is no longer optional.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/healthcheck/create.go
+++ b/pkg/healthcheck/create.go
@@ -3,7 +3,7 @@ package healthcheck
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // CreateCommand calls the Fastly API to create healthchecks.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.CreateHealthCheckInput
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("create", "Create a healthcheck on a Fastly service version").Alias("add")

--- a/pkg/healthcheck/delete.go
+++ b/pkg/healthcheck/delete.go
@@ -3,7 +3,7 @@ package healthcheck
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete healthchecks.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteHealthCheckInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/healthcheck/describe.go
+++ b/pkg/healthcheck/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a healthcheck.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetHealthCheckInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/healthcheck/list.go
+++ b/pkg/healthcheck/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list healthchecks.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListHealthChecksInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/healthcheck/root.go
+++ b/pkg/healthcheck/root.go
@@ -3,19 +3,19 @@ package healthcheck
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("healthcheck", "Manipulate Fastly service version healthchecks")

--- a/pkg/healthcheck/update.go
+++ b/pkg/healthcheck/update.go
@@ -3,7 +3,7 @@ package healthcheck
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,26 +13,26 @@ import (
 
 // UpdateCommand calls the Fastly API to update healthchecks.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	input    fastly.UpdateHealthCheckInput
 
-	NewName          common.OptionalString
-	Comment          common.OptionalString
-	Method           common.OptionalString
-	Host             common.OptionalString
-	Path             common.OptionalString
-	HTTPVersion      common.OptionalString
-	Timeout          common.OptionalUint
-	CheckInterval    common.OptionalUint
-	ExpectedResponse common.OptionalUint
-	Window           common.OptionalUint
-	Threshold        common.OptionalUint
-	Initial          common.OptionalUint
+	NewName          cmd.OptionalString
+	Comment          cmd.OptionalString
+	Method           cmd.OptionalString
+	Host             cmd.OptionalString
+	Path             cmd.OptionalString
+	HTTPVersion      cmd.OptionalString
+	Timeout          cmd.OptionalUint
+	CheckInterval    cmd.OptionalUint
+	ExpectedResponse cmd.OptionalUint
+	Window           cmd.OptionalUint
+	Threshold        cmd.OptionalUint
+	Initial          cmd.OptionalUint
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/azureblob/azureblob_test.go
+++ b/pkg/logging/azureblob/azureblob_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -149,16 +149,16 @@ func createCommandAll() *CreateCommand {
 		Container:         "container",
 		AccountName:       "account",
 		SASToken:          "token",
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/log"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "/log"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -170,7 +170,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "logs",
 		Version:      2,
@@ -179,25 +179,25 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "logs",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Container:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		AccountName:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		SASToken:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Container:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		AccountName:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		SASToken:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		GzipLevel:         cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
 	}
 }
 

--- a/pkg/logging/azureblob/create.go
+++ b/pkg/logging/azureblob/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,33 +14,33 @@ import (
 
 // CreateCommand calls the Fastly API to create an Azure Blob Storage logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Container    string
 	AccountName  string
 	SASToken     string
 
 	// optional
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	MessageType       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	PublicKey         common.OptionalString
-	FileMaxBytes      common.OptionalUint
-	CompressionCodec  common.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	FileMaxBytes      cmd.OptionalUint
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/azureblob/delete.go
+++ b/pkg/logging/azureblob/delete.go
@@ -3,7 +3,7 @@ package azureblob
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an Azure Blob Storage logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteBlobStorageInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/azureblob/describe.go
+++ b/pkg/logging/azureblob/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an Azure Blob Storage logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetBlobStorageInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/azureblob/list.go
+++ b/pkg/logging/azureblob/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Azure Blob Storage logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListBlobStoragesInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/azureblob/root.go
+++ b/pkg/logging/azureblob/root.go
@@ -3,19 +3,19 @@ package azureblob
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("azureblob", "Manipulate Fastly service version Azure Blob Storage logging endpoints")

--- a/pkg/logging/azureblob/update.go
+++ b/pkg/logging/azureblob/update.go
@@ -3,7 +3,7 @@ package azureblob
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,7 +13,7 @@ import (
 
 // UpdateCommand calls the Fastly API to update an Azure Blob Storage logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	//required
@@ -21,26 +21,26 @@ type UpdateCommand struct {
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	AccountName       common.OptionalString
-	Container         common.OptionalString
-	SASToken          common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	MessageType       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	PublicKey         common.OptionalString
-	FileMaxBytes      common.OptionalUint
-	CompressionCodec  common.OptionalString
+	NewName           cmd.OptionalString
+	AccountName       cmd.OptionalString
+	Container         cmd.OptionalString
+	SASToken          cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	FileMaxBytes      cmd.OptionalUint
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/bigquery/bigquery_test.go
+++ b/pkg/logging/bigquery/bigquery_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -147,11 +147,11 @@ func createCommandAll() *CreateCommand {
 		Table:             "table",
 		User:              "user",
 		SecretKey:         "-----BEGIN PRIVATE KEY-----foo",
-		Template:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "template"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
+		Template:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "template"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
 	}
 }
 
@@ -163,7 +163,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -172,21 +172,21 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		ProjectID:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Dataset:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		Table:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Template:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		ProjectID:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Dataset:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		Table:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Template:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
 	}
 }
 

--- a/pkg/logging/bigquery/create.go
+++ b/pkg/logging/bigquery/create.go
@@ -3,7 +3,7 @@ package bigquery
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,11 +13,11 @@ import (
 
 // CreateCommand calls the Fastly API to create a BigQuery logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	ProjectID    string
 	Dataset      string
@@ -26,15 +26,15 @@ type CreateCommand struct {
 	SecretKey    string
 
 	// optional
-	Template          common.OptionalString
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
+	Template          cmd.OptionalString
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/bigquery/delete.go
+++ b/pkg/logging/bigquery/delete.go
@@ -3,7 +3,7 @@ package bigquery
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a BigQuery logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteBigQueryInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/bigquery/describe.go
+++ b/pkg/logging/bigquery/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a BigQuery logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetBigQueryInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/bigquery/list.go
+++ b/pkg/logging/bigquery/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list BigQuery logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListBigQueriesInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/bigquery/root.go
+++ b/pkg/logging/bigquery/root.go
@@ -3,19 +3,19 @@ package bigquery
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("bigquery", "Manipulate Fastly service version BigQuery logging endpoints")

--- a/pkg/logging/bigquery/update.go
+++ b/pkg/logging/bigquery/update.go
@@ -3,7 +3,7 @@ package bigquery
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,29 +13,29 @@ import (
 
 // UpdateCommand calls the Fastly API to update a BigQuery logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	ProjectID         common.OptionalString
-	Dataset           common.OptionalString
-	Table             common.OptionalString
-	User              common.OptionalString
-	SecretKey         common.OptionalString
-	Template          common.OptionalString
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
+	NewName           cmd.OptionalString
+	ProjectID         cmd.OptionalString
+	Dataset           cmd.OptionalString
+	Table             cmd.OptionalString
+	User              cmd.OptionalString
+	SecretKey         cmd.OptionalString
+	Template          cmd.OptionalString
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/logging/cloudfiles/cloudfiles_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -151,17 +151,17 @@ func createCommandAll() *CreateCommand {
 		User:              "user",
 		AccessKey:         "key",
 		BucketName:        "bucket",
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/logs"},
-		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "abc"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "/logs"},
+		Region:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "abc"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -173,7 +173,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdate() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		Version:      2,
 		EndpointName: "log",
@@ -182,26 +182,26 @@ func updateCommandNoUpdate() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		Version:           2,
 		EndpointName:      "log",
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		BucketName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		AccessKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		BucketName:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Region:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		GzipLevel:         cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
 	}
 }
 

--- a/pkg/logging/cloudfiles/create.go
+++ b/pkg/logging/cloudfiles/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,11 +14,11 @@ import (
 
 // CreateCommand calls the Fastly API to create a Cloudfiles logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Token        string
 	Version      int
 	User         string
@@ -26,22 +26,22 @@ type CreateCommand struct {
 	BucketName   string
 
 	// optional
-	Path              common.OptionalString
-	Region            common.OptionalString
-	PublicKey         common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	MessageType       common.OptionalString
-	TimestampFormat   common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	Path              cmd.OptionalString
+	Region            cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/cloudfiles/delete.go
+++ b/pkg/logging/cloudfiles/delete.go
@@ -3,7 +3,7 @@ package cloudfiles
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Cloudfiles logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteCloudfilesInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/cloudfiles/describe.go
+++ b/pkg/logging/cloudfiles/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Cloudfiles logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetCloudfilesInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/cloudfiles/list.go
+++ b/pkg/logging/cloudfiles/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Cloudfiles logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListCloudfilesInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/cloudfiles/root.go
+++ b/pkg/logging/cloudfiles/root.go
@@ -3,19 +3,19 @@ package cloudfiles
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("cloudfiles", "Manipulate Fastly service version Cloudfiles logging endpoints")

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -3,7 +3,7 @@ package cloudfiles
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,34 +13,34 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Cloudfiles logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	User              common.OptionalString
-	AccessKey         common.OptionalString
-	BucketName        common.OptionalString
-	Path              common.OptionalString
-	Region            common.OptionalString
-	Placement         common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	MessageType       common.OptionalString
-	TimestampFormat   common.OptionalString
-	PublicKey         common.OptionalString
-	CompressionCodec  common.OptionalString
+	NewName           cmd.OptionalString
+	User              cmd.OptionalString
+	AccessKey         cmd.OptionalString
+	BucketName        cmd.OptionalString
+	Path              cmd.OptionalString
+	Region            cmd.OptionalString
+	Placement         cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	MessageType       cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/datadog/create.go
+++ b/pkg/logging/datadog/create.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // CreateCommand calls the Fastly API to create a Datadog logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Token        string
 	Version      int
 
 	// optional
-	Region            common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Region            cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/datadog/datadog_test.go
+++ b/pkg/logging/datadog/datadog_test.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -117,11 +117,11 @@ func createCommandOK() *CreateCommand {
 		EndpointName:      "log",
 		Token:             "tkn",
 		Version:           2,
-		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "US"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Region:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "US"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -142,7 +142,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -151,17 +151,17 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Region:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
 	}
 }
 

--- a/pkg/logging/datadog/delete.go
+++ b/pkg/logging/datadog/delete.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Datadog logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteDatadogInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/datadog/describe.go
+++ b/pkg/logging/datadog/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Datadog logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetDatadogInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/datadog/list.go
+++ b/pkg/logging/datadog/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Datadog logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListDatadogInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/datadog/root.go
+++ b/pkg/logging/datadog/root.go
@@ -3,19 +3,19 @@ package datadog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("datadog", "Manipulate Fastly service version Datadog logging endpoints")

--- a/pkg/logging/datadog/update.go
+++ b/pkg/logging/datadog/update.go
@@ -3,7 +3,7 @@ package datadog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,25 +13,25 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Datadog logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Token             common.OptionalString
-	Region            common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Token             cmd.OptionalString
+	Region            cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/digitalocean/create.go
+++ b/pkg/logging/digitalocean/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,33 +14,33 @@ import (
 
 // CreateCommand calls the Fastly API to create a DigitalOcean Spaces logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	BucketName   string
 	AccessKey    string
 	SecretKey    string
 
 	// optional
-	Domain            common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	MessageType       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	PublicKey         common.OptionalString
-	CompressionCodec  common.OptionalString
+	Domain            cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/digitalocean/delete.go
+++ b/pkg/logging/digitalocean/delete.go
@@ -3,7 +3,7 @@ package digitalocean
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a DigitalOcean Spaces logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteDigitalOceanInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/digitalocean/describe.go
+++ b/pkg/logging/digitalocean/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a DigitalOcean Spaces logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetDigitalOceanInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/digitalocean/digitalocean_test.go
+++ b/pkg/logging/digitalocean/digitalocean_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -151,17 +151,17 @@ func createCommandAll() *CreateCommand {
 		BucketName:        "bucket",
 		AccessKey:         "access",
 		SecretKey:         "secret",
-		Domain:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "nyc3.digitaloceanspaces.com"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/log"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		Domain:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "nyc3.digitaloceanspaces.com"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "/log"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -173,7 +173,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -182,26 +182,26 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		BucketName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Domain:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		BucketName:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Domain:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		AccessKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		GzipLevel:         cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
 	}
 }
 

--- a/pkg/logging/digitalocean/list.go
+++ b/pkg/logging/digitalocean/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list DigitalOcean Spaces logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListDigitalOceansInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/digitalocean/root.go
+++ b/pkg/logging/digitalocean/root.go
@@ -3,19 +3,19 @@ package digitalocean
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("digitalocean", "Manipulate Fastly service version DigitalOcean Spaces logging endpoints")

--- a/pkg/logging/digitalocean/update.go
+++ b/pkg/logging/digitalocean/update.go
@@ -3,7 +3,7 @@ package digitalocean
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,7 +13,7 @@ import (
 
 // UpdateCommand calls the Fastly API to update a DigitalOcean Spaces logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	//required
@@ -21,26 +21,26 @@ type UpdateCommand struct {
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	BucketName        common.OptionalString
-	Domain            common.OptionalString
-	AccessKey         common.OptionalString
-	SecretKey         common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	MessageType       common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	PublicKey         common.OptionalString
-	CompressionCodec  common.OptionalString
+	NewName           cmd.OptionalString
+	BucketName        cmd.OptionalString
+	Domain            cmd.OptionalString
+	AccessKey         cmd.OptionalString
+	SecretKey         cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	MessageType       cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/elasticsearch/create.go
+++ b/pkg/logging/elasticsearch/create.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,33 +13,33 @@ import (
 
 // CreateCommand calls the Fastly API to create an Elasticsearch logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Index        string
 	URL          string
 
 	// optional
-	Pipeline          common.OptionalString
-	RequestMaxEntries common.OptionalUint
-	RequestMaxBytes   common.OptionalUint
-	User              common.OptionalString
-	Password          common.OptionalString
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	TLSHostname       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	Pipeline          cmd.OptionalString
+	RequestMaxEntries cmd.OptionalUint
+	RequestMaxBytes   cmd.OptionalUint
+	User              cmd.OptionalString
+	Password          cmd.OptionalString
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/elasticsearch/delete.go
+++ b/pkg/logging/elasticsearch/delete.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an Elasticsearch logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteElasticsearchInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/elasticsearch/describe.go
+++ b/pkg/logging/elasticsearch/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an Elasticsearch logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetElasticsearchInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/logging/elasticsearch/elasticsearch_test.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -147,19 +147,19 @@ func createCommandAll() *CreateCommand {
 		Version:           2,
 		Index:             "logs",
 		URL:               "example.com",
-		Pipeline:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "my_pipeline_id"},
-		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "user"},
-		Password:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "password"},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "example.com"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+		Pipeline:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "my_pipeline_id"},
+		RequestMaxEntries: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		RequestMaxBytes:   cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "user"},
+		Password:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "password"},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "example.com"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
 	}
 }
 
@@ -171,7 +171,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -180,26 +180,26 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Index:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		Pipeline:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Password:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Index:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		URL:               cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		Pipeline:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		RequestMaxEntries: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		RequestMaxBytes:   cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Password:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
 	}
 }
 

--- a/pkg/logging/elasticsearch/list.go
+++ b/pkg/logging/elasticsearch/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Elasticsearch logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListElasticsearchInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/elasticsearch/root.go
+++ b/pkg/logging/elasticsearch/root.go
@@ -3,19 +3,19 @@ package elasticsearch
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("elasticsearch", "Manipulate Fastly service version Elasticsearch logging endpoints")

--- a/pkg/logging/elasticsearch/update.go
+++ b/pkg/logging/elasticsearch/update.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,34 +13,34 @@ import (
 
 // UpdateCommand calls the Fastly API to update an Elasticsearch logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Index             common.OptionalString
-	URL               common.OptionalString
-	Pipeline          common.OptionalString
-	RequestMaxEntries common.OptionalUint
-	RequestMaxBytes   common.OptionalUint
-	User              common.OptionalString
-	Password          common.OptionalString
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	TLSHostname       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	NewName           cmd.OptionalString
+	Index             cmd.OptionalString
+	URL               cmd.OptionalString
+	Pipeline          cmd.OptionalString
+	RequestMaxEntries cmd.OptionalUint
+	RequestMaxBytes   cmd.OptionalUint
+	User              cmd.OptionalString
+	Password          cmd.OptionalString
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,31 +14,31 @@ import (
 
 // CreateCommand calls the Fastly API to create an FTP logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Address      string
 	Username     string
 	Password     string
 
 	// optional
-	Port              common.OptionalUint
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint8
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	Port              cmd.OptionalUint
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint8
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/ftp/delete.go
+++ b/pkg/logging/ftp/delete.go
@@ -3,7 +3,7 @@ package ftp
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an FTP logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteFTPInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an FTP logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetFTPInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/ftp/ftp_test.go
+++ b/pkg/logging/ftp/ftp_test.go
@@ -3,7 +3,7 @@ package ftp
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -146,15 +146,15 @@ func createCommandAll() *CreateCommand {
 		Address:           "example.com",
 		Username:          "user",
 		Password:          "password",
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/logs"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 22},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "/logs"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -166,7 +166,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -175,25 +175,25 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},
-		Username:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		Password:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 0},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Address:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 23},
+		Username:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		Password:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		GzipLevel:         cmd.OptionalUint8{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
 	}
 }
 

--- a/pkg/logging/ftp/list.go
+++ b/pkg/logging/ftp/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list FTP logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListFTPsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/ftp/root.go
+++ b/pkg/logging/ftp/root.go
@@ -3,19 +3,19 @@ package ftp
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("ftp", "Manipulate Fastly service version FTP logging endpoints")

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -3,7 +3,7 @@ package ftp
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,33 +13,33 @@ import (
 
 // UpdateCommand calls the Fastly API to update an FTP logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Address           common.OptionalString
-	Port              common.OptionalUint
-	Username          common.OptionalString
-	Password          common.OptionalString
-	PublicKey         common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint8
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	NewName           cmd.OptionalString
+	Address           cmd.OptionalString
+	Port              cmd.OptionalUint
+	Username          cmd.OptionalString
+	Password          cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint8
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/gcs/create.go
+++ b/pkg/logging/gcs/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,31 +14,31 @@ import (
 
 // CreateCommand calls the Fastly API to create a GCS logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Bucket       string
 	User         string
 	SecretKey    string
 
 	// optional
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint8
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	MessageType       common.OptionalString
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint8
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/gcs/delete.go
+++ b/pkg/logging/gcs/delete.go
@@ -3,7 +3,7 @@ package gcs
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a GCS logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteGCSInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a GCS logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetGCSInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/gcs/gcs_test.go
+++ b/pkg/logging/gcs/gcs_test.go
@@ -3,7 +3,7 @@ package gcs
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -144,15 +144,15 @@ func createCommandAll() *CreateCommand {
 		Bucket:            "bucket",
 		User:              "user",
 		SecretKey:         "-----BEGIN PRIVATE KEY-----foo",
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/logs"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "/logs"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -164,7 +164,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -173,24 +173,24 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Bucket:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint8{Optional: common.Optional{WasSet: true}, Value: 0},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Bucket:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		GzipLevel:         cmd.OptionalUint8{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
 	}
 }
 

--- a/pkg/logging/gcs/list.go
+++ b/pkg/logging/gcs/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list GCS logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListGCSsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/gcs/root.go
+++ b/pkg/logging/gcs/root.go
@@ -3,19 +3,19 @@ package gcs
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("gcs", "Manipulate Fastly service version GCS logging endpoints")

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -3,7 +3,7 @@ package gcs
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,32 +13,32 @@ import (
 
 // UpdateCommand calls the Fastly API to update a GCS logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Bucket            common.OptionalString
-	User              common.OptionalString
-	SecretKey         common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	FormatVersion     common.OptionalUint
-	GzipLevel         common.OptionalUint8
-	Format            common.OptionalString
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	MessageType       common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	NewName           cmd.OptionalString
+	Bucket            cmd.OptionalString
+	User              cmd.OptionalString
+	SecretKey         cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	FormatVersion     cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint8
+	Format            cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	MessageType       cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/googlepubsub/create.go
+++ b/pkg/logging/googlepubsub/create.go
@@ -3,7 +3,7 @@ package googlepubsub
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,11 +13,11 @@ import (
 
 // CreateCommand calls the Fastly API to create a Google Cloud Pub/Sub logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	User         string
 	SecretKey    string
@@ -25,14 +25,14 @@ type CreateCommand struct {
 	ProjectID    string
 
 	// optional
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/googlepubsub/delete.go
+++ b/pkg/logging/googlepubsub/delete.go
@@ -3,7 +3,7 @@ package googlepubsub
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Google Cloud Pub/Sub logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeletePubsubInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/googlepubsub/describe.go
+++ b/pkg/logging/googlepubsub/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Google Cloud Pub/Sub logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetPubsubInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/logging/googlepubsub/googlepubsub_test.go
@@ -3,7 +3,7 @@ package googlepubsub
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -139,10 +139,10 @@ func createCommandAll() *CreateCommand {
 		ProjectID:         "project",
 		Topic:             "topic",
 		SecretKey:         "secret",
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -154,7 +154,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -163,19 +163,19 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		ProjectID:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Topic:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		ProjectID:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Topic:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
 	}
 }
 

--- a/pkg/logging/googlepubsub/list.go
+++ b/pkg/logging/googlepubsub/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Google Cloud Pub/Sub logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListPubsubsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/googlepubsub/root.go
+++ b/pkg/logging/googlepubsub/root.go
@@ -3,19 +3,19 @@ package googlepubsub
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("googlepubsub", "Manipulate Fastly service version Google Cloud Pub/Sub logging endpoints")

--- a/pkg/logging/googlepubsub/update.go
+++ b/pkg/logging/googlepubsub/update.go
@@ -3,7 +3,7 @@ package googlepubsub
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,27 +13,27 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Google Cloud Pub/Sub logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	User              common.OptionalString
-	SecretKey         common.OptionalString
-	ProjectID         common.OptionalString
-	Topic             common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	NewName           cmd.OptionalString
+	User              cmd.OptionalString
+	SecretKey         cmd.OptionalString
+	ProjectID         cmd.OptionalString
+	Topic             cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/heroku/create.go
+++ b/pkg/logging/heroku/create.go
@@ -3,7 +3,7 @@ package heroku
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // CreateCommand calls the Fastly API to create a Heroku logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Token        string
 	URL          string
 
 	// optional
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/heroku/delete.go
+++ b/pkg/logging/heroku/delete.go
@@ -3,7 +3,7 @@ package heroku
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Heroku logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteHerokuInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/heroku/describe.go
+++ b/pkg/logging/heroku/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Heroku logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetHerokuInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/heroku/heroku_test.go
+++ b/pkg/logging/heroku/heroku_test.go
@@ -3,7 +3,7 @@ package heroku
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -129,10 +129,10 @@ func createCommandAll() *CreateCommand {
 		Token:             "tkn",
 		URL:               "example.com",
 		Version:           2,
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -144,7 +144,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -153,17 +153,17 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		URL:               cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
 	}
 }
 

--- a/pkg/logging/heroku/list.go
+++ b/pkg/logging/heroku/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Heroku logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListHerokusInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/heroku/root.go
+++ b/pkg/logging/heroku/root.go
@@ -3,19 +3,19 @@ package heroku
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("heroku", "Manipulate Fastly service version Heroku logging endpoints")

--- a/pkg/logging/heroku/update.go
+++ b/pkg/logging/heroku/update.go
@@ -3,7 +3,7 @@ package heroku
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,25 +13,25 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Heroku logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	URL               common.OptionalString
-	Token             common.OptionalString
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	URL               cmd.OptionalString
+	Token             cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/honeycomb/create.go
+++ b/pkg/logging/honeycomb/create.go
@@ -3,7 +3,7 @@ package honeycomb
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // CreateCommand calls the Fastly API to create a Honeycomb logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Token        string
 	Dataset      string
 
 	// optional
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/honeycomb/delete.go
+++ b/pkg/logging/honeycomb/delete.go
@@ -3,7 +3,7 @@ package honeycomb
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Honeycomb logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteHoneycombInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/honeycomb/describe.go
+++ b/pkg/logging/honeycomb/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Honeycomb logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetHoneycombInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/honeycomb/honeycomb_test.go
+++ b/pkg/logging/honeycomb/honeycomb_test.go
@@ -3,7 +3,7 @@ package honeycomb
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -129,10 +129,10 @@ func createCommandAll() *CreateCommand {
 		Token:             "tkn",
 		Dataset:           "logs",
 		Version:           2,
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -144,7 +144,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -153,17 +153,17 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		Dataset:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		Dataset:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
 	}
 }
 

--- a/pkg/logging/honeycomb/list.go
+++ b/pkg/logging/honeycomb/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Honeycomb logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListHoneycombsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/honeycomb/root.go
+++ b/pkg/logging/honeycomb/root.go
@@ -3,19 +3,19 @@ package honeycomb
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("honeycomb", "Manipulate Fastly service version Honeycomb logging endpoints")

--- a/pkg/logging/honeycomb/update.go
+++ b/pkg/logging/honeycomb/update.go
@@ -3,7 +3,7 @@ package honeycomb
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,25 +13,25 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Honeycomb logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Dataset           common.OptionalString
-	Token             common.OptionalString
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Dataset           cmd.OptionalString
+	Token             cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/https/create.go
+++ b/pkg/logging/https/create.go
@@ -3,7 +3,7 @@ package https
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,35 +13,35 @@ import (
 
 // CreateCommand calls the Fastly API to create an HTTPS logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	URL          string
 
 	// optional
-	RequestMaxEntries common.OptionalUint
-	RequestMaxBytes   common.OptionalUint
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	TLSHostname       common.OptionalString
-	MessageType       common.OptionalString
-	ContentType       common.OptionalString
-	HeaderName        common.OptionalString
-	HeaderValue       common.OptionalString
-	Method            common.OptionalString
-	JSONFormat        common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	RequestMaxEntries cmd.OptionalUint
+	RequestMaxBytes   cmd.OptionalUint
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	MessageType       cmd.OptionalString
+	ContentType       cmd.OptionalString
+	HeaderName        cmd.OptionalString
+	HeaderValue       cmd.OptionalString
+	Method            cmd.OptionalString
+	JSONFormat        cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/https/delete.go
+++ b/pkg/logging/https/delete.go
@@ -3,7 +3,7 @@ package https
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an HTTPS logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteHTTPSInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/https/describe.go
+++ b/pkg/logging/https/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an HTTPS logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetHTTPSInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/https/https_test.go
+++ b/pkg/logging/https/https_test.go
@@ -3,7 +3,7 @@ package https
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -148,22 +148,22 @@ func createCommandAll() *CreateCommand {
 		EndpointName:      "logs",
 		Version:           2,
 		URL:               "example.com",
-		ContentType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "application/json"},
-		HeaderName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "name"},
-		HeaderValue:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "value"},
-		Method:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "GET"},
-		JSONFormat:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "1"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "example.com"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+		ContentType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "application/json"},
+		HeaderName:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "name"},
+		HeaderValue:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "value"},
+		Method:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "GET"},
+		JSONFormat:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "1"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		RequestMaxEntries: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		RequestMaxBytes:   cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "example.com"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
 	}
 }
 
@@ -175,7 +175,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -184,28 +184,28 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		ContentType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		HeaderName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		HeaderValue:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		Method:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		JSONFormat:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		RequestMaxEntries: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new14"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new15"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		URL:               cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		ContentType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		HeaderName:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		HeaderValue:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		Method:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		JSONFormat:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		RequestMaxEntries: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		RequestMaxBytes:   cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new14"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new15"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
 	}
 }
 

--- a/pkg/logging/https/list.go
+++ b/pkg/logging/https/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list HTTPS logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListHTTPSInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/https/root.go
+++ b/pkg/logging/https/root.go
@@ -3,19 +3,19 @@ package https
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("https", "Manipulate Fastly service version HTTPS logging endpoints")

--- a/pkg/logging/https/update.go
+++ b/pkg/logging/https/update.go
@@ -3,7 +3,7 @@ package https
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,36 +13,36 @@ import (
 
 // UpdateCommand calls the Fastly API to update an HTTPS logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	URL               common.OptionalString
-	RequestMaxEntries common.OptionalUint
-	RequestMaxBytes   common.OptionalUint
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	TLSHostname       common.OptionalString
-	MessageType       common.OptionalString
-	ContentType       common.OptionalString
-	HeaderName        common.OptionalString
-	HeaderValue       common.OptionalString
-	Method            common.OptionalString
-	JSONFormat        common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	NewName           cmd.OptionalString
+	URL               cmd.OptionalString
+	RequestMaxEntries cmd.OptionalUint
+	RequestMaxBytes   cmd.OptionalUint
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	MessageType       cmd.OptionalString
+	ContentType       cmd.OptionalString
+	HeaderName        cmd.OptionalString
+	HeaderValue       cmd.OptionalString
+	Method            cmd.OptionalString
+	JSONFormat        cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kafka/create.go
+++ b/pkg/logging/kafka/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,37 +14,37 @@ import (
 
 // CreateCommand calls the Fastly API to create a Kafka logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Topic        string
 	Brokers      string
 
 	// optional
-	UseTLS            common.OptionalBool
-	CompressionCodec  common.OptionalString
-	RequiredACKs      common.OptionalString
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	TLSHostname       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
-	ParseLogKeyvals   common.OptionalBool
-	RequestMaxBytes   common.OptionalUint
-	UseSASL           common.OptionalBool
-	AuthMethod        common.OptionalString
-	User              common.OptionalString
-	Password          common.OptionalString
+	UseTLS            cmd.OptionalBool
+	CompressionCodec  cmd.OptionalString
+	RequiredACKs      cmd.OptionalString
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	ParseLogKeyvals   cmd.OptionalBool
+	RequestMaxBytes   cmd.OptionalUint
+	UseSASL           cmd.OptionalBool
+	AuthMethod        cmd.OptionalString
+	User              cmd.OptionalString
+	Password          cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kafka/delete.go
+++ b/pkg/logging/kafka/delete.go
@@ -3,7 +3,7 @@ package kafka
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Kafka logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteKafkaInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kafka/describe.go
+++ b/pkg/logging/kafka/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Kafka logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetKafkaInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kafka/kafka_test.go
+++ b/pkg/logging/kafka/kafka_test.go
@@ -3,7 +3,7 @@ package kafka
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -269,17 +269,17 @@ func createCommandAll() *CreateCommand {
 		Version:           2,
 		Topic:             "logs",
 		Brokers:           "127.0.0.1,127.0.0.2",
-		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		RequiredACKs:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-1"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zippy"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "example.com"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+		UseTLS:            cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		RequiredACKs:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-1"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zippy"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "example.com"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
 	}
 }
 
@@ -290,12 +290,12 @@ func createCommandSASL(authMethod, user, password string) *CreateCommand {
 		Version:         2,
 		Topic:           "logs",
 		Brokers:         "127.0.0.1,127.0.0.2",
-		ParseLogKeyvals: common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		RequestMaxBytes: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 11111},
-		UseSASL:         common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		AuthMethod:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: authMethod},
-		User:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: user},
-		Password:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: password},
+		ParseLogKeyvals: cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		RequestMaxBytes: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 11111},
+		UseSASL:         cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		AuthMethod:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: authMethod},
+		User:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: user},
+		Password:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: password},
 	}
 }
 
@@ -306,12 +306,12 @@ func createCommandNoSASL(authMethod, user, password string) *CreateCommand {
 		Version:         2,
 		Topic:           "logs",
 		Brokers:         "127.0.0.1,127.0.0.2",
-		ParseLogKeyvals: common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		RequestMaxBytes: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 11111},
-		UseSASL:         common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: false},
-		AuthMethod:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: authMethod},
-		User:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: user},
-		Password:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: password},
+		ParseLogKeyvals: cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		RequestMaxBytes: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 11111},
+		UseSASL:         cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: false},
+		AuthMethod:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: authMethod},
+		User:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: user},
+		Password:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: password},
 	}
 }
 
@@ -323,7 +323,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -332,64 +332,64 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Topic:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Brokers:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: false},
-		RequiredACKs:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		ParseLogKeyvals:   common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: false},
-		RequestMaxBytes:   common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22222},
-		UseSASL:           common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		AuthMethod:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "plain"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
-		Password:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new14"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Topic:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Brokers:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		UseTLS:            cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: false},
+		RequiredACKs:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		ParseLogKeyvals:   cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: false},
+		RequestMaxBytes:   cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 22222},
+		UseSASL:           cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		AuthMethod:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "plain"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
+		Password:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new14"},
 	}
 }
 
 func updateCommandSASL(authMethod, user, password string) *UpdateCommand {
 	return &UpdateCommand{
-		Base:            common.Base{Globals: &config.Data{Client: nil}},
+		Base:            cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:        manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:    "log",
 		Version:         2,
-		Topic:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "logs"},
-		Brokers:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "127.0.0.1,127.0.0.2"},
-		ParseLogKeyvals: common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		RequestMaxBytes: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 11111},
-		UseSASL:         common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		AuthMethod:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: authMethod},
-		User:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: user},
-		Password:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: password},
+		Topic:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "logs"},
+		Brokers:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "127.0.0.1,127.0.0.2"},
+		ParseLogKeyvals: cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		RequestMaxBytes: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 11111},
+		UseSASL:         cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		AuthMethod:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: authMethod},
+		User:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: user},
+		Password:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: password},
 	}
 }
 
 func updateCommandNoSASL() *UpdateCommand {
 	return &UpdateCommand{
-		Base:            common.Base{Globals: &config.Data{Client: nil}},
+		Base:            cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:        manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:    "log",
 		Version:         2,
-		Topic:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "logs"},
-		Brokers:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "127.0.0.1,127.0.0.2"},
-		ParseLogKeyvals: common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		RequestMaxBytes: common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 11111},
-		UseSASL:         common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: false},
-		AuthMethod:      common.OptionalString{Optional: common.Optional{WasSet: false}, Value: ""},
-		User:            common.OptionalString{Optional: common.Optional{WasSet: false}, Value: ""},
-		Password:        common.OptionalString{Optional: common.Optional{WasSet: false}, Value: ""},
+		Topic:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "logs"},
+		Brokers:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "127.0.0.1,127.0.0.2"},
+		ParseLogKeyvals: cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		RequestMaxBytes: cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 11111},
+		UseSASL:         cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: false},
+		AuthMethod:      cmd.OptionalString{Optional: cmd.Optional{WasSet: false}, Value: ""},
+		User:            cmd.OptionalString{Optional: cmd.Optional{WasSet: false}, Value: ""},
+		Password:        cmd.OptionalString{Optional: cmd.Optional{WasSet: false}, Value: ""},
 	}
 }
 

--- a/pkg/logging/kafka/list.go
+++ b/pkg/logging/kafka/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Kafka logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListKafkasInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kafka/root.go
+++ b/pkg/logging/kafka/root.go
@@ -3,19 +3,19 @@ package kafka
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("kafka", "Manipulate Fastly service version Kafka logging endpoints")

--- a/pkg/logging/kafka/update.go
+++ b/pkg/logging/kafka/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,39 +14,39 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Kafka logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Index             common.OptionalString
-	Topic             common.OptionalString
-	Brokers           common.OptionalString
-	UseTLS            common.OptionalBool
-	CompressionCodec  common.OptionalString
-	RequiredACKs      common.OptionalString
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	TLSHostname       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
-	ParseLogKeyvals   common.OptionalBool
-	RequestMaxBytes   common.OptionalUint
-	UseSASL           common.OptionalBool
-	AuthMethod        common.OptionalString
-	User              common.OptionalString
-	Password          common.OptionalString
+	NewName           cmd.OptionalString
+	Index             cmd.OptionalString
+	Topic             cmd.OptionalString
+	Brokers           cmd.OptionalString
+	UseTLS            cmd.OptionalBool
+	CompressionCodec  cmd.OptionalString
+	RequiredACKs      cmd.OptionalString
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	ParseLogKeyvals   cmd.OptionalBool
+	RequestMaxBytes   cmd.OptionalUint
+	UseSASL           cmd.OptionalBool
+	AuthMethod        cmd.OptionalString
+	User              cmd.OptionalString
+	Password          cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,30 +14,30 @@ import (
 
 // CreateCommand calls the Fastly API to create an Amazon Kinesis logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	StreamName   string
 	Region       string
 
 	// mutual exclusions
 	// AccessKey + SecretKey or IAMRole must be provided
-	AccessKey common.OptionalString
-	SecretKey common.OptionalString
-	IAMRole   common.OptionalString
+	AccessKey cmd.OptionalString
+	SecretKey cmd.OptionalString
+	IAMRole   cmd.OptionalString
 
 	// optional
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -3,7 +3,7 @@ package kinesis
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an Amazon Kinesis logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteKinesisInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kinesis/describe.go
+++ b/pkg/logging/kinesis/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an Amazon Kinesis logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetKinesisInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kinesis/kinesis_test.go
+++ b/pkg/logging/kinesis/kinesis_test.go
@@ -3,7 +3,7 @@ package kinesis
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -135,8 +135,8 @@ func createCommandRequired() *CreateCommand {
 		EndpointName: "log",
 		Version:      2,
 		StreamName:   "stream",
-		AccessKey:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
-		SecretKey:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
+		AccessKey:    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "access"},
+		SecretKey:    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "secret"},
 	}
 }
 
@@ -146,7 +146,7 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		EndpointName: "log",
 		Version:      2,
 		StreamName:   "stream",
-		IAMRole:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/KinesisAccess"},
+		IAMRole:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/KinesisAccess"},
 	}
 }
 
@@ -156,13 +156,13 @@ func createCommandAll() *CreateCommand {
 		EndpointName:      "logs",
 		Version:           2,
 		StreamName:        "stream",
-		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
+		AccessKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "access"},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "secret"},
 		Region:            "us-east-1",
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -174,7 +174,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -183,20 +183,20 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		StreamName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		IAMRole:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: ""},
-		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		StreamName:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		AccessKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		IAMRole:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: ""},
+		Region:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
 	}
 }
 

--- a/pkg/logging/kinesis/list.go
+++ b/pkg/logging/kinesis/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Amazon Kinesis logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListKinesisInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/kinesis/root.go
+++ b/pkg/logging/kinesis/root.go
@@ -3,19 +3,19 @@ package kinesis
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("kinesis", "Manipulate a Kinesis logging endpoint for a specific Fastly service version")

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -3,7 +3,7 @@ package kinesis
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,28 +13,28 @@ import (
 
 // UpdateCommand calls the Fastly API to update an Amazon Kinesis logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	StreamName        common.OptionalString
-	AccessKey         common.OptionalString
-	SecretKey         common.OptionalString
-	IAMRole           common.OptionalString
-	Region            common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	StreamName        cmd.OptionalString
+	AccessKey         cmd.OptionalString
+	SecretKey         cmd.OptionalString
+	IAMRole           cmd.OptionalString
+	Region            cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logentries/create.go
+++ b/pkg/logging/logentries/create.go
@@ -3,7 +3,7 @@ package logentries
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,25 +13,25 @@ import (
 
 // CreateCommand calls the Fastly API to create a Logentries logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	Port              common.OptionalUint
-	UseTLS            common.OptionalBool
-	Token             common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Port              cmd.OptionalUint
+	UseTLS            cmd.OptionalBool
+	Token             cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logentries/delete.go
+++ b/pkg/logging/logentries/delete.go
@@ -3,7 +3,7 @@ package logentries
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Logentries logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteLogentriesInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logentries/describe.go
+++ b/pkg/logging/logentries/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Logentries logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetLogentriesInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logentries/list.go
+++ b/pkg/logging/logentries/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Logentries logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListLogentriesInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logentries/logentries_test.go
+++ b/pkg/logging/logentries/logentries_test.go
@@ -3,7 +3,7 @@ package logentries
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -117,13 +117,13 @@ func createCommandOK() *CreateCommand {
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22},
-		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "tkn"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 22},
+		UseTLS:            cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "tkn"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -143,7 +143,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -152,18 +152,18 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},
-		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 23},
+		UseTLS:            cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
 	}
 }
 

--- a/pkg/logging/logentries/root.go
+++ b/pkg/logging/logentries/root.go
@@ -3,19 +3,19 @@ package logentries
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("logentries", "Manipulate Fastly service version Logentries logging endpoints")

--- a/pkg/logging/logentries/update.go
+++ b/pkg/logging/logentries/update.go
@@ -3,7 +3,7 @@ package logentries
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,26 +13,26 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Logentries logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Port              common.OptionalUint
-	UseTLS            common.OptionalBool
-	Token             common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Port              cmd.OptionalUint
+	UseTLS            cmd.OptionalBool
+	Token             cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/loggly/create.go
+++ b/pkg/logging/loggly/create.go
@@ -3,7 +3,7 @@ package loggly
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,23 +13,23 @@ import (
 
 // CreateCommand calls the Fastly API to create a Loggly logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Token        string
 	Version      int
 
 	// optional
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/loggly/delete.go
+++ b/pkg/logging/loggly/delete.go
@@ -3,7 +3,7 @@ package loggly
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Loggly logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteLogglyInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/loggly/describe.go
+++ b/pkg/logging/loggly/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Loggly logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetLogglyInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/loggly/list.go
+++ b/pkg/logging/loggly/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Loggly logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListLogglyInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/loggly/loggly_test.go
+++ b/pkg/logging/loggly/loggly_test.go
@@ -3,7 +3,7 @@ package loggly
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -115,10 +115,10 @@ func createCommandOK() *CreateCommand {
 		EndpointName:      "log",
 		Token:             "tkn",
 		Version:           2,
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -139,7 +139,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -148,16 +148,16 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
 	}
 }
 

--- a/pkg/logging/loggly/root.go
+++ b/pkg/logging/loggly/root.go
@@ -3,19 +3,19 @@ package loggly
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("loggly", "Manipulate Fastly service version Loggly logging endpoints")

--- a/pkg/logging/loggly/update.go
+++ b/pkg/logging/loggly/update.go
@@ -3,7 +3,7 @@ package loggly
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Loggly logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Token             common.OptionalString
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Token             cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logshuttle/create.go
+++ b/pkg/logging/logshuttle/create.go
@@ -3,7 +3,7 @@ package logshuttle
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // CreateCommand calls the Fastly API to create a Logshuttle logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Token        string
 	URL          string
 
 	// optional
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/logshuttle/delete.go
+++ b/pkg/logging/logshuttle/delete.go
@@ -3,7 +3,7 @@ package logshuttle
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Logshuttle logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteLogshuttleInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logshuttle/describe.go
+++ b/pkg/logging/logshuttle/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Logshuttle logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetLogshuttleInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logshuttle/list.go
+++ b/pkg/logging/logshuttle/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Logshuttle logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListLogshuttlesInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/logshuttle/logshuttle_test.go
+++ b/pkg/logging/logshuttle/logshuttle_test.go
@@ -3,7 +3,7 @@ package logshuttle
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -129,10 +129,10 @@ func createCommandAll() *CreateCommand {
 		Token:             "tkn",
 		URL:               "example.com",
 		Version:           2,
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -144,7 +144,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdate() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -153,17 +153,17 @@ func updateCommandNoUpdate() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		URL:               cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
 	}
 }
 

--- a/pkg/logging/logshuttle/root.go
+++ b/pkg/logging/logshuttle/root.go
@@ -3,19 +3,19 @@ package logshuttle
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("logshuttle", "Manipulate Fastly service version Logshuttle logging endpoints")

--- a/pkg/logging/logshuttle/update.go
+++ b/pkg/logging/logshuttle/update.go
@@ -3,7 +3,7 @@ package logshuttle
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,25 +13,25 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Logshuttle logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Token             common.OptionalString
-	URL               common.OptionalString
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Token             cmd.OptionalString
+	URL               cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/openstack/create.go
+++ b/pkg/logging/openstack/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,11 +14,11 @@ import (
 
 // CreateCommand calls the Fastly API to create an OpenStack logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	BucketName   string
 	AccessKey    string
@@ -26,21 +26,21 @@ type CreateCommand struct {
 	URL          string
 
 	// optional
-	PublicKey         common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	MessageType       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	PublicKey         cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/openstack/delete.go
+++ b/pkg/logging/openstack/delete.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an OpenStack logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteOpenstackInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/openstack/describe.go
+++ b/pkg/logging/openstack/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an OpenStack logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetOpenstackInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/openstack/list.go
+++ b/pkg/logging/openstack/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list OpenStack logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListOpenstackInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/openstack/openstack_test.go
+++ b/pkg/logging/openstack/openstack_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -153,16 +153,16 @@ func createCommandAll() *CreateCommand {
 		AccessKey:         "access",
 		User:              "user",
 		URL:               "https://example.com",
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/log"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "/log"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: pgpPublicKey()},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -174,7 +174,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -183,26 +183,26 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		BucketName:        common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		AccessKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		BucketName:        cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		AccessKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		URL:               cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		GzipLevel:         cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
 	}
 }
 

--- a/pkg/logging/openstack/root.go
+++ b/pkg/logging/openstack/root.go
@@ -3,19 +3,19 @@ package openstack
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("openstack", "Manipulate Fastly service version OpenStack logging endpoints")

--- a/pkg/logging/openstack/update.go
+++ b/pkg/logging/openstack/update.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,7 +13,7 @@ import (
 
 // UpdateCommand calls the Fastly API to update an OpenStack logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	//required
@@ -21,26 +21,26 @@ type UpdateCommand struct {
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	BucketName        common.OptionalString
-	AccessKey         common.OptionalString
-	User              common.OptionalString
-	URL               common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	GzipLevel         common.OptionalUint
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	MessageType       common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	PublicKey         common.OptionalString
-	CompressionCodec  common.OptionalString
+	NewName           cmd.OptionalString
+	BucketName        cmd.OptionalString
+	AccessKey         cmd.OptionalString
+	User              cmd.OptionalString
+	URL               cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	MessageType       cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/papertrail/create.go
+++ b/pkg/logging/papertrail/create.go
@@ -3,7 +3,7 @@ package papertrail
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // CreateCommand calls the Fastly API to create a Papertrail logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Address      string
 
 	// optional
-	Port              common.OptionalUint
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	Port              cmd.OptionalUint
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/papertrail/delete.go
+++ b/pkg/logging/papertrail/delete.go
@@ -3,7 +3,7 @@ package papertrail
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Papertrail logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeletePapertrailInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/papertrail/describe.go
+++ b/pkg/logging/papertrail/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Papertrail logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetPapertrailInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/papertrail/list.go
+++ b/pkg/logging/papertrail/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Papertrail logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListPapertrailsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/papertrail/papertrail_test.go
+++ b/pkg/logging/papertrail/papertrail_test.go
@@ -3,7 +3,7 @@ package papertrail
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -126,11 +126,11 @@ func createCommandAll() *CreateCommand {
 		EndpointName:      "log",
 		Version:           2,
 		Address:           "example.com",
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 22},
 	}
 }
 
@@ -142,7 +142,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -151,17 +151,17 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Address:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 23},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
 	}
 }
 

--- a/pkg/logging/papertrail/root.go
+++ b/pkg/logging/papertrail/root.go
@@ -3,19 +3,19 @@ package papertrail
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("papertrail", "Manipulate Fastly service version Papertrail logging endpoints.")

--- a/pkg/logging/papertrail/update.go
+++ b/pkg/logging/papertrail/update.go
@@ -3,7 +3,7 @@ package papertrail
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,7 +13,7 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Papertrail logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
@@ -21,17 +21,17 @@ type UpdateCommand struct {
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Address           common.OptionalString
-	Port              common.OptionalUint
-	FormatVersion     common.OptionalUint
-	Format            common.OptionalString
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Address           cmd.OptionalString
+	Port              cmd.OptionalUint
+	FormatVersion     cmd.OptionalUint
+	Format            cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/root.go
+++ b/pkg/logging/root.go
@@ -3,19 +3,19 @@ package logging
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("logging", "Manipulate Fastly service version logging endpoints")

--- a/pkg/logging/s3/create.go
+++ b/pkg/logging/s3/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,40 +14,40 @@ import (
 
 // CreateCommand calls the Fastly API to create an Amazon S3 logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	BucketName   string
 
 	// mutual exclusions
 	// AccessKey + SecretKey or IAMRole must be provided
-	AccessKey common.OptionalString
-	SecretKey common.OptionalString
-	IAMRole   common.OptionalString
+	AccessKey cmd.OptionalString
+	SecretKey cmd.OptionalString
+	IAMRole   cmd.OptionalString
 
 	// optional
-	Domain                       common.OptionalString
-	Path                         common.OptionalString
-	Period                       common.OptionalUint
-	GzipLevel                    common.OptionalUint
-	Format                       common.OptionalString
-	FormatVersion                common.OptionalUint
-	MessageType                  common.OptionalString
-	ResponseCondition            common.OptionalString
-	TimestampFormat              common.OptionalString
-	Placement                    common.OptionalString
-	Redundancy                   common.OptionalString
-	PublicKey                    common.OptionalString
-	ServerSideEncryption         common.OptionalString
-	ServerSideEncryptionKMSKeyID common.OptionalString
-	CompressionCodec             common.OptionalString
+	Domain                       cmd.OptionalString
+	Path                         cmd.OptionalString
+	Period                       cmd.OptionalUint
+	GzipLevel                    cmd.OptionalUint
+	Format                       cmd.OptionalString
+	FormatVersion                cmd.OptionalUint
+	MessageType                  cmd.OptionalString
+	ResponseCondition            cmd.OptionalString
+	TimestampFormat              cmd.OptionalString
+	Placement                    cmd.OptionalString
+	Redundancy                   cmd.OptionalString
+	PublicKey                    cmd.OptionalString
+	ServerSideEncryption         cmd.OptionalString
+	ServerSideEncryptionKMSKeyID cmd.OptionalString
+	CompressionCodec             cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/s3/delete.go
+++ b/pkg/logging/s3/delete.go
@@ -3,7 +3,7 @@ package s3
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an Amazon S3 logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteS3Input
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an Amazon S3 logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetS3Input
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/s3/list.go
+++ b/pkg/logging/s3/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Amazon S3 logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListS3sInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/s3/root.go
+++ b/pkg/logging/s3/root.go
@@ -3,19 +3,19 @@ package s3
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("s3", "Manipulate Fastly service version S3 logging endpoints")

--- a/pkg/logging/s3/s3_test.go
+++ b/pkg/logging/s3/s3_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -155,8 +155,8 @@ func createCommandRequired() *CreateCommand {
 		EndpointName: "log",
 		Version:      2,
 		BucketName:   "bucket",
-		AccessKey:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
-		SecretKey:    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
+		AccessKey:    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "access"},
+		SecretKey:    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "secret"},
 	}
 }
 
@@ -166,7 +166,7 @@ func createCommandRequiredIAMRole() *CreateCommand {
 		EndpointName: "log",
 		Version:      2,
 		BucketName:   "bucket",
-		IAMRole:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/S3Access"},
+		IAMRole:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "arn:aws:iam::123456789012:role/S3Access"},
 	}
 }
 
@@ -176,22 +176,22 @@ func createCommandAll() *CreateCommand {
 		EndpointName:                 "logs",
 		Version:                      2,
 		BucketName:                   "bucket",
-		AccessKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "access"},
-		SecretKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "secret"},
-		Domain:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "domain"},
-		Path:                         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "path"},
-		Period:                       common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:                common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		MessageType:                  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		ResponseCondition:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		TimestampFormat:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		Placement:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		PublicKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
-		Redundancy:                   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: string(fastly.S3RedundancyStandard)},
-		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: string(fastly.S3ServerSideEncryptionAES)},
-		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "kmskey"},
-		CompressionCodec:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		AccessKey:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "access"},
+		SecretKey:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "secret"},
+		Domain:                       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "domain"},
+		Path:                         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "path"},
+		Period:                       cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:                       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:                cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		MessageType:                  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		ResponseCondition:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		TimestampFormat:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		Placement:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		PublicKey:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: pgpPublicKey()},
+		Redundancy:                   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: string(fastly.S3RedundancyStandard)},
+		ServerSideEncryption:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: string(fastly.S3ServerSideEncryptionAES)},
+		ServerSideEncryptionKMSKeyID: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "kmskey"},
+		CompressionCodec:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -203,7 +203,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -212,30 +212,30 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:                         common.Base{Globals: &config.Data{Client: nil}},
+		Base:                         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:                     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:                 "log",
 		Version:                      2,
-		NewName:                      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		BucketName:                   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		AccessKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		SecretKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		IAMRole:                      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: ""},
-		Domain:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Path:                         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Period:                       common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		GzipLevel:                    common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
-		Format:                       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		FormatVersion:                common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		MessageType:                  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		ResponseCondition:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		TimestampFormat:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		Placement:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		Redundancy:                   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: string(fastly.S3RedundancyReduced)},
-		ServerSideEncryption:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: string(fastly.S3ServerSideEncryptionKMS)},
-		ServerSideEncryptionKMSKeyID: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		PublicKey:                    common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
-		CompressionCodec:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new14"},
+		NewName:                      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		BucketName:                   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		AccessKey:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		SecretKey:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		IAMRole:                      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: ""},
+		Domain:                       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Path:                         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Period:                       cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		GzipLevel:                    cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		Format:                       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		FormatVersion:                cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		MessageType:                  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		ResponseCondition:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		TimestampFormat:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		Placement:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		Redundancy:                   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: string(fastly.S3RedundancyReduced)},
+		ServerSideEncryption:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: string(fastly.S3ServerSideEncryptionKMS)},
+		ServerSideEncryptionKMSKeyID: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		PublicKey:                    cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
+		CompressionCodec:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new14"},
 	}
 }
 

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -3,7 +3,7 @@ package s3
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,39 +13,39 @@ import (
 
 // UpdateCommand calls the Fastly API to update an Amazon S3 logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName                      common.OptionalString
-	Address                      common.OptionalString
-	BucketName                   common.OptionalString
-	AccessKey                    common.OptionalString
-	SecretKey                    common.OptionalString
-	IAMRole                      common.OptionalString
-	Domain                       common.OptionalString
-	Path                         common.OptionalString
-	Period                       common.OptionalUint
-	GzipLevel                    common.OptionalUint
-	Format                       common.OptionalString
-	FormatVersion                common.OptionalUint
-	MessageType                  common.OptionalString
-	ResponseCondition            common.OptionalString
-	TimestampFormat              common.OptionalString
-	Placement                    common.OptionalString
-	PublicKey                    common.OptionalString
-	Redundancy                   common.OptionalString
-	ServerSideEncryption         common.OptionalString
-	ServerSideEncryptionKMSKeyID common.OptionalString
-	CompressionCodec             common.OptionalString
+	NewName                      cmd.OptionalString
+	Address                      cmd.OptionalString
+	BucketName                   cmd.OptionalString
+	AccessKey                    cmd.OptionalString
+	SecretKey                    cmd.OptionalString
+	IAMRole                      cmd.OptionalString
+	Domain                       cmd.OptionalString
+	Path                         cmd.OptionalString
+	Period                       cmd.OptionalUint
+	GzipLevel                    cmd.OptionalUint
+	Format                       cmd.OptionalString
+	FormatVersion                cmd.OptionalUint
+	MessageType                  cmd.OptionalString
+	ResponseCondition            cmd.OptionalString
+	TimestampFormat              cmd.OptionalString
+	Placement                    cmd.OptionalString
+	PublicKey                    cmd.OptionalString
+	Redundancy                   cmd.OptionalString
+	ServerSideEncryption         cmd.OptionalString
+	ServerSideEncryptionKMSKeyID cmd.OptionalString
+	CompressionCodec             cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/scalyr/create.go
+++ b/pkg/logging/scalyr/create.go
@@ -3,7 +3,7 @@ package scalyr
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // CreateCommand calls the Fastly API to create a Scalyr logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Token        string
 	Version      int
 
 	// optional
-	Region            common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	Region            cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/scalyr/delete.go
+++ b/pkg/logging/scalyr/delete.go
@@ -3,7 +3,7 @@ package scalyr
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Scalyr logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteScalyrInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Scalyr logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetScalyrInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/scalyr/list.go
+++ b/pkg/logging/scalyr/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Scalyr logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListScalyrsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/scalyr/root.go
+++ b/pkg/logging/scalyr/root.go
@@ -3,19 +3,19 @@ package scalyr
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("scalyr", "Manipulate Fastly service version Scalyr logging endpoints")

--- a/pkg/logging/scalyr/scalyr_test.go
+++ b/pkg/logging/scalyr/scalyr_test.go
@@ -3,7 +3,7 @@ package scalyr
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -126,11 +126,11 @@ func createCommandAll() *CreateCommand {
 		EndpointName:      "log",
 		Version:           2,
 		Token:             "tkn",
-		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "US"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
+		Region:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "US"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
 	}
 }
 
@@ -142,7 +142,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -151,17 +151,17 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Region:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Region:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
 	}
 }
 

--- a/pkg/logging/scalyr/update.go
+++ b/pkg/logging/scalyr/update.go
@@ -3,7 +3,7 @@ package scalyr
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,25 +13,25 @@ import (
 
 // UpdateCommand calls the Fastly API to update Scalyr logging endpoints.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Token             common.OptionalString
-	Region            common.OptionalString
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Token             cmd.OptionalString
+	Region            cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sftp/create.go
+++ b/pkg/logging/sftp/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,35 +14,35 @@ import (
 
 // CreateCommand calls the Fastly API to create an SFTP logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName  string // Can't shadow common.Base method Name().
+	EndpointName  string // Can't shadow cmd.Base method Name().
 	Version       int
 	Address       string
 	User          string
 	SSHKnownHosts string
 
 	// optional
-	Port              common.OptionalUint
-	Password          common.OptionalString
-	PublicKey         common.OptionalString
-	SecretKey         common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	GzipLevel         common.OptionalUint
-	MessageType       common.OptionalString
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	Port              cmd.OptionalUint
+	Password          cmd.OptionalString
+	PublicKey         cmd.OptionalString
+	SecretKey         cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 
 	c.Globals = globals

--- a/pkg/logging/sftp/delete.go
+++ b/pkg/logging/sftp/delete.go
@@ -3,7 +3,7 @@ package sftp
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete an SFTP logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteSFTPInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sftp/describe.go
+++ b/pkg/logging/sftp/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe an SFTP logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetSFTPInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sftp/list.go
+++ b/pkg/logging/sftp/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list SFTP logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListSFTPsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sftp/root.go
+++ b/pkg/logging/sftp/root.go
@@ -3,19 +3,19 @@ package sftp
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("sftp", "Manipulate Fastly service version SFTP logging endpoints")

--- a/pkg/logging/sftp/sftp_test.go
+++ b/pkg/logging/sftp/sftp_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -154,19 +154,19 @@ func createCommandAll() *CreateCommand {
 		Address:           "127.0.0.1",
 		User:              "user",
 		SSHKnownHosts:     knownHosts(),
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 80},
-		Password:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "password"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: pgpPublicKey()},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: sshPrivateKey()},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "/log"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3600},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "zstd"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 80},
+		Password:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "password"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: pgpPublicKey()},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: sshPrivateKey()},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "/log"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3600},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "zstd"},
 	}
 }
 
@@ -178,7 +178,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -187,28 +187,28 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		User:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		SSHKnownHosts:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 81},
-		Password:          common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		PublicKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		SecretKey:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		Path:              common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		Period:            common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3601},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		GzipLevel:         common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 0},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new12"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new13"},
-		CompressionCodec:  common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new14"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Address:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		User:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		SSHKnownHosts:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 81},
+		Password:          cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		PublicKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		SecretKey:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		Path:              cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		Period:            cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3601},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		GzipLevel:         cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 0},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new12"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new13"},
+		CompressionCodec:  cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new14"},
 	}
 }
 

--- a/pkg/logging/sftp/update.go
+++ b/pkg/logging/sftp/update.go
@@ -3,7 +3,7 @@ package sftp
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,7 +13,7 @@ import (
 
 // UpdateCommand calls the Fastly API to update an SFTP logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
@@ -21,28 +21,28 @@ type UpdateCommand struct {
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Address           common.OptionalString
-	Port              common.OptionalUint
-	PublicKey         common.OptionalString
-	SecretKey         common.OptionalString
-	SSHKnownHosts     common.OptionalString
-	User              common.OptionalString
-	Password          common.OptionalString
-	Path              common.OptionalString
-	Period            common.OptionalUint
-	FormatVersion     common.OptionalUint
-	GzipLevel         common.OptionalUint
-	Format            common.OptionalString
-	MessageType       common.OptionalString
-	ResponseCondition common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
-	CompressionCodec  common.OptionalString
+	NewName           cmd.OptionalString
+	Address           cmd.OptionalString
+	Port              cmd.OptionalUint
+	PublicKey         cmd.OptionalString
+	SecretKey         cmd.OptionalString
+	SSHKnownHosts     cmd.OptionalString
+	User              cmd.OptionalString
+	Password          cmd.OptionalString
+	Path              cmd.OptionalString
+	Period            cmd.OptionalUint
+	FormatVersion     cmd.OptionalUint
+	GzipLevel         cmd.OptionalUint
+	Format            cmd.OptionalString
+	MessageType       cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
+	CompressionCodec  cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/splunk/create.go
+++ b/pkg/logging/splunk/create.go
@@ -3,7 +3,7 @@ package splunk
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,29 +13,29 @@ import (
 
 // CreateCommand calls the Fastly API to create a Splunk logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	URL          string
 
 	// optional
-	TLSHostname       common.OptionalString
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Token             common.OptionalString
-	TimestampFormat   common.OptionalString
-	Placement         common.OptionalString
+	TLSHostname       cmd.OptionalString
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Token             cmd.OptionalString
+	TimestampFormat   cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/splunk/delete.go
+++ b/pkg/logging/splunk/delete.go
@@ -3,7 +3,7 @@ package splunk
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Splunk logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteSplunkInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/splunk/describe.go
+++ b/pkg/logging/splunk/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Splunk logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetSplunkInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/splunk/list.go
+++ b/pkg/logging/splunk/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Splunk logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListSplunksInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/splunk/root.go
+++ b/pkg/logging/splunk/root.go
@@ -3,19 +3,19 @@ package splunk
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("splunk", "Manipulate Fastly service version Splunk logging endpoints")

--- a/pkg/logging/splunk/splunk_test.go
+++ b/pkg/logging/splunk/splunk_test.go
@@ -3,7 +3,7 @@ package splunk
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -134,16 +134,16 @@ func createCommandAll() *CreateCommand {
 		EndpointName:      "log",
 		Version:           2,
 		URL:               "example.com",
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		TimestampFormat:   common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "tkn"},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "example.com"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		TimestampFormat:   cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "%Y-%m-%dT%H:%M:%S.000"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "tkn"},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "example.com"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
 	}
 }
 
@@ -155,7 +155,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -164,21 +164,21 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		URL:               cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
 	}
 }
 

--- a/pkg/logging/splunk/update.go
+++ b/pkg/logging/splunk/update.go
@@ -3,7 +3,7 @@ package splunk
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,29 +13,29 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Splunk logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	URL               common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
-	Token             common.OptionalString
-	TLSCACert         common.OptionalString
-	TLSHostname       common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
+	NewName           cmd.OptionalString
+	URL               cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
+	Token             cmd.OptionalString
+	TLSCACert         cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sumologic/create.go
+++ b/pkg/logging/sumologic/create.go
@@ -3,7 +3,7 @@ package sumologic
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,24 +13,24 @@ import (
 
 // CreateCommand calls the Fastly API to create a Sumologic logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	URL          string
 
 	// optional
-	Format            common.OptionalString
-	FormatVersion     common.OptionalInt
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
-	MessageType       common.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalInt
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
+	MessageType       cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sumologic/delete.go
+++ b/pkg/logging/sumologic/delete.go
@@ -3,7 +3,7 @@ package sumologic
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Sumologic logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteSumologicInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sumologic/describe.go
+++ b/pkg/logging/sumologic/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Sumologic logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetSumologicInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sumologic/list.go
+++ b/pkg/logging/sumologic/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Sumologic logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListSumologicsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/sumologic/root.go
+++ b/pkg/logging/sumologic/root.go
@@ -3,19 +3,19 @@ package sumologic
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("sumologic", "Manipulate Fastly service version Sumologic logging endpoints")

--- a/pkg/logging/sumologic/sumologic_test.go
+++ b/pkg/logging/sumologic/sumologic_test.go
@@ -3,7 +3,7 @@ package sumologic
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -117,11 +117,11 @@ func createCommandOK() *CreateCommand {
 		EndpointName:      "log",
 		URL:               "example.com",
 		Version:           2,
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalInt{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalInt{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
 	}
 }
 
@@ -142,7 +142,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -151,17 +151,17 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		URL:               common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		FormatVersion:     common.OptionalInt{Optional: common.Optional{WasSet: true}, Value: 3},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		URL:               cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		FormatVersion:     cmd.OptionalInt{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
 	}
 }
 

--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -3,7 +3,7 @@ package sumologic
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,25 +13,25 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Sumologic logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	URL               common.OptionalString
-	Format            common.OptionalString
-	ResponseCondition common.OptionalString
-	MessageType       common.OptionalString
-	FormatVersion     common.OptionalInt // Inconsistent with other logging endpoints, but remaining as int to avoid breaking changes in fastly/go-fastly.
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	URL               cmd.OptionalString
+	Format            cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	MessageType       cmd.OptionalString
+	FormatVersion     cmd.OptionalInt // Inconsistent with other logging endpoints, but remaining as int to avoid breaking changes in fastly/go-fastly.
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/syslog/create.go
+++ b/pkg/logging/syslog/create.go
@@ -3,7 +3,7 @@ package syslog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,31 +13,31 @@ import (
 
 // CreateCommand calls the Fastly API to create a Syslog logging endpoint.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
-	EndpointName string // Can't shadow common.Base method Name().
+	EndpointName string // Can't shadow cmd.Base method Name().
 	Version      int
 	Address      string
 
 	// optional
-	Port              common.OptionalUint
-	UseTLS            common.OptionalBool
-	Token             common.OptionalString
-	TLSCACert         common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	TLSHostname       common.OptionalString
-	MessageType       common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	Placement         common.OptionalString
-	ResponseCondition common.OptionalString
+	Port              cmd.OptionalUint
+	UseTLS            cmd.OptionalBool
+	Token             cmd.OptionalString
+	TLSCACert         cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	MessageType       cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	Placement         cmd.OptionalString
+	ResponseCondition cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/syslog/delete.go
+++ b/pkg/logging/syslog/delete.go
@@ -3,7 +3,7 @@ package syslog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeleteCommand calls the Fastly API to delete a Syslog logging endpoint.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteSyslogInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/syslog/describe.go
+++ b/pkg/logging/syslog/describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a Syslog logging endpoint.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetSyslogInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/syslog/list.go
+++ b/pkg/logging/syslog/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,13 +14,13 @@ import (
 
 // ListCommand calls the Fastly API to list Syslog logging endpoints.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListSyslogsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logging/syslog/root.go
+++ b/pkg/logging/syslog/root.go
@@ -3,19 +3,19 @@ package syslog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("syslog", "Manipulate Fastly service version Syslog logging endpoints")

--- a/pkg/logging/syslog/syslog_test.go
+++ b/pkg/logging/syslog/syslog_test.go
@@ -3,7 +3,7 @@ package syslog
 import (
 	"testing"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -140,18 +140,18 @@ func createCommandAll() *CreateCommand {
 		EndpointName:      "log",
 		Version:           2,
 		Address:           "example.com",
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 2},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "Prevent default logging"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "none"},
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 22},
-		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: true},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "example.com"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "tkn"},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "classic"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: `%h %l %u %t "%r" %>s %b`},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 2},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "Prevent default logging"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "none"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 22},
+		UseTLS:            cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: true},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----foo"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "example.com"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN CERTIFICATE-----bar"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "-----BEGIN PRIVATE KEY-----bar"},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "tkn"},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "classic"},
 	}
 }
 
@@ -163,7 +163,7 @@ func createCommandMissingServiceID() *CreateCommand {
 
 func updateCommandNoUpdates() *UpdateCommand {
 	return &UpdateCommand{
-		Base:         common.Base{Globals: &config.Data{Client: nil}},
+		Base:         cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:     manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName: "log",
 		Version:      2,
@@ -172,24 +172,24 @@ func updateCommandNoUpdates() *UpdateCommand {
 
 func updateCommandAll() *UpdateCommand {
 	return &UpdateCommand{
-		Base:              common.Base{Globals: &config.Data{Client: nil}},
+		Base:              cmd.Base{Globals: &config.Data{Client: nil}},
 		manifest:          manifest.Data{Flag: manifest.Flag{ServiceID: "123"}},
 		EndpointName:      "log",
 		Version:           2,
-		NewName:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new1"},
-		Address:           common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new2"},
-		Port:              common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 23},
-		UseTLS:            common.OptionalBool{Optional: common.Optional{WasSet: true}, Value: false},
-		TLSCACert:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new3"},
-		TLSHostname:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new4"},
-		TLSClientCert:     common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new5"},
-		TLSClientKey:      common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new6"},
-		Token:             common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new7"},
-		Format:            common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new8"},
-		FormatVersion:     common.OptionalUint{Optional: common.Optional{WasSet: true}, Value: 3},
-		MessageType:       common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new9"},
-		ResponseCondition: common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new10"},
-		Placement:         common.OptionalString{Optional: common.Optional{WasSet: true}, Value: "new11"},
+		NewName:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new1"},
+		Address:           cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new2"},
+		Port:              cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 23},
+		UseTLS:            cmd.OptionalBool{Optional: cmd.Optional{WasSet: true}, Value: false},
+		TLSCACert:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new3"},
+		TLSHostname:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new4"},
+		TLSClientCert:     cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new5"},
+		TLSClientKey:      cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new6"},
+		Token:             cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new7"},
+		Format:            cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new8"},
+		FormatVersion:     cmd.OptionalUint{Optional: cmd.Optional{WasSet: true}, Value: 3},
+		MessageType:       cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new9"},
+		ResponseCondition: cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new10"},
+		Placement:         cmd.OptionalString{Optional: cmd.Optional{WasSet: true}, Value: "new11"},
 	}
 }
 

--- a/pkg/logging/syslog/update.go
+++ b/pkg/logging/syslog/update.go
@@ -3,7 +3,7 @@ package syslog
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,7 +13,7 @@ import (
 
 // UpdateCommand calls the Fastly API to update a Syslog logging endpoint.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	// required
@@ -21,24 +21,24 @@ type UpdateCommand struct {
 	Version      int
 
 	// optional
-	NewName           common.OptionalString
-	Address           common.OptionalString
-	Port              common.OptionalUint
-	UseTLS            common.OptionalBool
-	TLSCACert         common.OptionalString
-	TLSHostname       common.OptionalString
-	TLSClientCert     common.OptionalString
-	TLSClientKey      common.OptionalString
-	Token             common.OptionalString
-	Format            common.OptionalString
-	FormatVersion     common.OptionalUint
-	MessageType       common.OptionalString
-	ResponseCondition common.OptionalString
-	Placement         common.OptionalString
+	NewName           cmd.OptionalString
+	Address           cmd.OptionalString
+	Port              cmd.OptionalUint
+	UseTLS            cmd.OptionalBool
+	TLSCACert         cmd.OptionalString
+	TLSHostname       cmd.OptionalString
+	TLSClientCert     cmd.OptionalString
+	TLSClientKey      cmd.OptionalString
+	Token             cmd.OptionalString
+	Format            cmd.OptionalString
+	FormatVersion     cmd.OptionalUint
+	MessageType       cmd.OptionalString
+	ResponseCondition cmd.OptionalString
+	Placement         cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/logs/root.go
+++ b/pkg/logs/root.go
@@ -3,19 +3,19 @@ package logs
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("logs", "Compute@Edge Log Tailing")

--- a/pkg/logs/tail.go
+++ b/pkg/logs/tail.go
@@ -17,7 +17,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -29,7 +29,7 @@ import (
 type (
 	// TailCommand represents the CLI subcommand for Log Tailing.
 	TailCommand struct {
-		common.Base
+		cmd.Base
 		manifest manifest.Data
 		Input    fastly.CreateManagedLoggingInput
 
@@ -95,7 +95,7 @@ type (
 )
 
 // NewTailCommand returns a usable command registered under the parent.
-func NewTailCommand(parent common.Registerer, globals *config.Data) *TailCommand {
+func NewTailCommand(parent cmd.Registerer, globals *config.Data) *TailCommand {
 	var c TailCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/service/create.go
+++ b/pkg/service/create.go
@@ -3,7 +3,7 @@ package service
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -11,12 +11,12 @@ import (
 
 // CreateCommand calls the Fastly API to create services.
 type CreateCommand struct {
-	common.Base
+	cmd.Base
 	Input fastly.CreateServiceInput
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
-func NewCreateCommand(parent common.Registerer, globals *config.Data) *CreateCommand {
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
 	var c CreateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("create", "Create a Fastly service").Alias("add")

--- a/pkg/service/delete.go
+++ b/pkg/service/delete.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,14 +14,14 @@ import (
 
 // DeleteCommand calls the Fastly API to delete services.
 type DeleteCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeleteServiceInput
 	force    bool
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
-func NewDeleteCommand(parent common.Registerer, globals *config.Data) *DeleteCommand {
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
 	var c DeleteCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/service/describe.go
+++ b/pkg/service/describe.go
@@ -3,7 +3,7 @@ package service
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DescribeCommand calls the Fastly API to describe a service.
 type DescribeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.GetServiceInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
-func NewDescribeCommand(parent common.Registerer, globals *config.Data) *DescribeCommand {
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/service/list.go
+++ b/pkg/service/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
@@ -13,12 +13,12 @@ import (
 
 // ListCommand calls the Fastly API to list services.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	Input fastly.ListServicesInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("list", "List Fastly services")

--- a/pkg/service/root.go
+++ b/pkg/service/root.go
@@ -3,19 +3,19 @@ package service
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("service", "Manipulate Fastly services")

--- a/pkg/service/search.go
+++ b/pkg/service/search.go
@@ -3,7 +3,7 @@ package service
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
@@ -12,13 +12,13 @@ import (
 
 // SearchCommand calls the Fastly API to describe a service.
 type SearchCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.SearchServiceInput
 }
 
 // NewSearchCommand returns a usable command registered under the parent.
-func NewSearchCommand(parent common.Registerer, globals *config.Data) *SearchCommand {
+func NewSearchCommand(parent cmd.Registerer, globals *config.Data) *SearchCommand {
 	var c SearchCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/service/update.go
+++ b/pkg/service/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,20 +14,20 @@ import (
 
 // UpdateCommand calls the Fastly API to create services.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	input    fastly.UpdateServiceInput
 
 	// TODO(integralist):
 	// Ensure consistency in capitalization, should be lowercase to avoid
-	// ambiguity in common.Command interface.
+	// ambiguity in cmd.Command interface.
 	//
-	name    common.OptionalString
-	comment common.OptionalString
+	name    cmd.OptionalString
+	comment cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/serviceversion/activate.go
+++ b/pkg/serviceversion/activate.go
@@ -3,7 +3,7 @@ package serviceversion
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // ActivateCommand calls the Fastly API to activate a service version.
 type ActivateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ActivateVersionInput
 }
 
 // NewActivateCommand returns a usable command registered under the parent.
-func NewActivateCommand(parent common.Registerer, globals *config.Data) *ActivateCommand {
+func NewActivateCommand(parent cmd.Registerer, globals *config.Data) *ActivateCommand {
 	var c ActivateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/serviceversion/clone.go
+++ b/pkg/serviceversion/clone.go
@@ -3,7 +3,7 @@ package serviceversion
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // CloneCommand calls the Fastly API to clone a service version.
 type CloneCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.CloneVersionInput
 }
 
 // NewCloneCommand returns a usable command registered under the parent.
-func NewCloneCommand(parent common.Registerer, globals *config.Data) *CloneCommand {
+func NewCloneCommand(parent cmd.Registerer, globals *config.Data) *CloneCommand {
 	var c CloneCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/serviceversion/deactivate.go
+++ b/pkg/serviceversion/deactivate.go
@@ -3,7 +3,7 @@ package serviceversion
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // DeactivateCommand calls the Fastly API to deactivate a service version.
 type DeactivateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.DeactivateVersionInput
 }
 
 // NewDeactivateCommand returns a usable command registered under the parent.
-func NewDeactivateCommand(parent common.Registerer, globals *config.Data) *DeactivateCommand {
+func NewDeactivateCommand(parent cmd.Registerer, globals *config.Data) *DeactivateCommand {
 	var c DeactivateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/serviceversion/list.go
+++ b/pkg/serviceversion/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -15,13 +15,13 @@ import (
 
 // ListCommand calls the Fastly API to list services.
 type ListCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.ListVersionsInput
 }
 
 // NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent common.Registerer, globals *config.Data) *ListCommand {
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/serviceversion/lock.go
+++ b/pkg/serviceversion/lock.go
@@ -3,7 +3,7 @@ package serviceversion
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -13,13 +13,13 @@ import (
 
 // LockCommand calls the Fastly API to lock a service version.
 type LockCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	Input    fastly.LockVersionInput
 }
 
 // NewLockCommand returns a usable command registered under the parent.
-func NewLockCommand(parent common.Registerer, globals *config.Data) *LockCommand {
+func NewLockCommand(parent cmd.Registerer, globals *config.Data) *LockCommand {
 	var c LockCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/serviceversion/root.go
+++ b/pkg/serviceversion/root.go
@@ -3,19 +3,19 @@ package serviceversion
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	// no flags
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("service-version", "Manipulate Fastly service versions")

--- a/pkg/serviceversion/update.go
+++ b/pkg/serviceversion/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -14,15 +14,15 @@ import (
 
 // UpdateCommand calls the Fastly API to update a service version.
 type UpdateCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 	input    fastly.UpdateVersionInput
 
-	comment common.OptionalString
+	comment cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.
-func NewUpdateCommand(parent common.Registerer, globals *config.Data) *UpdateCommand {
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)

--- a/pkg/stats/historical.go
+++ b/pkg/stats/historical.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -16,7 +16,7 @@ const statusSuccess = "success"
 
 // HistoricalCommand exposes the Historical Stats API.
 type HistoricalCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	Input      fastly.GetStatsInput
@@ -24,7 +24,7 @@ type HistoricalCommand struct {
 }
 
 // NewHistoricalCommand is the "stats historical" subcommand.
-func NewHistoricalCommand(parent common.Registerer, globals *config.Data) *HistoricalCommand {
+func NewHistoricalCommand(parent cmd.Registerer, globals *config.Data) *HistoricalCommand {
 	var c HistoricalCommand
 	c.Globals = globals
 

--- a/pkg/stats/realtime.go
+++ b/pkg/stats/realtime.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
@@ -15,14 +15,14 @@ import (
 
 // RealtimeCommand exposes the Realtime Metrics API.
 type RealtimeCommand struct {
-	common.Base
+	cmd.Base
 	manifest manifest.Data
 
 	formatFlag string
 }
 
 // NewRealtimeCommand is the "stats realtime" subcommand.
-func NewRealtimeCommand(parent common.Registerer, globals *config.Data) *RealtimeCommand {
+func NewRealtimeCommand(parent cmd.Registerer, globals *config.Data) *RealtimeCommand {
 	var c RealtimeCommand
 	c.Globals = globals
 

--- a/pkg/stats/regions.go
+++ b/pkg/stats/regions.go
@@ -4,18 +4,18 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 )
 
 // RegionsCommand exposes the Stats Regions API.
 type RegionsCommand struct {
-	common.Base
+	cmd.Base
 }
 
 // NewRegionsCommand returns a new command registered under parent.
-func NewRegionsCommand(parent common.Registerer, globals *config.Data) *RegionsCommand {
+func NewRegionsCommand(parent cmd.Registerer, globals *config.Data) *RegionsCommand {
 	var c RegionsCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("regions", "List stats regions")

--- a/pkg/stats/root.go
+++ b/pkg/stats/root.go
@@ -3,17 +3,17 @@ package stats
 import (
 	"io"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 )
 
 // RootCommand dispatches all "stats" commands.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 }
 
 // NewRootCommand returns a new top level "stats" command.
-func NewRootCommand(parent common.Registerer, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("stats", "View statistics (historical and realtime) for a Fastly service")

--- a/pkg/update/root.go
+++ b/pkg/update/root.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/revision"
@@ -18,14 +18,14 @@ import (
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	cliVersioner   Versioner
 	client         api.HTTPClient
 	configFilePath string
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, configFilePath string, cliVersioner Versioner, client api.HTTPClient, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, configFilePath string, cliVersioner Versioner, client api.HTTPClient, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("update", "Update the CLI to the latest version")

--- a/pkg/version/root.go
+++ b/pkg/version/root.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/useragent"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -22,11 +22,11 @@ func init() {
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer) *RootCommand {
+func NewRootCommand(parent cmd.Registerer) *RootCommand {
 	var c RootCommand
 	c.CmdClause = parent.Command("version", "Display version information for the Fastly CLI")
 	return &c

--- a/pkg/whoami/root.go
+++ b/pkg/whoami/root.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/useragent"
@@ -18,12 +18,12 @@ import (
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
-	common.Base
+	cmd.Base
 	client api.HTTPClient
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent common.Registerer, client api.HTTPClient, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, client api.HTTPClient, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.client = client


### PR DESCRIPTION
**Problem**: I'm increasingly stumbling into issues with the `common` package being too broad/generic. This materialises as an "import cycle error". It is also considered bad practice to have folders named `common` or `utils` etc.
**Solution**: Move these behaviours into their own packages.
**Example**: I would like to add a remediation error type to some code in our `config` package. This isn't possible because importing the `errors` package will import `text` which will import `common` and the common package has already been imported earlier in the import cycle:

```
package github.com/fastly/cli/cmd/fastly
        imports github.com/fastly/cli/pkg/app
        imports github.com/fastly/cli/pkg/backend
        imports github.com/fastly/cli/pkg/common << command stuff like: Base/Register/StreamingExec + lots more other misc stuff.
        imports github.com/fastly/cli/pkg/config
        imports github.com/fastly/cli/pkg/errors
        imports github.com/fastly/cli/pkg/text
        imports github.com/fastly/cli/pkg/common: import cycle not allowed
```