### PR TITLE
Sanitise name when packing the wasm file

### DIFF
--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -213,7 +213,7 @@ func TestBuildRust(t *testing.T) {
 			client: versionClient{
 				fastlyVersions: []string{"0.6.0"},
 			},
-			wantError:            "rustc constraint '>= 1.0.0 < 1.40.0' not met: 1.54.0",
+			wantError:            "rustc constraint '>= 1.0.0 < 1.40.0' not met:",
 			wantRemediationError: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint (e.g. `channel = \"stable\"`).",
 		},
 		{

--- a/pkg/commands/compute/pack_test.go
+++ b/pkg/commands/compute/pack_test.go
@@ -21,7 +21,7 @@ func TestPack(t *testing.T) {
 		wantOutput    []string
 		expectedFiles [][]string
 	}{
-		// The following test validates that the expected directory struture was
+		// The following test validates that the expected directory structure was
 		// created successfully.
 		{
 			name:     "success",
@@ -37,6 +37,24 @@ func TestPack(t *testing.T) {
 				{"pkg", "precompiled", "bin", "main.wasm"},
 				{"pkg", "precompiled", "fastly.toml"},
 				{"pkg", "precompiled.tar.gz"},
+			},
+		},
+		// The following test validates that the expected directory structure was
+		// created successfully when `name` contains whitespace.
+		{
+			name:     "success",
+			args:     args("compute pack --path ./main.wasm"),
+			manifest: `name = "another name"`,
+			wantOutput: []string{
+				"Initializing...",
+				"Copying wasm binary...",
+				"Copying manifest...",
+				"Creating .tar.gz file...",
+			},
+			expectedFiles: [][]string{
+				{"pkg", "another-name", "bin", "main.wasm"},
+				{"pkg", "another-name", "fastly.toml"},
+				{"pkg", "another-name.tar.gz"},
 			},
 		},
 		// The following tests validate that a valid path flag value should be


### PR DESCRIPTION
This matches what build does and fixes deploy when name includes e.g., whitespace.