### PR TITLE
Use a non-interactive progress writer in non-TTY environments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/google/jsonapi v0.0.0-20201022225600-f822737867f6 // indirect
 	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
-	github.com/mattn/go-isatty v0.0.13 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1yA=
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mholt/archiver v3.1.1+incompatible h1:1dCVxuqs0dJseYEhi5pl7MYPH9zDa1wBi7mF09cbNkU=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=
@@ -135,6 +137,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210903071746-97244b99971b h1:3Dq0eVHn0uaQJmPO+/aYPI/fRMqdrVDbu7MQcku54gg=
 golang.org/x/sys v0.0.0-20210903071746-97244b99971b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -97,12 +97,7 @@ func NewBuildCommand(parent cmd.Registerer, client api.HTTPClient, globals *conf
 
 // Exec implements the command interface.
 func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
-	var progress text.Progress
-	if c.Globals.Verbose() {
-		progress = text.NewVerboseProgress(out)
-	} else {
-		progress = text.NewQuietProgress(out)
-	}
+	progress := text.NewProgress(out, c.Globals.Verbose())
 
 	defer func(errLog errors.LogInterface) {
 		if err != nil {

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -211,13 +211,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	// RESOURCE CREATION...
 
-	var progress text.Progress
-	if verbose {
-		progress = text.NewVerboseProgress(out)
-	} else {
-		progress = text.NewQuietProgress(out)
-	}
-
+	progress := text.NewProgress(out, c.Globals.Verbose())
 	undoStack := undo.NewStack()
 
 	defer func(errLog errors.LogInterface, progress text.Progress) {
@@ -418,13 +412,7 @@ func manageNoServiceIDFlow(
 		text.Break(out)
 	}
 
-	var progress text.Progress
-
-	if verbose {
-		progress = text.NewVerboseProgress(out)
-	} else {
-		progress = text.NewQuietProgress(out)
-	}
+	progress := text.NewProgress(out, verbose)
 
 	// There is no service and so we'll do a one time creation of the service
 	//

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -212,7 +212,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		text.Break(out)
 
 		if !c.Globals.Verbose() {
-			progress = text.NewQuietProgress(out)
+			progress = text.NewProgress(out, false)
 		}
 
 		_, err = exec.LookPath("git")

--- a/pkg/commands/compute/pack.go
+++ b/pkg/commands/compute/pack.go
@@ -38,12 +38,7 @@ func NewPackCommand(parent cmd.Registerer, globals *config.Data) *PackCommand {
 
 // Exec implements the command interface.
 func (c *PackCommand) Exec(in io.Reader, out io.Writer) (err error) {
-	var progress text.Progress
-	if c.Globals.Verbose() {
-		progress = text.NewVerboseProgress(out)
-	} else {
-		progress = text.NewQuietProgress(out)
-	}
+	progress := text.NewProgress(out, c.Globals.Verbose())
 
 	defer func(errLog errors.LogInterface) {
 		if err != nil {

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -88,12 +88,7 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		text.Break(out)
 	}
 
-	var progress text.Progress
-	if c.Globals.Verbose() {
-		progress = text.NewVerboseProgress(out)
-	} else {
-		progress = text.NewQuietProgress(out)
-	}
+	progress := text.NewProgress(out, c.Globals.Verbose())
 
 	bin, err := getViceroy(progress, out, c.viceroyVersioner)
 	if err != nil {

--- a/pkg/commands/compute/update.go
+++ b/pkg/commands/compute/update.go
@@ -65,7 +65,7 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return err
 	}
 
-	progress := text.NewQuietProgress(out)
+	progress := text.NewProgress(out, c.Globals.Verbose())
 	defer func() {
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{

--- a/pkg/commands/configure/root.go
+++ b/pkg/commands/configure/root.go
@@ -96,7 +96,7 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	text.Break(out)
 
-	progress := text.NewQuietProgress(out)
+	progress := text.NewProgress(out, c.Globals.Verbose())
 	defer func() {
 		if err != nil {
 			c.Globals.ErrLog.Add(err)

--- a/pkg/commands/update/root.go
+++ b/pkg/commands/update/root.go
@@ -51,7 +51,7 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	text.Output(out, "Latest version: %s", latest)
 	text.Break(out)
 
-	progress := text.NewQuietProgress(out)
+	progress := text.NewProgress(out, c.Globals.Verbose())
 	progress.Step("Updating versioning information...")
 
 	err = c.Globals.File.Load(c.Globals.File.CLI.RemoteConfig, c.client, config.ConfigRequestTimeout, config.FilePath)


### PR DESCRIPTION
Closes: #175 

### TL;DR
The current default progress writer uses interactive spinners on an event loop; while this style of output is useful in user terminal environments to give constant feedback of progression, it is not ideal in non-TTY environments, such as in continuous integration builds. 

### What?
This PR solves the CI issue by renaming the existing `text.QuietProgress` to `text.InteractiveProgress`, as it's not really "quiet", and then creates a new implementation of `text.QuietProgress` which only writes the step functions and not the intermediary writes to stdout. Lastly, we have a new constructor `text.NewProgress()` which is used throughout the program as a helper to abstract the logic which determines which progress should be used. 