### PR TITLE
Set defaults for backend creation

### DIFF
--- a/pkg/commands/backend/create.go
+++ b/pkg/commands/backend/create.go
@@ -15,16 +15,21 @@ import (
 // CreateCommand calls the Fastly API to create backends.
 type CreateCommand struct {
 	cmd.Base
-	manifest       manifest.Data
-	Input          fastly.CreateBackendInput
-	serviceVersion cmd.OptionalServiceVersion
-	autoClone      cmd.OptionalAutoClone
+	manifest manifest.Data
+
+	Input fastly.CreateBackendInput
 
 	// We must store all of the boolean flags separately to the input structure
 	// so they can be casted to go-fastly's custom `Compatibool` type later.
 	AutoLoadbalance bool
-	UseSSL          bool
 	SSLCheckCert    bool
+	UseSSL          bool
+
+	autoClone       cmd.OptionalAutoClone
+	overrideHost    cmd.OptionalString
+	serviceVersion  cmd.OptionalServiceVersion
+	sslCertHostname cmd.OptionalString
+	sslSNIHostname  cmd.OptionalString
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -45,7 +50,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.CmdClause.Flag("address", "A hostname, IPv4, or IPv6 address for the backend").Required().StringVar(&c.Input.Address)
 	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.Input.Comment)
 	c.CmdClause.Flag("port", "Port number of the address").UintVar(&c.Input.Port)
-	c.CmdClause.Flag("override-host", "The hostname to override the Host header").StringVar(&c.Input.OverrideHost)
+	c.CmdClause.Flag("override-host", "The hostname to override the Host header").Action(c.overrideHost.Set).StringVar(&c.overrideHost.Value)
 	c.CmdClause.Flag("connect-timeout", "How long to wait for a timeout in milliseconds").UintVar(&c.Input.ConnectTimeout)
 	c.CmdClause.Flag("max-conn", "Maximum number of connections").UintVar(&c.Input.MaxConn)
 	c.CmdClause.Flag("first-byte-timeout", "How long to wait for the first bytes in milliseconds").UintVar(&c.Input.FirstByteTimeout)
@@ -60,8 +65,8 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.CmdClause.Flag("ssl-ca-cert", "CA certificate attached to origin").StringVar(&c.Input.SSLCACert)
 	c.CmdClause.Flag("ssl-client-cert", "Client certificate attached to origin").StringVar(&c.Input.SSLClientCert)
 	c.CmdClause.Flag("ssl-client-key", "Client key attached to origin").StringVar(&c.Input.SSLClientKey)
-	c.CmdClause.Flag("ssl-cert-hostname", "Overrides ssl_hostname, but only for cert verification. Does not affect SNI at all.").StringVar(&c.Input.SSLCertHostname)
-	c.CmdClause.Flag("ssl-sni-hostname", "Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all.").StringVar(&c.Input.SSLSNIHostname)
+	c.CmdClause.Flag("ssl-cert-hostname", "Overrides ssl_hostname, but only for cert verification. Does not affect SNI at all.").Action(c.sslCertHostname.Set).StringVar(&c.sslCertHostname.Value)
+	c.CmdClause.Flag("ssl-sni-hostname", "Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all.").Action(c.sslSNIHostname.Set).StringVar(&c.sslSNIHostname.Value)
 	c.CmdClause.Flag("min-tls-version", "Minimum allowed TLS version on SSL connections to this backend").StringVar(&c.Input.MinTLSVersion)
 	c.CmdClause.Flag("max-tls-version", "Maximum allowed TLS version on SSL connections to this backend").StringVar(&c.Input.MaxTLSVersion)
 	c.CmdClause.Flag("ssl-ciphers", "Colon delimited list of OpenSSL ciphers (see https://www.openssl.org/docs/man1.0.2/man1/ciphers for details)").StringVar(&c.Input.SSLCiphers)
@@ -104,11 +109,21 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		c.Input.Port = 443
 	}
 
-	if c.Input.OverrideHost == "" && c.Input.SSLSNIHostname == "" && c.Input.SSLCertHostname == "" {
+	if !c.overrideHost.WasSet && !c.sslCertHostname.WasSet && !c.sslSNIHostname.WasSet {
 		overrideHost, sslSNIHostname, sslCertHostname := SetBackendHostDefaults(c.Input.Address)
 		c.Input.OverrideHost = overrideHost
 		c.Input.SSLSNIHostname = sslSNIHostname
 		c.Input.SSLCertHostname = sslCertHostname
+	} else {
+		if c.overrideHost.WasSet {
+			c.Input.OverrideHost = c.overrideHost.Value
+		}
+		if c.sslCertHostname.WasSet {
+			c.Input.SSLCertHostname = c.sslCertHostname.Value
+		}
+		if c.sslSNIHostname.WasSet {
+			c.Input.SSLSNIHostname = c.sslSNIHostname.Value
+		}
 	}
 
 	b, err := c.Globals.Client.CreateBackend(&c.Input)


### PR DESCRIPTION
We want to avoid this situation where we have to set the flags to the same value:

```
fastly backend create --name=example --address=example.com --override-host=example.com --ssl-cert-hostname=example.com --ssl-sni-hostname=example.com
```

Instead it would better if the user could just set:

```
fastly backend create --name=example --address=example.com
```

**NOTE**: I went back and updated the `compute deploy` logic so it included `ssl-cert-hostname` as we were only handling `override-host` and `ssl-sni-hostname`.

## Examples

1. Allow empty values
2. Allow individual values
3. Ensure sensible defaults
4. Validate IP address behaviour

### 1. Allow empty values

If user sets the flags (`--override-host`, `--ssl-cert-hostname`, `--ssl-sni-hostname`) with an empty string, then let those values be used.

```
$ fastly backend create --name allow_empty --address example.com --override-host "" --ssl-cert-hostname "" --ssl-sni-hostname "" --service-id ... --version latest
$ fastly backend list --service-id ... --version latest --verbose

                Name: allow_empty
                Comment:
                Address: example.com
                Port: 80
                Override host:
                Connect timeout: 1000
                Max connections: 200
                First byte timeout: 15000
                Between bytes timeout: 10000
                Auto loadbalance: false
                Weight: 100
                Healthcheck:
                Shield:
                Use SSL: false
                SSL check cert: false
                SSL CA cert:
                SSL client cert:
                SSL client key:
                SSL cert hostname:
                SSL SNI hostname:
                Min TLS version:
                Max TLS version:
                SSL ciphers:
```

### 2. Allow individual values

If user sets the flags (`--override-host`, `--ssl-cert-hostname`, `--ssl-sni-hostname`) with unique values, then let those values be used.

```
$ fastly backend create --name allow_individual --address example.com --override-host "example-one.com" --ssl-cert-hostname "example-two.com" --ssl-sni-hostname "example-three.com" --service-id ... --version latest
$ fastly backend list --service-id ... --version latest --verbose

                Name: allow_individual
                Comment:
                Address: example.com
                Port: 80
                Override host: example-one.com
                Connect timeout: 1000
                Max connections: 200
                First byte timeout: 15000
                Between bytes timeout: 10000
                Auto loadbalance: false
                Weight: 100
                Healthcheck:
                Shield:
                Use SSL: false
                SSL check cert: false
                SSL CA cert:
                SSL client cert:
                SSL client key:
                SSL cert hostname: example-two.com
                SSL SNI hostname: example-three.com
                Min TLS version:
                Max TLS version:
                SSL ciphers:
```

### 3. Ensure sensible defaults

If user omits all three flags (`--override-host`, `--ssl-cert-hostname`, `--ssl-sni-hostname`) and if `--address` is a hostname, then set all three field values to the hostname given in the `--address` flag.

```
$ fastly backend create --name ensure_sensible_defaults --address example.com --service-id ... --version latest
$ fastly backend list --service-id ... --version latest --verbose

                Name: ensure_sensible_defaults
                Comment:
                Address: example.com
                Port: 80
                Override host: example.com
                Connect timeout: 1000
                Max connections: 200
                First byte timeout: 15000
                Between bytes timeout: 10000
                Auto loadbalance: false
                Weight: 100
                Healthcheck:
                Shield:
                Use SSL: false
                SSL check cert: false
                SSL CA cert:
                SSL client cert:
                SSL client key:
                SSL cert hostname: example.com
                SSL SNI hostname: example.com
                Min TLS version:
                Max TLS version:
                SSL ciphers:
```
### 4. Validate IP address behaviour

If user omits all three flags (`--override-host`, `--ssl-cert-hostname`, `--ssl-sni-hostname`) and if `--address` is an IP, then don't set a value for any of the field values.

```
$ fastly backend create --name validate_ip_address --address 8.8.8.8 --service-id ... --version latest
$ fastly backend list --service-id ... --version latest --verbose

                Name: validate_ip_address_behaviour
                Comment:
                Address: 8.8.8.8
                Port: 80
                Override host:
                Connect timeout: 1000
                Max connections: 200
                First byte timeout: 15000
                Between bytes timeout: 10000
                Auto loadbalance: false
                Weight: 100
                Healthcheck:
                Shield:
                Use SSL: false
                SSL check cert: false
                SSL CA cert:
                SSL client cert:
                SSL client key:
                SSL cert hostname:
                SSL SNI hostname:
                Min TLS version:
                Max TLS version:
                SSL ciphers:
```