### PR TITLE
Remove support for Scoop, the Window's command-line installer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,14 +80,6 @@ nfpms:
     formats:
       - deb
       - rpm
-scoop:
-  bucket:
-    owner: fastly
-    name: scoop-cli
-  homepage: https://github.com/fastly/cli
-  skip_upload: auto
-  description: Fastly CLI
-  license: Apache 2.0
 checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS"
 snapshot:


### PR DESCRIPTION
This PR should not be part of a published released until the Fastly developer documentation site is updated to reflect that Window users should download prebuilt binaries from the CLI releases page.