### PR TITLE
Pass `--name` value to deploy

### DIFF
--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -97,6 +97,9 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	text.Break(out)
 
 	// Reset the fields on the DeployCommand based on PublishCommand values.
+	if c.name.WasSet {
+		c.manifest.Flag.Name = c.name.Value
+	}
 	if c.acceptDefaults.WasSet {
 		c.deploy.AcceptDefaults = c.acceptDefaults.Value
 	}


### PR DESCRIPTION
Previously, when running `fastly compute publish --name foo`, "foo"
was used as the package name for the build but deploy was ignoring
it and only looking at the manifest's name.