### PR TITLE
Implement comment flag to compute deploy and publish (#328)

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -335,6 +335,7 @@ COMMANDS
                                  package backend
         --backend-port=BACKEND-PORT
                                  A port number for the package backend
+        --comment=COMMENT        Human-readable comment
 
   compute publish [<flags>]
     Build and deploy a Compute@Edge package to a Fastly service
@@ -356,6 +357,7 @@ COMMANDS
                                  package backend
         --backend-port=BACKEND-PORT
                                  A port number for the package backend
+        --comment=COMMENT        Human-readable comment
 
   compute pack --path=PATH
     Package a pre-compiled Wasm binary for a Fastly Compute@Edge service

--- a/pkg/compute/compute_deploy_test.go
+++ b/pkg/compute/compute_deploy_test.go
@@ -357,6 +357,27 @@ func TestDeploy(t *testing.T) {
 				"Deployed package (service 123, version 4)",
 			},
 		},
+		{
+			name: "success with comment",
+			args: args("compute deploy --token 123 -s 123 -p pkg/package.tar.gz --version 2 --comment foo"),
+			api: mock.API{
+				GetServiceFn:      getServiceOK,
+				ListVersionsFn:    testutil.ListVersions,
+				CloneVersionFn:    testutil.CloneVersionResult(3),
+				ListDomainsFn:     listDomainsOk,
+				ListBackendsFn:    listBackendsOk,
+				GetPackageFn:      getPackageOk,
+				UpdatePackageFn:   updatePackageOk,
+				ActivateVersionFn: activateVersionOk,
+				UpdateVersionFn:   updateVersionOk,
+			},
+			manifest: "name = \"package\"\nservice_id = \"123\"\n",
+			wantOutput: []string{
+				"Uploading package...",
+				"Activating version...",
+				"Deployed package (service 123, version 3)",
+			},
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			// We're going to chdir to a deploy environment,

--- a/pkg/compute/compute_deploy_test.go
+++ b/pkg/compute/compute_deploy_test.go
@@ -363,7 +363,7 @@ func TestDeploy(t *testing.T) {
 			api: mock.API{
 				GetServiceFn:      getServiceOK,
 				ListVersionsFn:    testutil.ListVersions,
-				CloneVersionFn:    testutil.CloneVersionResult(3),
+				CloneVersionFn:    testutil.CloneVersionResult(4),
 				ListDomainsFn:     listDomainsOk,
 				ListBackendsFn:    listBackendsOk,
 				GetPackageFn:      getPackageOk,
@@ -375,7 +375,7 @@ func TestDeploy(t *testing.T) {
 			wantOutput: []string{
 				"Uploading package...",
 				"Activating version...",
-				"Deployed package (service 123, version 3)",
+				"Deployed package (service 123, version 4)",
 			},
 		},
 	} {

--- a/pkg/compute/compute_mocks_test.go
+++ b/pkg/compute/compute_mocks_test.go
@@ -53,6 +53,10 @@ func activateVersionOk(i *fastly.ActivateVersionInput) (*fastly.Version, error) 
 	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion}, nil
 }
 
+func updateVersionOk(i *fastly.UpdateVersionInput) (*fastly.Version, error) {
+	return &fastly.Version{ServiceID: i.ServiceID, Number: i.ServiceVersion, Comment: *i.Comment}, nil
+}
+
 func listDomainsOk(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	return []*fastly.Domain{
 		{Name: "https://directly-careful-coyote.edgecompute.app"},

--- a/pkg/compute/deploy.go
+++ b/pkg/compute/deploy.go
@@ -301,7 +301,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		})
 
 		if err != nil {
-			text.Error(out, "failed to set comment for version %d: %e", version.Number, err)
+			return fmt.Errorf("error setting comment for service version %d: %w", version.Number, err)
 		}
 	}
 

--- a/pkg/compute/publish.go
+++ b/pkg/compute/publish.go
@@ -22,6 +22,7 @@ type PublishCommand struct {
 	backend        cmd.OptionalString
 	backendPort    cmd.OptionalUint
 	serviceVersion cmd.OptionalServiceVersion
+	comment        cmd.OptionalString
 
 	// Build fields
 	name       cmd.OptionalString
@@ -59,6 +60,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)
 	c.CmdClause.Flag("backend", "A hostname, IPv4, or IPv6 address for the package backend").Action(c.backend.Set).StringVar(&c.backend.Value)
 	c.CmdClause.Flag("backend-port", "A port number for the package backend").Action(c.backendPort.Set).UintVar(&c.backendPort.Value)
+	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.comment.Set).StringVar(&c.comment.Value)
 
 	return &c
 }
@@ -110,6 +112,9 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}
 	if c.backendPort.WasSet {
 		c.deploy.BackendPort = c.backendPort.Value
+	}
+	if c.comment.WasSet {
+		c.deploy.Comment = c.comment
 	}
 	c.deploy.Manifest = c.manifest
 


### PR DESCRIPTION
I added support for passing comments to compute deploy & publish. The command line for both commands will now accept a --comment flag that updates the new version with the desired comment. This closes #328.