### PR TITLE
Rename `--force` to `--skip-verification`

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -231,8 +231,8 @@ SUBCOMMANDS
     Create a Fastly service
 
     -n, --name=NAME        Service name
-        --type=wasm        Service type. Can be one of "wasm" or "vcl", defaults
-                           to "wasm".
+        --type=vcl         Service type. Can be one of "wasm" or "vcl", defaults
+                           to "vcl".
         --comment=COMMENT  Human-readable comment
 
   service delete [<flags>]
@@ -3980,8 +3980,8 @@ COMMANDS
     Create a Fastly service
 
     -n, --name=NAME        Service name
-        --type=wasm        Service type. Can be one of "wasm" or "vcl", defaults
-                           to "wasm".
+        --type=vcl         Service type. Can be one of "wasm" or "vcl", defaults
+                           to "vcl".
         --comment=COMMENT  Human-readable comment
 
   service delete [<flags>]

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -576,7 +576,7 @@ COMMANDS
     --name=NAME          Package name
     --language=LANGUAGE  Language type
     --include-source     Include source code in built package
-    --force              Skip verification steps and force build
+    --skip-verification  Skip verification steps and force build
     --timeout=TIMEOUT    Timeout, in seconds, for the build compilation step
 
   compute deploy [<flags>]
@@ -621,7 +621,7 @@ COMMANDS
         --name=NAME              Package name
         --language=LANGUAGE      Language type
         --include-source         Include source code in built package
-        --force                  Skip verification steps and force build
+        --skip-verification      Skip verification steps and force build
         --timeout=TIMEOUT        Timeout, in seconds, for the build compilation
                                  step
         --accept-defaults        Accept default values for all prompts and
@@ -641,11 +641,11 @@ COMMANDS
     --addr="127.0.0.1:7676"  The IPv4 address and port to listen on
     --env=ENV                The environment configuration to use (e.g. stage)
     --file="bin/main.wasm"   The Wasm file to run
-    --force                  Skip verification steps and force build
     --include-source         Include source code in built package
     --language=LANGUAGE      Language type
     --name=NAME              Package name
     --skip-build             Skip the build step
+    --skip-verification      Skip verification steps and force build
 
   compute update --version=VERSION --path=PATH [<flags>]
     Update a package on a Fastly Compute@Edge service version

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -59,7 +59,7 @@ func NewBuildCommand(parent cmd.Registerer, client api.HTTPClient, globals *conf
 	c.CmdClause.Flag("name", "Package name").StringVar(&c.PackageName)
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Lang)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.IncludeSrc)
-	c.CmdClause.Flag("force", "Skip verification steps and force build").BoolVar(&c.Force)
+	c.CmdClause.Flag("skip-verification", "Skip verification steps and force build").BoolVar(&c.Force)
 	c.CmdClause.Flag("timeout", "Timeout, in seconds, for the build compilation step").IntVar(&c.Timeout)
 
 	return &c

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -44,7 +44,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.CmdClause.Flag("name", "Package name").Action(c.name.Set).StringVar(&c.name.Value)
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
-	c.CmdClause.Flag("force", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
+	c.CmdClause.Flag("skip-verification", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
 	c.CmdClause.Flag("timeout", "Timeout, in seconds, for the build compilation step").Action(c.timeout.Set).IntVar(&c.timeout.Value)
 
 	// Deploy flags

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -52,11 +52,11 @@ func NewServeCommand(parent cmd.Registerer, globals *config.Data, build *BuildCo
 	c.CmdClause.Flag("addr", "The IPv4 address and port to listen on").Default("127.0.0.1:7676").StringVar(&c.addr)
 	c.CmdClause.Flag("env", "The environment configuration to use (e.g. stage)").Action(c.env.Set).StringVar(&c.env.Value)
 	c.CmdClause.Flag("file", "The Wasm file to run").Default("bin/main.wasm").StringVar(&c.file)
-	c.CmdClause.Flag("force", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("name", "Package name").Action(c.name.Set).StringVar(&c.name.Value)
 	c.CmdClause.Flag("skip-build", "Skip the build step").BoolVar(&c.skipBuild)
+	c.CmdClause.Flag("skip-verification", "Skip verification steps and force build").Action(c.force.Set).BoolVar(&c.force.Value)
 
 	return &c
 }

--- a/pkg/commands/configure/root.go
+++ b/pkg/commands/configure/root.go
@@ -46,18 +46,31 @@ func NewRootCommand(parent cmd.Registerer, configFilePath string, cf APIClientFa
 
 // Exec implements the command interface.
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) (err error) {
-	if c.location || c.display {
-		if c.location {
-			fmt.Printf("\n%s\n\n%s\n", text.Bold("LOCATION"), config.FilePath)
+	if c.location && c.display {
+		fmt.Printf("\n%s\n\n%s\n", text.Bold("LOCATION"), config.FilePath)
+
+		data, err := os.ReadFile(config.FilePath)
+		if err != nil {
+			c.Globals.ErrLog.Add(err)
+			return err
 		}
-		if c.display {
-			data, err := os.ReadFile(config.FilePath)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return err
-			}
-			fmt.Printf("\n%s\n\n%s\n", text.Bold("CONFIG"), string(data))
+		fmt.Printf("\n%s\n\n%s\n", text.Bold("CONFIG"), string(data))
+
+		return nil
+	}
+
+	if c.location {
+		fmt.Println(config.FilePath)
+		return nil
+	}
+
+	if c.display {
+		data, err := os.ReadFile(config.FilePath)
+		if err != nil {
+			c.Globals.ErrLog.Add(err)
+			return err
 		}
+		fmt.Println(string(data))
 		return nil
 	}
 

--- a/pkg/commands/service/create.go
+++ b/pkg/commands/service/create.go
@@ -21,7 +21,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data) *CreateComman
 	c.Globals = globals
 	c.CmdClause = parent.Command("create", "Create a Fastly service").Alias("add")
 	c.CmdClause.Flag("name", "Service name").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("type", `Service type. Can be one of "wasm" or "vcl", defaults to "wasm".`).Default("wasm").EnumVar(&c.Input.Type, "wasm", "vcl")
+	c.CmdClause.Flag("type", `Service type. Can be one of "wasm" or "vcl", defaults to "vcl".`).Default("vcl").EnumVar(&c.Input.Type, "wasm", "vcl")
 	c.CmdClause.Flag("comment", "Human-readable comment").StringVar(&c.Input.Comment)
 	return &c
 }


### PR DESCRIPTION
This PR also makes two other corrections... 

1. The `fastly configure` command output when using the `--location` and `--display` flags currently displays a header (e.g. **LOCATION** and **CONFIG**) before the output. If the user only provides one of the flags then a header isn't displayed (as this actually makes it hard to use the location as part of a bash script parsing the path or piping the file content etc), but if the user provides _both_ flags then the headers are still displayed to help distinguish the output.

2. We default the `service create` command's `--type` flag to 'vcl' instead of 'wasm' as the latter isn't GA and so it doesn't make sense for it to be the default behaviour.