### PR TITLE
Provide better remediation for unrecognised `manifest_version`

### DIFF
--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/fastly/cli/pkg/api"
@@ -53,6 +54,24 @@ type LanguageOptions struct {
 
 // NewLanguage constructs a new Language from a LangaugeOptions.
 func NewLanguage(options *LanguageOptions) *Language {
+	// Ensure the 'default' starter kit is always first.
+	sort.Slice(options.StarterKits, func(i, j int) bool {
+		suffix := fmt.Sprintf("%s-default", options.Name)
+		a := strings.HasSuffix(options.StarterKits[i].Path, suffix)
+		b := strings.HasSuffix(options.StarterKits[j].Path, suffix)
+		var (
+			bitSetA int8
+			bitSetB int8
+		)
+		if a {
+			bitSetA = 1
+		}
+		if b {
+			bitSetB = 1
+		}
+		return bitSetA > bitSetB
+	})
+
 	return &Language{
 		options.Name,
 		options.DisplayName,

--- a/pkg/commands/compute/manifest/manifest_test.go
+++ b/pkg/commands/compute/manifest/manifest_test.go
@@ -18,9 +18,10 @@ func TestManifest(t *testing.T) {
 	prefix := filepath.Join("../", "testdata", "init")
 
 	tests := map[string]struct {
-		manifest      string
-		valid         bool
-		expectedError error
+		manifest             string
+		valid                bool
+		expectedError        error
+		wantRemediationError string
 	}{
 		"valid: semver": {
 			manifest: "fastly-valid-semver.toml",
@@ -39,14 +40,16 @@ func TestManifest(t *testing.T) {
 			valid:    true,
 		},
 		"invalid: manifest_version Atoi error": {
-			manifest:      "fastly-invalid-unrecognised.toml",
-			valid:         false,
-			expectedError: errs.ErrUnrecognisedManifestVersion,
+			manifest:             "fastly-invalid-unrecognised.toml",
+			valid:                false,
+			expectedError:        errs.ErrUnrecognisedManifestVersion,
+			wantRemediationError: errs.ErrUnrecognisedManifestVersion.Remediation,
 		},
 		"unrecognised: manifest_version exceeded limit": {
-			manifest:      "fastly-invalid-version-exceeded.toml",
-			valid:         false,
-			expectedError: errs.ErrUnrecognisedManifestVersion,
+			manifest:             "fastly-invalid-version-exceeded.toml",
+			valid:                false,
+			expectedError:        errs.ErrUnrecognisedManifestVersion,
+			wantRemediationError: errs.ErrUnrecognisedManifestVersion.Remediation,
 		},
 	}
 
@@ -103,6 +106,8 @@ func TestManifest(t *testing.T) {
 				if !errors.As(err, &tc.expectedError) {
 					t.Fatalf("incorrect error type: %T, expected: %T", err, tc.expectedError)
 				}
+				// Ensure the remediation error is as expected.
+				testutil.AssertRemediationErrorContains(t, err, tc.wantRemediationError)
 			}
 		})
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -14,11 +14,17 @@ var ErrMissingManifestVersion = RemediationError{Inner: fmt.Errorf("no manifest_
 
 // ErrUnrecognisedManifestVersion means an invalid manifest (fastly.toml)
 // version has been specified.
-var ErrUnrecognisedManifestVersion = RemediationError{Inner: fmt.Errorf("unrecognised manifest_version found in the fastly.toml"), Remediation: BugRemediation}
+var ErrUnrecognisedManifestVersion = RemediationError{
+	Inner:       fmt.Errorf("unrecognised manifest_version found in the fastly.toml"),
+	Remediation: CLIUpdateRemediation,
+}
 
 // ErrInvalidManifestVersion means the manifest_version is defined as a toml
 // section.
-var ErrInvalidManifestVersion = RemediationError{Inner: fmt.Errorf("failed to parse fastly.toml when checking if manifest_version was valid"), Remediation: "Delete `[manifest_version]` from the fastly.toml if present"}
+var ErrInvalidManifestVersion = RemediationError{
+	Inner:       fmt.Errorf("failed to parse fastly.toml when checking if manifest_version was valid"),
+	Remediation: "Delete `[manifest_version]` from the fastly.toml if present",
+}
 
 // ErrSignalInterrupt means a SIGINT was received.
 var ErrSignalInterrupt = fmt.Errorf("a SIGINT was received")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,15 +2,30 @@ package errors
 
 import "fmt"
 
+// ErrSignalInterrupt means a SIGINT was received.
+var ErrSignalInterrupt = fmt.Errorf("a SIGINT was received")
+
+// ErrSignalKilled means a SIGTERM was received.
+var ErrSignalKilled = fmt.Errorf("a SIGTERM was received")
+
 // ErrNoToken means no --token has been provided.
-var ErrNoToken = RemediationError{Inner: fmt.Errorf("no token provided"), Remediation: AuthRemediation}
+var ErrNoToken = RemediationError{
+	Inner:       fmt.Errorf("no token provided"),
+	Remediation: AuthRemediation,
+}
 
 // ErrNoServiceID means no --service-id or service_id package manifest value has
 // been provided.
-var ErrNoServiceID = RemediationError{Inner: fmt.Errorf("error reading service: no service ID found"), Remediation: ServiceIDRemediation}
+var ErrNoServiceID = RemediationError{
+	Inner:       fmt.Errorf("error reading service: no service ID found"),
+	Remediation: ServiceIDRemediation,
+}
 
 // ErrMissingManifestVersion means an invalid manifest (fastly.toml) has been used.
-var ErrMissingManifestVersion = RemediationError{Inner: fmt.Errorf("no manifest_version found in the fastly.toml"), Remediation: BugRemediation}
+var ErrMissingManifestVersion = RemediationError{
+	Inner:       fmt.Errorf("no manifest_version found in the fastly.toml"),
+	Remediation: BugRemediation,
+}
 
 // ErrUnrecognisedManifestVersion means an invalid manifest (fastly.toml)
 // version has been specified.
@@ -26,11 +41,8 @@ var ErrInvalidManifestVersion = RemediationError{
 	Remediation: "Delete `[manifest_version]` from the fastly.toml if present",
 }
 
-// ErrSignalInterrupt means a SIGINT was received.
-var ErrSignalInterrupt = fmt.Errorf("a SIGINT was received")
-
-// ErrSignalKilled means a SIGTERM was received.
-var ErrSignalKilled = fmt.Errorf("a SIGTERM was received")
-
 // ErrNoID means no --id value has been provided.
-var ErrNoID = RemediationError{Inner: fmt.Errorf("no ID found"), Remediation: IDRemediation}
+var ErrNoID = RemediationError{
+	Inner:       fmt.Errorf("no ID found"),
+	Remediation: IDRemediation,
+}

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -103,3 +103,10 @@ var PackageSizeRemediation = strings.Join([]string{
 	"Please check our Compute@Edge resource limits:",
 	"https://developer.fastly.com/learning/compute/#limitations-and-constraints",
 }, " ")
+
+// CLIUpdateRemediation suggests updating the installed CLI version.
+var CLIUpdateRemediation = strings.Join([]string{
+	"Please try updating the installed CLI version using:",
+	"`fastly update`.",
+	BugRemediation,
+}, " ")


### PR DESCRIPTION
**NOTE**: This PR also fixes two other issues... 

1. An external library function (`toml.Unmarshal()`) manipulates the returned error, resulting in the intended remediation error message being hidden.
2. The 'default' starter kit is no longer showing as the first option.