### PR TITLE
Service ID lookup to include fallback to environment variable

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -148,19 +148,22 @@ SUBCOMMANDS
   service describe [<flags>]
     Show detailed information about a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   service update [<flags>]
     Update a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
     -n, --name=NAME              Service name
         --comment=COMMENT        Human-readable comment
 
   service delete [<flags>]
     Delete a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
     -f, --force                  Force deletion of an active service
 
   service search [<flags>]
@@ -225,19 +228,22 @@ COMMANDS
   service describe [<flags>]
     Show detailed information about a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   service update [<flags>]
     Update a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
     -n, --name=NAME              Service name
         --comment=COMMENT        Human-readable comment
 
   service delete [<flags>]
     Delete a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
     -f, --force                  Force deletion of an active service
 
   service search [<flags>]
@@ -248,19 +254,22 @@ COMMANDS
   service-version clone --version=VERSION [<flags>]
     Clone a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
   service-version list [<flags>]
     List Fastly service versions
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   service-version update --version=VERSION [<flags>]
     Update a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -270,7 +279,8 @@ COMMANDS
   service-version activate --version=VERSION [<flags>]
     Activate a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -279,14 +289,16 @@ COMMANDS
   service-version deactivate --version=VERSION [<flags>]
     Deactivate a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
   service-version lock --version=VERSION [<flags>]
     Lock a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -315,7 +327,8 @@ COMMANDS
   compute deploy [<flags>]
     Deploy a package to a Fastly Compute@Edge service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -p, --path=PATH              Path to package
@@ -333,7 +346,8 @@ COMMANDS
         --language=LANGUAGE      Language type
         --include-source         Include source code in built package
         --force                  Skip verification steps and force build
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -p, --path=PATH              Path to package
@@ -352,7 +366,8 @@ COMMANDS
   compute update --version=VERSION --path=PATH [<flags>]
     Update a package on a Fastly Compute@Edge service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -369,7 +384,8 @@ COMMANDS
 
     -n, --name=NAME              Domain name
         --comment=COMMENT        A descriptive note
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -378,14 +394,16 @@ COMMANDS
   domain list --version=VERSION [<flags>]
     List domains on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
   domain describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a domain on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              Name of domain
@@ -393,7 +411,8 @@ COMMANDS
   domain update --version=VERSION --name=NAME [<flags>]
     Update a domain on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -406,7 +425,8 @@ COMMANDS
     Delete a domain on a Fastly service version
 
     -n, --name=NAME              Domain name
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -415,7 +435,8 @@ COMMANDS
   backend create --version=VERSION --name=NAME --address=ADDRESS [<flags>]
     Create a backend on a Fastly service version
 
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --version=VERSION          'latest', 'active', or the number of a
                                    specific version
         --autoclone                If the selected service version is not
@@ -478,14 +499,16 @@ COMMANDS
   backend list --version=VERSION [<flags>]
     List backends on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
   backend describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a backend on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              Name of backend
@@ -493,7 +516,8 @@ COMMANDS
   backend update --version=VERSION --name=NAME [<flags>]
     Update a backend on a Fastly service version
 
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --version=VERSION          'latest', 'active', or the number of a
                                    specific version
         --autoclone                If the selected service version is not
@@ -557,7 +581,8 @@ COMMANDS
   backend delete --version=VERSION --name=NAME [<flags>]
     Delete a backend on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -567,7 +592,8 @@ COMMANDS
   healthcheck create --version=VERSION --name=NAME [<flags>]
     Create a healthcheck on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -595,14 +621,16 @@ COMMANDS
   healthcheck list --version=VERSION [<flags>]
     List healthchecks on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
   healthcheck describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a healthcheck on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              Name of healthcheck
@@ -610,7 +638,8 @@ COMMANDS
   healthcheck update --version=VERSION --name=NAME [<flags>]
     Update a healthcheck on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -639,7 +668,8 @@ COMMANDS
   healthcheck delete --version=VERSION --name=NAME [<flags>]
     Delete a healthcheck on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -649,7 +679,8 @@ COMMANDS
   dictionary create --version=VERSION --name=NAME [<flags>]
     Create a Fastly edge dictionary on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -661,7 +692,8 @@ COMMANDS
   dictionary describe --version=VERSION --name=NAME [<flags>]
     Show detailed information about a Fastly edge dictionary
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              Name of Dictionary
@@ -669,7 +701,8 @@ COMMANDS
   dictionary delete --version=VERSION --name=NAME [<flags>]
     Delete a Fastly edge dictionary from a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -679,14 +712,16 @@ COMMANDS
   dictionary list --version=VERSION [<flags>]
     List all dictionaries on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
   dictionary update --version=VERSION --name=NAME [<flags>]
     Update name of dictionary on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --autoclone              If the selected service version is not
@@ -699,14 +734,16 @@ COMMANDS
   dictionaryitem list --dictionary-id=DICTIONARY-ID [<flags>]
     List items in a Fastly edge dictionary
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --dictionary-id=DICTIONARY-ID
                                  Dictionary ID
 
   dictionaryitem describe --dictionary-id=DICTIONARY-ID --key=KEY [<flags>]
     Show detailed information about a Fastly edge dictionary item
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --dictionary-id=DICTIONARY-ID
                                  Dictionary ID
         --key=KEY                Dictionary item key
@@ -714,7 +751,8 @@ COMMANDS
   dictionaryitem create --dictionary-id=DICTIONARY-ID --key=KEY --value=VALUE [<flags>]
     Create a new item on a Fastly edge dictionary
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --dictionary-id=DICTIONARY-ID
                                  Dictionary ID
         --key=KEY                Dictionary item key
@@ -723,7 +761,8 @@ COMMANDS
   dictionaryitem update --dictionary-id=DICTIONARY-ID --key=KEY --value=VALUE [<flags>]
     Update or insert an item on a Fastly edge dictionary
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --dictionary-id=DICTIONARY-ID
                                  Dictionary ID
         --key=KEY                Dictionary item key
@@ -732,7 +771,8 @@ COMMANDS
   dictionaryitem delete --dictionary-id=DICTIONARY-ID --key=KEY [<flags>]
     Delete an item from a Fastly edge dictionary
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --dictionary-id=DICTIONARY-ID
                                  Dictionary ID
         --key=KEY                Dictionary item key
@@ -740,7 +780,8 @@ COMMANDS
   dictionaryitem batchmodify --dictionary-id=DICTIONARY-ID --file=FILE [<flags>]
     Update multiple items in a Fastly edge dictionary
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --dictionary-id=DICTIONARY-ID
                                  Dictionary ID
         --file=FILE              Batch update json file
@@ -763,7 +804,8 @@ COMMANDS
         --secret-key=SECRET-KEY  Your Google Cloud Platform account secret key.
                                  The private_key field in your service account
                                  authentication JSON.
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --template-suffix=TEMPLATE-SUFFIX
                                  BigQuery table name suffix template
         --format=FORMAT          Apache style log formatting. Must produce JSON
@@ -788,7 +830,8 @@ COMMANDS
   logging bigquery list --version=VERSION [<flags>]
     List BigQuery endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -796,7 +839,8 @@ COMMANDS
     Show detailed information about a BigQuery logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the BigQuery logging object
@@ -809,7 +853,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the BigQuery logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the BigQuery logging object
         --project-id=PROJECT-ID  Your Google Cloud Platform project ID
         --dataset=DATASET        Your BigQuery dataset
@@ -849,7 +894,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the BigQuery logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging s3 create --name=NAME --version=VERSION --bucket=BUCKET [<flags>]
     Create an Amazon S3 logging endpoint on a Fastly service version
@@ -864,7 +910,8 @@ COMMANDS
         --access-key=ACCESS-KEY  Your S3 account access key
         --secret-key=SECRET-KEY  Your S3 account secret key
         --iam-role=IAM-ROLE      The IAM role ARN for logging
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --domain=DOMAIN          The domain of the S3 endpoint
         --path=PATH              The path to upload logs to
         --period=PERIOD          How frequently log files are finalized so they
@@ -914,7 +961,8 @@ COMMANDS
   logging s3 list --version=VERSION [<flags>]
     List S3 endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -922,7 +970,8 @@ COMMANDS
     Show detailed information about a S3 logging endpoint on a Fastly service
     version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the S3 logging object
@@ -935,7 +984,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the S3 logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the S3 logging object
         --bucket=BUCKET          Your S3 bucket name
         --access-key=ACCESS-KEY  Your S3 account access key
@@ -995,7 +1045,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the S3 logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging kinesis create --name=NAME --version=VERSION --stream-name=STREAM-NAME --region=REGION [<flags>]
     Create an Amazon Kinesis logging endpoint on a Fastly service version
@@ -1014,7 +1065,8 @@ COMMANDS
         --iam-role=IAM-ROLE        The IAM role ARN for logging
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --format=FORMAT            Apache style log formatting
         --format-version=FORMAT-VERSION
                                    The version of the custom logging format used
@@ -1032,7 +1084,8 @@ COMMANDS
   logging kinesis list --version=VERSION [<flags>]
     List Kinesis endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1040,7 +1093,8 @@ COMMANDS
     Show detailed information about a Kinesis logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Kinesis logging object
@@ -1053,7 +1107,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
     -n, --name=NAME                The name of the Kinesis logging object
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --new-name=NEW-NAME        New name of the Kinesis logging object
         --stream-name=STREAM-NAME  Your Kinesis stream name
         --access-key=ACCESS-KEY    Your Kinesis account access key
@@ -1083,7 +1138,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Kinesis logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging syslog create --name=NAME --version=VERSION --address=ADDRESS [<flags>]
     Create a Syslog logging endpoint on a Fastly service version
@@ -1095,7 +1151,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
         --address=ADDRESS          A hostname or IPv4 address
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --port=PORT                The port number
         --use-tls                  Whether to use TLS for secure logging. Can be
                                    either true or false
@@ -1132,7 +1189,8 @@ COMMANDS
   logging syslog list --version=VERSION [<flags>]
     List Syslog endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1140,7 +1198,8 @@ COMMANDS
     Show detailed information about a Syslog logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Syslog logging object
@@ -1153,7 +1212,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
     -n, --name=NAME                The name of the Syslog logging object
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --new-name=NEW-NAME        New name of the Syslog logging object
         --address=ADDRESS          A hostname or IPv4 address
         --port=PORT                The port number
@@ -1197,14 +1257,16 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Syslog logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging logentries create --name=NAME --version=VERSION [<flags>]
     Create a Logentries logging endpoint on a Fastly service version
 
     -n, --name=NAME              The name of the Logentries logging object. Used
                                  as a primary key for API access
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --port=PORT              The port number
         --use-tls                Whether to use TLS for secure logging. Can be
                                  either true or false
@@ -1235,7 +1297,8 @@ COMMANDS
   logging logentries list --version=VERSION [<flags>]
     List Logentries endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1243,7 +1306,8 @@ COMMANDS
     Show detailed information about a Logentries logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Logentries logging object
@@ -1256,7 +1320,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Logentries logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Logentries logging object
         --port=PORT              The port number
         --use-tls                Whether to use TLS for secure logging. Can be
@@ -1289,7 +1354,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Logentries logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging papertrail create --name=NAME --version=VERSION --address=ADDRESS [<flags>]
     Create a Papertrail logging endpoint on a Fastly service version
@@ -1301,7 +1367,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
         --address=ADDRESS        A hostname or IPv4 address
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --port=PORT              The port number
         --format-version=FORMAT-VERSION
                                  The version of the custom logging format used
@@ -1324,7 +1391,8 @@ COMMANDS
   logging papertrail list --version=VERSION [<flags>]
     List Papertrail endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1332,7 +1400,8 @@ COMMANDS
     Show detailed information about a Papertrail logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Papertrail logging object
@@ -1345,7 +1414,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Papertrail logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Papertrail logging object
         --address=ADDRESS        A hostname or IPv4 address
         --port=PORT              The port number
@@ -1375,7 +1445,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Papertrail logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging sumologic create --name=NAME --version=VERSION --url=URL [<flags>]
     Create a Sumologic logging endpoint on a Fastly service version
@@ -1387,7 +1458,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
         --url=URL                The URL to POST to
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
                                  The version of the custom logging format used
@@ -1412,7 +1484,8 @@ COMMANDS
   logging sumologic list --version=VERSION [<flags>]
     List Sumologic endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1420,7 +1493,8 @@ COMMANDS
     Show detailed information about a Sumologic logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Sumologic logging object
@@ -1433,7 +1507,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Sumologic logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Sumologic logging object
         --url=URL                The URL to POST to
         --format=FORMAT          Apache style log formatting
@@ -1465,7 +1540,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Sumologic logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging gcs create --name=NAME --version=VERSION --user=USER --bucket=BUCKET --secret-key=SECRET-KEY [<flags>]
     Create a GCS logging endpoint on a Fastly service version
@@ -1483,7 +1559,8 @@ COMMANDS
         --secret-key=SECRET-KEY  Your GCS account secret key. The private_key
                                  field in your service account authentication
                                  JSON
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --period=PERIOD          How frequently log files are finalized so they
                                  can be available for reading (in seconds,
                                  default 3600)
@@ -1525,7 +1602,8 @@ COMMANDS
   logging gcs list --version=VERSION [<flags>]
     List GCS endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1533,7 +1611,8 @@ COMMANDS
     Show detailed information about a GCS logging endpoint on a Fastly service
     version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the GCS logging object
@@ -1546,7 +1625,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the GCS logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the GCS logging object
         --bucket=BUCKET          The bucket of the GCS bucket
         --user=USER              Your GCS service account email address. The
@@ -1601,7 +1681,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the GCS logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging ftp create --name=NAME --version=VERSION --address=ADDRESS --user=USER --password=PASSWORD [<flags>]
     Create an FTP logging endpoint on a Fastly service version
@@ -1616,7 +1697,8 @@ COMMANDS
         --user=USER              The username for the server (can be anonymous)
         --password=PASSWORD      The password for the server (for anonymous use
                                  an email address)
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --port=PORT              The port number
         --path=PATH              The path to upload log files to. If the path
                                  ends in / then it is treated as a directory
@@ -1653,7 +1735,8 @@ COMMANDS
   logging ftp list --version=VERSION [<flags>]
     List FTP endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1661,7 +1744,8 @@ COMMANDS
     Show detailed information about an FTP logging endpoint on a Fastly service
     version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the FTP logging object
@@ -1674,7 +1758,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the FTP logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the FTP logging object
         --address=ADDRESS        An hostname or IPv4 address
         --port=PORT              The port number
@@ -1728,7 +1813,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the FTP logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging splunk create --name=NAME --version=VERSION --url=URL [<flags>]
     Create a Splunk logging endpoint on a Fastly service version
@@ -1740,7 +1826,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
         --url=URL                  The URL to POST to
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
                                    server with. Must be in PEM format
         --tls-hostname=TLS-HOSTNAME
@@ -1772,7 +1859,8 @@ COMMANDS
   logging splunk list --version=VERSION [<flags>]
     List Splunk endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1780,7 +1868,8 @@ COMMANDS
     Show detailed information about a Splunk logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Splunk logging object
@@ -1793,7 +1882,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
     -n, --name=NAME                The name of the Splunk logging object
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --new-name=NEW-NAME        New name of the Splunk logging object
         --url=URL                  The URL to POST to.
         --tls-ca-cert=TLS-CA-CERT  A secure certificate to authenticate the
@@ -1832,7 +1922,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Splunk logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging scalyr create --name=NAME --version=VERSION --auth-token=AUTH-TOKEN [<flags>]
     Create a Scalyr logging endpoint on a Fastly service version
@@ -1845,7 +1936,8 @@ COMMANDS
                                  editable, clone it and use the clone.
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://www.scalyr.com/keys)
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --region=REGION          The region that log data will be sent to. One
                                  of US or EU. Defaults to US if undefined
         --format=FORMAT          Apache style log formatting
@@ -1864,7 +1956,8 @@ COMMANDS
   logging scalyr list --version=VERSION [<flags>]
     List Scalyr endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1872,7 +1965,8 @@ COMMANDS
     Show detailed information about a Scalyr logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Scalyr logging object
@@ -1885,7 +1979,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Scalyr logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Scalyr logging object
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
@@ -1912,7 +2007,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Scalyr logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging loggly create --name=NAME --version=VERSION --auth-token=AUTH-TOKEN [<flags>]
     Create a Loggly logging endpoint on a Fastly service version
@@ -1925,7 +2021,8 @@ COMMANDS
                                  editable, clone it and use the clone.
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://www.loggly.com/docs/customer-token-authentication-token/)
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
                                  The version of the custom logging format used
@@ -1942,7 +2039,8 @@ COMMANDS
   logging loggly list --version=VERSION [<flags>]
     List Loggly endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -1950,7 +2048,8 @@ COMMANDS
     Show detailed information about a Loggly logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Loggly logging object
@@ -1963,7 +2062,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Loggly logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Loggly logging object
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://www.loggly.com/docs/customer-token-authentication-token/)
@@ -1988,7 +2088,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Loggly logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging honeycomb create --name=NAME --version=VERSION --dataset=DATASET --auth-token=AUTH-TOKEN [<flags>]
     Create a Honeycomb logging endpoint on a Fastly service version
@@ -2002,7 +2103,8 @@ COMMANDS
         --dataset=DATASET        The Honeycomb Dataset you want to log to
         --auth-token=AUTH-TOKEN  The Write Key from the Account page of your
                                  Honeycomb account
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --format=FORMAT          Apache style log formatting. Your log must
                                  produce valid JSON that Honeycomb can ingest
         --format-version=FORMAT-VERSION
@@ -2020,7 +2122,8 @@ COMMANDS
   logging honeycomb list --version=VERSION [<flags>]
     List Honeycomb endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2028,7 +2131,8 @@ COMMANDS
     Show detailed information about a Honeycomb logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Honeycomb logging object
@@ -2041,7 +2145,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Honeycomb logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Honeycomb logging object
         --format=FORMAT          Apache style log formatting. Your log must
                                  produce valid JSON that Honeycomb can ingest
@@ -2068,7 +2173,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Honeycomb logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging heroku create --name=NAME --version=VERSION --url=URL --auth-token=AUTH-TOKEN [<flags>]
     Create a Heroku logging endpoint on a Fastly service version
@@ -2082,7 +2188,8 @@ COMMANDS
         --url=URL                The url to stream logs to
         --auth-token=AUTH-TOKEN  The token to use for authentication
                                  (https://devcenter.heroku.com/articles/add-on-partner-log-integration)
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
                                  The version of the custom logging format used
@@ -2099,7 +2206,8 @@ COMMANDS
   logging heroku list --version=VERSION [<flags>]
     List Heroku endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2107,7 +2215,8 @@ COMMANDS
     Show detailed information about a Heroku logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Heroku logging object
@@ -2120,7 +2229,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Heroku logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Heroku logging object
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
@@ -2146,7 +2256,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Heroku logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging sftp create --name=NAME --version=VERSION --address=ADDRESS --user=USER --ssh-known-hosts=SSH-KNOWN-HOSTS [<flags>]
     Create an SFTP logging endpoint on a Fastly service version
@@ -2162,7 +2273,8 @@ COMMANDS
         --ssh-known-hosts=SSH-KNOWN-HOSTS
                                  A list of host keys for all hosts we can
                                  connect to over SFTP
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --port=PORT              The port number
         --password=PASSWORD      The password for the server. If both password
                                  and secret_key are passed, secret_key will be
@@ -2212,7 +2324,8 @@ COMMANDS
   logging sftp list --version=VERSION [<flags>]
     List SFTP endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2220,7 +2333,8 @@ COMMANDS
     Show detailed information about an SFTP logging endpoint on a Fastly service
     version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the SFTP logging object
@@ -2233,7 +2347,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the SFTP logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the SFTP logging object
         --address=ADDRESS        The hostname or IPv4 address
         --port=PORT              The port number
@@ -2294,7 +2409,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the SFTP logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging logshuttle create --name=NAME --version=VERSION --url=URL --auth-token=AUTH-TOKEN [<flags>]
     Create a Logshuttle logging endpoint on a Fastly service version
@@ -2308,7 +2424,8 @@ COMMANDS
         --url=URL                Your Log Shuttle endpoint url
         --auth-token=AUTH-TOKEN  The data authentication token associated with
                                  this endpoint
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
                                  The version of the custom logging format used
@@ -2325,7 +2442,8 @@ COMMANDS
   logging logshuttle list --version=VERSION [<flags>]
     List Logshuttle endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2333,7 +2451,8 @@ COMMANDS
     Show detailed information about a Logshuttle logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Logshuttle logging object
@@ -2346,7 +2465,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Logshuttle logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Logshuttle logging object
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
@@ -2372,7 +2492,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Logshuttle logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging cloudfiles create --name=NAME --version=VERSION --user=USER --access-key=ACCESS-KEY --bucket=BUCKET [<flags>]
     Create a Cloudfiles logging endpoint on a Fastly service version
@@ -2386,7 +2507,8 @@ COMMANDS
         --user=USER              The username for your Cloudfile account
         --access-key=ACCESS-KEY  Your Cloudfile account access key
         --bucket=BUCKET          The name of your Cloudfiles container
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --path=PATH              The path to upload logs to
         --region=REGION          The region to stream logs to. One of:
                                  DFW-Dallas, ORD-Chicago, IAD-Northern Virginia,
@@ -2430,7 +2552,8 @@ COMMANDS
   logging cloudfiles list --version=VERSION [<flags>]
     List Cloudfiles endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2438,7 +2561,8 @@ COMMANDS
     Show detailed information about a Cloudfiles logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Cloudfiles logging object
@@ -2451,7 +2575,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Cloudfiles logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Cloudfiles logging object
         --user=USER              The username for your Cloudfile account
         --access-key=ACCESS-KEY  Your Cloudfile account access key
@@ -2504,7 +2629,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Cloudfiles logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging digitalocean create --name=NAME --version=VERSION --bucket=BUCKET --access-key=ACCESS-KEY --secret-key=SECRET-KEY [<flags>]
     Create a DigitalOcean Spaces logging endpoint on a Fastly service version
@@ -2518,7 +2644,8 @@ COMMANDS
         --bucket=BUCKET          The name of the DigitalOcean Space
         --access-key=ACCESS-KEY  Your DigitalOcean Spaces account access key
         --secret-key=SECRET-KEY  Your DigitalOcean Spaces account secret key
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --domain=DOMAIN          The domain of the DigitalOcean Spaces endpoint
                                  (default 'nyc3.digitaloceanspaces.com')
         --path=PATH              The path to upload logs to
@@ -2561,7 +2688,8 @@ COMMANDS
   logging digitalocean list --version=VERSION [<flags>]
     List DigitalOcean Spaces logging endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2569,7 +2697,8 @@ COMMANDS
     Show detailed information about a DigitalOcean Spaces logging endpoint on a
     Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
@@ -2584,7 +2713,8 @@ COMMANDS
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the DigitalOcean Spaces logging
                                  object
         --bucket=BUCKET          The name of the DigitalOcean Space
@@ -2638,7 +2768,8 @@ COMMANDS
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the DigitalOcean Spaces logging
                                  object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging elasticsearch create --name=NAME --version=VERSION --index=INDEX --url=URL [<flags>]
     Create an Elasticsearch logging endpoint on a Fastly service version
@@ -2659,7 +2790,8 @@ COMMANDS
                                    with a pound symbol. For example, #{%F} will
                                    interpolate as YYYY-MM-DD with today's date
         --url=URL                  The URL to stream logs to. Must use HTTPS.
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --pipeline=PIPELINE        The ID of the Elasticsearch ingest pipeline
                                    to apply pre-process transformations to
                                    before indexing. For example my_pipeline_id.
@@ -2703,7 +2835,8 @@ COMMANDS
   logging elasticsearch list --version=VERSION [<flags>]
     List Elasticsearch endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2711,7 +2844,8 @@ COMMANDS
     Show detailed information about an Elasticsearch logging endpoint on a
     Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Elasticsearch logging object
@@ -2724,7 +2858,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
     -n, --name=NAME                The name of the Elasticsearch logging object
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --new-name=NEW-NAME        New name of the Elasticsearch logging object
         --index=INDEX              The name of the Elasticsearch index to send
                                    documents (logs) to. The index must follow
@@ -2784,7 +2919,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Elasticsearch logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging azureblob create --name=NAME --version=VERSION --container=CONTAINER --account-name=ACCOUNT-NAME --sas-token=SAS-TOKEN [<flags>]
     Create an Azure Blob Storage logging endpoint on a Fastly service version
@@ -2804,7 +2940,8 @@ COMMANDS
                                  write access to the blob service objects. Be
                                  sure to update your token before it expires or
                                  the logging functionality will not work
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --path=PATH              The path to upload logs to
         --period=PERIOD          How frequently log files are finalized so they
                                  can be available for reading (in seconds,
@@ -2847,7 +2984,8 @@ COMMANDS
   logging azureblob list --version=VERSION [<flags>]
     List Azure Blob Storage logging endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2855,7 +2993,8 @@ COMMANDS
     Show detailed information about an Azure Blob Storage logging endpoint on a
     Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Azure Blob Storage logging
@@ -2870,7 +3009,8 @@ COMMANDS
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Azure Blob Storage logging
                                  object
         --container=CONTAINER    The name of the Azure Blob Storage container in
@@ -2930,7 +3070,8 @@ COMMANDS
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Azure Blob Storage logging
                                  object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging datadog create --name=NAME --version=VERSION --auth-token=AUTH-TOKEN [<flags>]
     Create a Datadog logging endpoint on a Fastly service version
@@ -2942,7 +3083,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
         --auth-token=AUTH-TOKEN  The API key from your Datadog account
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --region=REGION          The region that log data will be sent to. One
                                  of US or EU. Defaults to US if undefined
         --format=FORMAT          Apache style log formatting. For details on the
@@ -2963,7 +3105,8 @@ COMMANDS
   logging datadog list --version=VERSION [<flags>]
     List Datadog endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -2971,7 +3114,8 @@ COMMANDS
     Show detailed information about a Datadog logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Datadog logging object
@@ -2984,7 +3128,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Datadog logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Datadog logging object
         --auth-token=AUTH-TOKEN  The API key from your Datadog account
         --region=REGION          The region that log data will be sent to. One
@@ -3012,7 +3157,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Datadog logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging https create --name=NAME --version=VERSION --url=URL [<flags>]
     Create an HTTPS logging endpoint on a Fastly service version
@@ -3025,7 +3171,8 @@ COMMANDS
                                    editable, clone it and use the clone.
         --url=URL                  URL that log data will be sent to. Must use
                                    the https protocol
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --content-type=CONTENT-TYPE
                                    Content type of the header sent with the
                                    request
@@ -3080,7 +3227,8 @@ COMMANDS
   logging https list --version=VERSION [<flags>]
     List HTTPS endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -3088,7 +3236,8 @@ COMMANDS
     Show detailed information about an HTTPS logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the HTTPS logging object
@@ -3101,7 +3250,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
     -n, --name=NAME                The name of the HTTPS logging object
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --new-name=NEW-NAME        New name of the HTTPS logging object
         --url=URL                  URL that log data will be sent to. Must use
                                    the https protocol
@@ -3164,7 +3314,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the HTTPS logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging kafka create --name=NAME --version=VERSION --topic=TOPIC --brokers=BROKERS [<flags>]
     Create a Kafka logging endpoint on a Fastly service version
@@ -3178,7 +3329,8 @@ COMMANDS
         --topic=TOPIC              The Kafka topic to send logs to
         --brokers=BROKERS          A comma-separated list of IP addresses or
                                    hostnames of Kafka brokers
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --compression-codec=COMPRESSION-CODEC
                                    The codec used for compression of your logs.
                                    One of: gzip, snappy, lz4
@@ -3233,7 +3385,8 @@ COMMANDS
   logging kafka list --version=VERSION [<flags>]
     List Kafka endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -3241,7 +3394,8 @@ COMMANDS
     Show detailed information about a Kafka logging endpoint on a Fastly service
     version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Kafka logging object
@@ -3254,7 +3408,8 @@ COMMANDS
         --autoclone                If the selected service version is not
                                    editable, clone it and use the clone.
     -n, --name=NAME                The name of the Kafka logging object
-    -s, --service-id=SERVICE-ID    Service ID
+    -s, --service-id=SERVICE-ID    Service ID (falls back to FASTLY_SERVICE_ID,
+                                   then fastly.toml)
         --new-name=NEW-NAME        New name of the Kafka logging object
         --topic=TOPIC              The Kafka topic to send logs to
         --brokers=BROKERS          A comma-separated list of IP addresses or
@@ -3318,7 +3473,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Kafka logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging googlepubsub create --name=NAME --version=VERSION --user=USER --secret-key=SECRET-KEY --topic=TOPIC --project-id=PROJECT-ID [<flags>]
     Create a Google Cloud Pub/Sub logging endpoint on a Fastly service version
@@ -3338,7 +3494,8 @@ COMMANDS
         --topic=TOPIC            The Google Cloud Pub/Sub topic to which logs
                                  will be published
         --project-id=PROJECT-ID  The ID of your Google Cloud Platform project
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --format=FORMAT          Apache style log formatting
         --format-version=FORMAT-VERSION
                                  The version of the custom logging format used
@@ -3356,7 +3513,8 @@ COMMANDS
   logging googlepubsub list --version=VERSION [<flags>]
     List Google Cloud Pub/Sub endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -3364,7 +3522,8 @@ COMMANDS
     Show detailed information about a Google Cloud Pub/Sub logging endpoint on a
     Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
@@ -3379,7 +3538,8 @@ COMMANDS
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the Google Cloud Pub/Sub logging
                                  object
         --user=USER              Your Google Cloud Platform service account
@@ -3414,7 +3574,8 @@ COMMANDS
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the Google Cloud Pub/Sub logging
                                  object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logging openstack create --name=NAME --version=VERSION --bucket=BUCKET --access-key=ACCESS-KEY --user=USER --url=URL [<flags>]
     Create an OpenStack logging endpoint on a Fastly service version
@@ -3429,7 +3590,8 @@ COMMANDS
         --access-key=ACCESS-KEY  Your OpenStack account access key
         --user=USER              The username for your OpenStack account
         --url=URL                Your OpenStack auth url
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --public-key=PUBLIC-KEY  A PGP public key that Fastly will use to
                                  encrypt your log files before writing them to
                                  disk
@@ -3470,7 +3632,8 @@ COMMANDS
   logging openstack list --version=VERSION [<flags>]
     List OpenStack logging endpoints on a Fastly service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
 
@@ -3478,7 +3641,8 @@ COMMANDS
     Show detailed information about an OpenStack logging endpoint on a Fastly
     service version
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
     -n, --name=NAME              The name of the OpenStack logging object
@@ -3491,7 +3655,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the OpenStack logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --new-name=NEW-NAME      New name of the OpenStack logging object
         --bucket=BUCKET          The name of the Openstack Space
         --access-key=ACCESS-KEY  Your OpenStack account access key
@@ -3542,12 +3707,14 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
     -n, --name=NAME              The name of the OpenStack logging object
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   logs tail [<flags>]
     Tail Compute@Edge logs
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --from=FROM              From time, in unix seconds
         --to=TO                  To time, in unix seconds
         --sort-buffer=1s         Sort buffer is how long to buffer logs,
@@ -3563,10 +3730,11 @@ COMMANDS
     List stats regions
 
 
-  stats historical --service-id=SERVICE-ID [<flags>]
+  stats historical [<flags>]
     View historical stats for a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --from=FROM              From time, accepted formats at
                                  https://fastly.dev/reference/api/metrics-stats/historical-stats
         --to=TO                  To time
@@ -3574,10 +3742,11 @@ COMMANDS
         --region=REGION          Filter by region ('stats regions' to list)
         --format=FORMAT          Output format (json)
 
-  stats realtime --service-id=SERVICE-ID [<flags>]
+  stats realtime [<flags>]
     View realtime stats for a Fastly service
 
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
         --format=FORMAT          Output format (json)
 
   vcl custom create --content=CONTENT --name=NAME --version=VERSION [<flags>]
@@ -3591,7 +3760,8 @@ COMMANDS
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
         --main                   Whether the VCL is the 'main' entrypoint
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl custom delete --name=NAME --version=VERSION [<flags>]
     Delete the uploaded VCL for a particular service and version
@@ -3601,7 +3771,8 @@ COMMANDS
                                  version
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl custom describe --name=NAME --version=VERSION [<flags>]
     Get the uploaded VCL for a particular service and version
@@ -3609,14 +3780,16 @@ COMMANDS
         --name=NAME              The name of the VCL
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl custom list --version=VERSION [<flags>]
     List the uploaded VCLs for a particular service and version
 
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl custom update --name=NAME --version=VERSION [<flags>]
     Update the uploaded VCL for a particular service and version
@@ -3629,7 +3802,8 @@ COMMANDS
         --new-name=NEW-NAME      New name for the VCL
         --content=CONTENT        VCL passed as file path or content, e.g. $(cat
                                  main.vcl)
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl snippet create --content=CONTENT --name=NAME --version=VERSION --type=TYPE [<flags>]
     Create a snippet for a particular service and version
@@ -3646,7 +3820,8 @@ COMMANDS
         --dynamic                Whether the VCL snippet is dynamic or versioned
     -p, --priority=PRIORITY      Priority determines execution order. Lower
                                  numbers execute first
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl snippet delete --name=NAME --version=VERSION [<flags>]
     Delete a specific snippet for a particular service and version
@@ -3656,7 +3831,8 @@ COMMANDS
                                  version
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl snippet describe --name=NAME --version=VERSION --snippet-id=SNIPPET-ID [<flags>]
     Get the uploaded VCL snippet for a particular service and version
@@ -3666,14 +3842,16 @@ COMMANDS
                                  version
     -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
         --dynamic                Whether the VCL snippet is dynamic or versioned
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl snippet list --version=VERSION [<flags>]
     List the uploaded VCL snippets for a particular service and version
 
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
 
   vcl snippet update --name=NAME --version=VERSION [<flags>]
     Update a VCL snippet for a particular service and version
@@ -3689,7 +3867,8 @@ COMMANDS
         --new-name=NEW-NAME      New name for the VCL snippet
     -p, --priority=PRIORITY      Priority determines execution order. Lower
                                  numbers execute first
-    -s, --service-id=SERVICE-ID  Service ID
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
     -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
         --type=TYPE              The location in generated VCL where the snippet
                                  should be placed (e.g. recv, miss, fetch etc)

--- a/pkg/backend/create.go
+++ b/pkg/backend/create.go
@@ -35,7 +35,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a backend on a Fastly service version").Alias("add")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/backend/delete.go
+++ b/pkg/backend/delete.go
@@ -26,7 +26,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a backend on a Fastly service version").Alias("remove")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/backend/describe.go
+++ b/pkg/backend/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a backend on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/backend/list.go
+++ b/pkg/backend/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List backends on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/backend/update.go
+++ b/pkg/backend/update.go
@@ -52,7 +52,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a backend on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -16,6 +16,14 @@ import (
 	"github.com/fastly/kingpin"
 )
 
+// RegisterServiceIDFlag defines a --service-id flag that will attempt to
+// acquire the Service ID from multiple sources.
+//
+// See: manifest.Data.ServiceID() for the sources.
+func (b Base) RegisterServiceIDFlag(dst *string) {
+	b.CmdClause.Flag("service-id", "Service ID (falls back to FASTLY_SERVICE_ID, then fastly.toml)").Short('s').StringVar(dst)
+}
+
 // ServiceVersionFlagOpts enables easy configuration of the --version flag
 // defined via the RegisterServiceVersionFlag constructor.
 //

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -59,7 +59,7 @@ func NewDeployCommand(parent cmd.Registerer, client api.HTTPClient, globals *con
 
 	// NOTE: when updating these flags, be sure to update the composite command:
 	// `compute publish`.
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.Manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.Manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Action:   c.ServiceVersion.Set,
 		Dst:      &c.ServiceVersion.Value,

--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/fastly/cli/pkg/env"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
 	toml "github.com/pelletier/go-toml"
@@ -36,6 +37,9 @@ const (
 
 	// SourceFile indicates the parameter came from a manifest file.
 	SourceFile
+
+	// SourceEnv indicates the parameter came from the user's shell environment.
+	SourceEnv
 
 	// SourceFlag indicates the parameter came from an explicit flag.
 	SourceFlag
@@ -78,6 +82,10 @@ func (d *Data) Name() (string, Source) {
 func (d *Data) ServiceID() (string, Source) {
 	if d.Flag.ServiceID != "" {
 		return d.Flag.ServiceID, SourceFlag
+	}
+
+	if sid := os.Getenv(env.ServiceID); sid != "" {
+		return sid, SourceEnv
 	}
 
 	if d.File.ServiceID != "" {

--- a/pkg/compute/manifest/manifest_test.go
+++ b/pkg/compute/manifest/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fastly/cli/pkg/env"
 	errs "github.com/fastly/cli/pkg/errors"
 )
 
@@ -157,5 +158,44 @@ func TestManifestPrepend(t *testing.T) {
 
 	if err = f.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDataServiceID(t *testing.T) {
+	sid := os.Getenv(env.ServiceID)
+	defer func(sid string) {
+		os.Setenv(env.ServiceID, sid)
+	}(sid)
+
+	err := os.Setenv(env.ServiceID, "001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// SourceFlag
+	d := Data{
+		Flag: Flag{ServiceID: "123"},
+		File: File{ServiceID: "456"},
+	}
+	_, src := d.ServiceID()
+	if src != SourceFlag {
+		t.Fatal("expected SourceFlag")
+	}
+
+	// SourceEnv
+	d.Flag = Flag{}
+	_, src = d.ServiceID()
+	if src != SourceEnv {
+		t.Fatal("expected SourceEnv")
+	}
+
+	// SourceFile
+	err = os.Setenv(env.ServiceID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, src = d.ServiceID()
+	if src != SourceFile {
+		t.Fatal("expected SourceFile")
 	}
 }

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -47,7 +47,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.CmdClause.Flag("force", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
 
 	// Deploy flags
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Action:   c.serviceVersion.Set,
 		Dst:      &c.serviceVersion.Value,

--- a/pkg/compute/update.go
+++ b/pkg/compute/update.go
@@ -29,7 +29,7 @@ func NewUpdateCommand(parent cmd.Registerer, client api.HTTPClient, globals *con
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a package on a Fastly Compute@Edge service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/domain/create.go
+++ b/pkg/domain/create.go
@@ -28,7 +28,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause = parent.Command("create", "Create a domain on a Fastly service version").Alias("add")
 	c.CmdClause.Flag("name", "Domain name").Short('n').Required().StringVar(&c.Input.Name)
 	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.Input.Comment)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/domain/delete.go
+++ b/pkg/domain/delete.go
@@ -27,7 +27,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a domain on a Fastly service version").Alias("remove")
 	c.CmdClause.Flag("name", "Domain name").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/domain/describe.go
+++ b/pkg/domain/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a domain on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/domain/list.go
+++ b/pkg/domain/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List domains on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/domain/update.go
+++ b/pkg/domain/update.go
@@ -28,7 +28,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	var c UpdateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("update", "Update a domain on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/edgedictionary/create.go
+++ b/pkg/edgedictionary/create.go
@@ -29,7 +29,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Fastly edge dictionary on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/edgedictionary/delete.go
+++ b/pkg/edgedictionary/delete.go
@@ -26,7 +26,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Fastly edge dictionary from a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/edgedictionary/describe.go
+++ b/pkg/edgedictionary/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Fastly edge dictionary").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/edgedictionary/list.go
+++ b/pkg/edgedictionary/list.go
@@ -23,9 +23,9 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
-	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List all dictionaries on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.manifest.File.Read(manifest.Filename)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/edgedictionary/list.go
+++ b/pkg/edgedictionary/list.go
@@ -23,8 +23,8 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	var c ListCommand
 	c.Globals = globals
 	c.manifest.File.SetOutput(c.Globals.Output)
-	c.CmdClause = parent.Command("list", "List all dictionaries on a Fastly service version")
 	c.manifest.File.Read(manifest.Filename)
+	c.CmdClause = parent.Command("list", "List all dictionaries on a Fastly service version")
 	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,

--- a/pkg/edgedictionary/update.go
+++ b/pkg/edgedictionary/update.go
@@ -33,7 +33,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update name of dictionary on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/edgedictionaryitem/batch.go
+++ b/pkg/edgedictionaryitem/batch.go
@@ -30,7 +30,7 @@ func NewBatchCommand(parent cmd.Registerer, globals *config.Data) *BatchCommand 
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("batchmodify", "Update multiple items in a Fastly edge dictionary")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("dictionary-id", "Dictionary ID").Required().StringVar(&c.Input.DictionaryID)
 	c.CmdClause.Flag("file", "Batch update json file").Required().Action(c.file.Set).StringVar(&c.file.Value)
 	return &c

--- a/pkg/edgedictionaryitem/create.go
+++ b/pkg/edgedictionaryitem/create.go
@@ -25,7 +25,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a new item on a Fastly edge dictionary")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("dictionary-id", "Dictionary ID").Required().StringVar(&c.Input.DictionaryID)
 	c.CmdClause.Flag("key", "Dictionary item key").Required().StringVar(&c.Input.ItemKey)
 	c.CmdClause.Flag("value", "Dictionary item value").Required().StringVar(&c.Input.ItemValue)

--- a/pkg/edgedictionaryitem/delete.go
+++ b/pkg/edgedictionaryitem/delete.go
@@ -25,7 +25,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete an item from a Fastly edge dictionary")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("dictionary-id", "Dictionary ID").Required().StringVar(&c.Input.DictionaryID)
 	c.CmdClause.Flag("key", "Dictionary item key").Required().StringVar(&c.Input.ItemKey)
 	return &c

--- a/pkg/edgedictionaryitem/describe.go
+++ b/pkg/edgedictionaryitem/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Fastly edge dictionary item").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("dictionary-id", "Dictionary ID").Required().StringVar(&c.Input.DictionaryID)
 	c.CmdClause.Flag("key", "Dictionary item key").Required().StringVar(&c.Input.ItemKey)
 	return &c

--- a/pkg/edgedictionaryitem/list.go
+++ b/pkg/edgedictionaryitem/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List items in a Fastly edge dictionary")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("dictionary-id", "Dictionary ID").Required().StringVar(&c.Input.DictionaryID)
 	return &c
 }

--- a/pkg/edgedictionaryitem/update.go
+++ b/pkg/edgedictionaryitem/update.go
@@ -25,7 +25,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update or insert an item on a Fastly edge dictionary")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("dictionary-id", "Dictionary ID").Required().StringVar(&c.Input.DictionaryID)
 	c.CmdClause.Flag("key", "Dictionary item key").Required().StringVar(&c.Input.ItemKey)
 	c.CmdClause.Flag("value", "Dictionary item value").Required().StringVar(&c.Input.ItemValue)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -10,4 +10,7 @@ const (
 
 	// Endpoint is the env var we look in for the API endpoint.
 	Endpoint = "FASTLY_API_ENDPOINT"
+
+	// ServiceID is the env var we look in for the required Service ID.
+	ServiceID = "FASTLY_SERVICE_ID"
 )

--- a/pkg/healthcheck/create.go
+++ b/pkg/healthcheck/create.go
@@ -24,7 +24,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	var c CreateCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("create", "Create a healthcheck on a Fastly service version").Alias("add")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/healthcheck/delete.go
+++ b/pkg/healthcheck/delete.go
@@ -26,7 +26,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a healthcheck on a Fastly service version").Alias("remove")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/healthcheck/describe.go
+++ b/pkg/healthcheck/describe.go
@@ -26,7 +26,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a healthcheck on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/healthcheck/list.go
+++ b/pkg/healthcheck/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List healthchecks on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/healthcheck/update.go
+++ b/pkg/healthcheck/update.go
@@ -39,7 +39,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a healthcheck on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/azureblob/create.go
+++ b/pkg/logging/azureblob/create.go
@@ -57,7 +57,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("container", "The name of the Azure Blob Storage container in which to store logs").Required().StringVar(&c.Container)
 	c.CmdClause.Flag("account-name", "The unique Azure Blob Storage namespace in which your data objects are stored").Required().StringVar(&c.AccountName)
 	c.CmdClause.Flag("sas-token", "The Azure shared access signature providing write access to the blob service objects. Be sure to update your token before it expires or the logging functionality will not work").Required().StringVar(&c.SASToken)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
 	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).UintVar(&c.GzipLevel.Value)

--- a/pkg/logging/azureblob/delete.go
+++ b/pkg/logging/azureblob/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Azure Blob Storage logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/azureblob/describe.go
+++ b/pkg/logging/azureblob/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an Azure Blob Storage logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/azureblob/list.go
+++ b/pkg/logging/azureblob/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Azure Blob Storage logging endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/azureblob/update.go
+++ b/pkg/logging/azureblob/update.go
@@ -54,7 +54,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Azure Blob Storage logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Azure Blob Storage logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("container", "The name of the Azure Blob Storage container in which to store logs").Action(c.Container.Set).StringVar(&c.Container.Value)
 	c.CmdClause.Flag("account-name", "The unique Azure Blob Storage namespace in which your data objects are stored").Action(c.AccountName.Set).StringVar(&c.AccountName.Value)

--- a/pkg/logging/bigquery/create.go
+++ b/pkg/logging/bigquery/create.go
@@ -53,7 +53,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("table", "Your BigQuery table").Required().StringVar(&c.Table)
 	c.CmdClause.Flag("user", "Your Google Cloud Platform service account email address. The client_email field in your service account authentication JSON.").Required().StringVar(&c.User)
 	c.CmdClause.Flag("secret-key", "Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON.").Required().StringVar(&c.SecretKey)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("template-suffix", "BigQuery table name suffix template").Action(c.Template.Set).StringVar(&c.Template.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. Must produce JSON that matches the schema of your BigQuery table").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)

--- a/pkg/logging/bigquery/delete.go
+++ b/pkg/logging/bigquery/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the BigQuery logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/bigquery/describe.go
+++ b/pkg/logging/bigquery/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a BigQuery logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/bigquery/list.go
+++ b/pkg/logging/bigquery/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List BigQuery endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/bigquery/update.go
+++ b/pkg/logging/bigquery/update.go
@@ -49,7 +49,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the BigQuery logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the BigQuery logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("project-id", "Your Google Cloud Platform project ID").Action(c.ProjectID.Set).StringVar(&c.ProjectID.Value)
 	c.CmdClause.Flag("dataset", "Your BigQuery dataset").Action(c.Dataset.Set).StringVar(&c.Dataset.Value)

--- a/pkg/logging/cloudfiles/create.go
+++ b/pkg/logging/cloudfiles/create.go
@@ -58,7 +58,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("user", "The username for your Cloudfile account").Required().StringVar(&c.User)
 	c.CmdClause.Flag("access-key", "Your Cloudfile account access key").Required().StringVar(&c.AccessKey)
 	c.CmdClause.Flag("bucket", "The name of your Cloudfiles container").Required().StringVar(&c.BucketName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("region", "The region to stream logs to. One of: DFW-Dallas, ORD-Chicago, IAD-Northern Virginia, LON-London, SYD-Sydney, HKG-Hong Kong").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)

--- a/pkg/logging/cloudfiles/delete.go
+++ b/pkg/logging/cloudfiles/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/cloudfiles/describe.go
+++ b/pkg/logging/cloudfiles/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Cloudfiles logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/cloudfiles/list.go
+++ b/pkg/logging/cloudfiles/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Cloudfiles endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/cloudfiles/update.go
+++ b/pkg/logging/cloudfiles/update.go
@@ -54,7 +54,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Cloudfiles logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Cloudfiles logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("user", "The username for your Cloudfile account").Action(c.User.Set).StringVar(&c.User.Value)
 	c.CmdClause.Flag("access-key", "Your Cloudfile account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)

--- a/pkg/logging/datadog/create.go
+++ b/pkg/logging/datadog/create.go
@@ -45,7 +45,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("auth-token", "The API key from your Datadog account").Required().StringVar(&c.Token)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. For details on the default value refer to the documentation (https://developer.fastly.com/reference/api/logging/datadog/)").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)

--- a/pkg/logging/datadog/delete.go
+++ b/pkg/logging/datadog/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/datadog/describe.go
+++ b/pkg/logging/datadog/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Datadog logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/datadog/list.go
+++ b/pkg/logging/datadog/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Datadog endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/datadog/update.go
+++ b/pkg/logging/datadog/update.go
@@ -45,7 +45,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Datadog logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Datadog logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("auth-token", "The API key from your Datadog account").Action(c.Token.Set).StringVar(&c.Token.Value)
 	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)

--- a/pkg/logging/digitalocean/create.go
+++ b/pkg/logging/digitalocean/create.go
@@ -57,7 +57,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("bucket", "The name of the DigitalOcean Space").Required().StringVar(&c.BucketName)
 	c.CmdClause.Flag("access-key", "Your DigitalOcean Spaces account access key").Required().StringVar(&c.AccessKey)
 	c.CmdClause.Flag("secret-key", "Your DigitalOcean Spaces account secret key").Required().StringVar(&c.SecretKey)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("domain", "The domain of the DigitalOcean Spaces endpoint (default 'nyc3.digitaloceanspaces.com')").Action(c.Domain.Set).StringVar(&c.Domain.Value)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)

--- a/pkg/logging/digitalocean/delete.go
+++ b/pkg/logging/digitalocean/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/digitalocean/describe.go
+++ b/pkg/logging/digitalocean/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a DigitalOcean Spaces logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/digitalocean/list.go
+++ b/pkg/logging/digitalocean/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List DigitalOcean Spaces logging endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/digitalocean/update.go
+++ b/pkg/logging/digitalocean/update.go
@@ -54,7 +54,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the DigitalOcean Spaces logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the DigitalOcean Spaces logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("bucket", "The name of the DigitalOcean Space").Action(c.BucketName.Set).StringVar(&c.BucketName.Value)
 	c.CmdClause.Flag("domain", "The domain of the DigitalOcean Spaces endpoint (default 'nyc3.digitaloceanspaces.com')").Action(c.Domain.Set).StringVar(&c.Domain.Value)

--- a/pkg/logging/elasticsearch/create.go
+++ b/pkg/logging/elasticsearch/create.go
@@ -55,7 +55,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	})
 	c.CmdClause.Flag("index", `The name of the Elasticsearch index to send documents (logs) to. The index must follow the Elasticsearch index format rules (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). We support strftime (http://man7.org/linux/man-pages/man3/strftime.3.html) interpolated variables inside braces prefixed with a pound symbol. For example, #{%F} will interpolate as YYYY-MM-DD with today's date`).Required().StringVar(&c.Index)
 	c.CmdClause.Flag("url", "The URL to stream logs to. Must use HTTPS.").Required().StringVar(&c.URL)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("pipeline", "The ID of the Elasticsearch ingest pipeline to apply pre-process transformations to before indexing. For example my_pipeline_id. Learn more about creating a pipeline in the Elasticsearch docs (https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)").Action(c.Password.Set).StringVar(&c.Pipeline.Value)
 	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
 	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)

--- a/pkg/logging/elasticsearch/delete.go
+++ b/pkg/logging/elasticsearch/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/elasticsearch/describe.go
+++ b/pkg/logging/elasticsearch/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an Elasticsearch logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/elasticsearch/list.go
+++ b/pkg/logging/elasticsearch/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Elasticsearch endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/elasticsearch/update.go
+++ b/pkg/logging/elasticsearch/update.go
@@ -54,7 +54,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Elasticsearch logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Elasticsearch logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("index", `The name of the Elasticsearch index to send documents (logs) to. The index must follow the Elasticsearch index format rules (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). We support strftime (http://man7.org/linux/man-pages/man3/strftime.3.html) interpolated variables inside braces prefixed with a pound symbol. For example, #{%F} will interpolate as YYYY-MM-DD with today's date`).Action(c.Index.Set).StringVar(&c.Index.Value)
 	c.CmdClause.Flag("url", "The URL to stream logs to. Must use HTTPS.").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/logging/ftp/create.go
+++ b/pkg/logging/ftp/create.go
@@ -55,7 +55,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("address", "An hostname or IPv4 address").Required().StringVar(&c.Address)
 	c.CmdClause.Flag("user", "The username for the server (can be anonymous)").Required().StringVar(&c.Username)
 	c.CmdClause.Flag("password", "The password for the server (for anonymous use an email address)").Required().StringVar(&c.Password)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("path", "The path to upload log files to. If the path ends in / then it is treated as a directory").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)

--- a/pkg/logging/ftp/delete.go
+++ b/pkg/logging/ftp/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/ftp/describe.go
+++ b/pkg/logging/ftp/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an FTP logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/ftp/list.go
+++ b/pkg/logging/ftp/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List FTP endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/ftp/update.go
+++ b/pkg/logging/ftp/update.go
@@ -53,7 +53,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the FTP logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the FTP logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "An hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)

--- a/pkg/logging/gcs/create.go
+++ b/pkg/logging/gcs/create.go
@@ -55,7 +55,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Required().StringVar(&c.User)
 	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Required().StringVar(&c.Bucket)
 	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Required().StringVar(&c.SecretKey)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)
 	c.CmdClause.Flag("path", "The path to upload logs to (default '/')").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("gzip-level", "What level of GZIP encoding to have when dumping logs (default 0, no compression)").Action(c.GzipLevel.Set).Uint8Var(&c.GzipLevel.Value)

--- a/pkg/logging/gcs/delete.go
+++ b/pkg/logging/gcs/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/gcs/describe.go
+++ b/pkg/logging/gcs/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a GCS logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/gcs/list.go
+++ b/pkg/logging/gcs/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List GCS endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/gcs/update.go
+++ b/pkg/logging/gcs/update.go
@@ -52,7 +52,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the GCS logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the GCS logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("bucket", "The bucket of the GCS bucket").Action(c.Bucket.Set).StringVar(&c.Bucket.Value)
 	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Action(c.User.Set).StringVar(&c.User.Value)

--- a/pkg/logging/googlepubsub/create.go
+++ b/pkg/logging/googlepubsub/create.go
@@ -50,7 +50,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("secret-key", "Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON").Required().StringVar(&c.SecretKey)
 	c.CmdClause.Flag("topic", "The Google Cloud Pub/Sub topic to which logs will be published").Required().StringVar(&c.Topic)
 	c.CmdClause.Flag("project-id", "The ID of your Google Cloud Platform project").Required().StringVar(&c.ProjectID)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug. This field is not required and has no default value").Action(c.Placement.Set).StringVar(&c.Placement.Value)

--- a/pkg/logging/googlepubsub/delete.go
+++ b/pkg/logging/googlepubsub/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Google Cloud Pub/Sub logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/googlepubsub/describe.go
+++ b/pkg/logging/googlepubsub/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Google Cloud Pub/Sub logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/googlepubsub/list.go
+++ b/pkg/logging/googlepubsub/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Google Cloud Pub/Sub endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/googlepubsub/update.go
+++ b/pkg/logging/googlepubsub/update.go
@@ -47,7 +47,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Google Cloud Pub/Sub logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Google Cloud Pub/Sub logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("user", "Your Google Cloud Platform service account email address. The client_email field in your service account authentication JSON").Action(c.User.Set).StringVar(&c.User.Value)
 	c.CmdClause.Flag("secret-key", "Your Google Cloud Platform account secret key. The private_key field in your service account authentication JSON").Action(c.SecretKey.Set).StringVar(&c.SecretKey.Value)

--- a/pkg/logging/heroku/create.go
+++ b/pkg/logging/heroku/create.go
@@ -46,7 +46,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	})
 	c.CmdClause.Flag("url", "The url to stream logs to").Required().StringVar(&c.URL)
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://devcenter.heroku.com/articles/add-on-partner-log-integration)").Required().StringVar(&c.Token)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/heroku/delete.go
+++ b/pkg/logging/heroku/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Heroku logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/heroku/describe.go
+++ b/pkg/logging/heroku/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Heroku logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/heroku/list.go
+++ b/pkg/logging/heroku/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Heroku endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/heroku/update.go
+++ b/pkg/logging/heroku/update.go
@@ -45,7 +45,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Heroku logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Heroku logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)

--- a/pkg/logging/honeycomb/create.go
+++ b/pkg/logging/honeycomb/create.go
@@ -46,7 +46,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	})
 	c.CmdClause.Flag("dataset", "The Honeycomb Dataset you want to log to").Required().StringVar(&c.Dataset)
 	c.CmdClause.Flag("auth-token", "The Write Key from the Account page of your Honeycomb account").Required().StringVar(&c.Token)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/honeycomb/delete.go
+++ b/pkg/logging/honeycomb/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/honeycomb/describe.go
+++ b/pkg/logging/honeycomb/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Honeycomb logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/honeycomb/list.go
+++ b/pkg/logging/honeycomb/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Honeycomb endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/honeycomb/update.go
+++ b/pkg/logging/honeycomb/update.go
@@ -45,7 +45,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Honeycomb logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Honeycomb logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. Your log must produce valid JSON that Honeycomb can ingest").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)

--- a/pkg/logging/https/create.go
+++ b/pkg/logging/https/create.go
@@ -56,7 +56,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("url", "URL that log data will be sent to. Must use the https protocol").Required().StringVar(&c.URL)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("content-type", "Content type of the header sent with the request").Action(c.ContentType.Set).StringVar(&c.ContentType.Value)
 	c.CmdClause.Flag("header-name", "Name of the custom header sent with the request").Action(c.HeaderName.Set).StringVar(&c.HeaderName.Value)
 	c.CmdClause.Flag("header-value", "Value of the custom header sent with the request").Action(c.HeaderValue.Set).StringVar(&c.HeaderValue.Value)

--- a/pkg/logging/https/delete.go
+++ b/pkg/logging/https/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/https/describe.go
+++ b/pkg/logging/https/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an HTTPS logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/https/list.go
+++ b/pkg/logging/https/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List HTTPS endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/https/update.go
+++ b/pkg/logging/https/update.go
@@ -56,7 +56,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the HTTPS logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the HTTPS logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("url", "URL that log data will be sent to. Must use the https protocol").Action(c.URL.Set).StringVar(&c.URL.Value)
 	c.CmdClause.Flag("content-type", "Content type of the header sent with the request").Action(c.ContentType.Set).StringVar(&c.ContentType.Value)

--- a/pkg/logging/kafka/create.go
+++ b/pkg/logging/kafka/create.go
@@ -60,7 +60,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	})
 	c.CmdClause.Flag("topic", "The Kafka topic to send logs to").Required().StringVar(&c.Topic)
 	c.CmdClause.Flag("brokers", "A comma-separated list of IP addresses or hostnames of Kafka brokers").Required().StringVar(&c.Brokers)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("compression-codec", "The codec used for compression of your logs. One of: gzip, snappy, lz4").Action(c.CompressionCodec.Set).StringVar(&c.CompressionCodec.Value)
 	c.CmdClause.Flag("required-acks", "The Number of acknowledgements a leader must receive before a write is considered successful. One of: 1 (default) One server needs to respond. 0	No servers need to respond. -1	Wait for all in-sync replicas to respond").Action(c.RequiredACKs.Set).StringVar(&c.RequiredACKs.Value)
 	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)

--- a/pkg/logging/kafka/delete.go
+++ b/pkg/logging/kafka/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/kafka/describe.go
+++ b/pkg/logging/kafka/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Kafka logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/kafka/list.go
+++ b/pkg/logging/kafka/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Kafka endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/kafka/update.go
+++ b/pkg/logging/kafka/update.go
@@ -60,7 +60,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Kafka logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Kafka logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("topic", "The Kafka topic to send logs to").Action(c.Topic.Set).StringVar(&c.Topic.Value)
 	c.CmdClause.Flag("brokers", "A comma-separated list of IP addresses or hostnames of Kafka brokers").Action(c.Brokers.Set).StringVar(&c.Brokers.Value)

--- a/pkg/logging/kinesis/create.go
+++ b/pkg/logging/kinesis/create.go
@@ -62,7 +62,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/kinesis/delete.go
+++ b/pkg/logging/kinesis/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/logging/kinesis/describe.go
+++ b/pkg/logging/kinesis/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Kinesis logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/kinesis/list.go
+++ b/pkg/logging/kinesis/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Kinesis endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/kinesis/update.go
+++ b/pkg/logging/kinesis/update.go
@@ -48,7 +48,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Kinesis logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Kinesis logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("stream-name", "Your Kinesis stream name").Action(c.StreamName.Set).StringVar(&c.StreamName.Value)
 	c.CmdClause.Flag("access-key", "Your Kinesis account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)

--- a/pkg/logging/logentries/create.go
+++ b/pkg/logging/logentries/create.go
@@ -38,7 +38,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("create", "Create a Logentries logging endpoint on a Fastly service version").Alias("add")
 	c.CmdClause.Flag("name", "The name of the Logentries logging object. Used as a primary key for API access").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)
 	c.CmdClause.Flag("auth-token", "Use token based authentication (https://logentries.com/doc/input-token/)").Action(c.Token.Set).StringVar(&c.Token.Value)

--- a/pkg/logging/logentries/delete.go
+++ b/pkg/logging/logentries/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/logentries/describe.go
+++ b/pkg/logging/logentries/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logentries logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/logentries/list.go
+++ b/pkg/logging/logentries/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Logentries endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/logentries/update.go
+++ b/pkg/logging/logentries/update.go
@@ -46,7 +46,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Logentries logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Logentries logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)

--- a/pkg/logging/loggly/create.go
+++ b/pkg/logging/loggly/create.go
@@ -44,7 +44,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/)").Required().StringVar(&c.Token)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/loggly/delete.go
+++ b/pkg/logging/loggly/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Loggly logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/loggly/describe.go
+++ b/pkg/logging/loggly/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Loggly logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/loggly/list.go
+++ b/pkg/logging/loggly/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Loggly endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/loggly/update.go
+++ b/pkg/logging/loggly/update.go
@@ -44,7 +44,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Loggly logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Loggly logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.loggly.com/docs/customer-token-authentication-token/)").Action(c.Token.Set).StringVar(&c.Token.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)

--- a/pkg/logging/logshuttle/create.go
+++ b/pkg/logging/logshuttle/create.go
@@ -46,7 +46,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	})
 	c.CmdClause.Flag("url", "Your Log Shuttle endpoint url").Required().StringVar(&c.URL)
 	c.CmdClause.Flag("auth-token", "The data authentication token associated with this endpoint").Required().StringVar(&c.Token)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/logshuttle/delete.go
+++ b/pkg/logging/logshuttle/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/logshuttle/describe.go
+++ b/pkg/logging/logshuttle/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Logshuttle logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/logshuttle/list.go
+++ b/pkg/logging/logshuttle/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Logshuttle endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/logshuttle/update.go
+++ b/pkg/logging/logshuttle/update.go
@@ -45,7 +45,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Logshuttle logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Logshuttle logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)

--- a/pkg/logging/openstack/create.go
+++ b/pkg/logging/openstack/create.go
@@ -58,7 +58,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("access-key", "Your OpenStack account access key").Required().StringVar(&c.AccessKey)
 	c.CmdClause.Flag("user", "The username for your OpenStack account").Required().StringVar(&c.User)
 	c.CmdClause.Flag("url", "Your OpenStack auth url").Required().StringVar(&c.URL)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)

--- a/pkg/logging/openstack/delete.go
+++ b/pkg/logging/openstack/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the OpenStack logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/openstack/describe.go
+++ b/pkg/logging/openstack/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an OpenStack logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/openstack/list.go
+++ b/pkg/logging/openstack/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List OpenStack logging endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/openstack/update.go
+++ b/pkg/logging/openstack/update.go
@@ -57,7 +57,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	})
 	c.CmdClause.Flag("name", "The name of the OpenStack logging object").Short('n').Required().StringVar(&c.EndpointName)
 
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the OpenStack logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("bucket", "The name of the Openstack Space").Action(c.BucketName.Set).StringVar(&c.BucketName.Value)
 	c.CmdClause.Flag("access-key", "Your OpenStack account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)

--- a/pkg/logging/papertrail/create.go
+++ b/pkg/logging/papertrail/create.go
@@ -45,7 +45,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Required().StringVar(&c.Address)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)

--- a/pkg/logging/papertrail/delete.go
+++ b/pkg/logging/papertrail/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/papertrail/describe.go
+++ b/pkg/logging/papertrail/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Papertrail logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/papertrail/list.go
+++ b/pkg/logging/papertrail/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Papertrail endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/papertrail/update.go
+++ b/pkg/logging/papertrail/update.go
@@ -45,7 +45,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Papertrail logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Papertrail logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)

--- a/pkg/logging/s3/create.go
+++ b/pkg/logging/s3/create.go
@@ -65,7 +65,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("access-key", "Your S3 account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)
 	c.CmdClause.Flag("secret-key", "Your S3 account secret key").Action(c.SecretKey.Set).StringVar(&c.SecretKey.Value)
 	c.CmdClause.Flag("iam-role", "The IAM role ARN for logging").Action(c.IAMRole.Set).StringVar(&c.IAMRole.Value)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("domain", "The domain of the S3 endpoint").Action(c.Domain.Set).StringVar(&c.Domain.Value)
 	c.CmdClause.Flag("path", "The path to upload logs to").Action(c.Path.Set).StringVar(&c.Path.Value)
 	c.CmdClause.Flag("period", "How frequently log files are finalized so they can be available for reading (in seconds, default 3600)").Action(c.Period.Set).UintVar(&c.Period.Value)

--- a/pkg/logging/s3/delete.go
+++ b/pkg/logging/s3/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the S3 logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/s3/describe.go
+++ b/pkg/logging/s3/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a S3 logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/s3/list.go
+++ b/pkg/logging/s3/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List S3 endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/s3/update.go
+++ b/pkg/logging/s3/update.go
@@ -59,7 +59,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the S3 logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the S3 logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("bucket", "Your S3 bucket name").Action(c.BucketName.Set).StringVar(&c.BucketName.Value)
 	c.CmdClause.Flag("access-key", "Your S3 account access key").Action(c.AccessKey.Set).StringVar(&c.AccessKey.Value)

--- a/pkg/logging/scalyr/create.go
+++ b/pkg/logging/scalyr/create.go
@@ -45,7 +45,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("auth-token", "The token to use for authentication (https://www.scalyr.com/keys)").Required().StringVar(&c.Token)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)

--- a/pkg/logging/scalyr/delete.go
+++ b/pkg/logging/scalyr/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/scalyr/describe.go
+++ b/pkg/logging/scalyr/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Scalyr logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/scalyr/list.go
+++ b/pkg/logging/scalyr/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Scalyr endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/scalyr/update.go
+++ b/pkg/logging/scalyr/update.go
@@ -45,7 +45,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Scalyr logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Scalyr logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)

--- a/pkg/logging/sftp/create.go
+++ b/pkg/logging/sftp/create.go
@@ -59,7 +59,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.CmdClause.Flag("address", "The hostname or IPv4 addres").Required().StringVar(&c.Address)
 	c.CmdClause.Flag("user", "The username for the server").Required().StringVar(&c.User)
 	c.CmdClause.Flag("ssh-known-hosts", "A list of host keys for all hosts we can connect to over SFTP").Required().StringVar(&c.SSHKnownHosts)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("password", "The password for the server. If both password and secret_key are passed, secret_key will be used in preference").Action(c.Password.Set).StringVar(&c.Password.Value)
 	c.CmdClause.Flag("public-key", "A PGP public key that Fastly will use to encrypt your log files before writing them to disk").Action(c.PublicKey.Set).StringVar(&c.PublicKey.Value)

--- a/pkg/logging/sftp/delete.go
+++ b/pkg/logging/sftp/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the SFTP logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/sftp/describe.go
+++ b/pkg/logging/sftp/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about an SFTP logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/sftp/list.go
+++ b/pkg/logging/sftp/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List SFTP endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/sftp/update.go
+++ b/pkg/logging/sftp/update.go
@@ -56,7 +56,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the SFTP logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the SFTP logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "The hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)

--- a/pkg/logging/splunk/create.go
+++ b/pkg/logging/splunk/create.go
@@ -50,7 +50,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.URL)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)
 	c.CmdClause.Flag("tls-hostname", "The hostname used to verify the server's certificate. It can either be the Common Name or a Subject Alternative Name (SAN)").Action(c.TLSHostname.Set).StringVar(&c.TLSHostname.Value)
 	c.CmdClause.Flag("tls-client-cert", "The client certificate used to make authenticated requests. Must be in PEM format").Action(c.TLSClientCert.Set).StringVar(&c.TLSClientCert.Value)

--- a/pkg/logging/splunk/delete.go
+++ b/pkg/logging/splunk/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/splunk/describe.go
+++ b/pkg/logging/splunk/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Splunk logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/splunk/list.go
+++ b/pkg/logging/splunk/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Splunk endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/splunk/update.go
+++ b/pkg/logging/splunk/update.go
@@ -49,7 +49,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Splunk logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Splunk logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("url", "The URL to POST to.").Action(c.URL.Set).StringVar(&c.URL.Value)
 	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)

--- a/pkg/logging/sumologic/create.go
+++ b/pkg/logging/sumologic/create.go
@@ -45,7 +45,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("url", "The URL to POST to").Required().StringVar(&c.URL)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (the default, version 2 log format) or 1 (the version 1 log format). The logging call gets placed by default in vcl_log if format_version is set to 2 and in vcl_deliver if format_version is set to 1").Action(c.FormatVersion.Set).IntVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/logging/sumologic/delete.go
+++ b/pkg/logging/sumologic/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/sumologic/describe.go
+++ b/pkg/logging/sumologic/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Sumologic logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/sumologic/list.go
+++ b/pkg/logging/sumologic/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Sumologic endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/sumologic/update.go
+++ b/pkg/logging/sumologic/update.go
@@ -45,7 +45,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Sumologic logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Sumologic logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("url", "The URL to POST to").Action(c.URL.Set).StringVar(&c.URL.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting").Action(c.Format.Set).StringVar(&c.Format.Value)

--- a/pkg/logging/syslog/create.go
+++ b/pkg/logging/syslog/create.go
@@ -52,7 +52,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Required().StringVar(&c.Address)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)
 	c.CmdClause.Flag("use-tls", "Whether to use TLS for secure logging. Can be either true or false").Action(c.UseTLS.Set).BoolVar(&c.UseTLS.Value)
 	c.CmdClause.Flag("tls-ca-cert", "A secure certificate to authenticate the server with. Must be in PEM format").Action(c.TLSCACert.Set).StringVar(&c.TLSCACert.Value)

--- a/pkg/logging/syslog/delete.go
+++ b/pkg/logging/syslog/delete.go
@@ -34,7 +34,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/logging/syslog/describe.go
+++ b/pkg/logging/syslog/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Syslog logging endpoint on a Fastly service version").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/syslog/list.go
+++ b/pkg/logging/syslog/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Syslog endpoints on a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/logging/syslog/update.go
+++ b/pkg/logging/syslog/update.go
@@ -52,7 +52,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("name", "The name of the Syslog logging object").Short('n').Required().StringVar(&c.EndpointName)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("new-name", "New name of the Syslog logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("address", "A hostname or IPv4 address").Action(c.Address.Set).StringVar(&c.Address.Value)
 	c.CmdClause.Flag("port", "The port number").Action(c.Port.Set).UintVar(&c.Port.Value)

--- a/pkg/logs/tail.go
+++ b/pkg/logs/tail.go
@@ -101,7 +101,7 @@ func NewTailCommand(parent cmd.Registerer, globals *config.Data) *TailCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("tail", "Tail Compute@Edge logs")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("from", "From time, in unix seconds").Int64Var(&c.cfg.from)
 	c.CmdClause.Flag("to", "To time, in unix seconds").Int64Var(&c.cfg.to)
 	c.CmdClause.Flag("sort-buffer",

--- a/pkg/service/delete.go
+++ b/pkg/service/delete.go
@@ -27,7 +27,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("delete", "Delete a Fastly service").Alias("remove")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("force", "Force deletion of an active service").Short('f').BoolVar(&c.force)
 	return &c
 }

--- a/pkg/service/describe.go
+++ b/pkg/service/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("describe", "Show detailed information about a Fastly service").Alias("get")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/service/update.go
+++ b/pkg/service/update.go
@@ -33,7 +33,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a Fastly service")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("name", "Service name").Short('n').Action(c.name.Set).StringVar(&c.name.Value)
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.comment.Set).StringVar(&c.comment.Value)
 	return &c

--- a/pkg/serviceversion/activate.go
+++ b/pkg/serviceversion/activate.go
@@ -26,7 +26,7 @@ func NewActivateCommand(parent cmd.Registerer, globals *config.Data) *ActivateCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("activate", "Activate a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/serviceversion/clone.go
+++ b/pkg/serviceversion/clone.go
@@ -25,7 +25,7 @@ func NewCloneCommand(parent cmd.Registerer, globals *config.Data) *CloneCommand 
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("clone", "Clone a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/serviceversion/deactivate.go
+++ b/pkg/serviceversion/deactivate.go
@@ -25,7 +25,7 @@ func NewDeactivateCommand(parent cmd.Registerer, globals *config.Data) *Deactiva
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("deactivate", "Deactivate a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/serviceversion/list.go
+++ b/pkg/serviceversion/list.go
@@ -27,7 +27,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("list", "List Fastly service versions")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	return &c
 }
 

--- a/pkg/serviceversion/lock.go
+++ b/pkg/serviceversion/lock.go
@@ -25,7 +25,7 @@ func NewLockCommand(parent cmd.Registerer, globals *config.Data) *LockCommand {
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("lock", "Lock a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/serviceversion/update.go
+++ b/pkg/serviceversion/update.go
@@ -29,7 +29,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 	c.CmdClause = parent.Command("update", "Update a Fastly service version")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})

--- a/pkg/stats/historical.go
+++ b/pkg/stats/historical.go
@@ -29,7 +29,7 @@ func NewHistoricalCommand(parent cmd.Registerer, globals *config.Data) *Historic
 	c.Globals = globals
 
 	c.CmdClause = parent.Command("historical", "View historical stats for a Fastly service")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').Required().StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	c.CmdClause.Flag("from", "From time, accepted formats at https://fastly.dev/reference/api/metrics-stats/historical-stats").StringVar(&c.Input.From)
 	c.CmdClause.Flag("to", "To time").StringVar(&c.Input.To)

--- a/pkg/stats/realtime.go
+++ b/pkg/stats/realtime.go
@@ -27,7 +27,7 @@ func NewRealtimeCommand(parent cmd.Registerer, globals *config.Data) *RealtimeCo
 	c.Globals = globals
 
 	c.CmdClause = parent.Command("realtime", "View realtime stats for a Fastly service")
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').Required().StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	c.CmdClause.Flag("format", "Output format (json)").EnumVar(&c.formatFlag, "json")
 

--- a/pkg/vcl/custom/create.go
+++ b/pkg/vcl/custom/create.go
@@ -31,7 +31,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 		Dst:    &c.autoClone.Value,
 	})
 	c.CmdClause.Flag("main", "Whether the VCL is the 'main' entrypoint").Action(c.main.Set).BoolVar(&c.main.Value)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/custom/delete.go
+++ b/pkg/vcl/custom/delete.go
@@ -29,7 +29,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/custom/describe.go
+++ b/pkg/vcl/custom/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 	})
 
 	// Optional Flags
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/custom/list.go
+++ b/pkg/vcl/custom/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	})
 
 	// Optional Flags
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/custom/update.go
+++ b/pkg/vcl/custom/update.go
@@ -32,7 +32,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	})
 	c.CmdClause.Flag("new-name", "New name for the VCL").Action(c.newName.Set).StringVar(&c.newName.Value)
 	c.CmdClause.Flag("content", "VCL passed as file path or content, e.g. $(cat main.vcl)").Action(c.content.Set).StringVar(&c.content.Value)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/snippet/create.go
+++ b/pkg/vcl/snippet/create.go
@@ -33,7 +33,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	})
 	c.CmdClause.Flag("dynamic", "Whether the VCL snippet is dynamic or versioned").Action(c.dynamic.Set).BoolVar(&c.dynamic.Value)
 	c.CmdClause.Flag("priority", "Priority determines execution order. Lower numbers execute first").Short('p').IntVar(&c.priority)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/snippet/delete.go
+++ b/pkg/vcl/snippet/delete.go
@@ -29,7 +29,7 @@ func NewDeleteCommand(parent cmd.Registerer, globals *config.Data) *DeleteComman
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/snippet/describe.go
+++ b/pkg/vcl/snippet/describe.go
@@ -27,7 +27,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCo
 
 	// Optional Flags
 	c.CmdClause.Flag("dynamic", "Whether the VCL snippet is dynamic or versioned").Action(c.dynamic.Set).BoolVar(&c.dynamic.Value)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/snippet/list.go
+++ b/pkg/vcl/snippet/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data) *ListCommand {
 	})
 
 	// Optional Flags
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 
 	return &c
 }

--- a/pkg/vcl/snippet/update.go
+++ b/pkg/vcl/snippet/update.go
@@ -34,7 +34,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data) *UpdateComman
 	c.CmdClause.Flag("dynamic", "Whether the VCL snippet is dynamic or versioned").Action(c.dynamic.Set).BoolVar(&c.dynamic.Value)
 	c.CmdClause.Flag("new-name", "New name for the VCL snippet").Action(c.newName.Set).StringVar(&c.newName.Value)
 	c.CmdClause.Flag("priority", "Priority determines execution order. Lower numbers execute first").Short('p').IntVar(&c.priority)
-	c.CmdClause.Flag("service-id", "Service ID").Short('s').StringVar(&c.manifest.Flag.ServiceID)
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").Short('i').StringVar(&c.snippetID)
 	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed (e.g. recv, miss, fetch etc)").StringVar(&c.location)
 


### PR DESCRIPTION
**Problem**: currently the logic attempts to acquire a Service ID value from first the `--service-id` flag and then from the `fastly.toml` manifest.
**Solution**: add an env var lookup between the flag and file options.
**Notes**: to avoid having to duplicate the updated flag description (which is where I wanted to highlight to the user the lookup options) I've moved the flag to a separate function that each command calls.