### PR TITLE
Omit messaging when using `--accept-defaults`

### DIFF
--- a/cmd/fastly/static/config.toml
+++ b/cmd/fastly/static/config.toml
@@ -9,8 +9,8 @@ ttl = "5m"
 
 [language]
   [language.rust]
-  toolchain_version = "1.49.0"
-  toolchain_constraint = ">= 1.49.0 < 1.54.0"
+  toolchain_version = "1.54.0"
+  toolchain_constraint = ">= 1.54.0"
   wasm_wasi_target = "wasm32-wasi"
   fastly_sys_constraint = ">= 0.3.3 < 0.5.0"
   rustup_constraint = ">= 1.23.0"

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -122,11 +122,13 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	serviceID, sidSrc := c.Manifest.ServiceID()
 	if sidSrc == manifest.SourceUndefined {
-		text.Break(out)
-		text.Output(out, "There is no Fastly service associated with this package. To connect to an existing service add the Service ID to the fastly.toml file, otherwise follow the prompts to create a service now.")
-		text.Break(out)
-		text.Output(out, "Press ^C at any time to quit.")
-		text.Break(out)
+		if !c.AcceptDefaults {
+			text.Break(out)
+			text.Output(out, "There is no Fastly service associated with this package. To connect to an existing service add the Service ID to the fastly.toml file, otherwise follow the prompts to create a service now.")
+			text.Break(out)
+			text.Output(out, "Press ^C at any time to quit.")
+			text.Break(out)
+		}
 
 		backends, err = configureBackends(c, backends, c.Manifest.File.Setup.Backends, out, in)
 		if err != nil {


### PR DESCRIPTION
This was code that was supposed to be in https://github.com/fastly/cli/pull/355 but I neglected to commit it before merging.