### PR TITLE
Simplify logic for prefixing fastly spec to file

### DIFF
--- a/pkg/compute/manifest/manifest.go
+++ b/pkg/compute/manifest/manifest.go
@@ -331,7 +331,7 @@ func (f *File) Write(fpath string) error {
 		return err
 	}
 
-	if err := prependSpecRefToManifest(fp); err != nil {
+	if err := appendSpecRef(fp); err != nil {
 		return err
 	}
 
@@ -350,9 +350,8 @@ func (f *File) Write(fpath string) error {
 	return nil
 }
 
-// prependSpecRefToManifest checks if the manifest contains a reference to the
-// manifest specification and, if not, prepends it to the top of the file.
-func prependSpecRefToManifest(w io.Writer) error {
+// appendSpecRef appends the fastly.toml specification URL to the manifest.
+func appendSpecRef(w io.Writer) error {
 	s := fmt.Sprintf("# %s\n# %s\n\n", SpecIntro, SpecURL)
 	_, err := io.WriteString(w, s)
 	if err != nil {


### PR DESCRIPTION
Some users weren't seeing the `fastly.toml` spec URL in their configuration file (the logic was working for the majority of users who tested the code, but there appears to be an intermittent issue which would cause the spec URL insertion to fail). 

An internal recommendation was made to simplify the logic (described below), and that's what has been done in this PR (which we expect to also resolve the issue reported internally with the spec URL being omitted).

The original flow was to encode data to disk and then seek the start of the file, checking if the spec URL was absent, and if so prepend it to the file. This complex flow was done because previously the toml dependency would truncate the entire file and remove the fastly spec URL, but since changing to a new (maintained) toml dependency that truncation no longer happens when encoding data to disk.

This means the flow for writing the config back to disk is now simply: 

- Truncate `fastly.toml`.
- Write spec URL to disk.
- Encode the configuration data to disk (leaving the existing content unaffected).