### PR TITLE
fix shell autocomplete evaluation

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -99,6 +99,35 @@ _fastly_bash_autocomplete() {
 complete -F _fastly_bash_autocomplete fastly
 `,
 		},
+		{
+			Name: "shell evaluate completion options",
+			Args: args("--completion-bash"),
+			WantOutput: `help
+acl
+acl-entry
+auth-token
+backend
+compute
+configure
+dictionary
+dictionaryitem
+domain
+healthcheck
+ip-list
+logging
+logs
+pops
+purge
+service
+service-version
+stats
+update
+user
+vcl
+version
+whoami
+`,
+		},
 	}
 	for _, testcase := range scenarios {
 		t.Run(testcase.Name, func(t *testing.T) {

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -18,7 +18,8 @@ import (
 )
 
 var (
-	completionRegExp = regexp.MustCompile("completion-(?:script-)?(?:bash|zsh)$")
+	completionRegExp       = regexp.MustCompile("completion-bash$")
+	completionScriptRegExp = regexp.MustCompile("completion-script-(?:bash|zsh)$")
 )
 
 // RegisterServiceIDFlag defines a --service-id flag that will attempt to
@@ -195,8 +196,21 @@ func ContextHasHelpFlag(ctx *kingpin.ParseContext) bool {
 	return ok
 }
 
+// IsCompletionScript determines whether the supplied command arguments are for
+// shell completion output that is then eval()'ed by the user's shell.
+func IsCompletionScript(args []string) bool {
+	var found bool
+	for _, arg := range args {
+		if completionScriptRegExp.MatchString(arg) {
+			found = true
+		}
+	}
+	return found
+}
+
 // IsCompletion determines whether the supplied command arguments are for
-// bash/zsh completion output.
+// shell completion (i.e. --completion-bash) that should produce output that
+// the user's shell can utilise for handling autocomplete behaviour.
 func IsCompletion(args []string) bool {
 	var found bool
 	for _, arg := range args {


### PR DESCRIPTION
After fixing an issue with the autocomplete flags not working at all, and causing homebrew upgrades to reveal a runtime error I then discovered that the autocomplete feature itself was only partially working (mostly broken).

This PR fixes this by ensuring `fastly --completion-bash` produces the expected output. I've also added a test to validate the behaviour so we'll know if we break it in future.