### PR TITLE
add new 'ip-list' command

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -17,6 +17,7 @@ type HTTPClient interface {
 // Interface models the methods of the Fastly API client that we use.
 // It exists to allow for easier testing, in combination with Mock.
 type Interface interface {
+	AllIPs() (v4, v6 fastly.IPAddrs, err error)
 	GetTokenSelf() (*fastly.Token, error)
 
 	CreateService(*fastly.CreateServiceInput) (*fastly.Service, error)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fastly/cli/pkg/env"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/healthcheck"
+	"github.com/fastly/cli/pkg/ip"
 	"github.com/fastly/cli/pkg/logging"
 	"github.com/fastly/cli/pkg/logging/azureblob"
 	"github.com/fastly/cli/pkg/logging/bigquery"
@@ -117,6 +118,7 @@ func Run(args []string, environ config.Environment, file config.File, configFile
 	whoamiRoot := whoami.NewRootCommand(app, httpClient, &globals)
 	versionRoot := version.NewRootCommand(app)
 	updateRoot := update.NewRootCommand(app, configFilePath, cliVersioner, httpClient, &globals)
+	ipRoot := ip.NewRootCommand(app, &globals)
 
 	serviceRoot := service.NewRootCommand(app, &globals)
 	serviceCreate := service.NewCreateCommand(serviceRoot.CmdClause, &globals)
@@ -369,6 +371,7 @@ func Run(args []string, environ config.Environment, file config.File, configFile
 		whoamiRoot,
 		versionRoot,
 		updateRoot,
+		ipRoot,
 
 		serviceRoot,
 		serviceCreate,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -105,6 +105,7 @@ COMMANDS
   whoami           Get information about the currently authenticated account
   version          Display version information for the Fastly CLI
   update           Update the CLI to the latest version
+  ip-list          List Fastly's public IPs
   service          Manipulate Fastly services
   service-version  Manipulate Fastly service versions
   compute          Manage Compute@Edge packages
@@ -197,6 +198,10 @@ COMMANDS
 
   update
     Update the CLI to the latest version
+
+
+  ip-list
+    List Fastly's public IPs
 
 
   service create --name=NAME [<flags>]

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -1,0 +1,40 @@
+package ip_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/fastly/cli/pkg/api"
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/update"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+func TestAllIPs(t *testing.T) {
+	var (
+		args           = []string{"ip-list", "--token", "123"}
+		env            = config.Environment{}
+		file           = config.File{}
+		configFileName = "/dev/null"
+		clientFactory  = mock.APIClient(mock.API{
+			AllIPsFn: func() (v4, v6 fastly.IPAddrs, err error) {
+				return []string{
+						"00.123.45.6/78",
+					}, []string{
+						"0a12:3b45::/67",
+					}, nil
+			},
+		})
+		httpClient   api.HTTPClient   = nil
+		cliVersioner update.Versioner = mock.Versioner{Version: "v1.2.3"}
+		in           io.Reader        = nil
+		out          bytes.Buffer
+	)
+	err := app.Run(args, env, file, configFileName, clientFactory, httpClient, cliVersioner, in, &out)
+	testutil.AssertNoError(t, err)
+	testutil.AssertString(t, "\nIPv4\n\t00.123.45.6/78\n\nIPv6\n\t0a12:3b45::/67\n", out.String())
+}

--- a/pkg/ip/root.go
+++ b/pkg/ip/root.go
@@ -1,0 +1,50 @@
+package ip
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	cmd.Base
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("ip-list", "List Fastly's public IPs")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	// Exit early if no token configured.
+	_, s := c.Globals.Token()
+	if s == config.SourceUndefined {
+		return errors.ErrNoToken
+	}
+
+	ipv4, ipv6, err := c.Globals.Client.AllIPs()
+	if err != nil {
+		return err
+	}
+
+	text.Break(out)
+	fmt.Fprintf(out, "%s\n", text.Bold("IPv4"))
+	for _, ip := range ipv4 {
+		fmt.Fprintf(out, "\t%s\n", ip)
+	}
+	fmt.Fprintf(out, "\n%s\n", text.Bold("IPv6"))
+	for _, ip := range ipv6 {
+		fmt.Fprintf(out, "\t%s\n", ip)
+	}
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -8,6 +8,7 @@ import (
 // The zero value is useful, but will panic on all methods. Provide function
 // implementations for the method(s) your test will call.
 type API struct {
+	AllIPsFn       func() (v4, v6 fastly.IPAddrs, err error)
 	GetTokenSelfFn func() (*fastly.Token, error)
 
 	CreateServiceFn     func(*fastly.CreateServiceInput) (*fastly.Service, error)
@@ -219,6 +220,11 @@ type API struct {
 	GetStatsJSONFn func(i *fastly.GetStatsInput, dst interface{}) error
 
 	CreateManagedLoggingFn func(*fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
+}
+
+// AllIPs implements Interface.
+func (m API) AllIPs() (fastly.IPAddrs, fastly.IPAddrs, error) {
+	return m.AllIPsFn()
 }
 
 // GetTokenSelf implements Interface.


### PR DESCRIPTION
Example output of new command:

```bash
$ fastly ip-list

IPv4
        23.235.32.0/20
        43.249.72.0/22
        103.244.50.0/24
        103.245.222.0/23
        103.245.224.0/24
        104.156.80.0/20
        146.75.0.0/17
        151.101.0.0/16
        157.52.64.0/18
        167.82.0.0/17
        167.82.128.0/20
        167.82.160.0/20
        167.82.224.0/20
        172.111.64.0/18
        185.31.16.0/22
        199.27.72.0/21
        199.232.0.0/16

IPv6
        2a04:4e40::/32
        2a04:4e42::/32
```