### PR TITLE
Support multiple versions of Rust

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -82,7 +82,7 @@ func main() {
 	//
 	// To prevent issues we'll replace the config with what's embedded into the CLI,
 	// as we know that is compatible with the code currently being executed.
-	if err == config.ErrLegacyConfig || !file.ValidConfig() {
+	if err == config.ErrLegacyConfig || !file.ValidConfig(verboseOutput, out) {
 		err = file.UseStatic(cfg, config.FilePath)
 		if err != nil {
 			fsterrors.Deduce(err).Print(os.Stderr)

--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/fastly/cli/pkg/check"
 	"github.com/fastly/cli/pkg/config"
 	fsterrors "github.com/fastly/cli/pkg/errors"
-	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/sync"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/update"
@@ -79,12 +78,12 @@ func main() {
 	// There are two scenarios we now want to look out for...
 	//
 	// 1. The config is using a legacy format.
-	// 2. The config is from an older CLI version.
+	// 2. The config is invalid (e.g. major version bump) for CLI version running.
 	//
 	// To prevent issues we'll replace the config with what's embedded into the CLI,
 	// as we know that is compatible with the code currently being executed.
-	if err == config.ErrLegacyConfig || file.CLI.Version != revision.SemVer(revision.AppVersion) {
-		err := file.UseStatic(cfg, config.FilePath)
+	if err == config.ErrLegacyConfig || !file.ValidConfig() {
+		err = file.UseStatic(cfg, config.FilePath)
 		if err != nil {
 			fsterrors.Deduce(err).Print(os.Stderr)
 			os.Exit(1)

--- a/pkg/backend/create.go
+++ b/pkg/backend/create.go
@@ -13,9 +13,6 @@ import (
 // CreateCommand calls the Fastly API to create backends.
 type CreateCommand struct {
 	cmd.Base
-	// TODO(integralist): either consider a rename of manifest to account for
-	// this command being called in a VCL/non-C@E project or in the near future
-	// create a new VCL focused lookup flow (more likely the latter).
 	manifest       manifest.Data
 	Input          fastly.CreateBackendInput
 	serviceVersion cmd.OptionalServiceVersion

--- a/pkg/compute/compute_build_test.go
+++ b/pkg/compute/compute_build_test.go
@@ -97,7 +97,8 @@ func TestBuildRust(t *testing.T) {
 					Rust: config.Rust{
 						// TODO: pull actual version from .github/workflows/pr_test.yml
 						// when doing local run of integration tests.
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: "0.0.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -130,7 +131,8 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: "0.0.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -164,7 +166,8 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.4.0 <= 0.9.0", // the fastly-sys version in 0.6.0 is actually ^0.3.6 so a minimum of 0.4.0 causes the constraint to fail
 						RustupConstraint:    ">= 1.23.0",
@@ -187,7 +190,8 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -220,7 +224,8 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",

--- a/pkg/compute/compute_build_test.go
+++ b/pkg/compute/compute_build_test.go
@@ -95,8 +95,6 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						// TODO: pull actual version from .github/workflows/pr_test.yml
-						// when doing local run of integration tests.
 						ToolchainVersion:    "1.49.0",
 						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",

--- a/pkg/compute/compute_build_test.go
+++ b/pkg/compute/compute_build_test.go
@@ -97,7 +97,7 @@ func TestBuildRust(t *testing.T) {
 					Rust: config.Rust{
 						// TODO: pull actual version from .github/workflows/pr_test.yml
 						// when doing local run of integration tests.
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: "0.0.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -130,7 +130,7 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: "0.0.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -164,7 +164,7 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.4.0 <= 0.9.0", // the fastly-sys version in 0.6.0 is actually ^0.3.6 so a minimum of 0.4.0 causes the constraint to fail
 						RustupConstraint:    ">= 1.23.0",
@@ -187,7 +187,7 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -220,7 +220,7 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",

--- a/pkg/compute/compute_publish_test.go
+++ b/pkg/compute/compute_publish_test.go
@@ -35,7 +35,8 @@ func TestPublish(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -93,7 +94,8 @@ func TestPublish(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -151,7 +153,8 @@ func TestPublish(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
+						ToolchainVersion:    "1.49.0",
+						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",

--- a/pkg/compute/compute_publish_test.go
+++ b/pkg/compute/compute_publish_test.go
@@ -35,7 +35,7 @@ func TestPublish(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -93,7 +93,7 @@ func TestPublish(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -151,7 +151,7 @@ func TestPublish(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainVersion:    "1.49.0",
+						ToolchainVersion:    ">= 1.49.0 < 2.0.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -167,9 +167,9 @@ func (r *Rust) Verify(out io.Writer) error {
 	// We use rustup to assert that the toolchain is installed by streaming the output of
 	// `rustup toolchain list` and looking for a toolchain whose prefix matches our desired
 	// version.
-	fmt.Fprintf(out, "Checking if Rust %s is installed...\n", r.config.File.Language.Rust.ToolchainVersion)
+	fmt.Fprintf(out, "Checking if Rust %s is installed...\n", r.config.File.Language.Rust.ToolchainConstraint)
 
-	rustConstraint, err := semver.NewConstraint(r.config.File.Language.Rust.ToolchainVersion)
+	rustConstraint, err := semver.NewConstraint(r.config.File.Language.Rust.ToolchainConstraint)
 	if err != nil {
 		return fmt.Errorf("error parsing rust toolchain constraint: %w", err)
 	}
@@ -214,7 +214,7 @@ func (r *Rust) Verify(out io.Writer) error {
 	if !found {
 		return errors.RemediationError{
 			Inner:       fmt.Errorf("rust target %s not found", r.config.File.Language.Rust.WasmWasiTarget),
-			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s\n", text.Bold(fmt.Sprintf("rustup target add %s --toolchain %s", r.config.File.Language.Rust.WasmWasiTarget, r.config.File.Language.Rust.ToolchainVersion))),
+			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s\n", text.Bold(fmt.Sprintf("rustup target add %s --toolchain %s", r.config.File.Language.Rust.WasmWasiTarget, r.toolchain.String()))),
 		}
 	}
 
@@ -314,7 +314,7 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 	binName := m.Package.Name
 
 	if r.toolchain == nil {
-		rustConstraint, err := semver.NewConstraint(r.config.File.Language.Rust.ToolchainVersion)
+		rustConstraint, err := semver.NewConstraint(r.config.File.Language.Rust.ToolchainConstraint)
 		if err != nil {
 			return fmt.Errorf("error parsing rust toolchain constraint: %w", err)
 		}
@@ -418,8 +418,8 @@ func (r *Rust) toolchainVersion(rustConstraint *semver.Constraints) error {
 
 	if !found {
 		return errors.RemediationError{
-			Inner:       fmt.Errorf("rust toolchain %s not found", r.config.File.Language.Rust.ToolchainVersion),
-			Remediation: fmt.Sprintf("To fix this error, run the following command with a version within the given range %s:\n\n\t$ %s\n", r.config.File.Language.Rust.ToolchainVersion, text.Bold("rustup toolchain install <version>")),
+			Inner:       fmt.Errorf("rust toolchain %s not found", r.config.File.Language.Rust.ToolchainConstraint),
+			Remediation: fmt.Sprintf("To fix this error, run the following command with a version within the given range %s:\n\n\t$ %s\n", r.config.File.Language.Rust.ToolchainConstraint, text.Bold("rustup toolchain install <version>")),
 		}
 	}
 

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -190,10 +190,6 @@ func (r *Rust) Verify(out io.Writer) error {
 
 	// gosec flagged this:
 	// G204 (CWE-78): Subprocess launched with function call as argument or cmd arguments
-	//
-	// TODO: decide if this is safe or not. It should be as the only affected
-	// user should be the person making the local configuration change.
-	//
 	/* #nosec */
 	cmd = exec.Command("rustup", "target", "list", "--installed", "--toolchain", r.toolchain.String())
 	stdoutStderr, err = cmd.CombinedOutput()

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -317,12 +317,22 @@ func createConfigDir(fpath string) error {
 // ValidConfig checks the current config version isn't different from the
 // config statically embedded into the CLI binary. If it is then we consider
 // the config not valid and we'll fallback to the embedded config.
-func (f *File) ValidConfig() bool {
+func (f *File) ValidConfig(verbose bool, out io.Writer) bool {
 	var cfg File
 	err := toml.Unmarshal(f.Static, cfg)
 	if err != nil {
 		return false
 	}
+
+	if verbose {
+		text.Output(out, `
+			Found your local configuration file (required to use the CLI) to be incompatible with the current CLI version.
+			Your configuration will be migrated to a compatible configuration format.
+			Please update your CLI: %s
+		`, text.Bold("fastly update"))
+		text.Break(out)
+	}
+
 	if f.ConfigVersion != cfg.ConfigVersion {
 		return false
 	}

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -319,7 +319,7 @@ func createConfigDir(fpath string) error {
 // the config not valid and we'll fallback to the embedded config.
 func (f *File) ValidConfig(verbose bool, out io.Writer) bool {
 	var cfg File
-	err := toml.Unmarshal(f.Static, cfg)
+	err := toml.Unmarshal(f.Static, &cfg)
 	if err != nil {
 		return false
 	}
@@ -328,7 +328,7 @@ func (f *File) ValidConfig(verbose bool, out io.Writer) bool {
 		text.Output(out, `
 			Found your local configuration file (required to use the CLI) to be incompatible with the current CLI version.
 			Your configuration will be migrated to a compatible configuration format.
-			Please update your CLI: %s
+			Please also update your CLI by running: %s
 		`, text.Bold("fastly update"))
 		text.Break(out)
 	}

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -328,8 +328,7 @@ func (f *File) ValidConfig(verbose bool, out io.Writer) bool {
 		text.Output(out, `
 			Found your local configuration file (required to use the CLI) to be incompatible with the current CLI version.
 			Your configuration will be migrated to a compatible configuration format.
-			Please also update your CLI by running: %s
-		`, text.Bold("fastly update"))
+		`)
 		text.Break(out)
 	}
 

--- a/pkg/config/data_test.go
+++ b/pkg/config/data_test.go
@@ -413,8 +413,9 @@ func TestValidConfig(t *testing.T) {
 				t.Fatalf("want %t, have: %t", testcase.ok, ok)
 			}
 
+			output := strings.ReplaceAll(stdout.String(), "\n", " ")
 			if !testcase.ok && testcase.verboseOutput {
-				testutil.AssertStringContains(t, stdout.String(), "Please also update your CLI by running")
+				testutil.AssertStringContains(t, output, "incompatible with the current CLI version")
 			}
 		})
 	}

--- a/pkg/config/testdata/config-incompatible-config-version.toml
+++ b/pkg/config/testdata/config-incompatible-config-version.toml
@@ -1,0 +1,35 @@
+config_version = 0 # we expect the embedded config to be >= 1
+
+[fastly]
+api_endpoint = "https://api.fastly.com"
+
+[cli]
+remote_config = "https://developer.fastly.com/api/internal/cli-config"
+ttl = "5m"
+last_checked = "2021-06-18T15:13:34+01:00"
+version = "0.0.1"
+
+[language]
+  [language.rust]
+  toolchain_version = "1.49.0"
+  # we're also missing the 'toolchain_constraint' property
+  wasm_wasi_target = "wasm32-wasi"
+  fastly_sys_constraint = ">= 0.3.3 < 0.5.0"
+  rustup_constraint = ">= 1.23.0"
+
+[starter-kits]
+[[starter-kits.assemblyscript]]
+  name = "Default"
+  path = "https://github.com/fastly/compute-starter-kit-assemblyscript-default"
+  tag = "v0.2.1"
+[[starter-kits.rust]]
+  name = "Default"
+  path = "https://github.com/fastly/compute-starter-kit-rust-default.git"
+  branch = "0.7"
+[[starter-kits.rust]]
+  name = "Beacon"
+  path = "https://github.com/fastly/compute-starter-kit-rust-beacon-termination.git"
+[[starter-kits.rust]]
+  name = "Static"
+  path = "https://github.com/fastly/compute-starter-kit-rust-static-content.git"
+

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -1,3 +1,5 @@
+config_version = 1
+
 [fastly]
 api_endpoint = "https://api.fastly.com"
 
@@ -10,6 +12,7 @@ version = "0.0.1"
 [language]
   [language.rust]
   toolchain_version = "1.49.0"
+  toolchain_constraint = ">= 1.49.0 < 2.0.0"
   wasm_wasi_target = "wasm32-wasi"
   fastly_sys_constraint = ">= 0.3.3 < 0.5.0"
   rustup_constraint = ">= 1.23.0"

--- a/pkg/config/testdata/static/config.toml
+++ b/pkg/config/testdata/static/config.toml
@@ -1,3 +1,5 @@
+config_version = 1
+
 [fastly]
 api_endpoint = "https://api.fastly.com"
 
@@ -8,6 +10,7 @@ ttl = "5m"
 [language]
   [language.rust]
   toolchain_version = "1.49.0"
+  toolchain_constraint = ">= 1.49.0 < 2.0.0"
   wasm_wasi_target = "wasm32-wasi"
   fastly_sys_constraint = ">= 0.3.3 < 0.5.0"
   rustup_constraint = ">= 1.23.0"

--- a/pkg/configure/configure_test.go
+++ b/pkg/configure/configure_test.go
@@ -54,7 +54,8 @@ func TestConfigure(t *testing.T) {
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
-			wantFile: `
+			wantFile: `config_version = 0
+
 [cli]
   last_checked = ""
   remote_config = ""
@@ -69,6 +70,7 @@ func TestConfigure(t *testing.T) {
   [language.rust]
     fastly_sys_constraint = ""
     rustup_constraint = ""
+    toolchain_constraint = ""
     toolchain_version = ""
     wasm_wasi_target = ""
 
@@ -100,7 +102,8 @@ func TestConfigure(t *testing.T) {
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
-			wantFile: `
+			wantFile: `config_version = 0
+
 [cli]
   last_checked = ""
   remote_config = ""
@@ -115,6 +118,7 @@ func TestConfigure(t *testing.T) {
   [language.rust]
     fastly_sys_constraint = ""
     rustup_constraint = ""
+    toolchain_constraint = ""
     toolchain_version = ""
     wasm_wasi_target = ""
 
@@ -143,7 +147,8 @@ func TestConfigure(t *testing.T) {
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
-			wantFile: `
+			wantFile: `config_version = 0
+
 [cli]
   last_checked = ""
   remote_config = ""
@@ -158,6 +163,7 @@ func TestConfigure(t *testing.T) {
   [language.rust]
     fastly_sys_constraint = ""
     rustup_constraint = ""
+    toolchain_constraint = ""
     toolchain_version = ""
     wasm_wasi_target = ""
 
@@ -189,7 +195,8 @@ func TestConfigure(t *testing.T) {
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
-			wantFile: `
+			wantFile: `config_version = 0
+
 [cli]
   last_checked = ""
   remote_config = ""
@@ -204,6 +211,7 @@ func TestConfigure(t *testing.T) {
   [language.rust]
     fastly_sys_constraint = ""
     rustup_constraint = ""
+    toolchain_constraint = ""
     toolchain_version = ""
     wasm_wasi_target = ""
 
@@ -233,7 +241,8 @@ func TestConfigure(t *testing.T) {
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
-			wantFile: `
+			wantFile: `config_version = 0
+
 [cli]
   last_checked = ""
   remote_config = ""
@@ -248,6 +257,7 @@ func TestConfigure(t *testing.T) {
   [language.rust]
     fastly_sys_constraint = ""
     rustup_constraint = ""
+    toolchain_constraint = ""
     toolchain_version = ""
     wasm_wasi_target = ""
 
@@ -280,7 +290,8 @@ func TestConfigure(t *testing.T) {
 				"Configured the Fastly CLI",
 				"You can find your configuration file at",
 			},
-			wantFile: `
+			wantFile: `config_version = 0
+
 [cli]
   last_checked = ""
   remote_config = ""
@@ -295,6 +306,7 @@ func TestConfigure(t *testing.T) {
   [language.rust]
     fastly_sys_constraint = ""
     rustup_constraint = ""
+    toolchain_constraint = ""
     toolchain_version = ""
     wasm_wasi_target = ""
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/fastly/cli/pkg/errors"
 )
 
 // Streaming models a generic command execution that consumers can use to
@@ -54,7 +56,10 @@ func (s Streaming) Exec() error {
 		if s.verbose && stderrBuf.Len() > 0 {
 			return fmt.Errorf("error during execution process:\n%s", strings.TrimSpace(stderrBuf.String()))
 		}
-		return fmt.Errorf("error during execution process")
+		return errors.RemediationError{
+			Inner:       fmt.Errorf("error during execution process"),
+			Remediation: fmt.Sprintf("Re-run the command with --verbose to see specific error output."),
+		}
 	}
 
 	return nil

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/fastly/cli/pkg/errors"
 )
 
 // Streaming models a generic command execution that consumers can use to
@@ -53,13 +51,11 @@ func (s Streaming) Exec() error {
 	cmd.Stderr = io.MultiWriter(s.output, &stderrBuf)
 
 	if err := cmd.Run(); err != nil {
-		if s.verbose && stderrBuf.Len() > 0 {
-			return fmt.Errorf("error during execution process:\n%s", strings.TrimSpace(stderrBuf.String()))
+		var ctx string
+		if stderrBuf.Len() > 0 {
+			ctx = fmt.Sprintf(":\n%s", strings.TrimSpace(stderrBuf.String()))
 		}
-		return errors.RemediationError{
-			Inner:       fmt.Errorf("error during execution process"),
-			Remediation: "Re-run the command with --verbose to see specific error output.",
-		}
+		return fmt.Errorf("error during execution process%s", ctx)
 	}
 
 	return nil

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -58,7 +58,7 @@ func (s Streaming) Exec() error {
 		}
 		return errors.RemediationError{
 			Inner:       fmt.Errorf("error during execution process"),
-			Remediation: fmt.Sprintf("Re-run the command with --verbose to see specific error output."),
+			Remediation: "Re-run the command with --verbose to see specific error output.",
 		}
 	}
 

--- a/pkg/service/update.go
+++ b/pkg/service/update.go
@@ -15,15 +15,11 @@ import (
 // UpdateCommand calls the Fastly API to create services.
 type UpdateCommand struct {
 	cmd.Base
-	manifest manifest.Data
-	input    fastly.UpdateServiceInput
 
-	// TODO(integralist):
-	// Ensure consistency in capitalization, should be lowercase to avoid
-	// ambiguity in cmd.Command interface.
-	//
-	name    cmd.OptionalString
-	comment cmd.OptionalString
+	comment  cmd.OptionalString
+	input    fastly.UpdateServiceInput
+	manifest manifest.Data
+	name     cmd.OptionalString
 }
 
 // NewUpdateCommand returns a usable command registered under the parent.


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/157

This PR creates a new property `toolchain_constraint` and will implement a config versioning check.

**Context**:
When a new CLI release is cut we embed into the binary a copy of the [current config](https://github.com/fastly/cli-config/blob/main/src/config.toml). This ensures the CLI is runnable, for first time users, with config that is known to work with the CLI code. After a predetermined TTL (currently 5mins) the config is considered stale and will be refreshed asynchronously from the [remote endpoint](https://developer.fastly.com/api/internal/cli-config).

This is fine when the loaded configuration is a simple value change (e.g. changing a TTL from 5mins to 10mins) but it becomes a problem when the change being made is fundamentally a breaking change, such as changing `toolchain_version` from a simple semver (i.e. `1.49.0`) to a 'range' (i.e. `>= 1.49.0 < 2.0.0`) as we do in this PR.

We can't just update the remote config to use a range because the [current CLI code](https://github.com/fastly/cli/blob/main/pkg/compute/rust.go#L181) won't work with that. So it means we need the CLI code to be updated first to work with a range. We also can't replace the `toolchain_version` value with a range because users of an older CLI version would experience a runtime error from the binary's old logic. We also don't want to have to wait for users to upgrade to a newer version of the CLI, and so the best option is for us to continue to publish `toolchain_version` while now publishing a new `toolchain_constraint` property. This means users of an older CLI version will find the binary still functions correctly while users who upgrade the CLI version will start using the new property.

**Config Versioning**

To help identify whether the config is valid, is to introduce a `config_version` property (loosely based on semver, where a bump in the value indicates a _breaking_ change and thus an updated CLI version will be required).  

I've added a `config_version` property and set it to `1`. In the future we would cut a new CLI release with logic that checks the `config_version` value coming from the remote config endpoint, and if it matches the version in the _embed_ configuration (i.e. the configuration the CLI worked with at the time of cutting the release), then we know the remote config is still safe to use. 

Otherwise (e.g. if `config_version` was updated to `2`, along with breaking changes in the config values), then we inform the user that the remote configuration no longer works with their current version of the CLI and they need to upgrade using `fastly update`.