### PR TITLE
Fix error extracting package files from `.tgz` archive

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -31,10 +31,6 @@ const (
 // https://docs.fastly.com/products/compute-at-edge-billing-and-resource-limits#resource-limits
 var PackageSizeLimit int64 = 50000000
 
-// ErrStopWalk is used to indicate to filepath.WalkDir that it should stop
-// walking the directory tree.
-var ErrStopWalk = errors.New("stop directory walking")
-
 // DeployCommand deploys an artifact previously produced by build.
 type DeployCommand struct {
 	cmd.Base
@@ -455,7 +451,7 @@ func locateManifest(path string) (string, error) {
 		}
 		if !entry.IsDir() && filepath.Base(path) == manifest.Filename {
 			foundManifest = path
-			return ErrStopWalk
+			return fsterr.ErrStopWalk
 		}
 		return nil
 	})
@@ -463,7 +459,7 @@ func locateManifest(path string) (string, error) {
 	if err != nil {
 		// If the error isn't ErrStopWalk, then the WalkDir() function had an
 		// issue processing the directory tree.
-		if err != ErrStopWalk {
+		if err != fsterr.ErrStopWalk {
 			return "", err
 		}
 

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -596,9 +596,11 @@ mimes:
 		ext := filepath.Ext(filename)
 
 		for _, a := range archives {
-			if ext == a.Extension() {
-				archive = a
-				break
+			for _, e := range a.Extensions() {
+				if ext == e {
+					archive = a
+					break
+				}
 			}
 		}
 	}

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -553,6 +553,8 @@ func fetchPackageTemplate(
 	}
 
 	filename := filepath.Base(from)
+	ext := filepath.Ext(filename)
+
 	f, err := os.Create(filename)
 	if err != nil {
 		errLog.Add(err)
@@ -563,14 +565,14 @@ func fetchPackageTemplate(
 			errLog.Add(err)
 		}
 	}()
-	defer func(base string) {
+	defer func() {
 		err := os.Remove(filename)
 		if err != nil {
 			errLog.Add(err)
 			text.Break(out)
 			text.Info(out, "We were unable to clean-up the local %s file (it can be safely removed)", filename)
 		}
-	}(filename)
+	}()
 
 	_, err = io.Copy(f, res.Body)
 	if err != nil {
@@ -593,8 +595,6 @@ mimes:
 	}
 
 	if archive == nil {
-		ext := filepath.Ext(filename)
-
 		for _, a := range archives {
 			for _, e := range a.Extensions() {
 				if ext == e {
@@ -606,8 +606,20 @@ mimes:
 	}
 
 	if archive != nil {
+		// Ensure there is a file extension on our filename, otherwise we won't
+		// know what type of archive format we're dealing with when we come to call
+		// the archive.Extract() method.
+		if ext == "" {
+			filenameWithExt := filename + archive.Extensions()[0]
+			err := os.Rename(filename, filenameWithExt)
+			if err != nil {
+				errLog.Add(err)
+				return err
+			}
+			filename = filenameWithExt
+		}
+
 		archive.SetDestination(dst)
-		archive.SetFile(f)
 		archive.SetFilename(filename)
 
 		err = archive.Extract()

--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -21,6 +21,12 @@ type Source uint8
 const (
 	// Filename is the name of the package manifest file.
 	// It is expected to be a project specific configuration file.
+	//
+	// TODO: The filename needs to be referenced outside of the compute package
+	// so consider moving this constant to a different location in the top-level
+	// pkg directory instead or even moving the whole manifest package up to the
+	// top-level pkg directory as finding a suitable package for just the
+	// manifest filename could be tricky.
 	Filename = "fastly.toml"
 
 	// ManifestLatestVersion represents the latest known manifest schema version

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,6 +1,9 @@
 package errors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ErrSignalInterrupt means a SIGINT was received.
 var ErrSignalInterrupt = fmt.Errorf("a SIGINT was received")
@@ -77,4 +80,15 @@ var ErrReadingManifest = RemediationError{
 var ErrParsingManifest = RemediationError{
 	Inner:       fmt.Errorf("error parsing package manifest"),
 	Remediation: ComputeInitRemediation,
+}
+
+// ErrStopWalk is used to indicate to filepath.WalkDir that it should stop
+// walking the directory tree.
+var ErrStopWalk = errors.New("stop directory walking")
+
+// ErrInvalidArchive means the package archive didn't contain a recognised
+// directory structure.
+var ErrInvalidArchive = RemediationError{
+	Inner:       fmt.Errorf("invalid package archive structure"),
+	Remediation: "Ensure the archive contains all required package files (such as a 'fastly.toml' manifest, and a 'src' folder etc).",
 }

--- a/pkg/file/archive.go
+++ b/pkg/file/archive.go
@@ -23,7 +23,6 @@ type Archive interface {
 	Filename() string
 	MimeTypes() []string
 	SetDestination(d string)
-	SetFile(r io.ReadSeeker)
 	SetFilename(n string)
 }
 
@@ -80,14 +79,6 @@ func (a ArchiveBase) Filename() string {
 // SetDestination sets the destination for where files should be extracted.
 func (a *ArchiveBase) SetDestination(d string) {
 	a.Dst = d
-}
-
-// SetFile sets the local file descriptor where the archive should be written.
-//
-// NOTE: This archive file is the 'container' of the archived files that will
-// be extracted separately.
-func (a *ArchiveBase) SetFile(r io.ReadSeeker) {
-	a.File = r
 }
 
 // SetFilename sets the name of the local archive file.


### PR DESCRIPTION
## Problem

When trying to extract files from a `.tgz` archive, the following error was reported:

```
error creating gzip reader: gzip: invalid header.
```

## Solution

This PR refactors the original archive extraction logic to use a third-party package (already used elsewhere in the CLI). 

## Validation

The following examples work as the `--from` value:

- `https://fiddle.fastlydemo.net/fiddle/a9830b49`
- `https://storage.googleapis.com/.../a9830b49-src.tgz`
- `https://github.com/fastly/compute-starter-kit-rust-default/archive/refs/heads/main.zip`

The changes here have been tested successfully on macOS and also using various terminal environments in a Windows 10 VM (Command Prompt, Cygwin, Powershell, WSL).

<img width="2026" alt="Screenshot 2021-11-10 at 17 37 27" src="https://user-images.githubusercontent.com/180050/141181502-5c74ba2c-690d-4c2d-bbff-1e9274d302b9.png">