### PR TITLE
Use `EnumsVar` for `auth-token --scope`

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -394,7 +394,7 @@ COMMANDS
                              $FASTLY_API_TOKEN
     --expires=EXPIRES        Time-stamp (UTC) of when the token will expire
     --name=NAME              Name of the token
-    --scope=SCOPE ...        A comma-separated list of authorization scope
+    --scope=SCOPE ...        Authorization scope (repeat flag per scope)
     --services=SERVICES ...  A comma-separated list of alphanumeric strings
                              identifying services (default: access to all
                              services)

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -64,7 +64,7 @@ func TestCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("auth-token create --expires 2021-09-15T23:00:00Z --name Testing --password secure --scope purge_all,global:read --services a,b,c --token 123"),
+			Args:       args("auth-token create --expires 2021-09-15T23:00:00Z --name Testing --password secure --scope purge_all --scope global:read --services a,b,c --token 123"),
 			WantOutput: "Created token '123abc' (name: Testing, id: 123, scope: purge_all global:read, expires: 2021-09-15 23:00:00 +0000 UTC)",
 		},
 	}


### PR DESCRIPTION
## What?

The current interface offered a `--scope` flag that accepted a comma-separated list of scopes:

```
--scope global,purge_select,purge_all,global:read
```

We currently have no validation of the individual scopes provided by the user, we rely on the API to handle validation.

To take advantage of Kingpin's built-in validation I've switched the flag to using enums. 

## Breaking?

This is a breaking change as it changes the user interface. 

Usage becomes:

```
--scope global --scope purge_select --scope purge_all --scope global:read
```

## Screenshots

The following screenshot demonstrates we still get autocomplete hints for the appropriate flag values, but additionally now if I don't use autocomplete hints or just ignore them and type something unrecognised, then the CLI will report a clearer error to the user that the value they provided doesn't match accepted values.

<img width="938" alt="Screenshot 2021-10-21 at 14 46 58" src="https://user-images.githubusercontent.com/180050/138295517-6c5c4af9-9326-4063-8c53-f27d444daa5f.png">
