### PR TITLE
Ignore possible `rustup` output in `rustc --version`. Closes #452

### DIFF
--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -226,10 +226,6 @@ func rustcVersion() (string, error) {
 	// scanner quits, at which point `scanner.Text()` is the last observed line.
 	line := ""
 	for scanner.Scan() {
-		err = scanner.Err()
-		if err != nil {
-			return "", fmt.Errorf("error reading `%s` output: %w", strings.Join(cmd, " "), err)
-		}
 		line = scanner.Text()
 	}
 	err = scanner.Err()

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -222,14 +222,11 @@ func rustcVersion() (string, error) {
 	// (or any Rust distribution executable) will install it. This produces some
 	// `rustup` output before the real `rustc --version` command fires.
 	scanner := bufio.NewScanner(bytes.NewReader(stdoutStderr))
-	// As such, seek the *last* line in the scanner. This loops until the
-	// scanner quits, at which point `scanner.Text()` is the last observed line.
 	line := ""
 	for scanner.Scan() {
 		line = scanner.Text()
 	}
 	err = scanner.Err()
-	// If the scanner never fires, then something has clearly gone wrong
 	if line == "" || err != nil {
 		return "", fmt.Errorf("error reading `%s` output: %w", strings.Join(cmd, " "), err)
 	}


### PR DESCRIPTION
If the `rustc` executable that the CLI invokes is managed by `rustup`,
*and* the Rust toolchain that `rustup` considers active for the PWD is
not installed, then the first several lines of output are from `rustup`
installing the toolchain, and only after it finishes does `rustup`
execute the real `rustc --version` and print its output.

This patch collects and throws away all but the last output lines from
`rustc --version`, since the last line is *always* the version string.

It has been tested to work by using `fastly compute init`, changing the
`rust-toolchain` file to a named version not installed, then running
`fastly compute serve`. This caused an installation, then was able to
correctly parse the output of `rustc --version` and continue.