### PR TITLE
Always print config in CI so we can debug the release

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Pull config
       run: |
         make config
+    - name: Check config
+      run: cat cmd/fastly/static/config.toml
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         make config
     - name: Check config
-      run: cat cmd/fastly/static/config.toml
+      run: cat cmd/fastly/static/config.toml | grep 'remote_config = "https://developer.fastly.com/api/internal/cli-config"'
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -21,7 +21,9 @@ jobs:
     - name: Pull config
       run: |
         make config
-    - name: Check config
+    - name: Print config
+      run: cat cmd/fastly/static/config.toml
+    - name: Validate config
       run: cat cmd/fastly/static/config.toml | grep 'remote_config = "https://developer.fastly.com/api/internal/cli-config"'
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
I want to be able to validate that the expected config is pulled when building a new release.