### PR TITLE
Bump goreleaser to avoid Homebrew warning

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: "Run GoReleaser"
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: v0.177.0 # goreleaser version (NOT goreleaser-action version)
+        version: v0.183.0 # goreleaser version (NOT goreleaser-action version)
         args: release --rm-dist
       env:
         GOVERSION: ${{ env.GOVERSION }}


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the fastly/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/fastly/homebrew-tap/Formula/fastly.rb:9
```

The file is generated by goreleaser, and they have fixed this upstream: https://github.com/goreleaser/goreleaser/commit/ba9b75a0950e665b5c69ba1efac8979ef8908409