### PR TITLE
Update dependency to avoid dependabot warning in GitHub UI

### DIFF
--- a/cmd/fastly/static/config.toml
+++ b/cmd/fastly/static/config.toml
@@ -12,7 +12,7 @@ ttl = "5m"
   toolchain_version = "1.54.0"
   toolchain_constraint = ">= 1.54.0"
   wasm_wasi_target = "wasm32-wasi"
-  fastly_sys_constraint = ">= 0.3.3 < 0.5.0"
+  fastly_sys_constraint = ">= 0.3.3"
   rustup_constraint = ">= 1.23.0"
 
 [starter-kits]

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/klauspost/pgzip v1.2.1 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/nwaples/rardecode v1.0.0 // indirect
-	github.com/ulikunitz/xz v0.5.6 // indirect
+	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,9 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
-github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
+github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
See warning information here:
https://github.com/fastly/cli/security/dependabot/go.mod/github.com%2Fulikunitz%2Fxz/open

<img width="982" alt="Screenshot 2021-09-02 at 13 03 41" src="https://user-images.githubusercontent.com/180050/131840377-1c48c39b-d620-4b69-8482-78599efbdb36.png">
