### PR TITLE
Add `vcl snippet` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ debug:
 	@go build -gcflags="all=-N -l" -o "fastly" ./cmd/fastly
 
 .PHONY: all
-all: tidy fmt vet staticcheck lint gosec test build install
+all: config tidy fmt vet staticcheck lint gosec test build install
 
 .PHONY: dependencies
 dependencies:

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -236,6 +236,14 @@ type Interface interface {
 	GetVCL(*fastly.GetVCLInput) (*fastly.VCL, error)
 	UpdateVCL(*fastly.UpdateVCLInput) (*fastly.VCL, error)
 	DeleteVCL(*fastly.DeleteVCLInput) error
+
+	CreateSnippet(i *fastly.CreateSnippetInput) (*fastly.Snippet, error)
+	ListSnippets(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error)
+	GetSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error)
+	GetDynamicSnippet(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	UpdateSnippet(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error)
+	UpdateDynamicSnippet(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	DeleteSnippet(i *fastly.DeleteSnippetInput) error
 }
 
 // RealtimeStatsInterface is the subset of go-fastly's realtime stats API used here.

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -58,6 +58,7 @@ import (
 	"github.com/fastly/cli/pkg/update"
 	"github.com/fastly/cli/pkg/vcl"
 	"github.com/fastly/cli/pkg/vcl/custom"
+	"github.com/fastly/cli/pkg/vcl/snippet"
 	"github.com/fastly/cli/pkg/version"
 	"github.com/fastly/cli/pkg/whoami"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -371,12 +372,20 @@ func Run(args []string, environ config.Environment, file config.File, configFile
 	statsRealtime := stats.NewRealtimeCommand(statsRoot.CmdClause, &globals)
 
 	vclRoot := vcl.NewRootCommand(app, &globals)
+
 	vclCustomRoot := custom.NewRootCommand(vclRoot.CmdClause, &globals)
 	vclCustomCreate := custom.NewCreateCommand(vclCustomRoot.CmdClause, &globals)
 	vclCustomDelete := custom.NewDeleteCommand(vclCustomRoot.CmdClause, &globals)
 	vclCustomDescribe := custom.NewDescribeCommand(vclCustomRoot.CmdClause, &globals)
 	vclCustomList := custom.NewListCommand(vclCustomRoot.CmdClause, &globals)
 	vclCustomUpdate := custom.NewUpdateCommand(vclCustomRoot.CmdClause, &globals)
+
+	vclSnippetRoot := snippet.NewRootCommand(vclRoot.CmdClause, &globals)
+	vclSnippetCreate := snippet.NewCreateCommand(vclSnippetRoot.CmdClause, &globals)
+	vclSnippetDelete := snippet.NewDeleteCommand(vclSnippetRoot.CmdClause, &globals)
+	vclSnippetDescribe := snippet.NewDescribeCommand(vclSnippetRoot.CmdClause, &globals)
+	vclSnippetList := snippet.NewListCommand(vclSnippetRoot.CmdClause, &globals)
+	vclSnippetUpdate := snippet.NewUpdateCommand(vclSnippetRoot.CmdClause, &globals)
 
 	commands := []cmd.Command{
 		configureRoot,
@@ -633,12 +642,20 @@ func Run(args []string, environ config.Environment, file config.File, configFile
 		statsRealtime,
 
 		vclRoot,
+
 		vclCustomRoot,
 		vclCustomCreate,
 		vclCustomDelete,
 		vclCustomDescribe,
 		vclCustomList,
 		vclCustomUpdate,
+
+		vclSnippetRoot,
+		vclSnippetCreate,
+		vclSnippetDelete,
+		vclSnippetDescribe,
+		vclSnippetList,
+		vclSnippetUpdate,
 	}
 
 	// Handle parse errors and display contextal usage if possible. Due to bugs

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -3631,6 +3631,70 @@ COMMANDS
                                  main.vcl)
     -s, --service-id=SERVICE-ID  Service ID
 
+  vcl snippet create --content=CONTENT --name=NAME --version=VERSION --type=TYPE [<flags>]
+    Create a snippet for a particular service and version
+
+        --content=CONTENT        VCL snippet passed as file path or content,
+                                 e.g. $(cat snippet.vcl)
+        --name=NAME              The name of the VCL snippet
+        --version=VERSION        'latest', 'active', or the number of a specific
+                                 version
+        --type=TYPE              The location in generated VCL where the snippet
+                                 should be placed (e.g. recv, miss, fetch etc)
+        --autoclone              If the selected service version is not
+                                 editable, clone it and use the clone.
+        --dynamic                Whether the VCL snippet is dynamic or versioned
+    -p, --priority=PRIORITY      Priority determines execution order. Lower
+                                 numbers execute first
+    -s, --service-id=SERVICE-ID  Service ID
+
+  vcl snippet delete --name=NAME --version=VERSION [<flags>]
+    Delete a specific snippet for a particular service and version
+
+        --name=NAME              The name of the VCL snippet to delete
+        --version=VERSION        'latest', 'active', or the number of a specific
+                                 version
+        --autoclone              If the selected service version is not
+                                 editable, clone it and use the clone.
+    -s, --service-id=SERVICE-ID  Service ID
+
+  vcl snippet describe --name=NAME --version=VERSION --snippet-id=SNIPPET-ID [<flags>]
+    Get the uploaded VCL for a particular service and version
+
+        --name=NAME              The name of the VCL
+        --version=VERSION        'latest', 'active', or the number of a specific
+                                 version
+    -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
+        --dynamic                Whether the VCL snippet is dynamic or versioned
+    -s, --service-id=SERVICE-ID  Service ID
+
+  vcl snippet list --version=VERSION [<flags>]
+    List the uploaded VCLs for a particular service and version
+
+        --version=VERSION        'latest', 'active', or the number of a specific
+                                 version
+    -s, --service-id=SERVICE-ID  Service ID
+
+  vcl snippet update --name=NAME --version=VERSION [<flags>]
+    Update a VCL snippet for a particular service (and version, if not a dynamic
+    snippet)
+
+        --name=NAME              The name of the VCL snippet to update
+        --version=VERSION        'latest', 'active', or the number of a specific
+                                 version
+        --autoclone              If the selected service version is not
+                                 editable, clone it and use the clone.
+        --content=CONTENT        VCL snippet passed as file path or content,
+                                 e.g. $(cat snippet.vcl)
+        --dynamic                Whether the VCL snippet is dynamic or versioned
+        --new-name=NEW-NAME      New name for the VCL snippet
+    -p, --priority=PRIORITY      Priority determines execution order. Lower
+                                 numbers execute first
+    -s, --service-id=SERVICE-ID  Service ID
+    -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
+        --type=TYPE              The location in generated VCL where the snippet
+                                 should be placed (e.g. recv, miss, fetch etc)
+
 For help on a specific command, try e.g.
 
 	fastly help configure

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -3676,8 +3676,7 @@ COMMANDS
     -s, --service-id=SERVICE-ID  Service ID
 
   vcl snippet update --name=NAME --version=VERSION [<flags>]
-    Update a VCL snippet for a particular service (and version, if not a dynamic
-    snippet)
+    Update a VCL snippet for a particular service and version
 
         --name=NAME              The name of the VCL snippet to update
         --version=VERSION        'latest', 'active', or the number of a specific

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -3659,9 +3659,9 @@ COMMANDS
     -s, --service-id=SERVICE-ID  Service ID
 
   vcl snippet describe --name=NAME --version=VERSION --snippet-id=SNIPPET-ID [<flags>]
-    Get the uploaded VCL for a particular service and version
+    Get the uploaded VCL snippet for a particular service and version
 
-        --name=NAME              The name of the VCL
+        --name=NAME              The name of the VCL snippet
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
@@ -3669,7 +3669,7 @@ COMMANDS
     -s, --service-id=SERVICE-ID  Service ID
 
   vcl snippet list --version=VERSION [<flags>]
-    List the uploaded VCLs for a particular service and version
+    List the uploaded VCL snippets for a particular service and version
 
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -175,8 +175,5 @@ func Content(flagval string) string {
 
 // IntToBool converts a binary 0|1 to a boolean.
 func IntToBool(i int) bool {
-	if i <= 0 {
-		return false
-	}
-	return true
+	return i > 0
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -154,4 +156,19 @@ func GetSpecifiedVersion(vs []*fastly.Version, version string) (*fastly.Version,
 	}
 
 	return nil, fmt.Errorf("specified service version not found: %s", version)
+}
+
+// Content determines if the given flag value for --content is a file path,
+// and if so read the contents from disk, otherwise presume the given value is
+// the content.
+func Content(flagval string) string {
+	content := flagval
+	if path, err := filepath.Abs(flagval); err == nil {
+		if _, err := os.Stat(path); err == nil {
+			if data, err := os.ReadFile(path); err == nil {
+				content = string(data)
+			}
+		}
+	}
+	return content
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -172,3 +172,11 @@ func Content(flagval string) string {
 	}
 	return content
 }
+
+// IntToBool converts a binary 0|1 to a boolean.
+func IntToBool(i int) bool {
+	if i <= 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -61,9 +61,9 @@ func NewDeployCommand(parent cmd.Registerer, client api.HTTPClient, globals *con
 	// `compute publish`.
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Action:   c.ServiceVersion.Set,
 		Dst:      &c.ServiceVersion.Value,
 		Optional: true,
-		Action:   c.ServiceVersion.Set,
 	})
 	c.CmdClause.Flag("path", "Path to package").Short('p').StringVar(&c.Path)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.Domain)

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -49,9 +49,9 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	// Deploy flags
 	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Action:   c.serviceVersion.Set,
 		Dst:      &c.serviceVersion.Value,
 		Optional: true,
-		Action:   c.serviceVersion.Set,
 	})
 	c.CmdClause.Flag("path", "Path to package").Short('p').Action(c.path.Set).StringVar(&c.path.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -260,6 +260,7 @@ func (f *File) Load(configEndpoint string, c api.HTTPClient, d time.Duration, fp
 				Remediation: fsterr.NetworkRemediation,
 			}
 		}
+		return err
 	}
 	defer resp.Body.Close()
 

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -227,6 +227,14 @@ type API struct {
 	GetVCLFn    func(*fastly.GetVCLInput) (*fastly.VCL, error)
 	UpdateVCLFn func(*fastly.UpdateVCLInput) (*fastly.VCL, error)
 	DeleteVCLFn func(*fastly.DeleteVCLInput) error
+
+	CreateSnippetFn        func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error)
+	ListSnippetsFn         func(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error)
+	GetSnippetFn           func(i *fastly.GetSnippetInput) (*fastly.Snippet, error)
+	GetDynamicSnippetFn    func(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	UpdateSnippetFn        func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error)
+	UpdateDynamicSnippetFn func(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	DeleteSnippetFn        func(i *fastly.DeleteSnippetInput) error
 }
 
 // AllDatacenters implements Interface.

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -1141,3 +1141,38 @@ func (m API) UpdateVCL(i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 func (m API) DeleteVCL(i *fastly.DeleteVCLInput) error {
 	return m.DeleteVCLFn(i)
 }
+
+// CreateSnippet implements Interface.
+func (m API) CreateSnippet(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+	return m.CreateSnippetFn(i)
+}
+
+// ListSnippets implements Interface.
+func (m API) ListSnippets(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
+	return m.ListSnippetsFn(i)
+}
+
+// GetSnippet implements Interface.
+func (m API) GetSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
+	return m.GetSnippetFn(i)
+}
+
+// GetDynamicSnippet implements Interface.
+func (m API) GetDynamicSnippet(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+	return m.GetDynamicSnippetFn(i)
+}
+
+// UpdateSnippet implements Interface.
+func (m API) UpdateSnippet(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+	return m.UpdateSnippetFn(i)
+}
+
+// UpdateDynamicSnippet implements Interface.
+func (m API) UpdateDynamicSnippet(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+	return m.UpdateDynamicSnippetFn(i)
+}
+
+// DeleteSnippet implements Interface.
+func (m API) DeleteSnippet(i *fastly.DeleteSnippetInput) error {
+	return m.DeleteSnippetFn(i)
+}

--- a/pkg/testutil/assert.go
+++ b/pkg/testutil/assert.go
@@ -1,9 +1,11 @@
 package testutil
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/google/go-cmp/cmp"
 )
@@ -85,6 +87,29 @@ func AssertRemediationErrorContains(t *testing.T, err error, target string) {
 	case err != nil && target != "":
 		if want, have := target, re.Remediation; !strings.Contains(have, want) {
 			t.Fatalf("want %q, have %q", want, have)
+		}
+	}
+}
+
+// AssertContentFlag errors a test scenario if the --content flag value hasn't
+// been parsed as expected.
+//
+// Example: if --content is passed a file path, then we expect the
+// testdata/<fixture> to have been read, otherwise we expect the given flag
+// value to have been used as is.
+func AssertContentFlag(wantError string, args []string, fixture string, content string, t *testing.T) {
+	if wantError == "" {
+		for i, a := range args {
+			if a == "--content" {
+				want := args[i+1]
+				if want == fmt.Sprintf("./testdata/%s", fixture) {
+					want = cmd.Content(want)
+				}
+				if content != want {
+					t.Errorf("wanted %s, have %s", want, content)
+				}
+				break
+			}
 		}
 	}
 }

--- a/pkg/testutil/time.go
+++ b/pkg/testutil/time.go
@@ -1,0 +1,6 @@
+package testutil
+
+import "time"
+
+// Date is a consistent date object used by all tests.
+var Date = time.Date(2021, time.June, 15, 23, 0, 0, 0, time.UTC)

--- a/pkg/vcl/custom/create.go
+++ b/pkg/vcl/custom/create.go
@@ -77,7 +77,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 func (c *CreateCommand) constructInput(serviceID string, serviceVersion int) *fastly.CreateVCLInput {
 	var input fastly.CreateVCLInput
 
-	input.Content = cmd.Content(c.content) // Content() defined in update.go
+	input.Content = cmd.Content(c.content)
 	input.Name = c.name
 	input.ServiceID = serviceID
 	input.ServiceVersion = serviceVersion

--- a/pkg/vcl/custom/create.go
+++ b/pkg/vcl/custom/create.go
@@ -77,7 +77,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 func (c *CreateCommand) constructInput(serviceID string, serviceVersion int) *fastly.CreateVCLInput {
 	var input fastly.CreateVCLInput
 
-	input.Content = Content(c.content) // Content() defined in update.go
+	input.Content = cmd.Content(c.content) // Content() defined in update.go
 	input.Name = c.name
 	input.ServiceID = serviceID
 	input.ServiceVersion = serviceVersion

--- a/pkg/vcl/custom/custom_test.go
+++ b/pkg/vcl/custom/custom_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/cli/pkg/vcl/custom"
 	"github.com/fastly/go-fastly/v3/fastly"
 )
 
@@ -511,7 +511,7 @@ func validateContent(wantError string, args []string, content string, t *testing
 			if a == "--content" {
 				want := args[i+1]
 				if want == "./testdata/example.vcl" {
-					want = custom.Content(want)
+					want = cmd.Content(want)
 				}
 				if content != want {
 					t.Errorf("wanted %s, have %s", want, content)

--- a/pkg/vcl/custom/custom_test.go
+++ b/pkg/vcl/custom/custom_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/fastly/cli/pkg/app"
-	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -144,7 +143,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
-			validateContent(testcase.WantError, testcase.Args, content, t)
+			testutil.AssertContentFlag(testcase.WantError, testcase.Args, "example.vcl", content, t)
 		})
 	}
 }
@@ -451,7 +450,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
-			validateContent(testcase.WantError, testcase.Args, content, t)
+			testutil.AssertContentFlag(testcase.WantError, testcase.Args, "example.vcl", content, t)
 		})
 	}
 }
@@ -499,27 +498,4 @@ func listVCLs(i *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
 		},
 	}
 	return vs, nil
-}
-
-// When dealing with successful test scenarios: validate the --content value was
-// parsed as expected.
-//
-// Example: if --content is passed a file path, then we expect the
-// testdata/example.vcl to have been read, otherwise we expect the given flag
-// value to have been used as is.
-func validateContent(wantError string, args []string, content string, t *testing.T) {
-	if wantError == "" {
-		for i, a := range args {
-			if a == "--content" {
-				want := args[i+1]
-				if want == "./testdata/example.vcl" {
-					want = cmd.Content(want)
-				}
-				if content != want {
-					t.Errorf("wanted %s, have %s", want, content)
-				}
-				break
-			}
-		}
-	}
 }

--- a/pkg/vcl/custom/custom_test.go
+++ b/pkg/vcl/custom/custom_test.go
@@ -71,7 +71,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom create --service-id 123 --version 3 --name foo --content ./testdata/example.vcl"),
+			Args:       args("vcl custom create --content ./testdata/example.vcl --name foo --service-id 123 --version 3"),
 			WantOutput: "Created custom VCL 'foo' (service: 123, version: 3, main: false)",
 		},
 		{

--- a/pkg/vcl/custom/custom_test.go
+++ b/pkg/vcl/custom/custom_test.go
@@ -3,7 +3,6 @@ package custom_test
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/cmd"
@@ -458,7 +457,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 }
 
 func getVCL(i *fastly.GetVCLInput) (*fastly.VCL, error) {
-	t := time.Date(2021, time.June, 15, 23, 0, 0, 0, time.UTC)
+	t := testutil.Date
 
 	return &fastly.VCL{
 		Content:        "# some vcl content",
@@ -466,34 +465,37 @@ func getVCL(i *fastly.GetVCLInput) (*fastly.VCL, error) {
 		Name:           i.Name,
 		ServiceID:      i.ServiceID,
 		ServiceVersion: i.ServiceVersion,
-		CreatedAt:      &t,
-		UpdatedAt:      &t,
-		DeletedAt:      &t,
+
+		CreatedAt: &t,
+		DeletedAt: &t,
+		UpdatedAt: &t,
 	}, nil
 }
 
 func listVCLs(i *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
-	t := time.Date(2021, time.June, 15, 23, 0, 0, 0, time.UTC)
+	t := testutil.Date
 	vs := []*fastly.VCL{
 		{
+			Content:        "# some vcl content",
+			Main:           true,
+			Name:           "foo",
 			ServiceID:      i.ServiceID,
 			ServiceVersion: i.ServiceVersion,
-			Name:           "foo",
-			Main:           true,
-			Content:        "# some vcl content",
-			CreatedAt:      &t,
-			UpdatedAt:      &t,
-			DeletedAt:      &t,
+
+			CreatedAt: &t,
+			DeletedAt: &t,
+			UpdatedAt: &t,
 		},
 		{
+			Content:        "# some vcl content",
+			Main:           false,
+			Name:           "bar",
 			ServiceID:      i.ServiceID,
 			ServiceVersion: i.ServiceVersion,
-			Name:           "bar",
-			Main:           false,
-			Content:        "# some vcl content",
-			CreatedAt:      &t,
-			UpdatedAt:      &t,
-			DeletedAt:      &t,
+
+			CreatedAt: &t,
+			DeletedAt: &t,
+			UpdatedAt: &t,
 		},
 	}
 	return vs, nil

--- a/pkg/vcl/custom/update.go
+++ b/pkg/vcl/custom/update.go
@@ -3,8 +3,6 @@ package custom
 import (
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/compute/manifest"
@@ -98,23 +96,8 @@ func (c *UpdateCommand) constructInput(serviceID string, serviceVersion int) (*f
 		input.NewName = fastly.String(c.newName.Value)
 	}
 	if c.content.WasSet {
-		input.Content = fastly.String(Content(c.content.Value))
+		input.Content = fastly.String(cmd.Content(c.content.Value))
 	}
 
 	return &input, nil
-}
-
-// Content determines if the given flag value for --content is a file path,
-// and if so read the contents from disk, otherwise presume the given value is
-// the content.
-func Content(flagval string) string {
-	content := flagval
-	if path, err := filepath.Abs(flagval); err == nil {
-		if _, err := os.Stat(path); err == nil {
-			if data, err := os.ReadFile(path); err == nil {
-				content = string(data)
-			}
-		}
-	}
-	return content
 }

--- a/pkg/vcl/snippet/create.go
+++ b/pkg/vcl/snippet/create.go
@@ -21,13 +21,13 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	// Required flags
 	c.CmdClause.Flag("content", "VCL snippet passed as file path or content, e.g. $(cat snippet.vcl)").Required().StringVar(&c.content)
 	c.CmdClause.Flag("name", "The name of the VCL snippet").Required().StringVar(&c.name)
-	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})
 	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed (e.g. recv, miss, fetch etc)").Required().StringVar(&c.location)
 
 	// Optional flags
-	c.SetAutoCloneFlag(cmd.AutoCloneFlagOpts{
+	c.RegisterAutoCloneFlag(cmd.AutoCloneFlagOpts{
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})

--- a/pkg/vcl/snippet/create.go
+++ b/pkg/vcl/snippet/create.go
@@ -1,0 +1,96 @@
+package snippet
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateCommand {
+	var c CreateCommand
+	c.CmdClause = parent.Command("create", "Create a snippet for a particular service and version").Alias("add")
+	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
+	c.manifest.File.Read(manifest.Filename)
+
+	// Required flags
+	c.CmdClause.Flag("content", "VCL snippet passed as file path or content, e.g. $(cat snippet.vcl)").Required().StringVar(&c.content)
+	c.CmdClause.Flag("name", "The name of the VCL snippet").Required().StringVar(&c.name)
+	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Dst: &c.serviceVersion.Value,
+	})
+	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed (e.g. recv, miss, fetch etc)").Required().StringVar(&c.location)
+
+	// Optional flags
+	c.SetAutoCloneFlag(cmd.AutoCloneFlagOpts{
+		Action: c.autoClone.Set,
+		Dst:    &c.autoClone.Value,
+	})
+	c.CmdClause.Flag("dynamic", "Whether the VCL snippet is dynamic or versioned").Action(c.dynamic.Set).BoolVar(&c.dynamic.Value)
+	c.CmdClause.Flag("priority", "Priority determines execution order. Lower numbers execute first").Short('p').IntVar(&c.priority)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+
+	return &c
+}
+
+// CreateCommand calls the Fastly API to create an appropriate resource.
+type CreateCommand struct {
+	cmd.Base
+
+	autoClone      cmd.OptionalAutoClone
+	content        string
+	dynamic        cmd.OptionalBool
+	location       string
+	manifest       manifest.Data
+	name           string
+	priority       int
+	serviceVersion cmd.OptionalServiceVersion
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AutoCloneFlag:      c.autoClone,
+		Client:             c.Globals.Client,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flag.Verbose,
+	})
+	if err != nil {
+		return err
+	}
+
+	input := c.constructInput(serviceID, serviceVersion.Number)
+
+	v, err := c.Globals.Client.CreateSnippet(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Created VCL snippet '%s' (service: %s, version: %d, dynamic: %t, type: %s, priority: %d)", v.Name, v.ServiceID, v.ServiceVersion, c.dynamic.WasSet, c.location, v.Priority)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) constructInput(serviceID string, serviceVersion int) *fastly.CreateSnippetInput {
+	var input fastly.CreateSnippetInput
+
+	input.Content = cmd.Content(c.content) // Content() defined in update.go
+	input.Name = c.name
+	input.Priority = c.priority
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion
+	input.Type = fastly.SnippetType(c.location)
+
+	if c.dynamic.WasSet {
+		input.Dynamic = 1
+	}
+
+	return &input
+}

--- a/pkg/vcl/snippet/create.go
+++ b/pkg/vcl/snippet/create.go
@@ -81,7 +81,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 func (c *CreateCommand) constructInput(serviceID string, serviceVersion int) *fastly.CreateSnippetInput {
 	var input fastly.CreateSnippetInput
 
-	input.Content = cmd.Content(c.content) // Content() defined in update.go
+	input.Content = cmd.Content(c.content)
 	input.Name = c.name
 	input.Priority = c.priority
 	input.ServiceID = serviceID

--- a/pkg/vcl/snippet/delete.go
+++ b/pkg/vcl/snippet/delete.go
@@ -1,0 +1,81 @@
+package snippet
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.CmdClause = parent.Command("delete", "Delete a specific snippet for a particular service and version").Alias("remove")
+	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
+	c.manifest.File.Read(manifest.Filename)
+
+	// Required flags
+	c.CmdClause.Flag("name", "The name of the VCL snippet to delete").Required().StringVar(&c.name)
+	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Dst: &c.serviceVersion.Value,
+	})
+
+	// Optional flags
+	c.SetAutoCloneFlag(cmd.AutoCloneFlagOpts{
+		Action: c.autoClone.Set,
+		Dst:    &c.autoClone.Value,
+	})
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+
+	return &c
+}
+
+// DeleteCommand calls the Fastly API to delete an appropriate resource.
+type DeleteCommand struct {
+	cmd.Base
+
+	autoClone      cmd.OptionalAutoClone
+	manifest       manifest.Data
+	name           string
+	serviceVersion cmd.OptionalServiceVersion
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AutoCloneFlag:      c.autoClone,
+		Client:             c.Globals.Client,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flag.Verbose,
+	})
+	if err != nil {
+		return err
+	}
+
+	input := c.constructInput(serviceID, serviceVersion.Number)
+
+	err = c.Globals.Client.DeleteSnippet(input)
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "Deleted custom VCL '%s' (service: %s, version: %d)", c.name, serviceID, serviceVersion.Number)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DeleteCommand) constructInput(serviceID string, serviceVersion int) *fastly.DeleteSnippetInput {
+	var input fastly.DeleteSnippetInput
+
+	input.Name = c.name
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion
+
+	return &input
+}

--- a/pkg/vcl/snippet/delete.go
+++ b/pkg/vcl/snippet/delete.go
@@ -65,7 +65,7 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out, "Deleted custom VCL '%s' (service: %s, version: %d)", c.name, serviceID, serviceVersion.Number)
+	text.Success(out, "Deleted VCL snippet '%s' (service: %s, version: %d)", c.name, serviceID, serviceVersion.Number)
 	return nil
 }
 

--- a/pkg/vcl/snippet/delete.go
+++ b/pkg/vcl/snippet/delete.go
@@ -20,12 +20,12 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 
 	// Required flags
 	c.CmdClause.Flag("name", "The name of the VCL snippet to delete").Required().StringVar(&c.name)
-	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})
 
 	// Optional flags
-	c.SetAutoCloneFlag(cmd.AutoCloneFlagOpts{
+	c.RegisterAutoCloneFlag(cmd.AutoCloneFlagOpts{
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})

--- a/pkg/vcl/snippet/describe.go
+++ b/pkg/vcl/snippet/describe.go
@@ -76,6 +76,16 @@ func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	return nil
 }
 
+// constructDynamicInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DescribeCommand) constructDynamicInput(serviceID string, serviceVersion int) *fastly.GetDynamicSnippetInput {
+	var input fastly.GetDynamicSnippetInput
+
+	input.ID = c.snippetID
+	input.ServiceID = serviceID
+
+	return &input
+}
+
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
 func (c *DescribeCommand) constructInput(serviceID string, serviceVersion int) *fastly.GetSnippetInput {
 	var input fastly.GetSnippetInput
@@ -87,14 +97,17 @@ func (c *DescribeCommand) constructInput(serviceID string, serviceVersion int) *
 	return &input
 }
 
-// constructDynamicInput transforms values parsed from CLI flags into an object to be used by the API client library.
-func (c *DescribeCommand) constructDynamicInput(serviceID string, serviceVersion int) *fastly.GetDynamicSnippetInput {
-	var input fastly.GetDynamicSnippetInput
-
-	input.ID = c.snippetID
-	input.ServiceID = serviceID
-
-	return &input
+// print displays the 'dynamic' information returned from the API.
+func (c *DescribeCommand) printDynamic(out io.Writer, v *fastly.DynamicSnippet) {
+	fmt.Fprintf(out, "Service ID: %s\n", v.ServiceID)
+	fmt.Fprintf(out, "ID: %s\n", v.ID)
+	fmt.Fprintf(out, "Content: %s\n", v.Content)
+	if v.CreatedAt != nil {
+		fmt.Fprintf(out, "Created at: %s\n", v.CreatedAt)
+	}
+	if v.UpdatedAt != nil {
+		fmt.Fprintf(out, "Updated at: %s\n", v.UpdatedAt)
+	}
 }
 
 // print displays the information returned from the API.
@@ -115,18 +128,5 @@ func (c *DescribeCommand) print(out io.Writer, v *fastly.Snippet) {
 	}
 	if v.DeletedAt != nil {
 		fmt.Fprintf(out, "Deleted at: %s\n", v.DeletedAt)
-	}
-}
-
-// print displays the 'dynamic' information returned from the API.
-func (c *DescribeCommand) printDynamic(out io.Writer, v *fastly.DynamicSnippet) {
-	fmt.Fprintf(out, "Service ID: %s\n", v.ServiceID)
-	fmt.Fprintf(out, "ID: %s\n", v.ID)
-	fmt.Fprintf(out, "Content: %s\n", v.Content)
-	if v.CreatedAt != nil {
-		fmt.Fprintf(out, "Created at: %s\n", v.CreatedAt)
-	}
-	if v.UpdatedAt != nil {
-		fmt.Fprintf(out, "Updated at: %s\n", v.UpdatedAt)
 	}
 }

--- a/pkg/vcl/snippet/describe.go
+++ b/pkg/vcl/snippet/describe.go
@@ -13,13 +13,13 @@ import (
 // NewDescribeCommand returns a usable command registered under the parent.
 func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
 	var c DescribeCommand
-	c.CmdClause = parent.Command("describe", "Get the uploaded VCL for a particular service and version").Alias("get")
+	c.CmdClause = parent.Command("describe", "Get the uploaded VCL snippet for a particular service and version").Alias("get")
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
 	// Required flags
-	c.CmdClause.Flag("name", "The name of the VCL").Required().StringVar(&c.name)
+	c.CmdClause.Flag("name", "The name of the VCL snippet").Required().StringVar(&c.name)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/vcl/snippet/describe.go
+++ b/pkg/vcl/snippet/describe.go
@@ -20,7 +20,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 
 	// Required flags
 	c.CmdClause.Flag("name", "The name of the VCL").Required().StringVar(&c.name)
-	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})
 	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").Short('i').Required().StringVar(&c.snippetID)

--- a/pkg/vcl/snippet/describe.go
+++ b/pkg/vcl/snippet/describe.go
@@ -1,0 +1,132 @@
+package snippet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.CmdClause = parent.Command("describe", "Get the uploaded VCL for a particular service and version").Alias("get")
+	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
+	c.manifest.File.Read(manifest.Filename)
+
+	// Required flags
+	c.CmdClause.Flag("name", "The name of the VCL").Required().StringVar(&c.name)
+	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Dst: &c.serviceVersion.Value,
+	})
+	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").Short('i').Required().StringVar(&c.snippetID)
+
+	// Optional Flags
+	c.CmdClause.Flag("dynamic", "Whether the VCL snippet is dynamic or versioned").Action(c.dynamic.Set).BoolVar(&c.dynamic.Value)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+
+	return &c
+}
+
+// DescribeCommand calls the Fastly API to describe an appropriate resource.
+type DescribeCommand struct {
+	cmd.Base
+
+	dynamic        cmd.OptionalBool
+	manifest       manifest.Data
+	name           string
+	serviceVersion cmd.OptionalServiceVersion
+	snippetID      string
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AllowActiveLocked:  true,
+		Client:             c.Globals.Client,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flag.Verbose,
+	})
+	if err != nil {
+		return err
+	}
+
+	if c.dynamic.WasSet {
+		input := c.constructDynamicInput(serviceID, serviceVersion.Number)
+		v, err := c.Globals.Client.GetDynamicSnippet(input)
+		if err != nil {
+			return err
+		}
+		c.printDynamic(out, v)
+		return nil
+	}
+
+	input := c.constructInput(serviceID, serviceVersion.Number)
+	v, err := c.Globals.Client.GetSnippet(input)
+	if err != nil {
+		return err
+	}
+	c.print(out, v)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DescribeCommand) constructInput(serviceID string, serviceVersion int) *fastly.GetSnippetInput {
+	var input fastly.GetSnippetInput
+
+	input.Name = c.name
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion
+
+	return &input
+}
+
+// constructDynamicInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DescribeCommand) constructDynamicInput(serviceID string, serviceVersion int) *fastly.GetDynamicSnippetInput {
+	var input fastly.GetDynamicSnippetInput
+
+	input.ID = c.snippetID
+	input.ServiceID = serviceID
+
+	return &input
+}
+
+// print displays the information returned from the API.
+func (c *DescribeCommand) print(out io.Writer, v *fastly.Snippet) {
+	fmt.Fprintf(out, "Service ID: %s\n", v.ServiceID)
+	fmt.Fprintf(out, "Service Version: %d\n", v.ServiceVersion)
+	fmt.Fprintf(out, "Name: %s\n", v.Name)
+	fmt.Fprintf(out, "ID: %s\n", v.ID)
+	fmt.Fprintf(out, "Priority: %d\n", v.Priority)
+	fmt.Fprintf(out, "Dynamic: %t\n", cmd.IntToBool(v.Dynamic))
+	fmt.Fprintf(out, "Type: %s\n", v.Type)
+	fmt.Fprintf(out, "Content: %s\n", v.Content)
+	if v.CreatedAt != nil {
+		fmt.Fprintf(out, "Created at: %s\n", v.CreatedAt)
+	}
+	if v.UpdatedAt != nil {
+		fmt.Fprintf(out, "Updated at: %s\n", v.UpdatedAt)
+	}
+	if v.DeletedAt != nil {
+		fmt.Fprintf(out, "Deleted at: %s\n", v.DeletedAt)
+	}
+}
+
+// print displays the 'dynamic' information returned from the API.
+func (c *DescribeCommand) printDynamic(out io.Writer, v *fastly.DynamicSnippet) {
+	fmt.Fprintf(out, "Service ID: %s\n", v.ServiceID)
+	fmt.Fprintf(out, "ID: %s\n", v.ID)
+	fmt.Fprintf(out, "Content: %s\n", v.Content)
+	if v.CreatedAt != nil {
+		fmt.Fprintf(out, "Created at: %s\n", v.CreatedAt)
+	}
+	if v.UpdatedAt != nil {
+		fmt.Fprintf(out, "Updated at: %s\n", v.UpdatedAt)
+	}
+}

--- a/pkg/vcl/snippet/doc.go
+++ b/pkg/vcl/snippet/doc.go
@@ -1,0 +1,3 @@
+// Package snippet contains commands for managing versioned and dynamic VCL
+// snippets.
+package snippet

--- a/pkg/vcl/snippet/list.go
+++ b/pkg/vcl/snippet/list.go
@@ -1,0 +1,114 @@
+package snippet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
+	var c ListCommand
+	c.CmdClause = parent.Command("list", "List the uploaded VCLs for a particular service and version")
+	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
+	c.manifest.File.Read(manifest.Filename)
+
+	// Required flags
+	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Dst: &c.serviceVersion.Value,
+	})
+
+	// Optional Flags
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+
+	return &c
+}
+
+// ListCommand calls the Fastly API to list appropriate resources.
+type ListCommand struct {
+	cmd.Base
+
+	manifest       manifest.Data
+	serviceVersion cmd.OptionalServiceVersion
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AllowActiveLocked:  true,
+		Client:             c.Globals.Client,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flag.Verbose,
+	})
+	if err != nil {
+		return err
+	}
+
+	input := c.constructInput(serviceID, serviceVersion.Number)
+
+	vs, err := c.Globals.Client.ListSnippets(input)
+	if err != nil {
+		return err
+	}
+
+	if c.Globals.Verbose() {
+		c.printVerbose(out, serviceID, serviceVersion.Number, vs)
+	} else {
+		c.printSummary(out, vs)
+	}
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *ListCommand) constructInput(serviceID string, serviceVersion int) *fastly.ListSnippetsInput {
+	var input fastly.ListSnippetsInput
+
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion
+
+	return &input
+}
+
+// printVerbose displays the information returned from the API in a verbose
+// format.
+func (c *ListCommand) printVerbose(out io.Writer, serviceID string, serviceVersion int, vs []*fastly.Snippet) {
+	fmt.Fprintf(out, "Service ID: %s\n", serviceID)
+	fmt.Fprintf(out, "Service Version: %d\n", serviceVersion)
+
+	for _, v := range vs {
+		fmt.Fprintf(out, "Name: %s\n", v.Name)
+		fmt.Fprintf(out, "ID: %s\n", v.ID)
+		fmt.Fprintf(out, "Priority: %d\n", v.Priority)
+		fmt.Fprintf(out, "Dynamic: %t\n", cmd.IntToBool(v.Dynamic))
+		fmt.Fprintf(out, "Type: %s\n", v.Type)
+		fmt.Fprintf(out, "Content: %s\n", v.Content)
+		if v.CreatedAt != nil {
+			fmt.Fprintf(out, "Created at: %s\n", v.CreatedAt)
+		}
+		if v.UpdatedAt != nil {
+			fmt.Fprintf(out, "Updated at: %s\n", v.UpdatedAt)
+		}
+		if v.DeletedAt != nil {
+			fmt.Fprintf(out, "Deleted at: %s\n", v.DeletedAt)
+		}
+	}
+}
+
+// printSummary displays the information returned from the API in a summarised
+// format.
+func (c *ListCommand) printSummary(out io.Writer, vs []*fastly.Snippet) {
+	t := text.NewTable(out)
+	t.AddHeader("SERVICE ID", "VERSION", "NAME", "DYNAMIC")
+	for _, v := range vs {
+		t.AddLine(v.ServiceID, v.ServiceVersion, v.Name, cmd.IntToBool(v.Dynamic))
+	}
+	t.Print()
+}

--- a/pkg/vcl/snippet/list.go
+++ b/pkg/vcl/snippet/list.go
@@ -14,7 +14,7 @@ import (
 // NewListCommand returns a usable command registered under the parent.
 func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
-	c.CmdClause = parent.Command("list", "List the uploaded VCLs for a particular service and version")
+	c.CmdClause = parent.Command("list", "List the uploaded VCL snippets for a particular service and version")
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)

--- a/pkg/vcl/snippet/list.go
+++ b/pkg/vcl/snippet/list.go
@@ -20,7 +20,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.Read(manifest.Filename)
 
 	// Required flags
-	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})
 

--- a/pkg/vcl/snippet/root.go
+++ b/pkg/vcl/snippet/root.go
@@ -1,0 +1,28 @@
+package snippet
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	cmd.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("snippet", "Manipulate Fastly VCL snippets (blocks of VCL logic inserted into your service's configuration that don't require custom VCL)")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/vcl/snippet/snippet_test.go
+++ b/pkg/vcl/snippet/snippet_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/fastly/cli/pkg/app"
-	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/go-fastly/v3/fastly"
@@ -174,7 +173,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
-			validateContent(testcase.WantError, testcase.Args, content, t)
+			testutil.AssertContentFlag(testcase.WantError, testcase.Args, "snippet.vcl", content, t)
 		})
 	}
 }
@@ -529,7 +528,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
-			validateContent(testcase.WantError, testcase.Args, content, t)
+			testutil.AssertContentFlag(testcase.WantError, testcase.Args, "snippet.vcl", content, t)
 		})
 	}
 }
@@ -599,27 +598,4 @@ func listSnippets(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
 		},
 	}
 	return vs, nil
-}
-
-// When dealing with successful test scenarios: validate the --content value was
-// parsed as expected.
-//
-// Example: if --content is passed a file path, then we expect the
-// testdata/snippet.vcl to have been read, otherwise we expect the given flag
-// value to have been used as is.
-func validateContent(wantError string, args []string, content string, t *testing.T) {
-	if wantError == "" {
-		for i, a := range args {
-			if a == "--content" {
-				want := args[i+1]
-				if want == "./testdata/snippet.vcl" {
-					want = cmd.Content(want)
-				}
-				if content != want {
-					t.Errorf("wanted %s, have %s", want, content)
-				}
-				break
-			}
-		}
-	}
 }

--- a/pkg/vcl/snippet/snippet_test.go
+++ b/pkg/vcl/snippet/snippet_test.go
@@ -1,0 +1,625 @@
+package snippet_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+func TestVCLSnippetCreate(t *testing.T) {
+	var content string
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name:      "validate missing --content flag",
+			Args:      args("vcl snippet create --name foo --type recv --version 3"),
+			WantError: "error parsing arguments: required flag --content not provided",
+		},
+		{
+			Name:      "validate missing --name flag",
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --type recv --version 3"),
+			WantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			Name:      "validate missing --type flag",
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --version 3"),
+			WantError: "error parsing arguments: required flag --type not provided",
+		},
+		{
+			Name:      "validate missing --version flag",
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --type recv"),
+			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:      "validate missing --service-id flag",
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --type recv --version 3"),
+			WantError: "error reading service: no service ID found",
+		},
+		{
+			Name: "validate missing --autoclone flag",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("vcl snippet create --content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 1"),
+			WantError: "service version 1 is not editable",
+		},
+		{
+			Name: "validate CreateSnippet API error",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+					return nil, testutil.ErrAPI
+				},
+			},
+			Args:      args("vcl snippet create --content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 3"),
+			WantError: testutil.ErrAPI.Error(),
+		},
+		{
+			Name: "validate CreateSnippet API success for versioned Snippet",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Dynamic:        i.Dynamic,
+						Name:           i.Name,
+						Priority:       i.Priority,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 3"),
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, type: recv, priority: 0)",
+		},
+		{
+			Name: "validate CreateSnippet API success for dynamic Snippet",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Dynamic:        i.Dynamic,
+						Name:           i.Name,
+						Priority:       i.Priority,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --dynamic --name foo --service-id 123 --type recv --version 3"),
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: true, type: recv, priority: 0)",
+		},
+		{
+			Name: "validate Priority set",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Dynamic:        i.Dynamic,
+						Name:           i.Name,
+						Priority:       i.Priority,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --priority 1 --service-id 123 --type recv --version 3"),
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, type: recv, priority: 1)",
+		},
+		{
+			Name: "validate --autoclone results in cloned service version",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Dynamic:        i.Dynamic,
+						Name:           i.Name,
+						Priority:       i.Priority,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet create --autoclone --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 1"),
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 4, dynamic: false, type: recv, priority: 0)",
+		},
+		{
+			Name: "validate CreateSnippet API success with inline Snippet content",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Dynamic:        i.Dynamic,
+						Name:           i.Name,
+						Priority:       i.Priority,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet create --content inline_vcl --name foo --service-id 123 --type recv --version 3"),
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, type: recv, priority: 0)",
+		},
+	}
+
+	for _, testcase := range scenarios {
+		t.Run(testcase.Name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ara := testutil.NewAppRunArgs(testcase.Args, testcase.API, &buf)
+			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
+			validateContent(testcase.WantError, testcase.Args, content, t)
+		})
+	}
+}
+
+func TestVCLSnippetDelete(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name:      "validate missing --name flag",
+			Args:      args("vcl snippet delete --version 3"),
+			WantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			Name:      "validate missing --version flag",
+			Args:      args("vcl snippet delete --name foobar"),
+			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:      "validate missing --service-id flag",
+			Args:      args("vcl snippet delete --name foobar --version 3"),
+			WantError: "error reading service: no service ID found",
+		},
+		{
+			Name: "validate missing --autoclone flag",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("vcl snippet delete --name foobar --service-id 123 --version 1"),
+			WantError: "service version 1 is not editable",
+		},
+		{
+			Name: "validate DeleteSnippet API error",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				DeleteSnippetFn: func(i *fastly.DeleteSnippetInput) error {
+					return testutil.ErrAPI
+				},
+			},
+			Args:      args("vcl snippet delete --name foobar --service-id 123 --version 3"),
+			WantError: testutil.ErrAPI.Error(),
+		},
+		{
+			Name: "validate DeleteSnippet API success",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				DeleteSnippetFn: func(i *fastly.DeleteSnippetInput) error {
+					return nil
+				},
+			},
+			Args:       args("vcl snippet delete --name foobar --service-id 123 --version 3"),
+			WantOutput: "Deleted VCL snippet 'foobar' (service: 123, version: 3)",
+		},
+		{
+			Name: "validate --autoclone results in cloned service version",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteSnippetFn: func(i *fastly.DeleteSnippetInput) error {
+					return nil
+				},
+			},
+			Args:       args("vcl snippet delete --autoclone --name foo --service-id 123 --version 1"),
+			WantOutput: "Deleted VCL snippet 'foo' (service: 123, version: 4)",
+		},
+	}
+
+	for _, testcase := range scenarios {
+		t.Run(testcase.Name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ara := testutil.NewAppRunArgs(testcase.Args, testcase.API, &buf)
+			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func TestVCLSnippetDescribe(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name:      "validate missing --name flag",
+			Args:      args("vcl snippet describe --snippet-id 123 --version 3"),
+			WantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			Name:      "validate missing --snippet-id flag",
+			Args:      args("vcl snippet describe --name foobar --version 3"),
+			WantError: "error parsing arguments: required flag --snippet-id not provided",
+		},
+		{
+			Name:      "validate missing --version flag",
+			Args:      args("vcl snippet describe --name foobar --snippet-id 123"),
+			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:      "validate missing --service-id flag",
+			Args:      args("vcl snippet describe --name foobar --snippet-id 123 --version 3"),
+			WantError: "error reading service: no service ID found",
+		},
+		{
+			Name: "validate GetSnippet API error",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				GetSnippetFn: func(i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
+					return nil, testutil.ErrAPI
+				},
+			},
+			Args:      args("vcl snippet describe --name foobar --service-id 123 --snippet-id 456 --version 3"),
+			WantError: testutil.ErrAPI.Error(),
+		},
+		{
+			Name: "validate GetSnippet API success",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				GetSnippetFn:   getSnippet,
+			},
+			Args:       args("vcl snippet describe --name foobar --service-id 123 --snippet-id 456 --version 3"),
+			WantOutput: "Service ID: 123\nService Version: 3\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: # some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
+		},
+		{
+			Name: "validate missing --autoclone flag is OK",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				GetSnippetFn:   getSnippet,
+			},
+			Args:       args("vcl snippet describe --name foobar --service-id 123 --snippet-id 456 --version 1"),
+			WantOutput: "Service ID: 123\nService Version: 1\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: # some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
+		},
+		{
+			Name: "validate dynamic GetSnippet API success",
+			API: mock.API{
+				ListVersionsFn:      testutil.ListVersions,
+				GetDynamicSnippetFn: getDynamicSnippet,
+			},
+			Args:       args("vcl snippet describe --dynamic --name foobar --service-id 123 --snippet-id 456 --version 3"),
+			WantOutput: "Service ID: 123\nID: 456\nContent: # some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
+		},
+	}
+
+	for _, testcase := range scenarios {
+		t.Run(testcase.Name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ara := testutil.NewAppRunArgs(testcase.Args, testcase.API, &buf)
+			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func TestVCLSnippetList(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name:      "validate missing --version flag",
+			Args:      args("vcl snippet list"),
+			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:      "validate missing --service-id flag",
+			Args:      args("vcl snippet list --version 3"),
+			WantError: "error reading service: no service ID found",
+		},
+		{
+			Name: "validate ListSnippets API error",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				ListSnippetsFn: func(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
+					return nil, testutil.ErrAPI
+				},
+			},
+			Args:      args("vcl snippet list --service-id 123 --version 3"),
+			WantError: testutil.ErrAPI.Error(),
+		},
+		{
+			Name: "validate ListSnippets API success",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				ListSnippetsFn: listSnippets,
+			},
+			Args:       args("vcl snippet list --service-id 123 --version 3"),
+			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC\n123         3        foo   true\n123         3        bar   false\n",
+		},
+		{
+			Name: "validate missing --autoclone flag is OK",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				ListSnippetsFn: listSnippets,
+			},
+			Args:       args("vcl snippet list --service-id 123 --version 1"),
+			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC\n123         1        foo   true\n123         1        bar   false\n",
+		},
+		{
+			Name: "validate missing --verbose flag",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				ListSnippetsFn: listSnippets,
+			},
+			Args:       args("vcl snippet list --service-id 123 --verbose --version 1"),
+			WantOutput: "Fastly API token not provided\nFastly API endpoint: https://api.fastly.com\nService ID: 123\nService Version: 1\nName: foo\nID: abc\nPriority: 0\nDynamic: true\nType: recv\nContent: # some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nName: bar\nID: abc\nPriority: 0\nDynamic: false\nType: recv\nContent: # some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
+		},
+	}
+
+	for _, testcase := range scenarios {
+		t.Run(testcase.Name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ara := testutil.NewAppRunArgs(testcase.Args, testcase.API, &buf)
+			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func TestVCLSnippetUpdate(t *testing.T) {
+	var content string
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name:      "validate missing --name flag",
+			Args:      args("vcl snippet update --version 3"),
+			WantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			Name:      "validate missing --version flag",
+			Args:      args("vcl snippet update --name foobar"),
+			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:      "validate missing --service-id flag",
+			Args:      args("vcl snippet update --name foobar --version 3"),
+			WantError: "error reading service: no service ID found",
+		},
+		{
+			Name: "validate missing --autoclone flag",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("vcl snippet update --name foobar --service-id 123 --version 1"),
+			WantError: "service version 1 is not editable",
+		},
+		{
+			Name: "validate missing either --new-name or --content",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("vcl snippet update --name foobar --service-id 123 --version 3"),
+			WantError: "error parsing arguments: must provide either --new-name or --content to update the VCL snippet",
+		},
+		{
+			Name: "validate missing --snippet-id when updating dynamic snippet",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("vcl snippet update --dynamic --name foobar --service-id 123 --version 3"),
+			WantError: "error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet",
+		},
+		{
+			Name: "validate UpdateSnippet API error",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				UpdateSnippetFn: func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					return nil, testutil.ErrAPI
+				},
+			},
+			Args:      args("vcl snippet update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			WantError: testutil.ErrAPI.Error(),
+		},
+		{
+			Name: "validate UpdateSnippet API success with --new-name",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				UpdateSnippetFn: func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					return &fastly.Snippet{
+						Content:        "# untouched",
+						Dynamic:        i.Dynamic,
+						Name:           i.NewName,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			WantOutput: "Updated VCL snippet 'beepboop' (previously: 'foobar', service: 123, version: 3)",
+		},
+		{
+			Name: "validate UpdateSnippet API success with --content",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				UpdateSnippetFn: func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Dynamic:        i.Dynamic,
+						Name:           i.Name,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet update --content updated --name foobar --service-id 123 --version 3"),
+			WantOutput: "Updated VCL snippet 'foobar' (service: 123, version: 3)",
+		},
+		{
+			Name: "validate UpdateDynamicSnippet API success with --content",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				UpdateDynamicSnippetFn: func(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.DynamicSnippet{
+						Content:   i.Content,
+						ID:        i.ID,
+						ServiceID: i.ServiceID,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet update --content updated --dynamic --name foobar --service-id 123 --snippet-id foobar --version 3"),
+			WantOutput: "Updated dynamic VCL snippet 'foobar' (service: 123)",
+		},
+		{
+			Name: "validate --autoclone results in cloned service version",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateSnippetFn: func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					// Track the contents parsed
+					content = i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Dynamic:        i.Dynamic,
+						Name:           i.Name,
+						ServiceID:      i.ServiceID,
+						ServiceVersion: i.ServiceVersion,
+					}, nil
+				},
+			},
+			Args:       args("vcl snippet update --autoclone --content ./testdata/snippet.vcl --name foo --service-id 123 --version 1"),
+			WantOutput: "Updated VCL snippet 'foo' (service: 123, version: 4)",
+		},
+	}
+
+	for _, testcase := range scenarios {
+		t.Run(testcase.Name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ara := testutil.NewAppRunArgs(testcase.Args, testcase.API, &buf)
+			err := app.Run(ara.Args, ara.Env, ara.File, ara.AppConfigFile, ara.ClientFactory, ara.HTTPClient, ara.CLIVersioner, ara.In, ara.Out)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, buf.String(), testcase.WantOutput)
+			validateContent(testcase.WantError, testcase.Args, content, t)
+		})
+	}
+}
+
+func getSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
+	t := testutil.Date
+
+	return &fastly.Snippet{
+		Content:        "# some vcl content",
+		Dynamic:        0,
+		ID:             "456",
+		Name:           i.Name,
+		Priority:       0,
+		ServiceID:      i.ServiceID,
+		ServiceVersion: i.ServiceVersion,
+		Type:           "recv",
+
+		CreatedAt: &t,
+		DeletedAt: &t,
+		UpdatedAt: &t,
+	}, nil
+}
+
+func getDynamicSnippet(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+	t := testutil.Date
+
+	return &fastly.DynamicSnippet{
+		Content:   "# some vcl content",
+		ID:        i.ID,
+		ServiceID: i.ServiceID,
+
+		CreatedAt: &t,
+		UpdatedAt: &t,
+	}, nil
+}
+
+func listSnippets(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
+	t := testutil.Date
+	vs := []*fastly.Snippet{
+		{
+			Content:        "# some vcl content",
+			Dynamic:        1,
+			ID:             "abc",
+			Name:           "foo",
+			Priority:       0,
+			ServiceID:      i.ServiceID,
+			ServiceVersion: i.ServiceVersion,
+			Type:           "recv",
+
+			CreatedAt: &t,
+			DeletedAt: &t,
+			UpdatedAt: &t,
+		},
+		{
+			Content:        "# some vcl content",
+			Dynamic:        0,
+			ID:             "abc",
+			Name:           "bar",
+			Priority:       0,
+			ServiceID:      i.ServiceID,
+			ServiceVersion: i.ServiceVersion,
+			Type:           "recv",
+
+			CreatedAt: &t,
+			DeletedAt: &t,
+			UpdatedAt: &t,
+		},
+	}
+	return vs, nil
+}
+
+// When dealing with successful test scenarios: validate the --content value was
+// parsed as expected.
+//
+// Example: if --content is passed a file path, then we expect the
+// testdata/snippet.vcl to have been read, otherwise we expect the given flag
+// value to have been used as is.
+func validateContent(wantError string, args []string, content string, t *testing.T) {
+	if wantError == "" {
+		for i, a := range args {
+			if a == "--content" {
+				want := args[i+1]
+				if want == "./testdata/snippet.vcl" {
+					want = cmd.Content(want)
+				}
+				if content != want {
+					t.Errorf("wanted %s, have %s", want, content)
+				}
+				break
+			}
+		}
+	}
+}

--- a/pkg/vcl/snippet/testdata/snippet.vcl
+++ b/pkg/vcl/snippet/testdata/snippet.vcl
@@ -1,0 +1,1 @@
+# some vcl content

--- a/pkg/vcl/snippet/update.go
+++ b/pkg/vcl/snippet/update.go
@@ -1,0 +1,136 @@
+package snippet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
+	var c UpdateCommand
+	c.CmdClause = parent.Command("update", "Update a VCL snippet for a particular service (and version, if not a dynamic snippet)")
+	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
+	c.manifest.File.Read(manifest.Filename)
+
+	// Required flags
+	c.CmdClause.Flag("name", "The name of the VCL snippet to update").Required().StringVar(&c.name)
+	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Dst: &c.serviceVersion.Value,
+	})
+
+	// Optional flags
+	c.SetAutoCloneFlag(cmd.AutoCloneFlagOpts{
+		Action: c.autoClone.Set,
+		Dst:    &c.autoClone.Value,
+	})
+	c.CmdClause.Flag("content", "VCL snippet passed as file path or content, e.g. $(cat snippet.vcl)").Action(c.content.Set).StringVar(&c.content.Value)
+	c.CmdClause.Flag("dynamic", "Whether the VCL snippet is dynamic or versioned").Action(c.dynamic.Set).BoolVar(&c.dynamic.Value)
+	c.CmdClause.Flag("new-name", "New name for the VCL snippet").Action(c.newName.Set).StringVar(&c.newName.Value)
+	c.CmdClause.Flag("priority", "Priority determines execution order. Lower numbers execute first").Short('p').IntVar(&c.priority)
+	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").Short('i').StringVar(&c.snippetID)
+	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed (e.g. recv, miss, fetch etc)").StringVar(&c.location)
+
+	return &c
+}
+
+// UpdateCommand calls the Fastly API to update an appropriate resource.
+type UpdateCommand struct {
+	cmd.Base
+
+	autoClone      cmd.OptionalAutoClone
+	content        cmd.OptionalString
+	dynamic        cmd.OptionalBool
+	location       string
+	manifest       manifest.Data
+	name           string
+	newName        cmd.OptionalString
+	priority       int
+	serviceVersion cmd.OptionalServiceVersion
+	snippetID      string
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AutoCloneFlag:      c.autoClone,
+		Client:             c.Globals.Client,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flag.Verbose,
+	})
+	if err != nil {
+		return err
+	}
+
+	if c.dynamic.WasSet {
+		input, err := c.constructDynamicInput(serviceID, serviceVersion.Number)
+		if err != nil {
+			return err
+		}
+		v, err := c.Globals.Client.UpdateDynamicSnippet(input)
+		if err != nil {
+			return err
+		}
+		text.Success(out, "Updated VCL snippet '%s' (service: %s)", v.ID, v.ServiceID)
+		return nil
+	}
+
+	input, err := c.constructInput(serviceID, serviceVersion.Number)
+	if err != nil {
+		return err
+	}
+	v, err := c.Globals.Client.UpdateSnippet(input)
+	if err != nil {
+		return err
+	}
+	if input.NewName != "" {
+		text.Success(out, "Updated VCL snippet '%s' (previously: '%s', service: %s, version: %d)", v.Name, input.Name, v.ServiceID, v.ServiceVersion)
+	} else {
+		text.Success(out, "Updated VCL snippet '%s' (service: %s, version: %d)", v.Name, v.ServiceID, v.ServiceVersion)
+	}
+	return nil
+}
+
+// constructDynamicInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) constructDynamicInput(serviceID string, serviceVersion int) (*fastly.UpdateDynamicSnippetInput, error) {
+	var input fastly.UpdateDynamicSnippetInput
+
+	input.ServiceID = serviceID
+	input.ID = c.snippetID
+
+	if c.content.WasSet {
+		input.Content = cmd.Content(c.content.Value)
+	}
+
+	return &input, nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) constructInput(serviceID string, serviceVersion int) (*fastly.UpdateSnippetInput, error) {
+	var input fastly.UpdateSnippetInput
+
+	input.Name = c.name
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion
+
+	if !c.newName.WasSet && !c.content.WasSet {
+		return nil, fmt.Errorf("error parsing arguments: must provide either --new-name or --content to update the VCL snippet")
+	}
+	if c.newName.WasSet {
+		input.NewName = c.newName.Value
+	}
+	if c.content.WasSet {
+		input.Content = cmd.Content(c.content.Value)
+	}
+
+	return &input, nil
+}

--- a/pkg/vcl/snippet/update.go
+++ b/pkg/vcl/snippet/update.go
@@ -80,7 +80,7 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		if err != nil {
 			return err
 		}
-		text.Success(out, "Updated VCL snippet '%s' (service: %s)", v.ID, v.ServiceID)
+		text.Success(out, "Updated dynamic VCL snippet '%s' (service: %s)", v.ID, v.ServiceID)
 		return nil
 	}
 
@@ -106,6 +106,10 @@ func (c *UpdateCommand) constructDynamicInput(serviceID string, serviceVersion i
 
 	input.ServiceID = serviceID
 	input.ID = c.snippetID
+
+	if c.snippetID == "" {
+		return nil, fmt.Errorf("error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet")
+	}
 
 	if c.content.WasSet {
 		input.Content = cmd.Content(c.content.Value)

--- a/pkg/vcl/snippet/update.go
+++ b/pkg/vcl/snippet/update.go
@@ -21,12 +21,12 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 
 	// Required flags
 	c.CmdClause.Flag("name", "The name of the VCL snippet to update").Required().StringVar(&c.name)
-	c.SetServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})
 
 	// Optional flags
-	c.SetAutoCloneFlag(cmd.AutoCloneFlagOpts{
+	c.RegisterAutoCloneFlag(cmd.AutoCloneFlagOpts{
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})

--- a/pkg/vcl/snippet/update.go
+++ b/pkg/vcl/snippet/update.go
@@ -14,7 +14,7 @@ import (
 // NewUpdateCommand returns a usable command registered under the parent.
 func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateCommand {
 	var c UpdateCommand
-	c.CmdClause = parent.Command("update", "Update a VCL snippet for a particular service (and version, if not a dynamic snippet)")
+	c.CmdClause = parent.Command("update", "Update a VCL snippet for a particular service and version")
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)


### PR DESCRIPTION
- `fastly vcl snippet create`
- `fastly vcl snippet delete`
- `fastly vcl snippet describe`
- `fastly vcl snippet list`
- `fastly vcl snippet update`

**NOTES**: The 'describe' and 'update' commands are handling both _versioned_ and _dynamic_ snippets.