### PR TITLE
pkg/stats: don't allow short help to wrap

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -98,8 +98,7 @@ COMMANDS
   dictionaryitem   Manipulate Fastly edge dictionary items
   logging          Manipulate Fastly service version logging endpoints
   logs             Compute@Edge Log Tailing
-  stats            View statistics (historical and realtime) for a Fastly
-                   service
+  stats            View historical and realtime statistics for a Fastly service
   vcl              Manipulate Fastly service version VCL
 `) + "\n\n"
 

--- a/pkg/stats/root.go
+++ b/pkg/stats/root.go
@@ -16,7 +16,7 @@ type RootCommand struct {
 func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
-	c.CmdClause = parent.Command("stats", "View statistics (historical and realtime) for a Fastly service")
+	c.CmdClause = parent.Command("stats", "View historical and realtime statistics for a Fastly service")
 	return &c
 }
 


### PR DESCRIPTION
Before

```
USAGE
  fastly [<flags>] <command> [<args> ...]

A tool to interact with the Fastly API

GLOBAL FLAGS
      --help         Show context-sensitive help.
  -t, --token=TOKEN  Fastly API token (or via FASTLY_API_TOKEN)
  -v, --verbose      Verbose logging

COMMANDS
  help             Show help.
  configure        Configure the Fastly CLI
  whoami           Get information about the currently authenticated account
  version          Display version information for the Fastly CLI
  update           Update the CLI to the latest version
  ip-list          List Fastly's public IPs
  pops             List Fastly datacenters
  purge            Invalidate objects in the Fastly cache
  service          Manipulate Fastly services
  service-version  Manipulate Fastly service versions
  compute          Manage Compute@Edge packages
  domain           Manipulate Fastly service version domains
  backend          Manipulate Fastly service version backends
  healthcheck      Manipulate Fastly service version healthchecks
  dictionary       Manipulate Fastly edge dictionaries
  dictionaryitem   Manipulate Fastly edge dictionary items
  logging          Manipulate Fastly service version logging endpoints
  logs             Compute@Edge Log Tailing
  stats            View statistics (historical and realtime) for a Fastly
                   service
  vcl              Manipulate Fastly service version VCL
```

After

```
USAGE
  fastly [<flags>] <command> [<args> ...]

A tool to interact with the Fastly API

GLOBAL FLAGS
      --help         Show context-sensitive help.
  -t, --token=TOKEN  Fastly API token (or via FASTLY_API_TOKEN)
  -v, --verbose      Verbose logging

COMMANDS
  help             Show help.
  configure        Configure the Fastly CLI
  whoami           Get information about the currently authenticated account
  version          Display version information for the Fastly CLI
  update           Update the CLI to the latest version
  service          Manipulate Fastly services
  service-version  Manipulate Fastly service versions
  compute          Manage Compute@Edge packages
  domain           Manipulate Fastly service version domains
  backend          Manipulate Fastly service version backends
  healthcheck      Manipulate Fastly service version healthchecks
  dictionary       Manipulate Fastly edge dictionaries
  dictionaryitem   Manipulate Fastly edge dictionary items
  logging          Manipulate Fastly service version logging endpoints
  logs             Compute@Edge Log Tailing
  stats            View historical and realtime statistics for a Fastly service
  vcl              Manipulate Fastly service version VCL
```