### PR TITLE
Remove Rust debug flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/google/go-github/v38 v38.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/kennygrant/sanitize v1.2.4
-	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mholt/archiver/v3 v3.5.0
@@ -42,6 +41,7 @@ require (
 	github.com/google/jsonapi v0.0.0-20201022225600-f822737867f6 // indirect
 	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -431,14 +431,6 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 	if verbose {
 		args = append(args, "--verbose")
 	}
-	// Append debuginfo RUSTFLAGS to command environment to ensure DWARF debug
-	// information (such as, source mappings) are compiled into the binary.
-	rustflags := "-C debuginfo=2"
-	if val, ok := os.LookupEnv("RUSTFLAGS"); ok {
-		os.Setenv("RUSTFLAGS", fmt.Sprintf("%s %s", val, rustflags))
-	} else {
-		os.Setenv("RUSTFLAGS", rustflags)
-	}
 
 	// Execute the `cargo build` commands with the Wasm WASI target, release
 	// flags and env vars.


### PR DESCRIPTION
### TL;DR
Removes the `debuginfo=2` flag that we pass to `rustc` via a `RUSTFLAGS` env var, as its been found to slow down builds considerably and isn't really used for debugging.