### PR TITLE
Implement some `vcl snippet` improvements

### DIFF
--- a/pkg/vcl/snippet/list.go
+++ b/pkg/vcl/snippet/list.go
@@ -107,9 +107,9 @@ func (c *ListCommand) printVerbose(out io.Writer, serviceID string, serviceVersi
 // format.
 func (c *ListCommand) printSummary(out io.Writer, vs []*fastly.Snippet) {
 	t := text.NewTable(out)
-	t.AddHeader("SERVICE ID", "VERSION", "NAME", "DYNAMIC")
+	t.AddHeader("SERVICE ID", "VERSION", "NAME", "DYNAMIC", "SNIPPET ID")
 	for _, v := range vs {
-		t.AddLine(v.ServiceID, v.ServiceVersion, v.Name, cmd.IntToBool(v.Dynamic))
+		t.AddLine(v.ServiceID, v.ServiceVersion, v.Name, cmd.IntToBool(v.Dynamic), v.ID)
 	}
 	t.Print()
 }

--- a/pkg/vcl/snippet/snippet_test.go
+++ b/pkg/vcl/snippet/snippet_test.go
@@ -362,7 +362,7 @@ func TestVCLSnippetList(t *testing.T) {
 				ListSnippetsFn: listSnippets,
 			},
 			Args:       args("vcl snippet list --service-id 123 --version 3"),
-			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC\n123         3        foo   true\n123         3        bar   false\n",
+			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC  SNIPPET ID\n123         3        foo   true     abc\n123         3        bar   false    abc\n",
 		},
 		{
 			Name: "validate missing --autoclone flag is OK",
@@ -371,7 +371,7 @@ func TestVCLSnippetList(t *testing.T) {
 				ListSnippetsFn: listSnippets,
 			},
 			Args:       args("vcl snippet list --service-id 123 --version 1"),
-			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC\n123         1        foo   true\n123         1        bar   false\n",
+			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC  SNIPPET ID\n123         1        foo   true     abc\n123         1        bar   false    abc\n",
 		},
 		{
 			Name: "validate missing --verbose flag",

--- a/pkg/vcl/snippet/snippet_test.go
+++ b/pkg/vcl/snippet/snippet_test.go
@@ -434,6 +434,14 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			WantError: "error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet",
 		},
 		{
+			Name: "validate versioned snippet with --snippet-id is not allowed",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("vcl snippet update --content inline_vcl --new-name foobar --service-id 123 --snippet-id 456 --version 3"),
+			WantError: "error parsing arguments: --snippet-id is not supported when updating a versioned VCL snippet",
+		},
+		{
 			Name: "validate dynamic snippet with --new-name is not allowed",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,

--- a/pkg/vcl/snippet/snippet_test.go
+++ b/pkg/vcl/snippet/snippet_test.go
@@ -434,6 +434,14 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			WantError: "error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet",
 		},
 		{
+			Name: "validate dynamic snippet with --new-name is not allowed",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("vcl snippet update --content inline_vcl --dynamic --new-name foobar --service-id 123 --snippet-id 456 --version 3"),
+			WantError: "error parsing arguments: --new-name is not supported when updating a dynamic VCL snippet",
+		},
+		{
 			Name: "validate UpdateSnippet API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,

--- a/pkg/vcl/snippet/update.go
+++ b/pkg/vcl/snippet/update.go
@@ -103,6 +103,10 @@ func (c *UpdateCommand) constructDynamicInput(serviceID string, serviceVersion i
 	input.ID = c.snippetID
 	input.ServiceID = serviceID
 
+	if c.newName.WasSet {
+		return nil, fmt.Errorf("error parsing arguments: --new-name is not supported when updating a dynamic VCL snippet")
+	}
+
 	if c.snippetID == "" {
 		return nil, fmt.Errorf("error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet")
 	}

--- a/pkg/vcl/snippet/update.go
+++ b/pkg/vcl/snippet/update.go
@@ -125,6 +125,9 @@ func (c *UpdateCommand) constructInput(serviceID string, serviceVersion int) (*f
 	input.ServiceID = serviceID
 	input.ServiceVersion = serviceVersion
 
+	if c.snippetID != "" {
+		return nil, fmt.Errorf("error parsing arguments: --snippet-id is not supported when updating a versioned VCL snippet")
+	}
 	if c.name == "" {
 		return nil, fmt.Errorf("error parsing arguments: must provide --name to update a versioned VCL snippet")
 	}


### PR DESCRIPTION
- Add snippet id to non-verbose output.
- Validate dynamic snippet with --new-name is not allowed.
- Validate versioned snippet with --snippet-id is not allowed.