### PR TITLE
New flags for displaying the CLI config, and its location

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -169,9 +169,11 @@ COMMANDS
     Show help.
 
 
-  configure
+  configure [<flags>]
     Configure the Fastly CLI
 
+    -l, --location  Print the location of the CLI configuration file
+    -d, --display   Print the CLI configuration file
 
   whoami
     Get information about the currently authenticated account


### PR DESCRIPTION
**Problem**: When debugging an issue it's useful to consult the CLI's application configuration (the config is setup via the `fastly configure` command), but the path is long and difficult to remember. 

**Solution**: Add additional commands to the existing command that enable a user to print both the configuration file and its location.