### PR TITLE
Remove Scoop `skip_upload` configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,7 +85,6 @@ scoop:
     owner: fastly
     name: scoop-cli
   homepage: https://github.com/fastly/cli
-  skip_upload: auto
   description: Fastly CLI
   license: Apache 2.0
 checksum:


### PR DESCRIPTION
[Since moving away from automatically publishing releases](https://github.com/fastly/cli/pull/275) (e.g. since `v0.30.0` we manually curate the CHANGELOG) it turns out publishing an updated manifest file to https://github.com/fastly/scoop-cli has been broken. 

For example, when cutting a new CLI release you see the error `error=release is marked as draft`.

Looking at the https://goreleaser.com/customization/scoop/ documentation there is the setting `skip_upload` which we had set to `auto` (which would prevent the publishing from happening if the release looked like a pre-release). The default value is `false` and so by removing the setting I'm hoping that we'll see the published manifest data to succeed.