### PR TITLE
Add the `--name` flag to `compute deploy`

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -454,6 +454,7 @@ COMMANDS
         --comment=COMMENT        Human-readable comment
         --domain=DOMAIN          The name of the domain associated to the
                                  package
+        --name=NAME              Package name
     -p, --path=PATH              Path to package
 
   compute init [<flags>]

--- a/pkg/commands/compute/compute_test.go
+++ b/pkg/commands/compute/compute_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -37,37 +36,26 @@ func TestPublishFlagDivergence(t *testing.T) {
 	publishFlags := getFlags(pcmd.CmdClause)
 
 	var (
-		expect []string
-		have   []string
+		expect = make(map[string]int)
+		have   = make(map[string]int)
 	)
 
 	iter := buildFlags.MapRange()
 	for iter.Next() {
-		expect = append(expect, fmt.Sprintf("%s", iter.Key()))
+		expect[iter.Key().String()] = 1
 	}
 	iter = deployFlags.MapRange()
 	for iter.Next() {
-		expect = append(expect, fmt.Sprintf("%s", iter.Key()))
+		expect[iter.Key().String()] = 1
 	}
 
 	iter = publishFlags.MapRange()
 	for iter.Next() {
-		have = append(have, fmt.Sprintf("%s", iter.Key()))
+		have[iter.Key().String()] = 1
 	}
 
-	sort.Strings(expect)
-	sort.Strings(have)
-
-	errMsg := "the flags between build/deploy and publish don't match"
-
-	if len(expect) != len(have) {
-		t.Fatal(errMsg)
-	}
-
-	for i, v := range expect {
-		if have[i] != v {
-			t.Fatalf("%s, expected: %s, got: %s", errMsg, v, have[i])
-		}
+	if !reflect.DeepEqual(expect, have) {
+		t.Fatalf("the flags between build/deploy and publish don't match")
 	}
 }
 

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -76,6 +76,7 @@ func NewDeployCommand(parent cmd.Registerer, client api.HTTPClient, globals *con
 	c.CmdClause.Flag("accept-defaults", "Accept default values for all prompts and perform deploy non-interactively").BoolVar(&c.AcceptDefaults)
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.Comment.Set).StringVar(&c.Comment.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.Domain)
+	c.CmdClause.Flag("name", "Package name").StringVar(&c.Manifest.Flag.Name)
 	c.CmdClause.Flag("path", "Path to package").Short('p').StringVar(&c.Path)
 	return &c
 }


### PR DESCRIPTION
This is needed if e.g., --name was used with build, as the name is
used as the package filename.