### PR TITLE
Fix shell completion

### DIFF
--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -46,6 +46,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/purge"
 	"github.com/fastly/cli/pkg/commands/service"
 	"github.com/fastly/cli/pkg/commands/serviceversion"
+	"github.com/fastly/cli/pkg/commands/shellcomplete"
 	"github.com/fastly/cli/pkg/commands/stats"
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/commands/user"
@@ -63,6 +64,7 @@ func defineCommands(
 	globals *config.Data,
 	data manifest.Data,
 	opts RunOpts) []cmd.Command {
+	shellcompleteCmdRoot := shellcomplete.NewRootCommand(app, globals)
 	aclCmdRoot := acl.NewRootCommand(app, globals)
 	aclCreate := acl.NewCreateCommand(aclCmdRoot.CmdClause, globals, data)
 	aclDelete := acl.NewDeleteCommand(aclCmdRoot.CmdClause, globals, data)
@@ -326,6 +328,7 @@ func defineCommands(
 	whoamiCmdRoot := whoami.NewRootCommand(app, opts.HTTPClient, globals)
 
 	return []cmd.Command{
+		shellcompleteCmdRoot,
 		aclCmdRoot,
 		aclCreate,
 		aclDelete,

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,6 +15,10 @@ import (
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v5/fastly"
 	"github.com/fastly/kingpin"
+)
+
+var (
+	completionRegExp = regexp.MustCompile("completion-(?:script-)?(?:bash|zsh)$")
 )
 
 // RegisterServiceIDFlag defines a --service-id flag that will attempt to
@@ -188,4 +193,16 @@ func IntToBool(i int) bool {
 func ContextHasHelpFlag(ctx *kingpin.ParseContext) bool {
 	_, ok := ctx.Elements.FlagMap()["help"]
 	return ok
+}
+
+// IsCompletion determines whether the supplied command arguments are for
+// bash/zsh completion output.
+func IsCompletion(args []string) bool {
+	var found bool
+	for _, arg := range args {
+		if completionRegExp.MatchString(arg) {
+			found = true
+		}
+	}
+	return found
 }

--- a/pkg/commands/shellcomplete/root.go
+++ b/pkg/commands/shellcomplete/root.go
@@ -1,0 +1,28 @@
+package shellcomplete
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	cmd.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("shellcomplete", "Hidden command used to prevent help output when using --completion-script-<T>").Hidden()
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	panic("unreachable")
+}


### PR DESCRIPTION
An earlier refactor of `app.Run()` caused the shell completion flags to return a runtime panic.

This subsequently broke updating the app via Homebrew as it [calls the fastly binary with these flags automatically](https://github.com/fastly/homebrew-tap/blob/master/Formula/fastly.rb#L41-L42).

## TESTS

I've added tests to validate the shell completion output. This means in future if we were to accidentally break the behaviour again we should see it as a CI error and it will prevent us from merging the breaking code.

## NOTES

While implementing a fix for this feature I discovered `app.Parse()` (a Kingpin method) was resetting the values we set for where Kingpin should write its output (we use `app.Writers()` to set `os.Stdout` and `os.Stderr` temporarily to use `io.Discard` for reasons already documented in the CLI code). 

This was a problem because once I started working on a fix I noticed I was not only seeing the shell completion output but it was being followed by our verbose help output. This was happening because when we execute the CLI binary but only pass a shell completion flag, then we're not actually passing a command (e.g. like `fastly acl`), so the Kingpin parser thinks this is an error and provides the help output and tells us to provide a command.

Because Kingpin is internally overriding where it writes output to (it sets it to `os.Stdout` rather than what we had set, which was `io.Discard`) it means I can't stop Kingpin from displaying the help output. So to work around this I ensure the arguments provided to the Kingpin parser include a valid command (along with the shell completion flag). 

An example might look something like:

```bash
fastly --completion-script-bash acl
```

But rather than rely on an actual user feature command like `acl`, I define a 'hidden' command (i.e. it doesn't show up in the help output) called `shellcomplete` that we can safely append to the arguments list. We don't have to worry about this hidden command being accidentally removed in the future as we now have a test to validate the shell autocomplete behaviours.

For posterity I've added these notes as comments in the CLI code.