### PR TITLE
Move exec behaviour from common to own package

### DIFF
--- a/pkg/common/doc.go
+++ b/pkg/common/doc.go
@@ -1,3 +1,0 @@
-// Package common contains general-purpose types and helpers.
-// Ideally, it should remain as small as possible.
-package common

--- a/pkg/compute/assemblyscript.go
+++ b/pkg/compute/assemblyscript.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/errors"
+	fstexec "github.com/fastly/cli/pkg/exec"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/text"
 )
@@ -139,7 +139,7 @@ func (a AssemblyScript) Initialize(out io.Writer) error {
 	fmt.Fprintf(out, "Installing package dependencies...\n")
 
 	// Call npm install.
-	cmd := common.NewStreamingExec("npm", []string{"install"}, []string{}, false, out)
+	cmd := fstexec.NewStreaming("npm", []string{"install"}, []string{}, false, out)
 	return cmd.Exec()
 }
 
@@ -173,7 +173,7 @@ func (a AssemblyScript) Build(out io.Writer, verbose bool) error {
 	}
 
 	// Call asc with the build arguments.
-	cmd := common.NewStreamingExec(filepath.Join(npmdir, "asc"), args, []string{}, verbose, out)
+	cmd := fstexec.NewStreaming(filepath.Join(npmdir, "asc"), args, []string{}, verbose, out)
 	if err := cmd.Exec(); err != nil {
 		return err
 	}

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/fastly/cli/pkg/api"
-	"github.com/fastly/cli/pkg/common"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
+	fstexec "github.com/fastly/cli/pkg/exec"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/text"
 	toml "github.com/pelletier/go-toml"
@@ -352,7 +352,7 @@ func (r Rust) Build(out io.Writer, verbose bool) error {
 
 	// Execute the `cargo build` commands with the Wasm WASI target, release
 	// flags and env vars.
-	cmd := common.NewStreamingExec("cargo", args, os.Environ(), verbose, out)
+	cmd := fstexec.NewStreaming("cargo", args, os.Environ(), verbose, out)
 	if err := cmd.Exec(); err != nil {
 		return err
 	}

--- a/pkg/exec/doc.go
+++ b/pkg/exec/doc.go
@@ -1,0 +1,2 @@
+// Package exec contains helper abstractions for working with external commands.
+package exec

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,4 +1,4 @@
-package common
+package exec
 
 import (
 	"bytes"
@@ -7,14 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	// "sync"
 )
 
-// StreamingExec models a generic command execution that consumers can use to
+// Streaming models a generic command execution that consumers can use to
 // execute commands and stream their output to an io.Writer. For example
 // compute commands can use this to standardize the flow control for each
 // compiler toolchain.
-type StreamingExec struct {
+type Streaming struct {
 	command string
 	args    []string
 	env     []string
@@ -22,9 +21,9 @@ type StreamingExec struct {
 	output  io.Writer
 }
 
-// NewStreamingExec constructs a new StreamingExec instance.
-func NewStreamingExec(cmd string, args, env []string, verbose bool, out io.Writer) *StreamingExec {
-	return &StreamingExec{
+// NewStreaming constructs a new Streaming instance.
+func NewStreaming(cmd string, args, env []string, verbose bool, out io.Writer) *Streaming {
+	return &Streaming{
 		cmd,
 		args,
 		env,
@@ -36,7 +35,7 @@ func NewStreamingExec(cmd string, args, env []string, verbose bool, out io.Write
 // Exec executes the compiler command and pipes the child process stdout and
 // stderr output to the supplied io.Writer, it waits for the command to exit
 // cleanly or returns an error.
-func (s StreamingExec) Exec() error {
+func (s Streaming) Exec() error {
 	// Construct the command with given arguments and environment.
 	//
 	// gosec flagged this:


### PR DESCRIPTION
**Problem**: I'm increasingly stumbling into issues with the `common` package being too broad/generic. This materialises as an "import cycle error". It is also considered bad practice to have folders named `common` or `utils` etc.
**Solution**: Move these behaviours into their own packages.
**Example**: I would like to add a remediation error type to some code in our `config` package. This isn't possible because importing the `errors` package will import `text` which will import `common` and the common package has already been imported earlier in the import cycle:

```
package github.com/fastly/cli/cmd/fastly
        imports github.com/fastly/cli/pkg/app
        imports github.com/fastly/cli/pkg/backend
        imports github.com/fastly/cli/pkg/common << command stuff like: Base/Register/StreamingExec + lots more other misc stuff.
        imports github.com/fastly/cli/pkg/config
        imports github.com/fastly/cli/pkg/errors
        imports github.com/fastly/cli/pkg/text
        imports github.com/fastly/cli/pkg/common: import cycle not allowed
```