### PR TITLE
implement remediation error for dynamic config 'context deadline'

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	if err != nil || file.CLI.Version != revision.SemVer(revision.AppVersion) {
-		err := file.Load(config.RemoteEndpoint, httpClient)
+		err := file.Load(config.RemoteEndpoint, httpClient, config.ConfigRequestTimeout)
 		if err != nil {
 			errors.RemediationError{
 				Inner:       err,
@@ -102,7 +102,7 @@ func main() {
 			text.Break(out)
 		}
 
-		err := file.Load(config.RemoteEndpoint, httpClient)
+		err := file.Load(config.RemoteEndpoint, httpClient, config.ConfigRequestTimeout)
 		if err != nil {
 			errors.RemediationError{
 				Inner:       err,
@@ -133,7 +133,7 @@ Compatibility and versioning information for the Fastly CLI is being updated in 
 			// NOTE: we no longer use the hardcoded config.RemoteEndpoint constant.
 			// Instead we rely on the values inside of the application
 			// configuration file to determine where to load the config from.
-			err := file.Load(file.CLI.RemoteConfig, httpClient)
+			err := file.Load(file.CLI.RemoteConfig, httpClient, config.ConfigRequestTimeout)
 			if err != nil {
 				errLoadConfig = errors.RemediationError{
 					Inner:       fmt.Errorf("there was a problem updating the versioning information for the Fastly CLI:\n\n%w", err),

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fastly/cli/pkg/domain"
 	"github.com/fastly/cli/pkg/edgedictionary"
 	"github.com/fastly/cli/pkg/edgedictionaryitem"
+	"github.com/fastly/cli/pkg/env"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/healthcheck"
 	"github.com/fastly/cli/pkg/logging"
@@ -73,12 +74,12 @@ var (
 // The Run helper should NOT output any error-related information to the out
 // io.Writer. All error-related information should be encoded into an error type
 // and returned to the caller. This includes usage text.
-func Run(args []string, env config.Environment, file config.File, configFilePath string, cf APIClientFactory, httpClient api.HTTPClient, cliVersioner update.Versioner, in io.Reader, out io.Writer) error {
+func Run(args []string, environ config.Environment, file config.File, configFilePath string, cf APIClientFactory, httpClient api.HTTPClient, cliVersioner update.Versioner, in io.Reader, out io.Writer) error {
 	// The globals will hold generally-applicable configuration parameters
 	// from a variety of sources, and is provided to each concrete command.
 	globals := config.Data{
 		File:   file,
-		Env:    env,
+		Env:    environ,
 		Output: out,
 	}
 
@@ -107,7 +108,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	// WARNING: kingping has no way of decorating flags as being "global"
 	// therefore if you add/remove a global flag you will also need to update
 	// the globalFlag map in pkg/app/usage.go which is used for usage rendering.
-	tokenHelp := fmt.Sprintf("Fastly API token (or via %s)", config.EnvVarToken)
+	tokenHelp := fmt.Sprintf("Fastly API token (or via %s)", env.Token)
 	app.Flag("token", tokenHelp).Short('t').StringVar(&globals.Flag.Token)
 	app.Flag("verbose", "Verbose logging").Short('v').BoolVar(&globals.Flag.Verbose)
 	app.Flag("endpoint", "Fastly API endpoint").Hidden().StringVar(&globals.Flag.Endpoint)
@@ -679,7 +680,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 		case config.SourceFlag:
 			fmt.Fprintf(out, "Fastly API token provided via --token\n")
 		case config.SourceEnvironment:
-			fmt.Fprintf(out, "Fastly API token provided via %s\n", config.EnvVarToken)
+			fmt.Fprintf(out, "Fastly API token provided via %s\n", env.Token)
 		case config.SourceFile:
 			fmt.Fprintf(out, "Fastly API token provided via config file\n")
 		default:
@@ -705,7 +706,7 @@ func Run(args []string, env config.Environment, file config.File, configFilePath
 	if globals.Verbose() {
 		switch source {
 		case config.SourceEnvironment:
-			fmt.Fprintf(out, "Fastly API endpoint (via %s): %s\n", config.EnvVarEndpoint, endpoint)
+			fmt.Fprintf(out, "Fastly API endpoint (via %s): %s\n", env.Endpoint, endpoint)
 		case config.SourceFile:
 			fmt.Fprintf(out, "Fastly API endpoint (via config file): %s\n", endpoint)
 		default:

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -227,8 +227,8 @@ type StarterKit struct {
 
 // Load gets the configuration file from the CLI API endpoint and encodes it
 // from memory into config.File.
-func (f *File) Load(configEndpoint string, httpClient api.HTTPClient) error {
-	ctx, cancel := context.WithTimeout(context.Background(), ConfigRequestTimeout)
+func (f *File) Load(configEndpoint string, c api.HTTPClient, d time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), d)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, configEndpoint, nil)
@@ -237,7 +237,7 @@ func (f *File) Load(configEndpoint string, httpClient api.HTTPClient) error {
 	}
 
 	req.Header.Set("User-Agent", useragent.Name)
-	resp, err := httpClient.Do(req)
+	resp, err := c.Do(req)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return fsterr.RemediationError{

--- a/pkg/config/data_test.go
+++ b/pkg/config/data_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	fsterr "github.com/fastly/cli/pkg/errors"
+)
+
+type mockHTTPClient struct{}
+
+func (c mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{}, context.DeadlineExceeded
+}
+
+// TestConfigLoad validates that when a context.DeadlineExceeded error is
+// returned from a http.Client.Do request, that an appropriate remediation
+// error is returned to the user.
+func TestConfigLoad(t *testing.T) {
+	var (
+		c mockHTTPClient
+		d time.Duration
+		f *File
+	)
+	if err := f.Load("foo", c, d); err != nil {
+		if !errors.As(err, &fsterr.RemediationError{}) {
+			t.Errorf("expected RemediationError got: %T", err)
+		}
+		if err.(fsterr.RemediationError).Remediation != fsterr.NetworkRemediation {
+			t.Errorf("expected NetworkRemediation got: %s", err.(fsterr.RemediationError).Remediation)
+		}
+	} else {
+		t.Error("expected an error, got nil")
+	}
+}

--- a/pkg/configure/root.go
+++ b/pkg/configure/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/env"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v3/fastly"
 )
@@ -47,7 +48,7 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	case config.SourceFlag:
 		text.Output(out, "Fastly API endpoint (via --endpoint): %s", endpoint)
 	case config.SourceEnvironment:
-		text.Output(out, "Fastly API endpoint (via %s): %s", config.EnvVarEndpoint, endpoint)
+		text.Output(out, "Fastly API endpoint (via %s): %s", env.Endpoint, endpoint)
 	}
 
 	// Get the token provided by the user, if it was explicitly provided. If it
@@ -58,7 +59,7 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	case config.SourceFlag:
 		text.Output(out, "Fastly API token provided via --token")
 	case config.SourceEnvironment:
-		text.Output(out, "Fastly API token provided via %s", config.EnvVarToken)
+		text.Output(out, "Fastly API token provided via %s", env.Token)
 	default:
 		text.Output(out, `
 			An API token is used to authenticate requests to the Fastly API.

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,13 @@
+package env
+
+const (
+	// Token is the env var we look in for the Fastly API token.
+	// gosec flagged this:
+	// G101 (CWE-798): Potential hardcoded credentials
+	// Disabling as we use the value in the command help output.
+	/* #nosec */
+	Token = "FASTLY_API_TOKEN"
+
+	// Endpoint is the env var we look in for the API endpoint.
+	Endpoint = "FASTLY_API_ENDPOINT"
+)

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/env"
 	"github.com/fastly/cli/pkg/text"
 )
 
@@ -54,12 +54,12 @@ var AuthRemediation = fmt.Sprintf(strings.Join([]string{
 	"Check that you're supplying a valid token, either via --token,",
 	"through the environment variable %s, or through the config file via `fastly configure`.",
 	"Verify that the token is still valid via `fastly whoami`.",
-}, " "), config.EnvVarToken)
+}, " "), env.Token)
 
 // NetworkRemediation suggests, somewhat unhelpfully, to try again later.
 var NetworkRemediation = strings.Join([]string{
 	"This error may be caused by transient network issues.",
-	"Please verify your network connection and try again.",
+	"Please verify your network connection and DNS configuration, and try again.",
 }, " ")
 
 // HostRemediation suggests there might be an issue with the local host.

--- a/pkg/whoami/whoami_test.go
+++ b/pkg/whoami/whoami_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/env"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/update"
@@ -76,7 +77,7 @@ func TestWhoami(t *testing.T) {
 			client: verifyClient(basicResponse),
 			wantOutput: strings.ReplaceAll(basicOutputVerbose,
 				"Fastly API endpoint: https://api.fastly.com",
-				fmt.Sprintf("Fastly API endpoint (via %s): https://alternative.example.com", config.EnvVarEndpoint),
+				fmt.Sprintf("Fastly API endpoint (via %s): https://alternative.example.com", env.Endpoint),
 			),
 		},
 	} {


### PR DESCRIPTION
**Problem**: Requests for the remote/dynamic configuration used by the CLI has a timeout configured. When this error is triggered it is returned directly to the user.
**Solution**: Wrap the error in a remediation to help guide users on the possible next steps to take.
**Notes**: I've moved a couple of constant variables into their own package to avoid a "import cycle" error.