### PR TITLE
Bug fixes for `auth-token`

### DIFF
--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -40,30 +40,32 @@ func TestCreate(t *testing.T) {
 			API: mock.API{
 				CreateTokenFn: func(i *fastly.CreateTokenInput) (*fastly.Token, error) {
 					return &fastly.Token{
-						ExpiresAt: &testutil.Date,
-						ID:        "123",
-						Name:      "Example",
-						Scope:     "foobar",
+						ExpiresAt:   &testutil.Date,
+						ID:          "123",
+						Name:        "Example",
+						Scope:       "foobar",
+						AccessToken: "123abc",
 					}, nil
 				},
 			},
 			Args:       args("auth-token create --password secure --token 123"),
-			WantOutput: "Created token 'Example' (id: 123, scope: foobar, expires: 2021-06-15 23:00:00 +0000 UTC)",
+			WantOutput: "Created token '123abc' (name: Example, id: 123, scope: foobar, expires: 2021-06-15 23:00:00 +0000 UTC)",
 		},
 		{
 			Name: "validate CreateToken API success with all flags",
 			API: mock.API{
 				CreateTokenFn: func(i *fastly.CreateTokenInput) (*fastly.Token, error) {
 					return &fastly.Token{
-						ExpiresAt: i.ExpiresAt,
-						ID:        "123",
-						Name:      i.Name,
-						Scope:     i.Scope,
+						ExpiresAt:   i.ExpiresAt,
+						ID:          "123",
+						Name:        i.Name,
+						Scope:       i.Scope,
+						AccessToken: "123abc",
 					}, nil
 				},
 			},
 			Args:       args("auth-token create --expires 2021-09-15T23:00:00Z --name Testing --password secure --scope purge_all,global:read --services a,b,c --token 123"),
-			WantOutput: "Created token 'Testing' (id: 123, scope: purge_all global:read, expires: 2021-09-15 23:00:00 +0000 UTC)",
+			WantOutput: "Created token '123abc' (name: Testing, id: 123, scope: purge_all global:read, expires: 2021-09-15 23:00:00 +0000 UTC)",
 		},
 	}
 
@@ -286,16 +288,15 @@ func getToken() (*fastly.Token, error) {
 	t := testutil.Date
 
 	return &fastly.Token{
-		ID:          "123",
-		Name:        "Foo",
-		UserID:      "456",
-		Services:    []string{"a", "b"},
-		AccessToken: "xyz",
-		Scope:       fastly.TokenScope(fmt.Sprintf("%s %s", fastly.PurgeAllScope, fastly.GlobalReadScope)),
-		IP:          "127.0.0.1",
-		CreatedAt:   &t,
-		ExpiresAt:   &t,
-		LastUsedAt:  &t,
+		ID:         "123",
+		Name:       "Foo",
+		UserID:     "456",
+		Services:   []string{"a", "b"},
+		Scope:      fastly.TokenScope(fmt.Sprintf("%s %s", fastly.PurgeAllScope, fastly.GlobalReadScope)),
+		IP:         "127.0.0.1",
+		CreatedAt:  &t,
+		ExpiresAt:  &t,
+		LastUsedAt: &t,
 	}, nil
 }
 
@@ -305,16 +306,15 @@ func listTokens() ([]*fastly.Token, error) {
 	vs := []*fastly.Token{
 		token,
 		{
-			ID:          "456",
-			Name:        "Bar",
-			UserID:      "789",
-			Services:    []string{"a", "b"},
-			AccessToken: "999",
-			Scope:       fastly.GlobalScope,
-			IP:          "127.0.0.2",
-			CreatedAt:   &t,
-			ExpiresAt:   &t,
-			LastUsedAt:  &t,
+			ID:         "456",
+			Name:       "Bar",
+			UserID:     "789",
+			Services:   []string{"a", "b"},
+			Scope:      fastly.GlobalScope,
+			IP:         "127.0.0.2",
+			CreatedAt:  &t,
+			ExpiresAt:  &t,
+			LastUsedAt: &t,
 		},
 	}
 	return vs, nil
@@ -339,7 +339,6 @@ ID: 123
 Name: Foo
 User ID: 456
 Services: a, b
-Access Token: xyz
 Scope: purge_all global:read
 IP: 127.0.0.1
 
@@ -356,7 +355,6 @@ ID: 123
 Name: Foo
 User ID: 456
 Services: a, b
-Access Token: xyz
 Scope: purge_all global:read
 IP: 127.0.0.1
 
@@ -368,7 +366,6 @@ ID: 456
 Name: Bar
 User ID: 789
 Services: a, b
-Access Token: 999
 Scope: global
 IP: 127.0.0.2
 

--- a/pkg/commands/authtoken/create.go
+++ b/pkg/commands/authtoken/create.go
@@ -72,7 +72,12 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out, "Created token '%s' (name: %s, id: %s, scope: %s, expires: %s)", r.AccessToken, r.Name, r.ID, r.Scope, r.ExpiresAt)
+	expires := "never"
+	if r.ExpiresAt != nil {
+		expires = r.ExpiresAt.String()
+	}
+
+	text.Success(out, "Created token '%s' (name: %s, id: %s, scope: %s, expires: %s)", r.AccessToken, r.Name, r.ID, r.Scope, expires)
 	return nil
 }
 

--- a/pkg/commands/authtoken/create.go
+++ b/pkg/commands/authtoken/create.go
@@ -72,7 +72,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out, "Created token '%s' (id: %s, scope: %s, expires: %s)", r.Name, r.ID, r.Scope, r.ExpiresAt)
+	text.Success(out, "Created token '%s' (name: %s, id: %s, scope: %s, expires: %s)", r.AccessToken, r.Name, r.ID, r.Scope, r.ExpiresAt)
 	return nil
 }
 

--- a/pkg/commands/authtoken/describe.go
+++ b/pkg/commands/authtoken/describe.go
@@ -53,7 +53,6 @@ func (c *DescribeCommand) print(out io.Writer, r *fastly.Token) {
 	fmt.Fprintf(out, "Name: %s\n", r.Name)
 	fmt.Fprintf(out, "User ID: %s\n", r.UserID)
 	fmt.Fprintf(out, "Services: %s\n", strings.Join(r.Services, ", "))
-	fmt.Fprintf(out, "Access Token: %s\n", r.AccessToken)
 	fmt.Fprintf(out, "Scope: %s\n", r.Scope)
 	fmt.Fprintf(out, "IP: %s\n\n", r.IP)
 

--- a/pkg/commands/authtoken/list.go
+++ b/pkg/commands/authtoken/list.go
@@ -86,7 +86,6 @@ func (c *ListCommand) printVerbose(out io.Writer, rs []*fastly.Token) {
 		fmt.Fprintf(out, "Name: %s\n", r.Name)
 		fmt.Fprintf(out, "User ID: %s\n", r.UserID)
 		fmt.Fprintf(out, "Services: %s\n", strings.Join(r.Services, ", "))
-		fmt.Fprintf(out, "Access Token: %s\n", r.AccessToken)
 		fmt.Fprintf(out, "Scope: %s\n", r.Scope)
 		fmt.Fprintf(out, "IP: %s\n\n", r.IP)
 


### PR DESCRIPTION
- Display the returned access_token when creating a new token.
- Don't try to display access_token when describing or listing tokens as they aren't returned by the API.
- Fix create success message so the output doesn't show `<nil>` if `--expires` flag wasn't used.