### PR TITLE
Improve GitHub Actions intermittent test timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint:
 
 .PHONY: test
 test: config
-	GO_TEST_TIMEOUT_SCALE=2 go test -race $(TESTARGS)
+	go test -race $(TESTARGS)
 
 .PHONY: build
 build: config

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint:
 
 .PHONY: test
 test: config
-	go test -race $(TESTARGS)
+	GO_TEST_TIMEOUT_SCALE=2 go test -race $(TESTARGS)
 
 .PHONY: build
 build: config

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -319,6 +319,8 @@ COMMANDS
     --language=LANGUAGE  Language type
     --include-source     Include source code in built package
     --force              Skip verification steps and force build
+    --timeout=TIMEOUT    Numerical timeout, in minutes, for the build
+                         compilation step
 
   compute deploy [<flags>]
     Deploy a package to a Fastly Compute@Edge service
@@ -342,6 +344,8 @@ COMMANDS
         --language=LANGUAGE      Language type
         --include-source         Include source code in built package
         --force                  Skip verification steps and force build
+        --timeout=TIMEOUT        Numerical timeout, in minutes, for the build
+                                 compilation step
     -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
                                  then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -319,8 +319,7 @@ COMMANDS
     --language=LANGUAGE  Language type
     --include-source     Include source code in built package
     --force              Skip verification steps and force build
-    --timeout=TIMEOUT    Numerical timeout, in minutes, for the build
-                         compilation step
+    --timeout=TIMEOUT    Timeout, in seconds, for the build compilation step
 
   compute deploy [<flags>]
     Deploy a package to a Fastly Compute@Edge service
@@ -344,8 +343,8 @@ COMMANDS
         --language=LANGUAGE      Language type
         --include-source         Include source code in built package
         --force                  Skip verification steps and force build
-        --timeout=TIMEOUT        Numerical timeout, in minutes, for the build
-                                 compilation step
+        --timeout=TIMEOUT        Timeout, in seconds, for the build compilation
+                                 step
     -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
                                  then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific

--- a/pkg/compute/assemblyscript.go
+++ b/pkg/compute/assemblyscript.go
@@ -139,7 +139,7 @@ func (a AssemblyScript) Initialize(out io.Writer) error {
 	fmt.Fprintf(out, "Installing package dependencies...\n")
 
 	// Call npm install.
-	cmd := fstexec.NewStreaming("npm", []string{"install"}, []string{}, false, out)
+	cmd := fstexec.NewStreaming("npm", []string{"install"}, []string{}, out)
 	return cmd.Exec()
 }
 
@@ -173,7 +173,7 @@ func (a AssemblyScript) Build(out io.Writer, verbose bool) error {
 	}
 
 	// Call asc with the build arguments.
-	cmd := fstexec.NewStreaming(filepath.Join(npmdir, "asc"), args, []string{}, verbose, out)
+	cmd := fstexec.NewStreaming(filepath.Join(npmdir, "asc"), args, []string{}, out)
 	if err := cmd.Exec(); err != nil {
 		return err
 	}

--- a/pkg/compute/build.go
+++ b/pkg/compute/build.go
@@ -89,7 +89,7 @@ func NewBuildCommand(parent cmd.Registerer, client api.HTTPClient, globals *conf
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Lang)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.IncludeSrc)
 	c.CmdClause.Flag("force", "Skip verification steps and force build").BoolVar(&c.Force)
-	c.CmdClause.Flag("timeout", "Numerical timeout, in minutes, for the build compilation step").IntVar(&c.Timeout)
+	c.CmdClause.Flag("timeout", "Timeout, in seconds, for the build compilation step").IntVar(&c.Timeout)
 
 	return &c
 }

--- a/pkg/compute/build.go
+++ b/pkg/compute/build.go
@@ -73,6 +73,7 @@ type BuildCommand struct {
 	Lang        string
 	IncludeSrc  bool
 	Force       bool
+	Timeout     int
 }
 
 // NewBuildCommand returns a usable command registered under the parent.
@@ -88,6 +89,7 @@ func NewBuildCommand(parent cmd.Registerer, client api.HTTPClient, globals *conf
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Lang)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.IncludeSrc)
 	c.CmdClause.Flag("force", "Skip verification steps and force build").BoolVar(&c.Force)
+	c.CmdClause.Flag("timeout", "Numerical timeout, in minutes, for the build compilation step").IntVar(&c.Timeout)
 
 	return &c
 }
@@ -147,14 +149,14 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Name:            "assemblyscript",
 			SourceDirectory: "assembly",
 			IncludeFiles:    []string{"package.json"},
-			Toolchain:       NewAssemblyScript(),
+			Toolchain:       NewAssemblyScript(c.Timeout),
 		})
 	case "rust":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "rust",
 			SourceDirectory: "src",
 			IncludeFiles:    []string{"Cargo.toml"},
-			Toolchain:       NewRust(c.client, c.Globals),
+			Toolchain:       NewRust(c.client, c.Globals, c.Timeout),
 		})
 	default:
 		return fmt.Errorf("unsupported language %s", lang)

--- a/pkg/compute/compute_publish_test.go
+++ b/pkg/compute/compute_publish_test.go
@@ -2,6 +2,7 @@ package compute_test
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -242,7 +243,9 @@ func TestPublish(t *testing.T) {
 			defer os.Chdir(pwd)
 
 			var stdout bytes.Buffer
-			opts := testutil.NewRunOpts(testcase.args, &stdout)
+			testcase.args = append(testcase.args, "--verbose") // verbose has a side effect of avoiding spinners when the test fails in CI
+			testcase.args = append(testcase.args, "--timeout", "2")
+			opts := testutil.NewRunOpts(testcase.args, io.MultiWriter(&stdout, testutil.LogWriter{T: t}))
 			opts.APIClient = mock.APIClient(testcase.api)
 			opts.ConfigFile = testcase.applicationConfig
 			err = app.Run(opts)

--- a/pkg/compute/compute_publish_test.go
+++ b/pkg/compute/compute_publish_test.go
@@ -244,7 +244,7 @@ func TestPublish(t *testing.T) {
 
 			var stdout bytes.Buffer
 			testcase.args = append(testcase.args, "--verbose") // verbose has a side effect of avoiding spinners when the test fails in CI
-			testcase.args = append(testcase.args, "--timeout", "2")
+			testcase.args = append(testcase.args, "--timeout", "120")
 			opts := testutil.NewRunOpts(testcase.args, io.MultiWriter(&stdout, testutil.LogWriter{T: t}))
 			opts.APIClient = mock.APIClient(testcase.api)
 			opts.ConfigFile = testcase.applicationConfig

--- a/pkg/compute/init.go
+++ b/pkg/compute/init.go
@@ -102,18 +102,27 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		language *Language
 	)
 
+	// NOTE: We have to define a Toolchain below so that the resulting Language
+	// type will get the relevant embedded methods, one of which is called later
+	// (language.Initialize) and although is a no-op for Rust, it's still used by
+	// NPM to ensure the binary is available on the user's system.
+	//
+	// The 'timeout' value zero is passed into each New<Language> call as it's
+	// only useful during the `compute build` phase and is expected to be
+	// provided by the user via a flag on the build command.
+
 	languages := []*Language{
 		NewLanguage(&LanguageOptions{
 			Name:        "rust",
 			DisplayName: "Rust",
 			StarterKits: c.Globals.File.StarterKits.Rust,
-			Toolchain:   NewRust(c.client, c.Globals),
+			Toolchain:   NewRust(c.client, c.Globals, 0),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "assemblyscript",
 			DisplayName: "AssemblyScript (beta)",
 			StarterKits: c.Globals.File.StarterKits.AssemblyScript,
-			Toolchain:   NewAssemblyScript(),
+			Toolchain:   NewAssemblyScript(0),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "other",

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -28,6 +28,7 @@ type PublishCommand struct {
 	lang       cmd.OptionalString
 	includeSrc cmd.OptionalBool
 	force      cmd.OptionalBool
+	timeout    cmd.OptionalInt
 }
 
 // NewPublishCommand returns a usable command registered under the parent.
@@ -45,6 +46,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("force", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
+	c.CmdClause.Flag("timeout", "Numerical timeout, in minutes, for the build compilation step").Action(c.timeout.Set).IntVar(&c.timeout.Value)
 
 	// Deploy flags
 	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
@@ -81,6 +83,9 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 	if c.force.WasSet {
 		c.build.Force = c.force.Value
+	}
+	if c.timeout.WasSet {
+		c.build.Timeout = c.timeout.Value
 	}
 
 	err = c.build.Exec(in, out)

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -46,7 +46,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("force", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
-	c.CmdClause.Flag("timeout", "Numerical timeout, in minutes, for the build compilation step").Action(c.timeout.Set).IntVar(&c.timeout.Value)
+	c.CmdClause.Flag("timeout", "Timeout, in seconds, for the build compilation step").Action(c.timeout.Set).IntVar(&c.timeout.Value)
 
 	// Deploy flags
 	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -349,7 +349,7 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 
 	// Execute the `cargo build` commands with the Wasm WASI target, release
 	// flags and env vars.
-	cmd := fstexec.NewStreaming("cargo", args, os.Environ(), verbose, out)
+	cmd := fstexec.NewStreaming("cargo", args, os.Environ(), out)
 	if err := cmd.Exec(); err != nil {
 		return err
 	}

--- a/pkg/compute/rust.go
+++ b/pkg/compute/rust.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/fastly/cli/pkg/api"
@@ -83,13 +84,15 @@ type Rust struct {
 	client    api.HTTPClient
 	config    *config.Data
 	toolchain *semver.Version
+	timeout   int
 }
 
 // NewRust constructs a new Rust.
-func NewRust(client api.HTTPClient, config *config.Data) *Rust {
+func NewRust(client api.HTTPClient, config *config.Data, timeout int) *Rust {
 	return &Rust{
-		client: client,
-		config: config,
+		client:  client,
+		config:  config,
+		timeout: timeout,
 	}
 }
 
@@ -349,7 +352,15 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 
 	// Execute the `cargo build` commands with the Wasm WASI target, release
 	// flags and env vars.
-	cmd := fstexec.NewStreaming("cargo", args, os.Environ(), out)
+	cmd := fstexec.Streaming{
+		Command: "cargo",
+		Args:    args,
+		Env:     os.Environ(),
+		Output:  out,
+	}
+	if r.timeout > 0 {
+		cmd.Timeout = time.Duration(r.timeout) * time.Minute
+	}
 	if err := cmd.Exec(); err != nil {
 		return err
 	}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -2,11 +2,13 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Streaming models a generic command execution that consumers can use to
@@ -14,20 +16,11 @@ import (
 // compute commands can use this to standardize the flow control for each
 // compiler toolchain.
 type Streaming struct {
-	command string
-	args    []string
-	env     []string
-	output  io.Writer
-}
-
-// NewStreaming constructs a new Streaming instance.
-func NewStreaming(cmd string, args, env []string, out io.Writer) *Streaming {
-	return &Streaming{
-		cmd,
-		args,
-		env,
-		out,
-	}
+	Command string
+	Args    []string
+	Env     []string
+	Output  io.Writer
+	Timeout time.Duration
 }
 
 // Exec executes the compiler command and pipes the child process stdout and
@@ -35,18 +28,28 @@ func NewStreaming(cmd string, args, env []string, out io.Writer) *Streaming {
 // cleanly or returns an error.
 func (s Streaming) Exec() error {
 	// Construct the command with given arguments and environment.
-	//
-	// gosec flagged this:
-	// G204 (CWE-78): Subprocess launched with variable
-	// Disabling as the variables come from trusted sources.
-	/* #nosec */
-	cmd := exec.Command(s.command, s.args...)
-	cmd.Env = append(os.Environ(), s.env...)
+	var cmd *exec.Cmd
+	if s.Timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), s.Timeout)
+		defer cancel()
+		// gosec flagged this:
+		// G204 (CWE-78): Subprocess launched with variable
+		// Disabling as the variables come from trusted sources.
+		/* #nosec */
+		cmd = exec.CommandContext(ctx, s.Command, s.Args...)
+	} else {
+		// gosec flagged this:
+		// G204 (CWE-78): Subprocess launched with variable
+		// Disabling as the variables come from trusted sources.
+		/* #nosec */
+		cmd = exec.Command(s.Command, s.Args...)
+	}
+	cmd.Env = append(os.Environ(), s.Env...)
 
 	// Pipe the child process stdout and stderr to our own output writer.
 	var stderrBuf bytes.Buffer
-	cmd.Stdout = s.output
-	cmd.Stderr = io.MultiWriter(s.output, &stderrBuf)
+	cmd.Stdout = s.Output
+	cmd.Stderr = io.MultiWriter(s.Output, &stderrBuf)
 
 	if err := cmd.Run(); err != nil {
 		var ctx string

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -17,17 +17,15 @@ type Streaming struct {
 	command string
 	args    []string
 	env     []string
-	verbose bool
 	output  io.Writer
 }
 
 // NewStreaming constructs a new Streaming instance.
-func NewStreaming(cmd string, args, env []string, verbose bool, out io.Writer) *Streaming {
+func NewStreaming(cmd string, args, env []string, out io.Writer) *Streaming {
 	return &Streaming{
 		cmd,
 		args,
 		env,
-		verbose,
 		out,
 	}
 }

--- a/pkg/testutil/log.go
+++ b/pkg/testutil/log.go
@@ -1,0 +1,12 @@
+package testutil
+
+import "testing"
+
+// LogWriter is used to debug issues with our tests.
+type LogWriter struct{ T *testing.T }
+
+func (w LogWriter) Write(p []byte) (int, error) {
+	// NOTE: text printed only if test fails or -test.v set
+	w.T.Log(string(p))
+	return len(p), nil
+}


### PR DESCRIPTION
## Problem

We've seen regular, but intermittent, test timeouts in the GitHub Actions CI.

The source of the problem appears to be due to `exec.Command`’s `Run` method (or at least the command we're passing to it, which I believe for the issues I've seen it occur would be a `cargo build` command).

```
github.com/fastly/cli/pkg/exec.Streaming.Exec(0x1ea1c8c, 0x5, 0xc0000ca090, 0x9, 0x9, 0xc000240c00, 0x5d, 0x5d, 0x0, 0xb9e7678, ...)
	/Users/runner/work/cli/cli/pkg/exec/exec.go:53 +0x2de
github.com/fastly/cli/pkg/compute.Rust.Build(0x2038ee0, 0xc000552390, 0xc0001ce000, 0xb9e7678, 0xc002c8b200, 0xc0004a2b00, 0x104dac5, 0x1dc0180)
	/Users/runner/work/cli/cli/pkg/compute/rust.go:356 +0x7d8
github.com/fastly/cli/pkg/compute.(*BuildCommand).Exec(0xc000504000, 0x20388a0, 0xc00011e140, 0x2037c40, 0xc000210708, 0x0, 0x0)
	/Users/runner/work/cli/cli/pkg/compute/build.go:174 +0xace
github.com/fastly/cli/pkg/compute.(*PublishCommand).Exec(0xc0001ce9c0, 0x20388a0, 0xc00011e140, 0x2037c40, 0xc000210708, 0x203d718, 0xc0001ce9c0)
	/Users/runner/work/cli/cli/pkg/compute/publish.go:86 +0x145
github.com/fastly/cli/pkg/compute_test.TestPublish(0xc0000a8300)
	/Users/runner/work/cli/cli/pkg/compute/compute_integration_test.go:1313 +0x170a
```

## Solution

> **NOTE**: These aren't _solutions_ in that they don't resolve the timeout issue. These are attempts at trying to help us better identify the root cause of the timeout when they happen.

- Update the `TestPublish` test code to log the stdout (this only prints when the test fails).
  - This is so when it does fail randomly again, we'll be able to see what was happening.
- Implement `exec.CommandContext` so we can set a timeout around the subprocess.
  - This helps us to short-circuit the test run (rather than waiting the full 10mins).

## Notes

I did some Googling and it seems there’s a few open issues related to this:

- https://github.com/golang/go/issues/38824
- https://github.com/golang/go/issues/38768

One suggestion I stumbled across was to set `GO_TEST_TIMEOUT_SCALE` as some architectures can have problems with the default value. But we've _NOT_ done that here as just increasing the timeout isn't really a solution and considering the entire test run normally only takes 4mins (which is well under the 10min limit) and the fact it only occurs occasionally suggests a problem we should properly identify.

Another suggestion was to split up code into more granular packages to avoid timeouts, but that's not an appropriate solution because the tests aren't timing out because of a code logic error but because the command itself being executed (`cargo build` in this case) is taking too long (well, as far as I'm concerned _something_ is stalling randomly at the point of running the command).