### PR TITLE
Refactor `compute deploy` logic to better support [setup] configuration

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         go-version: [1.16.x]
         node-version: [12]
-        rust-toolchain: [1.49.0]
+        rust-toolchain: [1.54.0]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/TESTING.md
+++ b/TESTING.md
@@ -32,6 +32,7 @@ The available environment variables are:
 - `TEST_COMPUTE_BUILD`: runs `TestBuildRust` and `TestBuildAssemblyScript`.
 - `TEST_COMPUTE_BUILD_RUST`: runs `TestBuildRust`.
 - `TEST_COMPUTE_BUILD_ASSEMBLYSCRIPT`: runs `TestBuildAssemblyScript`.
+- `TEST_COMPUTE_DEPLOY`: runs `TestDeploy`.
 
 **Example**:
 

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -199,9 +199,13 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						// NOTE: my local rust environment has versions 1.[45|46|49].0
+						// NOTE: my local rust environment has versions 1.[45|46|49|54].0
 						// So I've set the constraint to ensure the test fails.
-						// Example, the code logic will select 1.49.0, which is outside the constraint limit 1.40.0
+						// Example, the code logic will select 1.54.0, which is outside the constraint limit 1.40.0
+						//
+						// The .github/workflows/pr_test.yml should have the same version
+						// 1.54.0 set which should align with the constraint defined in the
+						// CLI's dynamic config.
 						ToolchainVersion:    "1.0.0",
 						ToolchainConstraint: ">= 1.0.0 < 1.40.0",
 						WasmWasiTarget:      "wasm32-wasi",
@@ -213,7 +217,7 @@ func TestBuildRust(t *testing.T) {
 			client: versionClient{
 				fastlyVersions: []string{"0.6.0"},
 			},
-			wantError:            "rust toolchain 1.49.0 is incompatible with the constraint >= 1.0.0 < 1.40.0",
+			wantError:            "rust toolchain 1.54.0 is incompatible with the constraint >= 1.0.0 < 1.40.0",
 			wantRemediationError: "To fix this error, run the following command with a version within the given range >= 1.0.0 < 1.40.0:\n\n\t$ rustup toolchain install <version>\n",
 		},
 		{

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -28,11 +28,12 @@ import (
 // You can locate the default Cargo.toml here:
 // pkg/commands/compute/testdata/build/Cargo.toml
 func TestBuildRust(t *testing.T) {
-	args := testutil.Args
 	if os.Getenv("TEST_COMPUTE_BUILD_RUST") == "" && os.Getenv("TEST_COMPUTE_BUILD") == "" {
 		t.Log("skipping test")
 		t.Skip("Set TEST_COMPUTE_BUILD to run this test")
 	}
+
+	args := testutil.Args
 
 	for _, testcase := range []struct {
 		name                 string

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -463,7 +463,7 @@ func updateManifestServiceID(m *manifest.File, manifestFilename string, serviceI
 	return nil
 }
 
-// manageExistingServiceFlow handles BLAH.
+// manageExistingServiceFlow clones service version if required.
 func manageExistingServiceFlow(
 	serviceID string,
 	serviceVersionFlag cmd.OptionalServiceVersion,

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -176,7 +176,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	if !hasDomain || !hasRequiredBackends {
 		if !c.AcceptDefaults {
-			text.Output(out, "Service '%s' is missing required resources. These must be added before the Compute@Edge service can be deployed. Please follow the prompts.", serviceID)
+			text.Output(out, "Service '%s' is missing required resources. These must be added before the Compute@Edge service can be deployed. Please ensure your fastly.toml configuration reflects any manual changes made via manage.fastly.com, otherwise follow the prompts to create the required resources.", serviceID)
 			text.Break(out)
 		}
 	}

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -40,6 +40,11 @@ import (
 // testcase.stdin field so that there is a value provided for every prompt your
 // testcase user flow expects to encounter.
 func TestDeploy(t *testing.T) {
+	if os.Getenv("TEST_COMPUTE_DEPLOY") == "" {
+		t.Log("skipping test")
+		t.Skip("Set TEST_COMPUTE_DEPLOY to run this test")
+	}
+
 	// We're going to chdir to a deploy environment,
 	// so save the PWD to return to, afterwards.
 	pwd, err := os.Getwd()


### PR DESCRIPTION
This is a large refactor of the existing `compute deploy` logic.

The original logic had some issues...

1. It wasn't designed for supporting more than a few types of `[setup]` fields, so when looking to introduce extra fields like ACL, Dictionaries, Logging Endpoints (and potentially more in future) I realised the logic needed to be rewritten.

2. The logic that was checking which backends within the `[setup]` configuration were missing was flawed and would cause the same backend to be added multiple times. The bug was only surfaced upon refactoring the existing logic.

3. The specific user flow we had meant we needed to duplicate a bunch of calls to the same functions. For example, the functions `cfgDomain ` and `configureBackends` would need to be called _three_ separate times each, where as now they're only called once. This was caused primarily by the design of the original `validateService` function and because we would have a separate "new service" flow that was subsequently needed to be uniquely separate from the "existing service" flow.