### PR TITLE
defer container registry

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,23 +94,23 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   skip: true
-dockers:
-- <<: &build_opts
-    use: buildx
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "ghcr.io/fastly/cli:{{ .Version }}"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - --label=title={{ .ProjectName }}
-      - --label=description={{ .ProjectName }}
-      - --label=url=https://github.com/fastly/cli
-      - --label=source=https://github.com/fastly/cli
-      - --label=version={{ .Version }}
-      - --label=created={{ time "2006-01-02T15:04:05Z07:00" }}
-      - --label=revision={{ .FullCommit }}
-      - --label=licenses=Apache-2.0
-  dockerfile: Dockerfile-assemblyscript
-- <<: *build_opts
-  dockerfile: Dockerfile-rust
+# dockers:
+# - <<: &build_opts
+#     use: buildx
+#     goos: linux
+#     goarch: amd64
+#     image_templates:
+#       - "ghcr.io/fastly/cli:{{ .Version }}"
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - --label=title={{ .ProjectName }}
+#       - --label=description={{ .ProjectName }}
+#       - --label=url=https://github.com/fastly/cli
+#       - --label=source=https://github.com/fastly/cli
+#       - --label=version={{ .Version }}
+#       - --label=created={{ time "2006-01-02T15:04:05Z07:00" }}
+#       - --label=revision={{ .FullCommit }}
+#       - --label=licenses=Apache-2.0
+#   dockerfile: Dockerfile-assemblyscript
+# - <<: *build_opts
+#   dockerfile: Dockerfile-rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Enhancements:**
 
-- GitHub Packages support via goreleaser [#262](https://github.com/fastly/cli/pull/262)
+<!-- - GitHub Packages support via goreleaser [#262](https://github.com/fastly/cli/pull/262) -->
 - Update CLI config using flag on `update` command [#382](https://github.com/fastly/cli/pull/382)
 - Validate package size doesn't exceed limit [#380](https://github.com/fastly/cli/pull/380)
 - Log tailing should respect the configured `--endpoint` [#374](https://github.com/fastly/cli/pull/374)
@@ -18,7 +18,7 @@
 
 **Bug fixes:**
 
-- add executable permissions to Viceroy binary after renaming/moving it [#368](https://github.com/fastly/cli/pull/368)
+- Add executable permissions to Viceroy binary after renaming/moving it [#368](https://github.com/fastly/cli/pull/368)
 - Update rust toolchain validation steps [#371](https://github.com/fastly/cli/pull/371)
 
 **Security:**


### PR DESCRIPTION
There were issues cutting a new release as it seems we were missing some fundamental configuration/permissions/access to push container images to the GitHub Package Registry.

Due to time constraints, I'm commenting out the relevant code so we can revisit this and figure out the missing steps. 