### PR TITLE
Add an --addr flag to `compute serve` 

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -324,13 +324,14 @@ COMMANDS
   compute serve [<flags>]
     Build and run a Compute@Edge package locally
 
-    --env=ENV               The environment configuration to use (e.g. stage)
-    --file="bin/main.wasm"  The Wasm file to run
-    --force                 Skip verification steps and force build
-    --include-source        Include source code in built package
-    --language=LANGUAGE     Language type
-    --name=NAME             Package name
-    --skip-build            Skip the build step
+    --addr="127.0.0.1:7676"  The IPv4 address to listen on
+    --env=ENV                The environment configuration to use (e.g. stage)
+    --file="bin/main.wasm"   The Wasm file to run
+    --force                  Skip verification steps and force build
+    --include-source         Include source code in built package
+    --language=LANGUAGE      Language type
+    --name=NAME              Package name
+    --skip-build             Skip the build step
 
   compute pack --path=PATH
     Package a pre-compiled Wasm binary for a Fastly Compute@Edge service

--- a/pkg/compute/serve.go
+++ b/pkg/compute/serve.go
@@ -25,6 +25,7 @@ import (
 type ServeCommand struct {
 	cmd.Base
 
+	addr             string
 	build            *BuildCommand
 	env              cmd.OptionalString
 	file             string
@@ -50,6 +51,7 @@ func NewServeCommand(parent cmd.Registerer, globals *config.Data, build *BuildCo
 	c.manifest.File.SetOutput(c.Globals.Output)
 	c.manifest.File.Read(manifest.Filename)
 
+	c.CmdClause.Flag("addr", "The IPv4 address to listen on").Default("127.0.0.1:7676").StringVar(&c.addr)
 	c.CmdClause.Flag("env", "The environment configuration to use (e.g. stage)").Action(c.env.Set).StringVar(&c.env.Value)
 	c.CmdClause.Flag("file", "The Wasm file to run").Default("bin/main.wasm").StringVar(&c.file)
 	c.CmdClause.Flag("force", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
@@ -101,7 +103,7 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	progress.Step("Running local server...")
 	progress.Done()
 
-	err = local(bin, c.file, progress, out, c.env.Value, c.Globals.Verbose())
+	err = local(bin, c.file, progress, out, c.addr, c.env.Value, c.Globals.Verbose())
 	if err != nil {
 		if err == errors.ErrSignalInterrupt || err == errors.ErrSignalKilled {
 			text.Break(out)
@@ -266,7 +268,7 @@ func updateViceroy(progress text.Progress, version string, out io.Writer, versio
 }
 
 // local spawns a subprocess that runs the compiled binary.
-func local(bin string, file string, progress text.Progress, out io.Writer, env string, verbose bool) error {
+func local(bin string, file string, progress text.Progress, out io.Writer, addr string, env string, verbose bool) error {
 	if env != "" {
 		env = "." + env
 	}
@@ -277,7 +279,7 @@ func local(bin string, file string, progress text.Progress, out io.Writer, env s
 	}
 
 	manifest := filepath.Join(wd, fmt.Sprintf("fastly%s.toml", env))
-	args := []string{file, "-C", manifest}
+	args := []string{"-C", manifest, "--addr", addr, file}
 
 	if verbose {
 		text.Output(out, "Wasm file: %s", file)


### PR DESCRIPTION
Per user testing feedback from @dkegel-fastly; this adds an `--addr` flag to `compute serve` which allows a user to configure the IPv4 address which Viceroy listens on. This mirrors the flag exposed by Viceroy. 

### Note:
⚠️ This is a PR into @Integralist's working branch and not `main`. 