### PR TITLE
Implement `[setup]` configuration for backends

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -448,19 +448,11 @@ COMMANDS
                                  then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
-        --backend=BACKEND        A hostname, IPv4, or IPv6 address for the
-                                 package backend
-        --backend-port=BACKEND-PORT
-                                 A port number for the package backend
+        --accept-defaults        Accept default configuration from [setup]
         --comment=COMMENT        Human-readable comment
         --domain=DOMAIN          The name of the domain associated to the
                                  package
-        --override-host=OVERRIDE-HOST
-                                 The hostname to override the Host header
     -p, --path=PATH              Path to package
-        --ssl-sni-hostname=SSL-SNI-HOSTNAME
-                                 The hostname to use at the start of the TLS
-                                 handshake
 
   compute init [<flags>]
     Initialize a new Compute@Edge package locally
@@ -490,23 +482,15 @@ COMMANDS
         --force                  Skip verification steps and force build
         --timeout=TIMEOUT        Timeout, in seconds, for the build compilation
                                  step
+        --accept-defaults        Accept default configuration from [setup]
+        --comment=COMMENT        Human-readable comment
+        --domain=DOMAIN          The name of the domain associated to the
+                                 package
+    -p, --path=PATH              Path to package
     -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
                                  then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
-        --backend=BACKEND        A hostname, IPv4, or IPv6 address for the
-                                 package backend
-        --backend-port=BACKEND-PORT
-                                 A port number for the package backend
-        --comment=COMMENT        Human-readable comment
-        --domain=DOMAIN          The name of the domain associated to the
-                                 package
-        --override-host=OVERRIDE-HOST
-                                 The hostname to override the Host header
-    -p, --path=PATH              Path to package
-        --ssl-sni-hostname=SSL-SNI-HOSTNAME
-                                 The hostname to use at the start of the TLS
-                                 handshake
 
   compute serve [<flags>]
     Build and run a Compute@Edge package locally

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -448,7 +448,8 @@ COMMANDS
                                  then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
-        --accept-defaults        Accept default configuration from [setup]
+        --accept-defaults        Accept default values for all prompts and
+                                 perform deploy non-interactively
         --comment=COMMENT        Human-readable comment
         --domain=DOMAIN          The name of the domain associated to the
                                  package
@@ -482,7 +483,8 @@ COMMANDS
         --force                  Skip verification steps and force build
         --timeout=TIMEOUT        Timeout, in seconds, for the build compilation
                                  step
-        --accept-defaults        Accept default configuration from [setup]
+        --accept-defaults        Accept default values for all prompts and
+                                 perform deploy non-interactively
         --comment=COMMENT        Human-readable comment
         --domain=DOMAIN          The name of the domain associated to the
                                  package

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -65,7 +65,8 @@ func listDomainsOk(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 
 func listBackendsOk(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
 	return []*fastly.Backend{
-		{Name: "foobar"},
+		{Name: "foo"},
+		{Name: "bar"},
 	}, nil
 }
 

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -70,6 +70,10 @@ func listBackendsOk(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
 	}, nil
 }
 
+func listBackendsNone(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
+	return []*fastly.Backend{}, nil
+}
+
 type versionClient struct {
 	fastlyVersions    []string
 	fastlySysVersions []string

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -63,17 +63,6 @@ func listDomainsOk(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	}, nil
 }
 
-func listBackendsOk(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
-	return []*fastly.Backend{
-		{Name: "foo"},
-		{Name: "bar"},
-	}, nil
-}
-
-func listBackendsNone(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
-	return []*fastly.Backend{}, nil
-}
-
 type versionClient struct {
 	fastlyVersions    []string
 	fastlySysVersions []string

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -303,7 +303,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 
 		for _, backend := range backends {
-			err = createBackend(progress, c.Globals.Client, serviceID, version.Number, backend, undoStack)
+			err = createBackend(progress, c.Globals.Client, serviceID, version.Number, backend, undoStack, c.Globals.Verbose())
 			if err != nil {
 				c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
 					"Accept defaults": c.AcceptDefaults,
@@ -339,7 +339,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 				return err
 			}
 			for _, backend := range backends {
-				err = createBackend(progress, c.Globals.Client, serviceID, version.Number, backend, undoStack)
+				err = createBackend(progress, c.Globals.Client, serviceID, version.Number, backend, undoStack, c.Globals.Verbose())
 				if err != nil {
 					c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
 						"Accept defaults": c.AcceptDefaults,
@@ -361,7 +361,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			}
 		case resourceBackend:
 			for _, backend := range backends {
-				err = createBackend(progress, c.Globals.Client, serviceID, version.Number, backend, undoStack)
+				err = createBackend(progress, c.Globals.Client, serviceID, version.Number, backend, undoStack, c.Globals.Verbose())
 				if err != nil {
 					c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
 						"Accept defaults": c.AcceptDefaults,
@@ -877,10 +877,13 @@ func createDomain(progress text.Progress, client api.Interface, serviceID string
 
 // createBackend creates the given domain and handle unrolling the stack in case
 // of an error (i.e. will ensure the backend is deleted if there is an error).
-func createBackend(progress text.Progress, client api.Interface, serviceID string, version int, backend Backend, undoStack undo.Stacker) error {
+func createBackend(progress text.Progress, client api.Interface, serviceID string, version int, backend Backend, undoStack undo.Stacker, verbose bool) error {
 	display := ""
 	if backend.SetupConfig {
 		display = fmt.Sprintf(" '%s'", backend.Address)
+		if verbose {
+			display = fmt.Sprintf("%s (port: %d)", display, backend.Port)
+		}
 	}
 	progress.Step(fmt.Sprintf("Creating backend%s...", display))
 

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -852,7 +852,7 @@ func cfgBackends(c *DeployCommand, out io.Writer, in io.Reader, f validator) (ba
 			backend.Name = backend.Address
 		}
 
-		backend.Address, err = text.Input(out, "Backend (originless, hostname or IP address): [leave blank to stop adding backends] ", in, f)
+		backend.Address, err = text.Input(out, "Backend (hostname or IP address, or leave blank to stop adding backends): [originless] ", in, f)
 		if err != nil {
 			return backends, fmt.Errorf("error reading input %w", err)
 		}

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -779,7 +779,7 @@ func cfgSetupBackend(backend manifest.Mapper, c *DeployCommand, out io.Writer, i
 		// If no prompt text is provided by the [setup] configuration, then we'll
 		// default to using the name of the backend as the prompt text.
 		if prompt == "" {
-			prompt = fmt.Sprintf("Origin server for '%s'", b.Name)
+			prompt = fmt.Sprintf("Backend for '%s'", b.Name)
 		}
 	}
 
@@ -857,7 +857,7 @@ func cfgBackends(c *DeployCommand, out io.Writer, in io.Reader, f validator) (ba
 			backend.Name = backend.Address
 		}
 
-		backend.Address, err = text.Input(out, "Backend (hostname or IP address, or leave blank to stop adding backends): [originless] ", in, f)
+		backend.Address, err = text.Input(out, "Backend (hostname or IP address, or leave blank to stop adding backends): ", in, f)
 		if err != nil {
 			return backends, fmt.Errorf("error reading input %w", err)
 		}
@@ -1028,9 +1028,8 @@ func validateBackend(input string) error {
 		isAddr = true
 	}
 	isEmpty := input == ""
-	isOriginless := strings.ToLower(input) == "originless"
-	if !isEmpty && !isOriginless && !isHost && !isAddr {
-		return fmt.Errorf(`must be "originless" or a valid hostname, IPv4, or IPv6 address`)
+	if !isEmpty && !isHost && !isAddr {
+		return fmt.Errorf(`must be a valid hostname, IPv4, or IPv6 address`)
 	}
 	return nil
 }

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -675,14 +675,13 @@ func cfgDomain(domain string, def string, out io.Writer, in io.Reader, f validat
 // what will be referenced in a Compute@Edge starter kit.
 func cfgSetupBackend(backend manifest.Mapper, out io.Writer, in io.Reader, v validator) (Backend, error) {
 	var (
-		addr       string
-		b          Backend
-		err        error
-		name       string
-		ok         bool
-		port       uint
-		portnumber int64
-		prompt     string
+		addr   string
+		b      Backend
+		err    error
+		name   string
+		ok     bool
+		port   uint
+		prompt string
 	)
 
 	b.SetupConfig = true
@@ -723,12 +722,12 @@ func cfgSetupBackend(backend manifest.Mapper, out io.Writer, in io.Reader, v val
 	}
 
 	if _, ok = backend["port"]; ok {
-		portnumber, ok = backend["port"].(int64)
+		p, ok := backend["port"].(int64)
 		if !ok {
 			return b, backendRemediationError("port", remediation, innerErr)
 		}
+		port = uint(p)
 	}
-	port = uint(portnumber)
 	if port == 0 {
 		port = 80
 	}
@@ -746,11 +745,11 @@ func cfgSetupBackend(backend manifest.Mapper, out io.Writer, in io.Reader, v val
 		return b, fmt.Errorf("error reading input %w", err)
 	}
 	if input != "" {
-		portnumber, err := strconv.Atoi(input)
+		i, err := strconv.Atoi(input)
 		if err != nil {
 			text.Warning(out, fmt.Sprintf("error converting input, using default port number (%d)", port))
 		}
-		port = uint(portnumber)
+		port = uint(i)
 	}
 	b.Port = port
 

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -840,10 +840,7 @@ func backendRemediationError(field string, remediation string, err error) error 
 // NOTE: If `--accept-defaults` is set, then create a single "originless" backend.
 func cfgBackends(c *DeployCommand, out io.Writer, in io.Reader, f validator) (backends []Backend, err error) {
 	if c.AcceptDefaults {
-		var backend Backend
-		backend.Name = "originless"
-		backend.Address = "127.0.0.1"
-		backend.Port = uint(80)
+		backend := createOriginlessBackend()
 		backends = append(backends, backend)
 		return backends, nil
 	}
@@ -863,16 +860,10 @@ func cfgBackends(c *DeployCommand, out io.Writer, in io.Reader, f validator) (ba
 		// This block short-circuits the endless loop
 		if backend.Address == "" {
 			if len(backends) == 0 {
-				return backends, fmt.Errorf("error configuring a backend (no input given)")
+				backend := createOriginlessBackend()
+				backends = append(backends, backend)
+				return backends, nil
 			}
-			return backends, nil
-		}
-
-		if backend.Address == "originless" {
-			backend.Name = backend.Address
-			backend.Address = "127.0.0.1"
-			backend.Port = uint(80)
-			backends = append(backends, backend)
 			return backends, nil
 		}
 
@@ -906,6 +897,15 @@ func cfgBackends(c *DeployCommand, out io.Writer, in io.Reader, f validator) (ba
 
 		backends = append(backends, backend)
 	}
+}
+
+// createOriginlessBackend returns a Backend instance configured to the
+// localhost settings expected of an 'originless' backend.
+func createOriginlessBackend() (b Backend) {
+	b.Name = "originless"
+	b.Address = "127.0.0.1"
+	b.Port = uint(80)
+	return b
 }
 
 // genBackendName normalises a given name by replacing any period or hyphen

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -122,6 +122,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	serviceID, sidSrc := c.Manifest.ServiceID()
 	if sidSrc == manifest.SourceUndefined {
+		text.Break(out)
 		text.Output(out, "There is no Fastly service associated with this package. To connect to an existing service add the Service ID to the fastly.toml file, otherwise follow the prompts to create a service now.")
 		text.Break(out)
 		text.Output(out, "Press ^C at any time to quit.")

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -696,7 +696,7 @@ func cfgSetupBackend(backend manifest.Mapper, out io.Writer, in io.Reader, v val
 			Remediation: fmt.Sprintf(remediation, "prompt"),
 		}
 	}
-	// If not prompt text is provided by the [setup] configuration, then we'll
+	// If no prompt text is provided by the [setup] configuration, then we'll
 	// default to using the name of the backend as the prompt text.
 	if prompt == "" {
 		prompt = fmt.Sprintf("Origin server for '%s'", name)
@@ -714,13 +714,14 @@ func cfgSetupBackend(backend manifest.Mapper, out io.Writer, in io.Reader, v val
 		defaultAddr = fmt.Sprintf(": [%s]", addr)
 	}
 
-	port, ok = backend["port"].(uint)
+	portnumber, ok := backend["port"].(int64)
 	if !ok {
 		return b, errors.RemediationError{
 			Inner:       innerErr,
 			Remediation: fmt.Sprintf(remediation, "port"),
 		}
 	}
+	port = uint(portnumber)
 	if port == 0 {
 		port = 80
 	}
@@ -822,7 +823,7 @@ func createDomain(progress text.Progress, client api.Interface, serviceID string
 // createBackend creates the given domain and handle unrolling the stack in case
 // of an error (i.e. will ensure the backend is deleted if there is an error).
 func createBackend(progress text.Progress, client api.Interface, serviceID string, version int, backend Backend, undoStack undo.Stacker) error {
-	progress.Step("Creating backend...")
+	progress.Step(fmt.Sprintf("Creating backend %s...", backend.Address))
 
 	undoStack.Push(func() error {
 		return client.DeleteBackend(&fastly.DeleteBackendInput{

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -823,7 +823,7 @@ func createDomain(progress text.Progress, client api.Interface, serviceID string
 // createBackend creates the given domain and handle unrolling the stack in case
 // of an error (i.e. will ensure the backend is deleted if there is an error).
 func createBackend(progress text.Progress, client api.Interface, serviceID string, version int, backend Backend, undoStack undo.Stacker) error {
-	progress.Step(fmt.Sprintf("Creating backend %s...", backend.Address))
+	progress.Step(fmt.Sprintf("Creating backend '%s'...", backend.Address))
 
 	undoStack.Push(func() error {
 		return client.DeleteBackend(&fastly.DeleteBackendInput{

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -747,7 +747,6 @@ func cfgSetupBackend(backend manifest.Mapper, c *DeployCommand, out io.Writer, i
 		} else {
 			return b, backendRemediationError("address", remediation, innerErr)
 		}
-		defaultAddr = fmt.Sprintf(": [%s] ", addr)
 	}
 
 	// NAME DEFAULT
@@ -796,6 +795,7 @@ func cfgSetupBackend(backend manifest.Mapper, c *DeployCommand, out io.Writer, i
 	// PROMPT USER INTERACTIVELY FOR ADDRESS AND PORT...
 
 	if !c.AcceptDefaults {
+		defaultAddr = fmt.Sprintf(": [%s] ", addr)
 		b.Address, err = text.Input(out, fmt.Sprintf("%s%s ", prompt, defaultAddr), in, v)
 		if err != nil {
 			return b, fmt.Errorf("error reading input %w", err)

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -774,7 +774,7 @@ func cfgSetupBackend(backend manifest.Mapper, c *DeployCommand, out io.Writer, i
 		// If no prompt text is provided by the [setup] configuration, then we'll
 		// default to using the name of the backend as the prompt text.
 		if prompt == "" {
-			prompt = fmt.Sprintf("Origin server for '%s'", name)
+			prompt = fmt.Sprintf("Origin server for '%s'", b.Name)
 		}
 	}
 

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -233,7 +233,7 @@ func TestDeploy(t *testing.T) {
 			wantOutput: []string{
 				"Creating service...",
 				"Creating domain...",
-				"Creating backend '127.0.0.1'...",
+				"Creating backend...",
 			},
 		},
 		// The following test validates that the undoStack is executed as expected
@@ -483,13 +483,8 @@ func TestDeploy(t *testing.T) {
 				"Initializing...",
 				"Creating service...",
 				"Creating domain...",
-
-				// NOTE: The actual running code would display the backend.Address
-				// contents after "Creating backend" but because we can't provide an
-				// io.Reader that contains mocked input from the user, it means the
-				// value shows as empty here.
-				"Creating backend ''...",
-
+				"Creating backend 'developer.fastly.com'...",
+				"Creating backend 'httpbin.org'...",
 				"Uploading package...",
 				"Activating version...",
 				"SUCCESS: Deployed package (service 12345, version 1)",

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -724,6 +724,24 @@ func TestDeploy(t *testing.T) {
 				"SUCCESS: Deployed package (service 123, version 3)",
 			},
 		},
+		{
+			name: "success with no setup configuration and use of --accept-defaults for existing service",
+			args: args("compute deploy --accept-defaults --service-id 123 --token 123 --verbose"),
+			api: mock.API{
+				ListVersionsFn:    testutil.ListVersions,
+				GetServiceFn:      getServiceOK,
+				ListDomainsFn:     listDomainsOk,
+				ListBackendsFn:    listBackendsNone,
+				CreateBackendFn:   createBackendOK,
+				GetPackageFn:      getPackageOk,
+				UpdatePackageFn:   updatePackageOk,
+				ActivateVersionFn: activateVersionOk,
+			},
+			wantOutput: []string{
+				"Creating backend '127.0.0.1' (port: 80, name: originless)...",
+				"SUCCESS: Deployed package (service 123, version 3)",
+			},
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			// Because the manifest can be mutated on each test scenario, we recreate

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -102,10 +102,10 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --token 123 -v -p pkg/package.tar.gz"),
 			api: mock.API{
 				CreateServiceFn:   createServiceOK,
-				GetPackageFn:      getPackageOk,
-				UpdatePackageFn:   updatePackageOk,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
+				GetPackageFn:      getPackageOk,
+				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
 				ListDomainsFn:     listDomainsOk,
 			},
@@ -122,10 +122,10 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --token 123 -v"),
 			api: mock.API{
 				CreateServiceFn:   createServiceOK,
-				GetPackageFn:      getPackageOk,
-				UpdatePackageFn:   updatePackageOk,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
+				GetPackageFn:      getPackageOk,
+				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
 				ListDomainsFn:     listDomainsOk,
 			},
@@ -181,10 +181,6 @@ func TestDeploy(t *testing.T) {
 			name: "package API error",
 			args: args("compute deploy --token 123"),
 			api: mock.API{
-				GetServiceFn:    getServiceOK,
-				ListVersionsFn:  testutil.ListVersions,
-				ListDomainsFn:   listDomainsOk,
-				ListBackendsFn:  listBackendsOk,
 				CreateServiceFn: createServiceOK,
 				CreateDomainFn:  createDomainOK,
 				CreateBackendFn: createBackendOK,
@@ -226,7 +222,6 @@ func TestDeploy(t *testing.T) {
 			name: "service domain error",
 			args: args("compute deploy --token 123"),
 			api: mock.API{
-				GetServiceFn:    getServiceOK,
 				CreateServiceFn: createServiceOK,
 				CreateDomainFn:  createDomainError,
 				DeleteDomainFn:  deleteDomainOK,
@@ -247,7 +242,6 @@ func TestDeploy(t *testing.T) {
 			name: "service backend error",
 			args: args("compute deploy --token 123"),
 			api: mock.API{
-				GetServiceFn:    getServiceOK,
 				CreateServiceFn: createServiceOK,
 				CreateDomainFn:  createDomainOK,
 				CreateBackendFn: createBackendError,
@@ -269,8 +263,8 @@ func TestDeploy(t *testing.T) {
 			name: "activate error",
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				ListVersionsFn:    testutil.ListVersions,
+				GetServiceFn:      getServiceOK,
 				ListDomainsFn:     listDomainsOk,
 				ListBackendsFn:    listBackendsOk,
 				GetPackageFn:      getPackageOk,
@@ -287,8 +281,8 @@ func TestDeploy(t *testing.T) {
 			name: "identical package",
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
-				GetServiceFn:   getServiceOK,
 				ListVersionsFn: testutil.ListVersions,
+				GetServiceFn:   getServiceOK,
 				ListDomainsFn:  listDomainsOk,
 				ListBackendsFn: listBackendsOk,
 				GetPackageFn:   getPackageIdentical,
@@ -301,8 +295,8 @@ func TestDeploy(t *testing.T) {
 			name: "success",
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				ListVersionsFn:    testutil.ListVersions,
+				GetServiceFn:      getServiceOK,
 				ListDomainsFn:     listDomainsOk,
 				ListBackendsFn:    listBackendsOk,
 				GetPackageFn:      getPackageOk,
@@ -323,8 +317,8 @@ func TestDeploy(t *testing.T) {
 			name: "success with path",
 			args: args("compute deploy --service-id 123 --token 123 -p pkg/package.tar.gz --version latest"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				ListVersionsFn:    testutil.ListVersions,
+				GetServiceFn:      getServiceOK,
 				ListDomainsFn:     listDomainsOk,
 				ListBackendsFn:    listBackendsOk,
 				GetPackageFn:      getPackageOk,
@@ -345,8 +339,8 @@ func TestDeploy(t *testing.T) {
 			name: "success with inactive version",
 			args: args("compute deploy --service-id 123 --token 123 -p pkg/package.tar.gz"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				ListVersionsFn:    testutil.ListVersions,
+				GetServiceFn:      getServiceOK,
 				ListDomainsFn:     listDomainsOk,
 				ListBackendsFn:    listBackendsOk,
 				GetPackageFn:      getPackageOk,
@@ -429,13 +423,9 @@ func TestDeploy(t *testing.T) {
 			name: "success with setup configuration",
 			args: args("compute deploy --token 123 --verbose"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				CreateServiceFn:   createServiceOK,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
@@ -478,13 +468,9 @@ func TestDeploy(t *testing.T) {
 			name: "success with setup configuration and no prompts or ports defined",
 			args: args("compute deploy --token 123 --verbose"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				CreateServiceFn:   createServiceOK,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
@@ -523,13 +509,9 @@ func TestDeploy(t *testing.T) {
 			name: "success with setup configuration and accept-defaults",
 			args: args("compute deploy --accept-defaults --token 123"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				CreateServiceFn:   createServiceOK,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
@@ -575,9 +557,6 @@ func TestDeploy(t *testing.T) {
 		{
 			name: "error with setup configuration and missing required fields",
 			args: args("compute deploy --token 123"),
-			api: mock.API{
-				GetServiceFn: getServiceOK,
-			},
 			manifest: `
 			name = "package"
 			manifest_version = 1
@@ -598,9 +577,6 @@ func TestDeploy(t *testing.T) {
 		{
 			name: "error with setup configuration -- invalid setup.backends.name",
 			args: args("compute deploy --token 123"),
-			api: mock.API{
-				GetServiceFn: getServiceOK,
-			},
 			manifest: `
 			name = "package"
 			manifest_version = 1
@@ -627,13 +603,9 @@ func TestDeploy(t *testing.T) {
 			name: "success with no setup configuration and --accept-defaults for new service creation",
 			args: args("compute deploy --accept-defaults --token 123 --verbose"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				CreateServiceFn:   createServiceOK,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
@@ -648,13 +620,9 @@ func TestDeploy(t *testing.T) {
 			name: "success with no setup configuration and single backend entered at prompt for new service",
 			args: args("compute deploy --token 123 --verbose"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				CreateServiceFn:   createServiceOK,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
@@ -682,13 +650,9 @@ func TestDeploy(t *testing.T) {
 			name: "success with no setup configuration and multiple backends entered at prompt for new service",
 			args: args("compute deploy --token 123 --verbose"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				CreateServiceFn:   createServiceOK,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
@@ -721,13 +685,9 @@ func TestDeploy(t *testing.T) {
 			name: "error with no setup configuration and multiple backends prompted for new service",
 			args: args("compute deploy --token 123 --verbose"),
 			api: mock.API{
-				GetServiceFn:      getServiceOK,
 				CreateServiceFn:   createServiceOK,
 				CreateDomainFn:    createDomainOK,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
@@ -737,24 +697,31 @@ func TestDeploy(t *testing.T) {
 		},
 		{
 			name: "success with no setup configuration and multiple backends prompted for existing service with no backends",
-			args: args("compute deploy --token 123 --verbose"),
+			args: args("compute deploy --service-id 123 --token 123 --verbose"),
 			api: mock.API{
+				ListVersionsFn:    testutil.ListVersions,
 				GetServiceFn:      getServiceOK,
-				CreateServiceFn:   createServiceOK,
-				CreateDomainFn:    createDomainOK,
+				ListDomainsFn:     listDomainsOk,
+				ListBackendsFn:    listBackendsNone,
 				CreateBackendFn:   createBackendOK,
-				DeleteBackendFn:   deleteBackendOK,
-				DeleteDomainFn:    deleteDomainOK,
-				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				UpdatePackageFn:   updatePackageOk,
 				ActivateVersionFn: activateVersionOk,
-				ListDomainsFn:     listDomainsOk,
 			},
-			stdin: []string{"originless"},
+			stdin: []string{
+				"fastly.com",
+				"443",
+				"", // this is so we generate a backend name using a formula
+				"google.com",
+				"123",
+				"", // this is so we generate a backend name using a formula
+				"", // this stops prompting for backends
+			},
 			wantOutput: []string{
 				"Backend (originless, hostname or IP address): [leave blank to stop adding backends]",
-				"SUCCESS: Deployed package (service 12345, version 1)",
+				"Creating backend 'fastly.com' (port: 443, name: fastly_com)...",
+				"Creating backend 'google.com' (port: 123, name: google_com)...",
+				"SUCCESS: Deployed package (service 123, version 3)",
 			},
 		},
 	} {

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -543,6 +543,7 @@ func TestDeploy(t *testing.T) {
 				"Backend port number: [443]",
 				"Backend 2: [httpbin.org]",
 				"Backend port number: [443]",
+				"Domain: [",
 			},
 		},
 		// The follow test validates the setup.backends.address field is a required

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -56,6 +56,7 @@ func TestDeploy(t *testing.T) {
 		manifest         string
 		manifestIncludes string
 		name             string
+		noManifest       bool
 		stdin            string
 		wantError        string
 		wantOutput       []string
@@ -66,9 +67,10 @@ func TestDeploy(t *testing.T) {
 			wantError: "no token provided",
 		},
 		{
-			name:      "no fastly.toml manifest",
-			args:      args("compute deploy --token 123"),
-			wantError: "error reading package manifest",
+			name:       "no fastly.toml manifest",
+			args:       args("compute deploy --token 123"),
+			wantError:  "error reading package manifest",
+			noManifest: true,
 		},
 		{
 			// If no Service ID defined via flag or manifest, then the expectation is
@@ -509,7 +511,7 @@ func TestDeploy(t *testing.T) {
 			// of deleting the manifest and having to recreate it, we'll simply
 			// rename it, and then rename it back once the specific test scenario has
 			// finished running.
-			if testcase.manifest == "" {
+			if testcase.noManifest {
 				old := filepath.Join(rootdir, manifest.Filename)
 				tmp := filepath.Join(rootdir, manifest.Filename+"Tmp")
 				if err := os.Rename(old, tmp); err != nil {

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -233,7 +233,7 @@ func TestDeploy(t *testing.T) {
 			wantOutput: []string{
 				"Creating service...",
 				"Creating domain...",
-				"Creating backend...",
+				"Creating backend '127.0.0.1'...",
 			},
 		},
 		// The following test validates that the undoStack is executed as expected
@@ -488,7 +488,7 @@ func TestDeploy(t *testing.T) {
 				// contents after "Creating backend" but because we can't provide an
 				// io.Reader that contains mocked input from the user, it means the
 				// value shows as empty here.
-				"Creating backend ...",
+				"Creating backend ''...",
 
 				"Uploading package...",
 				"Activating version...",

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -490,6 +490,55 @@ func TestDeploy(t *testing.T) {
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
+		{
+			name: "error with setup configuration -- missing setup.backends.name",
+			args: args("compute deploy --token 123"),
+			api: mock.API{
+				GetServiceFn: getServiceOK,
+			},
+			manifest: `
+			name = "package"
+			manifest_version = 1
+			language = "rust"
+
+			[setup]
+				[[setup.backends]]
+					prompt = "Backend 1"
+					address = "developer.fastly.com"
+					port = 443
+				[[setup.backends]]
+					prompt = "Backend 2"
+					address = "httpbin.org"
+					port = 443
+			`,
+			wantError: "error parsing the [[setup.backends]] configuration",
+		},
+		// The 'name' field should be a string, not an integer
+		{
+			name: "error with setup configuration -- invalid setup.backends.name",
+			args: args("compute deploy --token 123"),
+			api: mock.API{
+				GetServiceFn: getServiceOK,
+			},
+			manifest: `
+			name = "package"
+			manifest_version = 1
+			language = "rust"
+
+			[setup]
+				[[setup.backends]]
+				  name = 123
+					prompt = "Backend 1"
+					address = "developer.fastly.com"
+					port = 443
+				[[setup.backends]]
+				  name = 456
+					prompt = "Backend 2"
+					address = "httpbin.org"
+					port = 443
+			`,
+			wantError: "error parsing the [[setup.backends]] configuration",
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			// Because the manifest can be mutated on each test scenario, we recreate

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -667,8 +667,8 @@ func TestDeploy(t *testing.T) {
 				"Backend (hostname or IP address, or leave blank to stop adding backends):",
 				"Backend port number: [80]",
 				"Backend name:",
-				"Creating backend 'fastly_com' (host: fastly.com, port: 443)...",
-				"Creating backend 'google_com' (host: google.com, port: 123)...",
+				"Creating backend 'backend_1' (host: fastly.com, port: 443)...",
+				"Creating backend 'backend_2' (host: google.com, port: 123)...",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -721,8 +721,8 @@ func TestDeploy(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Backend (hostname or IP address, or leave blank to stop adding backends):",
-				"Creating backend 'fastly_com' (host: fastly.com, port: 443)...",
-				"Creating backend 'google_com' (host: google.com, port: 123)...",
+				"Creating backend 'backend_1' (host: fastly.com, port: 443)...",
+				"Creating backend 'backend_2' (host: google.com, port: 123)...",
 				"SUCCESS: Deployed package (service 123, version 3)",
 			},
 		},
@@ -780,16 +780,25 @@ func TestDeploy(t *testing.T) {
 					prompt = "Backend 2"
 					address = "google.com"
 					port = 443
+				[[setup.backends]]
+					name = "another_backend_name"
+					prompt = "Backend 3"
+					address = "facebook.com"
+					port = 443
 			`,
 			stdin: []string{
 				"google.com",
 				"123",
 				"", // this is so we generate a backend name using a built-in formula
+				"facebook.com",
+				"456",
+				"", // this is so we generate a backend name using a built-in formula
 				"", // this stops prompting for backends
 			},
 			wantOutput: []string{
 				"Backend (hostname or IP address, or leave blank to stop adding backends):",
-				"Creating backend 'google_com' (host: google.com, port: 123)...",
+				"Creating backend 'backend_1' (host: google.com, port: 123)...",
+				"Creating backend 'backend_2' (host: facebook.com, port: 456)...",
 				"SUCCESS: Deployed package (service 123, version 3)",
 			},
 		},

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -484,9 +484,9 @@ func TestDeploy(t *testing.T) {
 					address = "httpbin.org"
 			`,
 			wantOutput: []string{
-				"Origin server for 'foo_backend': [developer.fastly.com]",
+				"Backend for 'foo_backend': [developer.fastly.com]",
 				"Backend port number: [80]",
-				"Origin server for 'bar_backend': [httpbin.org]",
+				"Backend for 'bar_backend': [httpbin.org]",
 				"Backend port number: [80]",
 				"Creating service...",
 				"Creating domain...",
@@ -631,7 +631,7 @@ func TestDeploy(t *testing.T) {
 				"", // this is to use the default domain
 			},
 			wantOutput: []string{
-				"Backend (hostname or IP address, or leave blank to stop adding backends): [originless]",
+				"Backend (hostname or IP address, or leave blank to stop adding backends):",
 				"Backend port number: [80]",
 				"Backend name:",
 				"Creating backend 'fastly.com' (port: 443, name: my_backend_name)...",
@@ -664,7 +664,7 @@ func TestDeploy(t *testing.T) {
 				"", // this is to use the default domain
 			},
 			wantOutput: []string{
-				"Backend (hostname or IP address, or leave blank to stop adding backends): [originless]",
+				"Backend (hostname or IP address, or leave blank to stop adding backends):",
 				"Backend port number: [80]",
 				"Backend name:",
 				"Creating backend 'fastly.com' (port: 443, name: fastly_com)...",
@@ -688,7 +688,7 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:     listDomainsOk,
 			},
 			wantOutput: []string{
-				"Backend (hostname or IP address, or leave blank to stop adding backends): [originless]",
+				"Backend (hostname or IP address, or leave blank to stop adding backends):",
 				"Creating backend '127.0.0.1' (port: 80, name: originless)...",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
@@ -718,7 +718,7 @@ func TestDeploy(t *testing.T) {
 				"", // this stops prompting for backends
 			},
 			wantOutput: []string{
-				"Backend (hostname or IP address, or leave blank to stop adding backends): [originless]",
+				"Backend (hostname or IP address, or leave blank to stop adding backends):",
 				"Creating backend 'fastly.com' (port: 443, name: fastly_com)...",
 				"Creating backend 'google.com' (port: 123, name: google_com)...",
 				"SUCCESS: Deployed package (service 123, version 3)",
@@ -784,7 +784,7 @@ func TestDeploy(t *testing.T) {
 				"", // this stops prompting for backends
 			},
 			wantOutput: []string{
-				"Backend (hostname or IP address, or leave blank to stop adding backends): [originless]",
+				"Backend (hostname or IP address, or leave blank to stop adding backends):",
 				"Creating backend 'google.com' (port: 123, name: google_com)...",
 				"SUCCESS: Deployed package (service 123, version 3)",
 			},

--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -198,10 +198,23 @@ type File struct {
 	Language        string      `toml:"language"`
 	ServiceID       string      `toml:"service_id"`
 	LocalServer     LocalServer `toml:"local_server"`
+	Setup           Setup       `toml:"setup"`
 
 	exists bool
 	output io.Writer
 }
+
+// Setup represents a set of service configuration that works with the code in
+// the package.
+type Setup struct {
+	Backends     []Mapper `toml:"backends"`
+	Dictionaries []Mapper `toml:"dictionaries"`
+	ACLs         []Mapper `toml:"acls"`
+	LogEndpoints []Mapper `toml:"log_endpoints"`
+}
+
+// Mapper represents a generic toml table.
+type Mapper map[string]interface{}
 
 // LocalServer represents a list of backends that should be mocked as per the
 // configuration values.

--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -197,8 +197,8 @@ type File struct {
 	Authors         []string    `toml:"authors"`
 	Language        string      `toml:"language"`
 	ServiceID       string      `toml:"service_id"`
-	LocalServer     LocalServer `toml:"local_server"`
-	Setup           Setup       `toml:"setup"`
+	LocalServer     LocalServer `toml:"local_server,omitempty"`
+	Setup           Setup       `toml:"setup,omitempty"`
 
 	exists bool
 	output io.Writer

--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -205,12 +205,9 @@ type File struct {
 }
 
 // Setup represents a set of service configuration that works with the code in
-// the package.
+// the package. See https://developer.fastly.com/reference/fastly-toml/.
 type Setup struct {
-	Backends     []Mapper `toml:"backends"`
-	Dictionaries []Mapper `toml:"dictionaries"`
-	ACLs         []Mapper `toml:"acls"`
-	LogEndpoints []Mapper `toml:"log_endpoints"`
+	Backends []Mapper `toml:"backends"`
 }
 
 // Mapper represents a generic toml table.

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -49,7 +49,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.CmdClause.Flag("timeout", "Timeout, in seconds, for the build compilation step").Action(c.timeout.Set).IntVar(&c.timeout.Value)
 
 	// Deploy flags
-	c.CmdClause.Flag("accept-defaults", "Accept default configuration from [setup]").Action(c.acceptDefaults.Set).BoolVar(&c.acceptDefaults.Value)
+	c.CmdClause.Flag("accept-defaults", "Accept default values for all prompts and perform deploy non-interactively").Action(c.acceptDefaults.Set).BoolVar(&c.acceptDefaults.Value)
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.comment.Set).StringVar(&c.comment.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)
 	c.CmdClause.Flag("path", "Path to package").Short('p').Action(c.path.Set).StringVar(&c.path.Value)

--- a/pkg/testutil/assert.go
+++ b/pkg/testutil/assert.go
@@ -42,6 +42,14 @@ func AssertStringContains(t *testing.T, s, substr string) {
 	}
 }
 
+// AssertStringDoesntContain fatals a test if the string does contain a substring.
+func AssertStringDoesntContain(t *testing.T, s, substr string) {
+	t.Helper()
+	if strings.Contains(s, substr) {
+		t.Fatalf("%q contains %q", s, substr)
+	}
+}
+
 // AssertNoError fatals a test if the error is not nil.
 func AssertNoError(t *testing.T, err error) {
 	t.Helper()


### PR DESCRIPTION
The implementation is based on the `[setup]` configuration defined in https://developer.fastly.com/reference/fastly-toml/

The PR also removes the existing backend related flags as they only worked for a single backend instance. They're replaced by prompting the user multiple times for backends (or using a user's own `[setup]` definition).

**BREAKING CHANGE?**: This PR deletes a set of backend flags, thus breaking existing user expectations, but as we are currently in the `0.x.x` range of releases for the CLI I think we should be OK to merge and release these changes as a new `0.x.x` release rather than a `1.0.0` because the general consensus around the `0.x.x` line is that the public API should not be considered stable _until_ `1.0.0`.

## Workflow scenarios

- If `[setup]` defined with Array of `backend` tables:
  - Prompt user for input unless `--accept-defaults` is set.
- Otherwise:
  - Prompt user repeatedly for backend info unless `--accept-defaults` is set (will create a single 'originless' backend).