### PR TITLE
Auto-migrate `manifest_version = 1` to latest version if `[setup]` not configured

### DIFF
--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -29,8 +29,7 @@ const (
 	// supported by the CLI.
 	//
 	// NOTE: The CLI is the primary consumer of the fastly.toml manifest
-	// specification so it's not unreasonable to presume that the latest version
-	// should be coupled to the latest version of the CLI.
+	// specification so its code is coupled to the specification.
 	ManifestLatestVersion = 2
 
 	// FilePermissions represents a read/write file mode.
@@ -310,7 +309,7 @@ func (f *File) Read(fpath string) (err error) {
 
 	// The Validate() method will either return the []byte unmodified or it will
 	// have updated the manifest_version field to reflect the latest version
-	// supported.
+	// supported by the Fastly CLI.
 	//
 	// We do this because we want to avoid a generic error from toml.Unmarshal
 	// when dealing with toml configuration that's in a older/unsupported format.

--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/fastly/cli/pkg/env"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -54,8 +53,6 @@ const (
 	// SpecURL points to the fastly.toml manifest specification reference.
 	SpecURL = "https://developer.fastly.com/reference/fastly-toml/"
 )
-
-var once sync.Once
 
 // Data holds global-ish manifest data from manifest files, and flag sources.
 // It has methods to give each parameter to the components that need it,
@@ -349,20 +346,11 @@ func (f *File) Read(fpath string) (err error) {
 	if f.ManifestVersion == 0 {
 		f.ManifestVersion = ManifestLatestVersion
 
-		// NOTE: the use of once is a quick-fix to side-step duplicate outputs.
-		// To fix this properly will require a refactor of the structure of how our
-		// global output is passed around.
-		//
-		// TODO: Now we only read the manifest once in app.Run() this logic block
-		// might be redundant and be ripe for deletion. Removing once.Do() will be
-		// blocked by https://github.com/fastly/cli/pull/433
-		once.Do(func() {
-			text.Warning(f.output, fmt.Sprintf("The fastly.toml was missing a `manifest_version` field. A default schema version of `%d` will be used.", ManifestLatestVersion))
-			text.Break(f.output)
-			text.Output(f.output, fmt.Sprintf("Refer to the fastly.toml package manifest format: %s", SpecURL))
-			text.Break(f.output)
-			f.Write(fpath)
-		})
+		text.Warning(f.output, fmt.Sprintf("The fastly.toml was missing a `manifest_version` field. A default schema version of `%d` will be used.", ManifestLatestVersion))
+		text.Break(f.output)
+		text.Output(f.output, fmt.Sprintf("Refer to the fastly.toml package manifest format: %s", SpecURL))
+		text.Break(f.output)
+		f.Write(fpath)
 	}
 
 	return nil

--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -27,8 +27,8 @@ const (
 	// ManifestLatestVersion represents the latest known manifest schema version
 	// supported by the CLI.
 	//
-	// NOTE: The CLI is the primary consumer of the fastly.toml manifest
-	// specification so its code is coupled to the specification.
+	// NOTE: The CLI is the primary consumer of the fastly.toml manifest so its
+	// code is typically coupled to the specification.
 	ManifestLatestVersion = 2
 
 	// FilePermissions represents a read/write file mode.

--- a/pkg/commands/compute/manifest/manifest_test.go
+++ b/pkg/commands/compute/manifest/manifest_test.go
@@ -99,6 +99,10 @@ func TestManifest(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+
+				if m.ManifestVersion != manifest.ManifestLatestVersion {
+					t.Fatalf("manifest_version '%d' doesn't match latest '%d'", m.ManifestVersion, manifest.ManifestLatestVersion)
+				}
 			} else {
 				// otherwise if we expect the manifest to be invalid/unrecognised then
 				// the error should match our expectations.

--- a/pkg/commands/compute/manifest/manifest_test.go
+++ b/pkg/commands/compute/manifest/manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -32,26 +33,23 @@ func TestManifest(t *testing.T) {
 			valid:    true,
 		},
 		"invalid: missing manifest_version": {
-			manifest:      "fastly-invalid-missing-version.toml",
-			valid:         false,
-			expectedError: errs.ErrMissingManifestVersion,
+			manifest: "fastly-invalid-missing-version.toml",
+			valid:    true, // expect manifest_version to be set to latest version
 		},
 		"invalid: manifest_version as a section": {
-			manifest:      "fastly-invalid-section-version.toml",
-			valid:         false,
-			expectedError: errs.ErrMissingManifestVersion,
+			manifest: "fastly-invalid-section-version.toml",
+			valid:    true, // expect manifest_version to be set to latest version
 		},
 		"invalid: manifest_version Atoi error": {
-			manifest:             "fastly-invalid-unrecognised.toml",
-			valid:                false,
-			expectedError:        errs.ErrUnrecognisedManifestVersion,
-			wantRemediationError: errs.ErrUnrecognisedManifestVersion.Remediation,
+			manifest:      "fastly-invalid-unrecognised.toml",
+			valid:         false,
+			expectedError: strconv.ErrSyntax,
 		},
 		"unrecognised: manifest_version exceeded limit": {
 			manifest:             "fastly-invalid-version-exceeded.toml",
 			valid:                false,
-			expectedError:        errs.ErrIncompatibleManifestVersion,
-			wantRemediationError: errs.ErrIncompatibleManifestVersion.Remediation,
+			expectedError:        errs.ErrUnrecognisedManifestVersion,
+			wantRemediationError: errs.ErrUnrecognisedManifestVersion.Remediation,
 		},
 	}
 

--- a/pkg/commands/compute/manifest/manifest_test.go
+++ b/pkg/commands/compute/manifest/manifest_test.go
@@ -55,17 +55,16 @@ func TestManifest(t *testing.T) {
 		},
 	}
 
-	// NOTE: the fixture files "fastly-invalid-missing-version.toml" and
-	// "fastly-invalid-section-version.toml" will be overwritten by the test as
-	// the internal logic is supposed to add back into the manifest a
-	// manifest_version field if one isn't found (or is invalid).
-	//
-	// To ensure future test runs complete successfully we do an initial read of
-	// the data and then write it back out when the tests have completed.
+	// NOTE: some of the fixture files are overwritten by the application logic
+	// and so to ensure future test runs can complete successfully we do an
+	// initial read of the data and then write it back to disk once the tests
+	// have completed.
 
 	for _, fpath := range []string{
 		"fastly-invalid-missing-version.toml",
 		"fastly-invalid-section-version.toml",
+		"fastly-invalid-unrecognised.toml",
+		"fastly-invalid-version-exceeded.toml",
 	} {
 		path, err := filepath.Abs(filepath.Join(prefix, fpath))
 		if err != nil {

--- a/pkg/commands/compute/testdata/init/fastly-valid-semver.toml
+++ b/pkg/commands/compute/testdata/init/fastly-valid-semver.toml
@@ -1,4 +1,4 @@
-manifest_version = "0.2.0"
+manifest_version = "0.99.0" # minor and patch versions are ignored and zero major is bumped to latest
 name = "Default Rust template"
 description = "Default package template for Rust based edge compute projects."
 authors = ["phamann <patrick@fastly.com>"]


### PR DESCRIPTION
The current release of the CLI gives a remediation error to users informing them that the fastly.toml `manifest_version` they have set is incompatible with the version supported by the CLI (currently version 2).

This is because version 2 of the manifest schema changed the way the `[setup]` configuration was structured, coupling a breaking change into the CLI code.

I've realised we can help mitigate this error messaging by checking if the `[setup]` configuration is set or not. As that configuration option is still very new and unlikely to be used by anyone (other than the [rust default starter kit](https://github.com/fastly/compute-starter-kit-rust-default)) it means the majority of users won't find themselves in the scenario where they have `manifest_version = 1` **_AND_** have a `[setup]` configured in the fastly.toml, so we should be safe to update their manifest file so it contains `manifest_version = 2` and thus avoid any errors about an incompatible manifest version.

> **NOTE**: This doesn't solve the problem long term for users who use the Fastly CLI within a CI environment. It just means that every time their code runs the local copy of the fastly.toml will be updated each time.