### PR TITLE
support Windows arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ builds:
   - <<: *build_defaults
     id: windows
     goos: [windows]
-    goarch: [386, amd64]
+    goarch: [386, amd64, arm64]
   - <<: *build_defaults
     id: generate-usage
     goos: [linux]


### PR DESCRIPTION
In issue https://github.com/fastly/cli/issues/367 customer also reported they tried to update the CLI on Windows from their old version but discovered there was no arm64 version available.