### PR TITLE
trim the rust version to fix parse errors

### DIFF
--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -190,7 +190,7 @@ func validateCompilerVersion(constraint string) error {
 
 	rustcVersion, err := semver.NewVersion(version)
 	if err != nil {
-		return fmt.Errorf("error parsing `%s` output into a semver: %w", "rustc --version", err)
+		return fmt.Errorf("error parsing `%s` output %q into a semver: %w", "rustc --version", version, err)
 	}
 
 	rustcConstraint, err := semver.NewConstraint(constraint)
@@ -222,6 +222,7 @@ func rustcVersion() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error reading `%s` output: %w", strings.Join(cmd, " "), err)
 	}
+	line = strings.TrimSpace(line)
 
 	// Example outputs:
 	// rustc 1.54.0 (a178d0322 2021-07-26)


### PR DESCRIPTION
## problem

some rust installations have a version string of just "rustc 1.55.0\n"
in this case, the \n doesn't get stripped out and the cli reports an invalid verion number and errors out

## solution

trim the line returned by the call to rustc --version
if it's "rustc 1.55.0\n", the \n will be immediately removed before any other processing on the string version