### PR TITLE
Respect active rust toolchain instead of the latest version

### DIFF
--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -213,7 +213,7 @@ func TestBuildRust(t *testing.T) {
 			client: versionClient{
 				fastlyVersions: []string{"0.6.0"},
 			},
-			wantError:            "rust toolchain 1.49.0 is incompatible with the constraint >= 1.0.0 < 1.40.0",
+			wantError:            "rust 1.49.0 is incompatible with the constraint >= 1.0.0 < 1.40.0",
 			wantRemediationError: "To fix this error, run the following command with a version within the given range >= 1.0.0 < 1.40.0:\n\n\t$ rustup toolchain install <version>\n",
 		},
 		{


### PR DESCRIPTION
The current implementation determines rust version by executing `rustup toolchain list` and pick the last line as the latest version, but should it use the active one?

I updated fastly cli and it started to fail with the following error (even though my rust-toochain is `1.49.0`)
```
$ fastly compute build
(snip)
Checking if Rust >= 1.49.0 < 1.54.0 is installed...

ERROR: rust toolchain 1.54.0 is incompatible with the constraint >= 1.49.0 < 1.54.0.

To fix this error, run the following command with a version within the given range >= 1.49.0 < 1.54.0:

        $ rustup toolchain install <version>
```