### PR TITLE
Update rust toolchain validation steps

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         go-version: [1.17.x]
         node-version: [12]
-        rust-toolchain: [1.54.0]
+        rust-toolchain: [stable]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
     - name: "Restore golang bin cache"
       id: go-bin-cache
       uses: actions/cache@v2
@@ -53,7 +53,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         node-version: [12]
         rust-toolchain: [1.54.0]
         platform: [ubuntu-latest, macos-latest, windows-latest]
@@ -85,6 +85,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust-toolchain }}
+        override: true
     - name: "Add wasm32-wasi Rust target"
       run: rustup target add wasm32-wasi --toolchain ${{ matrix.rust-toolchain }}
     - name: "Restore cargo cache"

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -85,20 +85,11 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust-toolchain }}
-        override: true
     - name: "Add wasm32-wasi Rust target"
       run: rustup target add wasm32-wasi --toolchain ${{ matrix.rust-toolchain }}
-    - name: "Restore cargo cache"
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.rustup/
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: "Validate Rust toolchain"
+      run: rustup show && rustup target list --installed --toolchain stable
+      shell: bash
     - name: "Install Node"
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -112,3 +112,4 @@ jobs:
       env:
         TEST_COMPUTE_INIT: true
         TEST_COMPUTE_BUILD: true
+        TEST_COMPUTE_DEPLOY: true

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -106,6 +106,9 @@ jobs:
     - name: "Download latest app config"
       run: |
         make config
+    - name: "Validate rust environment"
+      run: rustup show && rustc --print sysroot
+      shell: bash
     - name: "Test suite"
       run: make test
       shell: bash

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -106,9 +106,6 @@ jobs:
     - name: "Download latest app config"
       run: |
         make config
-    - name: "Validate rust environment"
-      run: rustup show && rustc --print sysroot
-      shell: bash
     - name: "Test suite"
       run: make test
       shell: bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 1. Merge all PRs intended for the release.
 2. Rebase latest remote main branch locally (`git pull --rebase origin main`).
-3. Ensure all analysis checks and tests are passing (`time TEST_COMPUTE_BUILD=1 TEST_COMPUTE_INIT=1 make all`).
+3. Ensure all analysis checks and tests are passing (`time TEST_COMPUTE_INIT=1 TEST_COMPUTE_BUILD=1 TEST_COMPUTE_DEPLOY=1 make all`).
 4. Open a new PR to update CHANGELOG ([example](https://github.com/fastly/cli/pull/273))<sup>[1](#note1)</sup>.
 5. Merge CHANGELOG.
 6. Rebase latest remote main branch locally (`git pull --rebase origin main`).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 1. Merge all PRs intended for the release.
 2. Rebase latest remote main branch locally (`git pull --rebase origin main`).
-3. Ensure all analysis checks and tests are passing (`make all`).
+3. Ensure all analysis checks and tests are passing (`time TEST_COMPUTE_BUILD=1 TEST_COMPUTE_INIT=1 make all`).
 4. Open a new PR to update CHANGELOG ([example](https://github.com/fastly/cli/pull/273))<sup>[1](#note1)</sup>.
 5. Merge CHANGELOG.
 6. Rebase latest remote main branch locally (`git pull --rebase origin main`).

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,9 +29,10 @@ Some integration tests aren't run outside of the CI environment, to enable these
 The available environment variables are:
 
 - `TEST_COMPUTE_INIT`: runs `TestInit`.
-- `TEST_COMPUTE_BUILD`: runs `TestBuildRust` and `TestBuildAssemblyScript`.
+- `TEST_COMPUTE_BUILD`: runs `TestBuildRust`, `TestBuildAssemblyScript` and `TestBuildJavaScript`.
 - `TEST_COMPUTE_BUILD_RUST`: runs `TestBuildRust`.
 - `TEST_COMPUTE_BUILD_ASSEMBLYSCRIPT`: runs `TestBuildAssemblyScript`.
+- `TEST_COMPUTE_BUILD_JAVASCRIPT`: runs `TestBuildJavaScript`.
 - `TEST_COMPUTE_DEPLOY`: runs `TestDeploy`.
 
 **Example**:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fastly/cli
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
@@ -31,4 +31,20 @@ require (
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+)
+
+require (
+	github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6 // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/jsonapi v0.0.0-20201022225600-f822737867f6 // indirect
+	github.com/klauspost/compress v1.9.2 // indirect
+	github.com/klauspost/pgzip v1.2.1 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/nwaples/rardecode v1.0.0 // indirect
+	github.com/ulikunitz/xz v0.5.6 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 )

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -200,13 +200,8 @@ func TestBuildRust(t *testing.T) {
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
-						// NOTE: my local rust environment has versions 1.[45|46|49|54].0
-						// So I've set the constraint to ensure the test fails.
-						// Example, the code logic will select 1.54.0, which is outside the constraint limit 1.40.0
-						//
-						// The .github/workflows/pr_test.yml should have the same version
-						// 1.54.0 set which should align with the constraint defined in the
-						// CLI's dynamic config.
+						// NOTE: A 'stable' release will fail the constraint, which is set
+						// to something lower than current stable.
 						ToolchainVersion:    "1.0.0",
 						ToolchainConstraint: ">= 1.0.0 < 1.40.0",
 						WasmWasiTarget:      "wasm32-wasi",

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -219,7 +219,7 @@ func TestBuildRust(t *testing.T) {
 				fastlyVersions: []string{"0.6.0"},
 			},
 			wantError:            "rust toolchain 1.54.0 is incompatible with the constraint >= 1.0.0 < 1.40.0",
-			wantRemediationError: "To fix this error, run the following command with a version within the given range >= 1.0.0 < 1.40.0:\n\n\t$ rustup toolchain install <version>\n",
+			wantRemediationError: "To fix this error, run the following command:\n\n\t$ rustup update stable\n",
 		},
 		{
 			name: "fastly crate prerelease",

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -218,8 +218,8 @@ func TestBuildRust(t *testing.T) {
 			client: versionClient{
 				fastlyVersions: []string{"0.6.0"},
 			},
-			wantError:            "rust toolchain 1.54.0 is incompatible with the constraint >= 1.0.0 < 1.40.0",
-			wantRemediationError: "To fix this error, run the following command:\n\n\t$ rustup update stable\n",
+			wantError:            "rustc constraint not met: >= 1.0.0 < 1.40.0",
+			wantRemediationError: "Ensure the `rustc` compiler version meets the constraint by installing an appropriate version of `rustc`.",
 		},
 		{
 			name: "fastly crate prerelease",

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -97,7 +97,7 @@ func TestBuildRust(t *testing.T) {
 				Language: config.Language{
 					Rust: config.Rust{
 						ToolchainVersion:    "1.49.0",
-						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
+						ToolchainConstraint: ">= 1.54.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: "0.0.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -131,7 +131,7 @@ func TestBuildRust(t *testing.T) {
 				Language: config.Language{
 					Rust: config.Rust{
 						ToolchainVersion:    "1.49.0",
-						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
+						ToolchainConstraint: ">= 1.54.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: "0.0.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -166,7 +166,7 @@ func TestBuildRust(t *testing.T) {
 				Language: config.Language{
 					Rust: config.Rust{
 						ToolchainVersion:    "1.49.0",
-						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
+						ToolchainConstraint: ">= 1.54.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.4.0 <= 0.9.0", // the fastly-sys version in 0.6.0 is actually ^0.3.6 so a minimum of 0.4.0 causes the constraint to fail
 						RustupConstraint:    ">= 1.23.0",
@@ -214,7 +214,7 @@ func TestBuildRust(t *testing.T) {
 				fastlyVersions: []string{"0.6.0"},
 			},
 			wantError:            "rustc constraint not met: >= 1.0.0 < 1.40.0",
-			wantRemediationError: "Ensure the `rustc` compiler version meets the constraint by installing an appropriate version of `rustc`.",
+			wantRemediationError: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint.",
 		},
 		{
 			name: "fastly crate prerelease",
@@ -227,7 +227,7 @@ func TestBuildRust(t *testing.T) {
 				Language: config.Language{
 					Rust: config.Rust{
 						ToolchainVersion:    "1.49.0",
-						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
+						ToolchainConstraint: ">= 1.54.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",
@@ -261,7 +261,7 @@ func TestBuildRust(t *testing.T) {
 				Language: config.Language{
 					Rust: config.Rust{
 						ToolchainVersion:    "1.49.0",
-						ToolchainConstraint: ">= 1.49.0 < 2.0.0",
+						ToolchainConstraint: ">= 1.54.0",
 						WasmWasiTarget:      "wasm32-wasi",
 						FastlySysConstraint: ">= 0.3.0 <= 0.6.0",
 						RustupConstraint:    ">= 1.23.0",

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -336,6 +336,7 @@ func TestBuildRust(t *testing.T) {
 			opts.ConfigFile = testcase.applicationConfig
 			opts.HTTPClient = testcase.client
 			err = app.Run(opts)
+			t.Log(stdout.String())
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertRemediationErrorContains(t, err, testcase.wantRemediationError)
 			if testcase.wantOutputContains != "" {

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -213,8 +213,8 @@ func TestBuildRust(t *testing.T) {
 			client: versionClient{
 				fastlyVersions: []string{"0.6.0"},
 			},
-			wantError:            "rustc constraint not met: >= 1.0.0 < 1.40.0",
-			wantRemediationError: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint.",
+			wantError:            "rustc constraint '>= 1.0.0 < 1.40.0' not met: 1.54.0",
+			wantRemediationError: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint (e.g. `channel = \"stable\"`).",
 		},
 		{
 			name: "fastly crate prerelease",

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -947,7 +947,7 @@ func TestDeploy(t *testing.T) {
 				err = app.Run(opts)
 			}
 
-			// t.Log(stdout.String())
+			t.Log(stdout.String())
 
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -326,7 +326,6 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 	}
 
 	args := []string{
-		"+stable", // this should point to same value as `rustc --version`
 		"build",
 		"--bin",
 		binName,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -109,12 +109,12 @@ func (r Rust) IncludeFiles() []string { return []string{"Cargo.toml"} }
 // NOTE:
 // Steps for validation are:
 //
-// 1. Lookup `rustc` in `$PATH`
-// 2. Execute `rustc --version`
-// 3. Validate `wasm32-wasi` target
-// 4. Lookup `cargo` in `$PATH`
-// 5. Validate `fastly-sys` crate version
-// 6. Validate `fastly` crate version (optional upgrade suggestion)
+// 1. Validate `rustc` installed.
+// 2. Validate `rustc --version` meets the constraint.
+// 3. Validate `wasm32-wasi` target is added to the relevant toolchain.
+// 4. Validate `cargo` is installed.
+// 5. Validate `fastly-sys` crate version.
+// 6. Validate `fastly` crate version (optional upgrade suggestion).
 func (r *Rust) Verify(out io.Writer) (err error) {
 	fmt.Fprintf(out, "Checking if `rustc` is installed...\n")
 

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -419,8 +419,6 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 	binName := m.Package.Name
 
 	args := []string{
-		"-v",
-		"-v",
 		"build",
 		"--bin",
 		binName,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -81,10 +81,9 @@ func (m *CargoMetadata) Read() error {
 
 // Rust implements a Toolchain for the Rust language.
 type Rust struct {
-	client    api.HTTPClient
-	config    *config.Data
-	toolchain *semver.Version
-	timeout   int
+	client  api.HTTPClient
+	config  *config.Data
+	timeout int
 }
 
 // NewRust constructs a new Rust.

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -415,6 +415,8 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 	binName := m.Package.Name
 
 	args := []string{
+		"-v",
+		"-v",
 		"build",
 		"--bin",
 		binName,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -200,8 +200,8 @@ func validateCompilerVersion(constraint string) error {
 
 	if !rustcConstraint.Check(rustcVersion) {
 		return errors.RemediationError{
-			Inner:       fmt.Errorf("rustc constraint not met: %s", constraint),
-			Remediation: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint.",
+			Inner:       fmt.Errorf("rustc constraint '%s' not met: %s", constraint, version),
+			Remediation: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint (e.g. `channel = \"stable\"`).",
 		}
 	}
 
@@ -234,8 +234,8 @@ func rustcVersion() (string, error) {
 	version := strings.Split(parts[1], "-")
 	if len(version) > 1 {
 		return "", errors.RemediationError{
-			Inner:       fmt.Errorf("non-stable releases are not supported `%s` output", strings.Join(cmd, " ")),
-			Remediation: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint. Alternatively utilise the CLI's `--force` flag.",
+			Inner:       fmt.Errorf("non-stable releases are not supported: %s", parts[1]),
+			Remediation: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint (e.g. `channel = \"stable\"`). Alternatively utilise the CLI's `--force` flag.",
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/363

There were issues with the original logic that used `rustup toolchain list` as well as using `rustup show active-toolchain` (as that only revealed, for example, `stable-x86_64-...` and so wasn't useful for checking against a semver constraint such as `>= 1.54.0`).

**The new validation steps are**:

1. Validate `rustc` installed.
2. Validate `rustc --version` meets the constraint.
3. Validate `wasm32-wasi` target is added to the relevant toolchain.
4. Validate `cargo` is installed.
5. Validate `fastly-sys` crate version.
6. Validate `fastly` crate version (optional upgrade suggestion).

This PR also need to be coordinated around a change to the CLI config so that the starter kits it references use the `main` branch for each of the Rust starter kit (rather than using various tags or non-main branches). This is because the latest release of each Rust starter kit is now using a `stable` channel:

- https://github.com/fastly/compute-starter-kit-rust-default/pull/44
- https://github.com/fastly/compute-starter-kit-rust-beacon-termination/pull/15
- https://github.com/fastly/compute-starter-kit-rust-static-content/pull/11