### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.0.0](https://github.com/fastly/cli/releases/tag/v1.0.0) (2021-11-02)
+
+[Full Changelog](https://github.com/fastly/cli/compare/v0.43.0...v1.0.0)
+
+**Changed:**
+
+* Use `EnumsVar` for `auth-token --scope` [#447](https://github.com/fastly/cli/pull/447)
+* Rename `logs tail` to `log-tail` [#456](https://github.com/fastly/cli/pull/456)
+* Rename `dictionaryitem` to `dictionary-item` [#459](https://github.com/fastly/cli/pull/459)
+* Rename `fastly compute ... --path` flags [#460](https://github.com/fastly/cli/pull/460)
+* Rename `--force` to `--skip-verification` [#461](https://github.com/fastly/cli/pull/461)
+
 ## [v0.43.0](https://github.com/fastly/cli/releases/tag/v0.43.0) (2021-11-01)
 
 [Full Changelog](https://github.com/fastly/cli/compare/v0.42.0...v0.43.0)


### PR DESCRIPTION
This PR leads us to our `v1.0.0` release of the CLI.

Prior to this PR we have merged into the `main` branch a set of changes that have been grouped together because they are seen as 'breaking' changes. 

This means if the CLI is being used in a CI (or otherwise scripted environment), then changes to a user's scripted use of the CLI may need to change depending on whether they're utilising one of the features that have since had an updated interface.

If using Fastly's [compute-actions](https://github.com/fastly/compute-actions#custom-workflows) GitHub Actions workflow, and the `v1.0.0` is breaking your workflow, then you might need to manually configure the CLI version to be a non-breaking version like so:

```yaml
- name: Setup Fastly CLI
  uses: fastly/compute-actions/setup@main
  with:
    cli_version: '0.43.0'
```