### PR TITLE
Define new --version and --autoclone flags

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -16,10 +16,6 @@ type HTTPClient interface {
 
 // Interface models the methods of the Fastly API client that we use.
 // It exists to allow for easier testing, in combination with Mock.
-//
-// TODO(integralist):
-// There are missing methods such as GetVersion from this list so review in
-// future the missing features in CLI and implement here.
 type Interface interface {
 	GetTokenSelf() (*fastly.Token, error)
 
@@ -33,6 +29,7 @@ type Interface interface {
 
 	CloneVersion(*fastly.CloneVersionInput) (*fastly.Version, error)
 	ListVersions(*fastly.ListVersionsInput) ([]*fastly.Version, error)
+	GetVersion(*fastly.GetVersionInput) (*fastly.Version, error)
 	UpdateVersion(*fastly.UpdateVersionInput) (*fastly.Version, error)
 	ActivateVersion(*fastly.ActivateVersionInput) (*fastly.Version, error)
 	DeactivateVersion(*fastly.DeactivateVersionInput) (*fastly.Version, error)

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -71,7 +71,7 @@ func (sv *OptionalServiceVersion) Parse(sid string) (*fastly.Version, error) {
 	case "latest":
 		return vs[0], nil
 	case "active":
-		v, err = getLatestActiveVersion(vs)
+		v, err = getActiveVersion(vs)
 	case "":
 		return vs[0], nil
 	default:
@@ -119,8 +119,8 @@ func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string) (*fastly.Versi
 	return v, nil
 }
 
-// getLatestActiveVersion returns the active service version.
-func getLatestActiveVersion(vs []*fastly.Version) (*fastly.Version, error) {
+// getActiveVersion returns the active service version.
+func getActiveVersion(vs []*fastly.Version) (*fastly.Version, error) {
 	for _, v := range vs {
 		if v.Active {
 			return v, nil

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -24,10 +24,10 @@ type ServiceVersionFlagOpts struct {
 	Action   kingpin.Action
 }
 
-// NewServiceVersionFlag defines a --version flag that accepts multiple values
+// SetServiceVersionFlag defines a --version flag that accepts multiple values
 // such as 'latest', 'active' and numerical values which are then converted
 // into the appropriate service version.
-func (b Base) NewServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string) {
+func (b Base) SetServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string) {
 	clause := b.CmdClause.Flag("version", "'latest', 'active', or the number of a specific version")
 	if !opts.Optional {
 		clause = clause.Required()
@@ -37,9 +37,9 @@ func (b Base) NewServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string)
 	clause.StringVar(opts.Dst)
 }
 
-// NewAutoCloneFlag defines a --autoclone flag that will cause a clone of the
+// SetAutoCloneFlag defines a --autoclone flag that will cause a clone of the
 // identified service version if its found to be active or locked.
-func (b Base) NewAutoCloneFlag(action kingpin.Action, dst *bool) {
+func (b Base) SetAutoCloneFlag(action kingpin.Action, dst *bool) {
 	b.CmdClause.Flag("autoclone", "If the selected service version is not editable, clone it and use the clone.").Action(action).BoolVar(dst)
 }
 

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -122,7 +122,7 @@ func getLatestActiveVersion(vs []*fastly.Version) (*fastly.Version, error) {
 			return v, nil
 		}
 	}
-	return nil, fmt.Errorf("error locating latest active service version")
+	return nil, fmt.Errorf("no active service version found")
 }
 
 // getLatestEditableVersion returns the latest editable service version.
@@ -145,7 +145,7 @@ func getLatestEditableVersion(vs []*fastly.Version) (*fastly.Version, error) {
 		if v.Active {
 			break
 		}
-		if !v.Active && !v.Locked {
+		if !v.Locked {
 			return v, nil
 		}
 	}
@@ -168,5 +168,5 @@ func getSpecifiedVersion(vs []*fastly.Version, version string) (*fastly.Version,
 		}
 	}
 
-	return nil, fmt.Errorf("error getting specified service version: %s", version)
+	return nil, fmt.Errorf("specified service version not found: %s", version)
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -40,7 +40,7 @@ func (b Base) SetServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string)
 }
 
 // SetAutoCloneFlag defines a --autoclone flag that will cause a clone of the
-// identified service version if its found to be active or locked.
+// identified service version if it's found to be active or locked.
 func (b Base) SetAutoCloneFlag(action kingpin.Action, dst *bool) {
 	b.CmdClause.Flag("autoclone", "If the selected service version is not editable, clone it and use the clone.").Action(action).BoolVar(dst)
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -28,7 +28,7 @@ type ServiceVersionFlagOpts struct {
 // such as 'latest', 'active' and numerical values which are then converted
 // into the appropriate service version.
 func (b Base) NewServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string) {
-	clause := b.CmdClause.Flag("version", "Number of service version, 'latest', 'active' or 'editable'")
+	clause := b.CmdClause.Flag("version", "'latest', 'active', or the number of a specific version")
 	if !opts.Optional {
 		clause = clause.Required()
 	} else {
@@ -40,7 +40,7 @@ func (b Base) NewServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string)
 // NewAutoCloneFlag defines a --autoclone flag that will cause a clone of the
 // identified service version if its found to be active or locked.
 func (b Base) NewAutoCloneFlag(action kingpin.Action, dst *bool) {
-	b.CmdClause.Flag("autoclone", "Automatically clone the identified service version if it's 'locked' or 'active'").Action(action).BoolVar(dst)
+	b.CmdClause.Flag("autoclone", "If the selected service version is not editable, clone it and use the clone.").Action(action).BoolVar(dst)
 }
 
 // OptionalServiceVersion represents a Fastly service version.

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/fastly/cli/pkg/api"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/v3/fastly"
+	"github.com/fastly/kingpin"
+)
+
+// ServiceVersionFlagOpts enables easy configuration of the --version flag
+// defined via the NewServiceVersionFlag constructor.
+//
+// NOTE: The reason we define an 'optional' field rather than a 'required'
+// field is because 99% of the use cases where --version is defined the flag
+// will be required, and so we cater for the common case. Meaning only those
+// subcommands that have --version as optional will need to set that field.
+type ServiceVersionFlagOpts struct {
+	Dst      *string
+	Optional bool
+	Action   kingpin.Action
+}
+
+// NewServiceVersionFlag defines a --version flag that accepts multiple values
+// such as 'latest', 'active' and numerical values which are then converted
+// into the appropriate service version.
+func (b Base) NewServiceVersionFlag(opts ServiceVersionFlagOpts, args ...string) {
+	clause := b.CmdClause.Flag("version", "Number of service version, 'latest', 'active' or 'editable'")
+	if !opts.Optional {
+		clause = clause.Required()
+	} else {
+		clause = clause.Action(opts.Action)
+	}
+	clause.StringVar(opts.Dst)
+}
+
+// NewAutoCloneFlag defines a --autoclone flag that will cause a clone of the
+// identified service version if its found to be active or locked.
+func (b Base) NewAutoCloneFlag(action kingpin.Action, dst *bool) {
+	b.CmdClause.Flag("autoclone", "Automatically clone the identified service version if it's 'locked' or 'active'").Action(action).BoolVar(dst)
+}
+
+// OptionalServiceVersion represents a Fastly service version.
+type OptionalServiceVersion struct {
+	OptionalString
+}
+
+// Parse returns a service version based on the given user input.
+func (sv *OptionalServiceVersion) Parse(sid string, c api.Interface) (*fastly.Version, error) {
+	vs, err := c.ListVersions(&fastly.ListVersionsInput{
+		ServiceID: sid,
+	})
+	if err != nil || len(vs) == 0 {
+		return nil, fmt.Errorf("error listing service versions: %w", err)
+	}
+
+	// Sort versions into descending order.
+	sort.Slice(vs, func(i, j int) bool {
+		return vs[i].Number > vs[j].Number
+	})
+
+	var v *fastly.Version
+
+	switch strings.ToLower(sv.Value) {
+	case "latest":
+		return vs[0], nil
+	case "active":
+		v, err = getLatestActiveVersion(vs)
+	case "editable":
+		v, err = getLatestEditableVersion(vs)
+	case "":
+		v, err = getLatestEditableVersion(vs)
+	default:
+		v, err = getSpecifiedVersion(vs, sv.Value)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// OptionalAutoClone defines a method set for abstracting the logic required to
+// identify if a given service version needs to be cloned.
+type OptionalAutoClone struct {
+	OptionalBool
+}
+
+// Parse returns a service version.
+//
+// The returned version is either the same as the input argument `v` or it's a
+// cloned version if the input argument was either active or locked.
+func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, c api.Interface) (*fastly.Version, error) {
+	// if user didn't provide --autoclone flag
+	if !ac.Value && (v.Active || v.Locked) {
+		return nil, fmt.Errorf("service version %d is not editable", v.Number)
+	}
+	if ac.Value && (v.Active || v.Locked) {
+		version, err := c.CloneVersion(&fastly.CloneVersionInput{
+			ServiceID:      sid,
+			ServiceVersion: v.Number,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error cloning service version: %w", err)
+		}
+		return version, nil
+	}
+
+	// Treat the function as a no-op if the version is editable.
+	return v, nil
+}
+
+// getLatestActiveVersion returns the latest active service version.
+func getLatestActiveVersion(vs []*fastly.Version) (*fastly.Version, error) {
+	for _, v := range vs {
+		if v.Active {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("error locating latest active service version")
+}
+
+// getLatestEditableVersion returns the latest editable service version.
+//
+// The returned version will be ahead of the latest active version. If there is
+// no editable version above the latest active, an error will be returned.
+//
+// When no --version flag is provided, this algorithm helps handle cases where
+// a command (such as `backend create`) is executable multiple times, as the
+// latest editable version will be reused and subsequently will contain each
+// new backend created from the prior executions.
+//
+// There could be a scenario where a customer has a single service version
+// which is activated and so there would be no match for an editable version
+// without us first cloning it. The act of cloning should be a decision made by
+// the user (i.e. --autoclone) and so this function will return an error if no
+// editable version available.
+func getLatestEditableVersion(vs []*fastly.Version) (*fastly.Version, error) {
+	for _, v := range vs {
+		if v.Active {
+			break
+		}
+		if !v.Active && !v.Locked {
+			return v, nil
+		}
+	}
+	return nil, fsterr.RemediationError{
+		Inner:       errors.New("error retrieving an editable service version: no editable version found"),
+		Remediation: "Please retry with --version=[latest|active] and --autoclone",
+	}
+}
+
+// getSpecifiedVersion returns the specified service version.
+func getSpecifiedVersion(vs []*fastly.Version, version string) (*fastly.Version, error) {
+	i, err := strconv.Atoi(version)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range vs {
+		if v.Number == i {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("error getting specified service version: %s", version)
+}

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -111,7 +111,7 @@ func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, c api.Interfac
 	return v, nil
 }
 
-// getLatestActiveVersion returns the latest active service version.
+// getLatestActiveVersion returns the active service version.
 func getLatestActiveVersion(vs []*fastly.Version) (*fastly.Version, error) {
 	for _, v := range vs {
 		if v.Active {

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -96,7 +96,7 @@ type OptionalAutoClone struct {
 //
 // The returned version is either the same as the input argument `v` or it's a
 // cloned version if the input argument was either active or locked.
-func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string) (*fastly.Version, error) {
+func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, verbose bool) (*fastly.Version, error) {
 	// if user didn't provide --autoclone flag
 	if !ac.Value && (v.Active || v.Locked) {
 		return nil, fmt.Errorf("service version %d is not editable", v.Number)
@@ -109,9 +109,11 @@ func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string) (*fastly.Versi
 		if err != nil {
 			return nil, fmt.Errorf("error cloning service version: %w", err)
 		}
-		msg := fmt.Sprintf("Service version %d is not editable, so it was automatically cloned because --autoclone is enabled. Now operating on version %d.", v.Number, version.Number)
-		text.Output(ac.Out, msg)
-		text.Break(ac.Out)
+		if verbose {
+			msg := fmt.Sprintf("Service version %d is not editable, so it was automatically cloned because --autoclone is enabled. Now operating on version %d.", v.Number, version.Number)
+			text.Output(ac.Out, msg)
+			text.Break(ac.Out)
+		}
 		return version, nil
 	}
 

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -287,7 +287,8 @@ func TestOptionalAutoCloneParse(t *testing.T) {
 				}
 			}
 
-			v, err := acv.Parse(c.version, "123")
+			verboseMode := true
+			v, err := acv.Parse(c.version, "123", verboseMode)
 			if err != nil {
 				if c.errExpected && errMatches(c.version.Number, err) {
 					return
@@ -309,7 +310,7 @@ func TestOptionalAutoCloneParse(t *testing.T) {
 			if !c.expectEditable {
 				want := fmt.Sprintf("Service version %d is not editable, so it was automatically cloned because --autoclone is enabled. Now operating on version %d.", c.version.Number, v.Number)
 				have := strings.Trim(strings.ReplaceAll(buf.String(), "\n", " "), " ")
-				if !strings.Contains(want, have) {
+				if !strings.Contains(have, want) {
 					t.Errorf("wanted %s, have %s", want, have)
 				}
 			}

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -162,7 +162,7 @@ func TestGetLatestActiveVersion(t *testing.T) {
 				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
 			})
 
-			v, err := getLatestActiveVersion(testcase.inputVersions)
+			v, err := getActiveVersion(testcase.inputVersions)
 			if err != nil {
 				if testcase.wantError != "" {
 					testutil.AssertString(t, testcase.wantError, err.Error())

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -5,9 +5,115 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/go-fastly/v3/fastly"
 )
+
+func TestParse(t *testing.T) {
+	cases := map[string]struct {
+		value       string
+		omitted     bool // represents flag not provided
+		want        int  // represent the service version number
+		errExpected bool
+	}{
+		"latest": {
+			value: "latest",
+			want:  3,
+		},
+		"active": {
+			value: "active",
+			want:  1,
+		},
+		"editable": {
+			value: "editable",
+			want:  3,
+		},
+		"empty": {
+			value: "",
+			want:  3,
+		},
+		"omitted": {
+			omitted: true,
+			want:    3,
+		},
+		"specific version OK": {
+			value: "3",
+			want:  3,
+		},
+		"specific version ERR": {
+			value:       "4",
+			errExpected: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var sv *OptionalServiceVersion
+
+			if c.omitted {
+				sv = &OptionalServiceVersion{}
+			} else {
+				sv = &OptionalServiceVersion{
+					OptionalString: OptionalString{
+						Value: c.value,
+					},
+				}
+			}
+
+			api := mock.API{
+				ListVersionsFn: listVersions,
+			}
+
+			v, err := sv.Parse("123", api)
+			if err != nil {
+				if c.errExpected {
+					return
+				} else {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+			if err == nil {
+				if c.errExpected {
+					t.Fatalf("expected error, have %v", v)
+				}
+			}
+
+			want := c.want
+			have := v.Number
+			if have != want {
+				t.Errorf("wanted %d, have %d", want, have)
+			}
+		})
+	}
+}
+
+// listVersions returns a list of service versions in different states.
+//
+// The first element is active, the second is locked, the third is editable.
+func listVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return []*fastly.Version{
+		{
+			ServiceID: i.ServiceID,
+			Number:    1,
+			Active:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    2,
+			Active:    false,
+			Locked:    true,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		},
+		{
+			ServiceID: i.ServiceID,
+			Number:    3,
+			Active:    false,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
+		},
+	}, nil
+}
 
 func TestGetLatestActiveVersion(t *testing.T) {
 	for _, testcase := range []struct {

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -319,8 +319,5 @@ func cloneVersionResult(version int) func(i *fastly.CloneVersionInput) (*fastly.
 // service version that is either locked or active, while also not providing
 // the --autoclone flag.
 func errMatches(version int, err error) bool {
-	if err.Error() == fmt.Sprintf("service version %d is not editable", version) {
-		return true
-	}
-	return false
+	return err.Error() == fmt.Sprintf("service version %d is not editable", version)
 }

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+func TestGetLatestActiveVersion(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+		wantError     string
+	}{
+		{
+			name: "active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "draft",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 1,
+		},
+		{
+			name: "locked",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 1,
+		},
+		{
+			name: "no active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
+			},
+			wantError: "error locating latest active service version",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			// NOTE: this is a duplicate of the sorting algorithm in
+			// common/command.go to make the test as realistic as possible
+			sort.Slice(testcase.inputVersions, func(i, j int) bool {
+				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
+			})
+
+			v, err := getLatestActiveVersion(testcase.inputVersions)
+			if err != nil {
+				if testcase.wantError != "" {
+					testutil.AssertString(t, testcase.wantError, err.Error())
+				} else {
+					t.Errorf("unexpected error returned: %v", err)
+				}
+			} else if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
+		})
+	}
+}
+
+func TestGetLatestEditableVersion(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+		wantError     string
+	}{
+		{
+			name: "success",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 2,
+		},
+		{
+			name: "no editable",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-02-02T01:00:00Z")},
+				{Number: 3, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-03-03T01:00:00Z")},
+			},
+			wantError: "error retrieving an editable service version: no editable version found",
+		},
+		{
+			name: "editable should be ahead of last active",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantError: "error retrieving an editable service version: no editable version found",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			// NOTE: this is a duplicate of the sorting algorithm in
+			// common/command.go to make the test as realistic as possible
+			sort.Slice(testcase.inputVersions, func(i, j int) bool {
+				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
+			})
+
+			v, err := getLatestEditableVersion(testcase.inputVersions)
+			if err != nil {
+				if testcase.wantError != "" {
+					testutil.AssertString(t, testcase.wantError, err.Error())
+				} else {
+					t.Errorf("unexpected error returned: %v", err)
+				}
+			} else if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
+		})
+	}
+}
+
+func TestGetSpecifiedVersion(t *testing.T) {
+	for _, testcase := range []struct {
+		name          string
+		inputVersions []*fastly.Version
+		wantVersion   int
+		wantError     string
+	}{
+		{
+			name: "success",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
+			},
+			wantVersion: 1,
+		},
+		{
+			name: "no version available",
+			inputVersions: []*fastly.Version{
+				{Number: 1, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
+				{Number: 2, Active: false, Locked: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-02-02T01:00:00Z")},
+				{Number: 3, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-03-03T01:00:00Z")},
+			},
+			wantVersion: 4,
+			wantError:   "error getting specified service version: 4",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			// NOTE: this is a duplicate of the sorting algorithm in
+			// common/command.go to make the test as realistic as possible
+			sort.Slice(testcase.inputVersions, func(i, j int) bool {
+				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
+			})
+
+			v, err := getSpecifiedVersion(testcase.inputVersions, strconv.Itoa(testcase.wantVersion))
+			if err != nil {
+				if testcase.wantError != "" {
+					testutil.AssertString(t, testcase.wantError, err.Error())
+				} else {
+					t.Errorf("unexpected error returned: %v", err)
+				}
+			} else if v.Number != testcase.wantVersion {
+				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
+			}
+		})
+	}
+}

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -48,20 +48,15 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			var sv *OptionalServiceVersion
-
-			api := mock.API{
-				ListVersionsFn: listVersions,
+			sv := &OptionalServiceVersion{
+				Client: mock.API{
+					ListVersionsFn: listVersions,
+				},
 			}
 
-			if c.flagOmitted {
-				sv = &OptionalServiceVersion{}
-			} else {
-				sv = &OptionalServiceVersion{
-					Client: api,
-					OptionalString: OptionalString{
-						Value: c.flagValue,
-					},
+			if !c.flagOmitted {
+				sv.OptionalString = OptionalString{
+					Value: c.flagValue,
 				}
 			}
 
@@ -276,18 +271,16 @@ func TestOptionalAutoCloneParse(t *testing.T) {
 				acv *OptionalAutoClone
 				bs  []byte
 			)
-
-			api := mock.API{
-				CloneVersionFn: cloneVersionResult(c.version.Number + 1),
-			}
 			buf := bytes.NewBuffer(bs)
 
 			if c.flagOmitted {
 				acv = &OptionalAutoClone{}
 			} else {
 				acv = &OptionalAutoClone{
-					Client: api,
-					Out:    buf,
+					Client: mock.API{
+						CloneVersionFn: cloneVersionResult(c.version.Number + 1),
+					},
+					Out: buf,
 					OptionalBool: OptionalBool{
 						Value: true,
 					},

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -47,12 +47,12 @@ func TestGetLatestActiveVersion(t *testing.T) {
 				{Number: 2, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
 				{Number: 3, Active: false, UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
 			},
-			wantError: "error locating latest active service version",
+			wantError: "no active service version found",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			// NOTE: this is a duplicate of the sorting algorithm in
-			// common/command.go to make the test as realistic as possible
+			// cmd/command.go to make the test as realistic as possible
 			sort.Slice(testcase.inputVersions, func(i, j int) bool {
 				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
 			})
@@ -106,7 +106,7 @@ func TestGetLatestEditableVersion(t *testing.T) {
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			// NOTE: this is a duplicate of the sorting algorithm in
-			// common/command.go to make the test as realistic as possible
+			// cmd/command.go to make the test as realistic as possible
 			sort.Slice(testcase.inputVersions, func(i, j int) bool {
 				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
 			})
@@ -148,12 +148,12 @@ func TestGetSpecifiedVersion(t *testing.T) {
 				{Number: 3, Active: true, UpdatedAt: testutil.MustParseTimeRFC3339("2000-03-03T01:00:00Z")},
 			},
 			wantVersion: 4,
-			wantError:   "error getting specified service version: 4",
+			wantError:   "specified service version not found: 4",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			// NOTE: this is a duplicate of the sorting algorithm in
-			// common/command.go to make the test as realistic as possible
+			// cmd/command.go to make the test as realistic as possible
 			sort.Slice(testcase.inputVersions, func(i, j int) bool {
 				return testcase.inputVersions[i].Number > testcase.inputVersions[j].Number
 			})

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -20,6 +20,7 @@ type API struct {
 
 	CloneVersionFn      func(*fastly.CloneVersionInput) (*fastly.Version, error)
 	ListVersionsFn      func(*fastly.ListVersionsInput) ([]*fastly.Version, error)
+	GetVersionFn        func(*fastly.GetVersionInput) (*fastly.Version, error)
 	UpdateVersionFn     func(*fastly.UpdateVersionInput) (*fastly.Version, error)
 	ActivateVersionFn   func(*fastly.ActivateVersionInput) (*fastly.Version, error)
 	DeactivateVersionFn func(*fastly.DeactivateVersionInput) (*fastly.Version, error)
@@ -268,6 +269,11 @@ func (m API) CloneVersion(i *fastly.CloneVersionInput) (*fastly.Version, error) 
 // ListVersions implements Interface.
 func (m API) ListVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return m.ListVersionsFn(i)
+}
+
+// GetVersion implements Interface.
+func (m API) GetVersion(i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return m.GetVersionFn(i)
 }
 
 // UpdateVersion implements Interface.

--- a/pkg/mock/versioner.go
+++ b/pkg/mock/versioner.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/fastly/cli/pkg/update"
 )
 
 // Versioner mocks the update.Versioner interface.
@@ -14,9 +13,6 @@ type Versioner struct {
 	Version string
 	Error   error
 }
-
-// Make sure mock.Versioner implements update.Versioner.
-var _ update.Versioner = (*Versioner)(nil)
 
 // LatestVersion returns the parsed version field, or error if it's non-nil.
 func (v Versioner) LatestVersion(context.Context) (semver.Version, error) {

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ServiceType is a utility function which returns the given type string if
-// non-empty otherwise returns the default `vcl`. This should be used unitl the
+// non-empty otherwise returns the default `vcl`. This should be used until the
 // API properly returns Service.Type for non-wasm services.
 // TODO(phamann): remove once API returns correct type.
 func ServiceType(t string) string {


### PR DESCRIPTION
**Problem**: Identifying the correct service version to use is a manual process which slows down a user's workflow.
**Solution**: Overload the `--version` flag and implement a new `--autoclone` flag (fixes: https://github.com/fastly/cli/issues/141).
**Notes**: This PR defines the new flags (and tests for the internal behaviours) but doesn't integrate them yet (see follow-up PRs).

The implementation can be summarised as follows:

```
--version=VERSION   Number of service version, 'latest', 'active'
                    or 'editable'
--autoclone         Automatically clone the identified service
                    version if it's 'locked' or 'active'
```

- Every command that implements `--version` will call a `serviceVersion.Parse` function.
  - This function makes an API call for a list of all available service versions.
  - The returned list is sorted in descending order (i.e. newest versions first).
  - If the `--version` flag is set with the value `latest`:
    - We consider the selected version to be the latest version available.
    - The version _could_ be 'active' or 'locked', so `--autoclone` might need to be specified too.
    - We do not expect the returned version to be older than the last active version.
  - If the `--version` flag is set with the value `active`:
    - We consider the selected version to be the latest 'active' version.
  - If the `--version` flag is set with a numerical value (e.g. `1`, `2`, `3` etc):
    - We consider the selected version to be the given version.
  - If the `--version` flag is set with the value `editable`:
    - We consider the selected version to be the latest _editable_ version.
    - If we find an active version before an editable version, then we return an error.
  - If the `--version` flag is _not_ set (or an empty value is provided):
    - We consider the selected version to be the latest _editable_ version.
    - If we find an active version before an editable version, then we return an error.
- Once the version has been identified, if `--autoclone` is defined, we call a `autoclone.Parse` function.
  - This function checks if the version is 'active' or 'locked' and will clone it if necessary.
  - The `autoclone.Parse` function should only be called inside of commands where an 'editable' version is required.
  - The `--autoclone` flag should only be defined on commands where an 'editable' version is required.

## Example Scenarios

### Version not set, no editable versions available

The user has a service with a single version that is 'active'. They execute `backend create` without passing the `--version` flag. 

In this scenario the CLI would internally call `getLatestEditableVersion` and, because there are no editable versions available, it would return an error message such as "error retrieving an editable service version".

The resolution for the user would be to pass both the `--version` flag and the `--autoclone` flag. The value of the `--version` flag could be either `latest`, `active` or `1`. With `--autoclone` also specified this would cause a new editable service version `2` to be created, and the backend created within that new version.

On subsequent calls to `backend create` the user could then omit the `--version` and `--autoclone` flags as the CLI would infer calling `getLatestEditableVersion` and (unless the user had 'activated' the newly cloned version) would result in the newly cloned/editable version being identified and the new backend resource created within it.

Alternatively, on subsequent calls the user could specify either `--version=latest` or `--version=editable`. Because each CLI invocation will acquire an updated versions list, which is then sorted in descending order, this should ensure (regardless of whether the value `latest` or `editable` was provided) the version returned was the newly cloned/editable version and thus `--autoclone` wouldn't be needed on the subsequent calls.

### Version not set, editable version available

The user has a service with a single version that is editable (i.e. it is neither 'locked' nor 'active'). They execute `backend create` multiple times without passing the `--version` flag.

In this scenario the CLI would internally call `getLatestEditableVersion` on each CLI invocation (resulting in the editable version `1` being identified each time), which means the three backends would be created within the same editable version.

Alternatively, the user could prefer to be _explicit_ about their intention and for each CLI invocation they could pass either `--version=editable`, which also would internally call `getLatestEditableVersion`, or `--version=latest`. Both would result in the editable version `1` being identified each time.