### PR TITLE
Capitalise n to indicate it is the default

### DIFF
--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -498,7 +498,7 @@ func verifyDirectory(out io.Writer, in io.Reader) (bool, error) {
 			return false, err
 		}
 
-		label := fmt.Sprintf("The current directory isn't empty. Are you sure you want to initialize a Compute@Edge project in %s? [y/n] ", dir)
+		label := fmt.Sprintf("The current directory isn't empty. Are you sure you want to initialize a Compute@Edge project in %s? [y/N] ", dir)
 		cont, err := text.Input(out, label, in)
 		if err != nil {
 			return false, fmt.Errorf("error reading input %w", err)


### PR DESCRIPTION
When there is no input or the input doesn't match `(?i:y|yes)`.