### PR TITLE
fix nondeterministic parsing of flags

### DIFF
--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -299,7 +299,7 @@ func TestACLUpdate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("acl update --version 3"),
+			Args:      args("acl update --new-name beepboop --version 3"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{


### PR DESCRIPTION
I noticed a couple of recent PRs failing the `TestACLUpdate` test...

```
--- FAIL: TestACLUpdate (0.07s)
    --- FAIL: TestACLUpdate/validate_missing_--name_flag (0.01s)
        acl_test.go:380: want "error parsing arguments: required flag --name not provided", have "error parsing arguments: required flag --new-name not provided"
```

Kingpin looks to be parsing the flags in a nondeterministic fashion, where I had believed it would parse them in the order they were defined, and so sometimes the test fails because it doesn't fail on the first flag defined (`--name`). 

By ensuring we set the other required flags (in this case `--new-name`) we can be sure the test will pass with the expected error message.