### PR TITLE
Add `generated` vcl command

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -268,6 +268,8 @@ type Interface interface {
 	GetNewRelic(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error)
 	ListNewRelic(i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error)
 	UpdateNewRelic(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error)
+
+	GetGeneratedVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
 }
 
 // RealtimeStatsInterface is the subset of go-fastly's realtime stats API used here.

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -57,6 +57,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/commands/vcl"
 	"github.com/fastly/cli/pkg/commands/vcl/custom"
+	"github.com/fastly/cli/pkg/commands/vcl/generated"
 	"github.com/fastly/cli/pkg/commands/vcl/snippet"
 	"github.com/fastly/cli/pkg/commands/version"
 	"github.com/fastly/cli/pkg/commands/whoami"
@@ -378,6 +379,8 @@ func Run(opts RunOpts) error {
 	statsRegions := stats.NewRegionsCommand(statsCmdRoot.CmdClause, &globals)
 	updateRoot := update.NewRootCommand(app, opts.ConfigPath, opts.Versioners.CLI, opts.HTTPClient, &globals)
 	vclCmdRoot := vcl.NewRootCommand(app, &globals)
+	vclGeneratedCmdRoot := generated.NewRootCommand(vclCmdRoot.CmdClause, &globals)
+	vclGeneratedDescribe := generated.NewDescribeCommand(vclGeneratedCmdRoot.CmdClause, &globals)
 	vclCustomCmdRoot := custom.NewRootCommand(vclCmdRoot.CmdClause, &globals)
 	vclCustomCreate := custom.NewCreateCommand(vclCustomCmdRoot.CmdClause, &globals)
 	vclCustomDelete := custom.NewDeleteCommand(vclCustomCmdRoot.CmdClause, &globals)
@@ -394,6 +397,9 @@ func Run(opts RunOpts) error {
 	whoamiCmdRoot := whoami.NewRootCommand(app, opts.HTTPClient, &globals)
 
 	commands := []cmd.Command{
+		vclCmdRoot,
+		vclGeneratedCmdRoot,
+		vclGeneratedDescribe,
 		aclCmdRoot,
 		aclCreate,
 		aclDelete,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -3935,6 +3935,14 @@ COMMANDS
     Update the CLI to the latest version
 
 
+  vcl generated describe --version=VERSION [<flags>]
+    Get the generated VCL content for a particular service and version
+
+        --version=VERSION        'latest', 'active', or the number of a specific
+                                 version
+    -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
+                                 then fastly.toml)
+
   vcl custom create --content=CONTENT --name=NAME --version=VERSION [<flags>]
     Upload a VCL for a particular service and version
 

--- a/pkg/commands/vcl/generated/describe.go
+++ b/pkg/commands/vcl/generated/describe.go
@@ -1,0 +1,89 @@
+package generated
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/commands/compute/manifest"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent cmd.Registerer, globals *config.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.CmdClause = parent.Command("describe", "Get the generated VCL content for a particular service and version").Alias("get")
+	c.Globals = globals
+	c.manifest.File.SetOutput(c.Globals.Output)
+	c.manifest.File.Read(manifest.Filename)
+
+	// Required flags
+	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
+		Dst: &c.serviceVersion.Value,
+	})
+
+	// Optional flags
+	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
+
+	return &c
+}
+
+// DescribeCommand calls the Fastly API to describe an appropriate resource.
+type DescribeCommand struct {
+	cmd.Base
+
+	manifest       manifest.Data
+	serviceVersion cmd.OptionalServiceVersion
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AllowActiveLocked:  true,
+		Client:             c.Globals.Client,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flag.Verbose,
+	})
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
+			"Service ID":      serviceID,
+			"Service Version": errors.ServiceVersion(serviceVersion),
+		})
+		return err
+	}
+
+	input := c.constructInput(serviceID, serviceVersion.Number)
+
+	r, err := c.Globals.Client.GetGeneratedVCL(input)
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
+			"Service ID":      serviceID,
+			"Service Version": serviceVersion.Number,
+		})
+		return err
+	}
+
+	c.print(out, r)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DescribeCommand) constructInput(serviceID string, serviceVersion int) *fastly.GetGeneratedVCLInput {
+	var input fastly.GetGeneratedVCLInput
+
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion
+
+	return &input
+}
+
+// print displays the information returned from the API.
+func (c *DescribeCommand) print(out io.Writer, r *fastly.VCL) {
+	fmt.Fprintf(out, "\nService ID: %s\n", r.ServiceID)
+	fmt.Fprintf(out, "Service Version: %d\n\n", r.ServiceVersion)
+	fmt.Fprintf(out, "Content: \n%s\n", r.Content)
+}

--- a/pkg/commands/vcl/generated/doc.go
+++ b/pkg/commands/vcl/generated/doc.go
@@ -1,0 +1,2 @@
+// Package generated contains commands to <...>.
+package generated

--- a/pkg/commands/vcl/generated/generated_test.go
+++ b/pkg/commands/vcl/generated/generated_test.go
@@ -1,0 +1,66 @@
+package generated_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v3/fastly"
+)
+
+func TestDescribe(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name:      "validate missing --version flag",
+			Args:      args("vcl generated describe"),
+			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:      "validate missing --service-id flag",
+			Args:      args("vcl generated describe --version 3"),
+			WantError: "error reading service: no service ID found",
+		},
+		{
+			Name: "validate GetGeneratedVCL API error",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				GetGeneratedVCLFn: func(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+					return nil, testutil.Err
+				},
+			},
+			Args:      args("vcl generated describe --service-id 123 --version 3"),
+			WantError: testutil.Err.Error(),
+		},
+		{
+			Name: "validate GetGeneratedVCL API success",
+			API: mock.API{
+				ListVersionsFn:    testutil.ListVersions,
+				GetGeneratedVCLFn: getGeneratedVCL,
+			},
+			Args:       args("vcl generated describe --service-id 123 --version 3"),
+			WantOutput: "\nService ID: 123\nService Version: 3\n\nContent: \n# some vcl content\n",
+		},
+	}
+
+	for _, testcase := range scenarios {
+		t.Run(testcase.Name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			opts := testutil.NewRunOpts(testcase.Args, &stdout)
+			opts.APIClient = mock.APIClient(testcase.API)
+			err := app.Run(opts)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func getGeneratedVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+	return &fastly.VCL{
+		ServiceID:      i.ServiceID,
+		ServiceVersion: i.ServiceVersion,
+		Content:        "# some vcl content",
+	}, nil
+}

--- a/pkg/commands/vcl/generated/root.go
+++ b/pkg/commands/vcl/generated/root.go
@@ -1,0 +1,28 @@
+package generated
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	cmd.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("generated", "Manipulate Fastly service version generated VCL")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -259,6 +259,8 @@ type API struct {
 	GetNewRelicFn    func(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error)
 	ListNewRelicFn   func(i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error)
 	UpdateNewRelicFn func(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error)
+
+	GetGeneratedVCLFn func(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
 }
 
 // AllDatacenters implements Interface.
@@ -1299,4 +1301,9 @@ func (m API) ListNewRelic(i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, erro
 // UpdateNewRelic implements Interface.
 func (m API) UpdateNewRelic(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
 	return m.UpdateNewRelicFn(i)
+}
+
+// GetGeneratedVCL implements Interface.
+func (m API) GetGeneratedVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+	return m.GetGeneratedVCLFn(i)
 }


### PR DESCRIPTION
usage:

```
$ fastly vcl generated describe --version=xx --service-id xx
```