### PR TITLE
Add command 'API' metadata

### DIFF
--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -2,53 +2,1864 @@
   "acl": {
     "create": {
       "examples": [{
-        "cmd": "fastly acl create --name=\"foo\"",
-        "description": "Create an ACL named \"foo\".",
-        "title": "Standard two level command"
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl/#create-acl"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl/#delete-acl"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl/#get-acl"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl/#list-acls"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl/#update-acl"]
+    }
+  },
+  "acl-entry": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#create-acl-entry"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#delete-acl-entry"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#get-acl-entry"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#list-acl-entries"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
       }],
       "apis": [
-        "beep",
-        "boop"
+        "https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries",
+        "https://developer.fastly.com/reference/api/acls/acl-entry/#update-acl-entry"
+      ]
+    }
+  },
+  "auth-token": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/auth/#create-token"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/auth/#revoke-token-current",
+        "https://developer.fastly.com/reference/api/auth/#bulk-revoke-tokens",
+        "https://developer.fastly.com/reference/api/auth/#revoke-token"
+      ]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/auth/#get-token-current"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/auth/#list-tokens-customer",
+        "https://developer.fastly.com/reference/api/auth/#list-tokens-user"
       ]
     }
   },
   "backend": {
     "create": {
       "examples": [{
-        "cmd": "fastly backend create --name=\"foo\"",
-        "description": "Create a backend named \"foo\".",
-        "title": "Another standard two level command"
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/backend/#create-backend"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/backend/#delete-backend"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/backend/#get-backend"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/backend/#list-backends"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/backend/#update-backend"]
+    }
+  },
+  "compute": {
+    "build": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }]
+    },
+    "deploy": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
       }],
       "apis": [
-        "foo",
-        "bar"
+        "https://developer.fastly.com/reference/api/services/service/#create-service",
+        "https://developer.fastly.com/reference/api/services/service/#get-service",
+        "https://developer.fastly.com/reference/api/services/package/#get-package",
+        "https://developer.fastly.com/reference/api/services/package/#put-package"
+      ]
+    },
+    "init": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }]
+    },
+    "pack": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }]
+    },
+    "publish": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/services/service/#create-service",
+        "https://developer.fastly.com/reference/api/services/service/#get-service",
+        "https://developer.fastly.com/reference/api/services/package/#get-package",
+        "https://developer.fastly.com/reference/api/services/package/#put-package"
+      ]
+    },
+    "serve": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/package/#put-package"]
+    },
+    "validate": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }]
+    }
+  },
+  "configure": {
+    "examples": [{
+      "cmd": "",
+      "description": "",
+      "title": ""
+    }],
+    "apis": [
+      "https://developer.fastly.com/reference/api/auth/#get-token-current",
+      "https://developer.fastly.com/reference/api/account/user/#get-user"
+    ]
+  },
+  "dictionary": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#get-dictionary"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#delete-dictionary"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/dictionaries/dictionary/#get-dictionary",
+        "https://developer.fastly.com/reference/api/dictionaries/dictionary-info/#get-dictionary-info",
+        "https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#list-dictionary-items"
+      ]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#list-dictionaries"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#update-dictionary"]
+    }
+  },
+  "dictionary-item": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#create-dictionary-item"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#delete-dictionary-item"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#get-dictionary-item"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#list-dictionary-items"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#bulk-update-dictionary-item",
+        "https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#upsert-dictionary-item"
       ]
     }
   },
+  "domain": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/domain/#create-domain"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/domain/#delete-domain"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/domain/#get-domain"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/domain/#list-domains"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/domain/#update-domain"]
+    },
+    "validate": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/services/domain/#check-domains",
+        "https://developer.fastly.com/reference/api/services/domain/#check-domain"
+      ]
+    }
+  },
+  "healthcheck": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#create-healthcheck"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#delete-healthcheck"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#get-healthcheck"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#list-healthchecks"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#update-healthcheck"]
+    }
+  },
+  "ip-list": {
+    "examples": [{
+      "cmd": "",
+      "description": "",
+      "title": ""
+    }],
+    "apis": ["https://developer.fastly.com/reference/api/utils/public-ip-list/"]
+  },
+  "log-tail": {
+    "examples": [{
+      "cmd": "",
+      "description": "",
+      "title": ""
+    }],
+    "apis": ["undocumented:https://api.fastly.com/service/%s/log_stream/managed/instance_output"]
+  },
   "logging": {
+    "azureblob": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#create-log-azure"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#delete-log-azure"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#get-log-azure"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#list-log-azure"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#update-log-azure"]
+      }
+    },
     "bigquery": {
       "create": {
         "examples": [{
-          "cmd": "fastly logging bigquery create --name=\"foo\"",
-          "description": "Create a bigquery log endpoint named \"foo\".",
-          "title": "Three level command"
+          "cmd": "",
+          "description": "",
+          "title": ""
         }],
-        "apis": [
-          "foo",
-          "bar"
-        ]
+        "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#create-log-bigquery"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#delete-log-bigquery"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#get-log-bigquery"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#list-log-bigquery"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#update-log-bigquery"]
+      }
+    },
+    "cloudfiles": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#create-log-cloudfiles"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#delete-log-cloudfiles"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#get-log-cloudfiles"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#list-log-cloudfiles"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#update-log-cloudfiles"]
+      }
+    },
+    "datadog": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#create-log-datadog"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#delete-log-datadog"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#get-log-datadog"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#list-log-datadog"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#update-log-datadog"]
+      }
+    },
+    "digitalocean": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#create-log-digocean"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#delete-log-digocean"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#get-log-digocean"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#list-log-digocean"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#update-log-digocean"]
+      }
+    },
+    "elasticsearch": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#create-log-elasticsearch"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#delete-log-elasticsearch"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#get-log-elasticsearch"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#list-log-elasticsearch"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#update-log-elasticsearch"]
+      }
+    },
+    "ftp": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#create-log-ftp"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#delete-log-ftp"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#get-log-ftp"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#list-log-ftp"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#update-log-ftp"]
+      }
+    },
+    "gcs": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#create-log-gcs"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#delete-log-gcs"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#get-log-gcs"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#list-log-gcs"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#update-log-gcs"]
+      }
+    },
+    "googlepubsub": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#create-log-gcp-pubsub"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#delete-log-gcp-pubsub"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#get-log-gcp-pubsub"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#list-log-gcp-pubsub"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#update-log-gcp-pubsub"]
+      }
+    },
+    "heroku": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#create-log-heroku"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#delete-log-heroku"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#get-log-heroku"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#list-log-heroku"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#update-log-heroku"]
+      }
+    },
+    "honeycomb": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#create-log-honeycomb"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#delete-log-honeycomb"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#get-log-honeycomb"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#list-log-honeycomb"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#update-log-honeycomb"]
+      }
+    },
+    "https": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/https/#create-log-https"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/https/#delete-log-https"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/https/#get-log-https"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/https/#list-log-https"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/https/#update-log-https"]
+      }
+    },
+    "kafka": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#create-log-kafka"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#delete-log-kafka"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#get-log-kafka"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#list-log-kafka"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#update-log-kafka"]
+      }
+    },
+    "kinesis": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#create-log-kinesis"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#delete-log-kinesis"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#get-log-kinesis"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#list-log-kinesis"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#update-log-kinesis"]
+      }
+    },
+    "logentries": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#create-log-logentries"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#delete-log-logentries"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#get-log-logentries"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#list-log-logentries"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#update-log-logentries"]
+      }
+    },
+    "loggly": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#create-log-loggly"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#delete-log-loggly"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#get-log-loggly"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#list-log-loggly"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#update-log-loggly"]
+      }
+    },
+    "logshuttle": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#create-log-logshuttle"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#delete-log-logshuttle"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#get-log-logshuttle"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#list-log-logshuttle"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#update-log-logshuttle"]
+      }
+    },
+    "newrelic": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#create-log-newrelic"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#delete-log-newrelic"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#get-log-newrelic"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#list-log-newrelic"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#update-log-newrelic"]
+      }
+    },
+    "openstack": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#get-log-openstack"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#delete-log-openstack"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#get-log-openstack"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#list-log-openstack"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#update-log-openstack"]
+      }
+    },
+    "papertrail": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#create-log-papertrail"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#delete-log-papertrail"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#get-log-papertrail"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#list-log-papertrail"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#update-log-papertrail"]
+      }
+    },
+    "s3": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/s3/#create-log-aws-s3"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/s3/#delete-log-aws-s3"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/s3/#get-log-aws-s3"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/s3/#list-log-aws-s3"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/s3/#update-log-aws-s3"]
+      }
+    },
+    "scalyr": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#create-log-scalyr"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#delete-log-scalyr"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#get-log-scalyr"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#list-log-scalyr"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#update-log-scalyr"]
+      }
+    },
+    "sftp": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#create-log-sftp"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#delete-log-sftp"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#get-log-sftp"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#list-log-sftp"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#update-log-sftp"]
+      }
+    },
+    "splunk": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#create-log-splunk"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#delete-log-splunk"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#get-log-splunk"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#list-log-splunk"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#update-log-splunk"]
+      }
+    },
+    "sumologic": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#create-log-sumologic"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#delete-log-sumologic"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#list-log-sumologic"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#list-log-sumologic"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#update-log-sumologic"]
+      }
+    },
+    "syslog": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#create-log-syslog"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#delete-log-syslog"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#get-log-syslog"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#list-log-syslog"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#update-log-syslog"]
       }
     }
   },
   "pops": {
     "examples": [{
-      "cmd": "fastly pops",
-      "description": "List Fastly datacenters.",
-      "title": "One level command"
+      "cmd": "",
+      "description": "",
+      "title": ""
+    }],
+    "apis": ["https://developer.fastly.com/reference/api/utils/pops/#list-pops"]
+  },
+  "purge": {
+    "examples": [{
+      "cmd": "",
+      "description": "",
+      "title": ""
     }],
     "apis": [
-      "foo",
-      "bar"
+      "https://developer.fastly.com/reference/api/purging/#purge-all",
+      "https://developer.fastly.com/reference/api/purging/#bulk-purge-tag",
+      "https://developer.fastly.com/reference/api/purging/#purge-tag",
+      "https://developer.fastly.com/reference/api/purging/#purge-single-url"
+    ]
+  },
+  "search": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/service/#create-service"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/services/service/#get-service-detail",
+        "https://developer.fastly.com/reference/api/services/version/#deactivate-service-version",
+        "https://developer.fastly.com/reference/api/services/service/#delete-service"
+      ]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/service/#get-service-detail"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/service/#list-services"]
+    },
+    "search": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/service/#search-service"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/service/#update-service"]
+    }
+  },
+  "service-version": {
+    "activate": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/version/#activate-service-version"]
+    },
+    "clone": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/version/#clone-service-version"]
+    },
+    "deactivate": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/version/#deactivate-service-version"]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/version/#list-service-versions"]
+    },
+    "lock": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/version/#lock-service-version"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/services/version/#update-service-version"]
+    }
+  },
+  "stats": {
+    "historical": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-hist-stats-service"]
+    },
+    "realtime": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/metrics-stats/realtime/#get-stats-last-second"]
+    },
+    "regional": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-regions"]
+    }
+  },
+  "update": {
+    "examples": [{
+      "cmd": "",
+      "description": "",
+      "title": ""
+    }]
+  },
+  "user": {
+    "create": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/account/user/#create-user"]
+    },
+    "delete": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/account/user/#delete-user"]
+    },
+    "describe": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/account/user/#get-current-user",
+        "https://developer.fastly.com/reference/api/account/user/#get-user"
+      ]
+    },
+    "list": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": ["https://developer.fastly.com/reference/api/account/customer/#list-users"]
+    },
+    "update": {
+      "examples": [{
+        "cmd": "",
+        "description": "",
+        "title": ""
+      }],
+      "apis": [
+        "https://developer.fastly.com/reference/api/account/user/#request-password-reset",
+        "https://developer.fastly.com/reference/api/account/user/#update-user"
+      ]
+    }
+  },
+  "vcl": {
+    "custom": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#create-custom-vcl"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#delete-custom-vcl"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#get-custom-vcl"]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#list-custom-vcl"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#update-custom-vcl"]
+      }
+    },
+    "snippet": {
+      "create": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#create-snippet"]
+      },
+      "delete": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#delete-snippet"]
+      },
+      "describe": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": [
+          "https://developer.fastly.com/reference/api/vcl-services/snippet/#get-snippet-dynamic",
+          "https://developer.fastly.com/reference/api/vcl-services/snippet/#get-snippet"
+        ]
+      },
+      "list": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#list-snippets"]
+      },
+      "update": {
+        "examples": [{
+          "cmd": "",
+          "description": "",
+          "title": ""
+        }],
+        "apis": [
+          "https://developer.fastly.com/reference/api/vcl-services/snippet/#update-snippet-dynamic",
+          "https://developer.fastly.com/reference/api/vcl-services/snippet/#update-snippet"
+        ]
+      }
+    }
+  },
+  "version": {
+    "examples": [{
+      "cmd": "",
+      "description": "",
+      "title": ""
+    }]
+  },
+  "whoami": {
+    "examples": [{
+      "cmd": "",
+      "description": "",
+      "title": ""
+    }],
+    "apis": [
+      "undocumented:https://api.fastly.com/verify"
     ]
   }
 }

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -166,7 +166,7 @@
       },
       {
         "cmd": "fastly compute deploy --package ./pkg/example.tar.gz",
-        "description": "Use the `compute pack` command to package up a pre-compiled Wasm binary and then reference the generated archive file when deploying.",
+        "description": "Use the <kdb>fastly compute pack</kbd> command to package up a pre-compiled Wasm binary and then reference the generated archive file when deploying.",
         "title": "Deploy a custom package to a Fastly Compute@Edge service"
       }],
       "apis": [
@@ -196,14 +196,14 @@
     "pack": {
       "examples": [{
         "cmd": "fastly compute pack --wasm-binary ./bin/main.wasm",
-        "description": "Write Compute@Edge applications in [any WASI-supporting language](https://developer.fastly.com/learning/compute/custom/) and use `compute pack` to package the pre-compiled Wasm binary into a supported format.",
+        "description": "Write Compute@Edge applications in [any WASI-supporting language](https://developer.fastly.com/learning/compute/custom/) and use <kbd>fastly compute pack</kbd> to package the pre-compiled Wasm binary into a supported format.",
         "title": "Package a pre-compiled Wasm binary for a Fastly Compute@Edge service"
       }]
     },
     "publish": {
       "examples": [{
         "cmd": "fastly compute publish --skip-verification --accept-defaults",
-        "description": "The <kbd>fastly compute publish</kbd> command is a convenience wrapper around the existing build and deploy commands. All flags present on the `compute build` and `compute deploy` commands are available to use here.",
+        "description": "The <kbd>fastly compute publish</kbd> command is a convenience wrapper around the existing build and deploy commands. All flags present on the <kbd>fastly compute build</kbd> and <kbd>fastly compute deploy</kbd> commands are available to use here.",
         "title": "Build and deploy a Compute@Edge package to a Fastly service"
       }],
       "apis": [
@@ -216,7 +216,7 @@
     "serve": {
       "examples": [{
         "cmd": "fastly compute serve --skip-verification --watch",
-        "description": "The `compute serve` command wraps the existing build command. All flags present on the `compute build` command are available to use here. Additionally, the `--watch` command enables 'hot reloading' of your project code whenever changes are made to the source code.",
+        "description": "The `compute serve` command wraps the existing build command. All flags present on the <kbd>fastly compute build</kbd> command are available to use here. Additionally, the `--watch` command enables 'hot reloading' of your project code whenever changes are made to the source code.",
         "title": "Build and run a Compute@Edge package locally"
       }]
     },

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -914,7 +914,7 @@
         {
           "cmd": "fastly vcl snippet create --name example --content \"$(< example.vcl)\" --type recv --version latest",
           "description": "The `--type` flag additionally supports tab completion hints for valid location values.",
-          "title": "Create a snippet using command substitution for the highest numbered existing service version"
+          "title": "Create a snippet on the highest numbered existing service version, using command substitution"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#create-snippet"]
       },

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -73,7 +73,7 @@
     "update": {
       "examples": [{
         "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --id x9KzsrACXZv8tPwlEDsKb6 --negated",
-        "title": "Update an ACL entry from the specified ACL"
+        "title": "Update an ACL entry in the specified ACL"
       },
       {
         "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --file ./batch.json",

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -450,8 +450,7 @@
       "cmd": "",
       "description": "",
       "title": ""
-    }],
-    "apis": ["undocumented:https://api.fastly.com/service/%s/log_stream/managed/instance_output"]
+    }]
   },
   "logging": {
     "azureblob": {
@@ -1857,9 +1856,6 @@
       "cmd": "",
       "description": "",
       "title": ""
-    }],
-    "apis": [
-      "undocumented:https://api.fastly.com/verify"
-    ]
+    }]
   }
 }

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -1,0 +1,54 @@
+{
+  "acl": {
+    "create": {
+      "examples": [{
+        "cmd": "fastly acl create --name=\"foo\"",
+        "description": "Create an ACL named \"foo\".",
+        "title": "Standard two level command"
+      }],
+      "apis": [
+        "beep",
+        "boop"
+      ]
+    }
+  },
+  "backend": {
+    "create": {
+      "examples": [{
+        "cmd": "fastly backend create --name=\"foo\"",
+        "description": "Create a backend named \"foo\".",
+        "title": "Another standard two level command"
+      }],
+      "apis": [
+        "foo",
+        "bar"
+      ]
+    }
+  },
+  "logging": {
+    "bigquery": {
+      "create": {
+        "examples": [{
+          "cmd": "fastly logging bigquery create --name=\"foo\"",
+          "description": "Create a bigquery log endpoint named \"foo\".",
+          "title": "Three level command"
+        }],
+        "apis": [
+          "foo",
+          "bar"
+        ]
+      }
+    }
+  },
+  "pops": {
+    "examples": [{
+      "cmd": "fastly pops",
+      "description": "List Fastly datacenters.",
+      "title": "One level command"
+    }],
+    "apis": [
+      "foo",
+      "bar"
+    ]
+  }
+}

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -78,7 +78,7 @@
       {
         "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --file ./batch.json",
         "description": "Update multiple ACL entries using a [JSON batch file](https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries).",
-        "title": "Update multiple ACL entries from the specified ACL using a local file"
+        "title": "Update multiple ACL entries in the specified ACL using a local file"
       },
       {
         "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --file \"$(< batch.json)\"",

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -291,8 +291,7 @@
     },
     "delete": {
       "examples": [{
-        "cmd": "",
-        "description": "",
+        "cmd": "fastly domain delete --name example.com --version latest",
         "title": "Delete a domain on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#delete-domain"]
@@ -921,8 +920,7 @@
       },
       "delete": {
         "examples": [{
-          "cmd": "",
-          "description": "",
+          "cmd": "fastly vcl snippet delete --name example --version latest",
           "title": "Delete a specific snippet for a particular service and version"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#delete-snippet"]

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -189,7 +189,7 @@
       },
       {
         "cmd": "fastly compute init --directory ./example",
-        "description": "It's recommended you change to the new project directory before executing further CLI commands.",
+        "description": "We recommend that you change to the new project directory after running this command, before executing further CLI commands.",
         "title": "Initialize a new Compute@Edge package locally in a different directory"
       }]
     },

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -162,9 +162,9 @@
     },
     "update": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "A",
+        "description": "B",
+        "title": "C"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#update-backend"]
     }

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -66,7 +66,7 @@
     "list": {
       "examples": [{
         "cmd": "fastly acl-entry list --acl-id SU1Z0isxPaozGVKXdv0eY",
-        "title": "List ACLs from the specified ACL"
+        "title": "List ACL entries from the specified ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#list-acl-entries"]
     },

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -203,7 +203,7 @@
     "publish": {
       "examples": [{
         "cmd": "fastly compute publish --skip-verification --accept-defaults",
-        "description": "The `compute publish` command is a convenience wrapper around the existing build and deploy commands. All flags present on the `compute build` and `compute deploy` commands are available to use here.",
+        "description": "The <kbd>fastly compute publish</kbd> command is a convenience wrapper around the existing build and deploy commands. All flags present on the `compute build` and `compute deploy` commands are available to use here.",
         "title": "Build and deploy a Compute@Edge package to a Fastly service"
       }],
       "apis": [

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -2,9 +2,9 @@
   "acl": {
     "create": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "A",
+        "description": "B",
+        "title": "C"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#create-acl"]
     },
@@ -34,9 +34,9 @@
     },
     "update": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "abc",
+        "description": "def",
+        "title": "ghi"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#update-acl"]
     }

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -2,41 +2,36 @@
   "acl": {
     "create": {
       "examples": [{
-        "cmd": "A",
-        "description": "B",
-        "title": "C"
+        "cmd": "fastly acl create --name robots --version latest",
+        "title": "Create a new ACL attached to the specified service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#create-acl"]
     },
     "delete": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl delete --name robots --version latest",
+        "title": "Delete an ACL from the specified service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#delete-acl"]
     },
     "describe": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl describe --name robots --version latest",
+        "title": "Retrieve a single ACL by name for the version and service"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#get-acl"]
     },
     "list": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl list --version latest",
+        "title": "List ACLs for the version and service"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#list-acls"]
     },
     "update": {
       "examples": [{
-        "cmd": "abc",
-        "description": "def",
-        "title": "ghi"
+        "cmd": "fastly acl update --name robots --new-name blocklist --version latest",
+        "title": "Update an ACL for a particular service and version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#update-acl"]
     }
@@ -44,41 +39,50 @@
   "acl-entry": {
     "create": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl-entry create --acl-id 50CCynNwD3BjaGJjMTFB1j --ip 64.18.0.0",
+        "title": "Add an ACL entry to an ACL"
+      },
+      {
+        "cmd": "fastly acl-entry create --acl-id 50CCynNwD3BjaGJjMTFB1j --ip 64.18.0.1 --negated",
+        "title": "Add a negated ACL entry to an ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#create-acl-entry"]
     },
     "delete": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl-entry delete --acl-id 50CCynNwD3BjaGJjMTFB1j --id 4DiuYrv9nVoa4HFmQmujT1",
+        "title": "Delete an ACL entry from a specified ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#delete-acl-entry"]
     },
     "describe": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl-entry describe --acl-id 50CCynNwD3BjaGJjMTFB1j --id 4bgjM6X1gb3670gJMEqdKX",
+        "title": "Retrieve a single ACL entry"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#get-acl-entry"]
     },
     "list": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl-entry list --acl-id 50CCynNwD3BjaGJjMTFB1j",
+        "title": "List ACLs from a specified ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#list-acl-entries"]
     },
     "update": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly acl-entry update --acl-id 50CCynNwD3BjaGJjMTFB1j --id 4bgjM6X1gb3670gJMEqdKX --negated",
+        "title": "Update a specific ACL entry"
+      },
+      {
+        "cmd": "fastly acl-entry update --acl-id 50CCynNwD3BjaGJjMTFB1j --file ./batch.json",
+        "description": "Update multiple ACL entries using JSON batch file. Refer to https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries for example structure.",
+        "title": "Update multiple ACL entries using a local file"
+      },
+      {
+        "cmd": "fastly acl-entry update --acl-id 50CCynNwD3BjaGJjMTFB1j --file \"$(< batch.json)\"",
+        "description": "Update multiple ACL entries using JSON batch file content passed in using shell command substitution. Refer to https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries for example structure.",
+        "title": "Update multiple ACL entries using command substitution"
       }],
       "apis": [
         "https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries",
@@ -88,19 +92,9 @@
   },
   "auth-token": {
     "create": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/auth/#create-token"]
     },
     "delete": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": [
         "https://developer.fastly.com/reference/api/auth/#revoke-token-current",
         "https://developer.fastly.com/reference/api/auth/#bulk-revoke-tokens",
@@ -108,19 +102,9 @@
       ]
     },
     "describe": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/auth/#get-token-current"]
     },
     "list": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": [
         "https://developer.fastly.com/reference/api/auth/#list-tokens-customer",
         "https://developer.fastly.com/reference/api/auth/#list-tokens-user"
@@ -130,41 +114,37 @@
   "backend": {
     "create": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly backend create --name example --address example.com --version latest",
+        "description": "Create a backend with a hostname assigned to the --address flag. The --override-host, --ssl-cert-hostname and --ssl-sni-hostname will default to the same hostname assigned to --address.",
+        "title": "Create a backend on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#create-backend"]
     },
     "delete": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly backend delete --name example --version latest",
+        "title": "Delete a backend on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#delete-backend"]
     },
     "describe": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly backend describe --name example --version latest",
+        "title": "Show detailed information about a backend on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#get-backend"]
     },
     "list": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly backend list --version latest",
+        "title": "List backends on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#list-backends"]
     },
     "update": {
       "examples": [{
-        "cmd": "A",
-        "description": "B",
-        "title": "C"
+        "cmd": "fastly backend update --name example --new-name testing --version latest",
+        "title": "Update a backend on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#update-backend"]
     }
@@ -172,16 +152,21 @@
   "compute": {
     "build": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute build --skip-verification",
+        "description": "The optional --skip-verification flag will prevent the CLI from validating your local environment has the required language toolchain installed to build your package.",
+        "title": "Build a Compute@Edge package locally"
       }]
     },
     "deploy": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute deploy --accept-defaults",
+        "description": "The optional --accept-defaults flag accepts default values for all prompts if configured via the fastly.toml `[setup]` section (refer to https://developer.fastly.com/reference/compute/fastly-toml/) and performs a deploy non-interactively",
+        "title": "Deploy a package to a Fastly Compute@Edge service"
+      },
+      {
+        "cmd": "fastly compute deploy --package ./pkg/example.tar.gz",
+        "description": "Use the `compute pack` command to package up a pre-compiled Wasm binary and then reference the generated archive file when deploying.",
+        "title": "Deploy a custom package to a Fastly Compute@Edge service"
       }],
       "apis": [
         "https://developer.fastly.com/reference/api/services/service/#create-service",
@@ -192,23 +177,33 @@
     },
     "init": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute init --name example --language rust",
+        "description": "To initialize a new Compute@Edge package you must select a supported language. The language can be provided using the optional --language flag, which supports tab completion hints, or the flag can be omitted and you'll be prompted interactively. The --name flag can also be omitted, which will result in the CLI prompting you interactively.",
+        "title": "Initialize a new Compute@Edge package locally"
+      },
+      {
+        "cmd": "fastly compute init --from=https://fiddle.fastlydemo.net/fiddle/0220c0d2",
+        "description": "Any Compute@Edge examples found on https://developer.fastly.com/solutions/examples/ can be used as a source template for your new package.",
+        "title": "Initialize a new Compute@Edge package locally using a remote package template"
+      },
+      {
+        "cmd": "fastly compute init --directory ./example",
+        "description": "It's recommended you change to the new project directory before executing further CLI commands.",
+        "title": "Initialize a new Compute@Edge package locally in a different directory"
       }]
     },
     "pack": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute pack --wasm-binary ./bin/main.wasm",
+        "description": "Write Compute@Edge applications in any WASI-supporting language and use `compute pack` to package the pre-compiled Wasm binary into a supported format. Refer to https://developer.fastly.com/learning/compute/custom/",
+        "title": "Package a pre-compiled Wasm binary for a Fastly Compute@Edge service"
       }]
     },
     "publish": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute publish --skip-verification --accept-defaults",
+        "description": "The `compute publish` command is a convenience wrapper around the existing build and deploy commands. All flags present on the `compute build` and `compute deploy` commands are available to use here.",
+        "title": "Build and deploy a Compute@Edge package to a Fastly service"
       }],
       "apis": [
         "https://developer.fastly.com/reference/api/services/service/#create-service",
@@ -219,33 +214,27 @@
     },
     "serve": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute serve --skip-verification --watch",
+        "description": "The `compute serve` command wraps the existing build command. All flags present on the `compute build` command are available to use here. Additionally, the `--watch` command enables 'hot reloading' of your project code whenever changes are made to the source code.",
+        "title": "Build and run a Compute@Edge package locally"
       }]
     },
     "update": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute update --package ./pkg/example.tar.gz --version latest --autoclone",
+        "description": "If unsure the given --version is editable, use --autoclone to automatically clone the version.",
+        "title": "Update a package on a Fastly Compute@Edge service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/package/#put-package"]
     },
     "validate": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly compute validate --package ./pkg/example.tar.gz",
+        "title": "Validate a Compute@Edge package"
       }]
     }
   },
   "configure": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }],
     "apis": [
       "https://developer.fastly.com/reference/api/auth/#get-token-current",
       "https://developer.fastly.com/reference/api/account/user/#get-user"
@@ -253,27 +242,12 @@
   },
   "dictionary": {
     "create": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#get-dictionary"]
     },
     "delete": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#delete-dictionary"]
     },
     "describe": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": [
         "https://developer.fastly.com/reference/api/dictionaries/dictionary/#get-dictionary",
         "https://developer.fastly.com/reference/api/dictionaries/dictionary-info/#get-dictionary-info",
@@ -281,61 +255,26 @@
       ]
     },
     "list": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#list-dictionaries"]
     },
     "update": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary/#update-dictionary"]
     }
   },
   "dictionary-item": {
     "create": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#create-dictionary-item"]
     },
     "delete": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#delete-dictionary-item"]
     },
     "describe": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#get-dictionary-item"]
     },
     "list": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#list-dictionary-items"]
     },
     "update": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": [
         "https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#bulk-update-dictionary-item",
         "https://developer.fastly.com/reference/api/dictionaries/dictionary-item/#upsert-dictionary-item"
@@ -345,9 +284,8 @@
   "domain": {
     "create": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly domain create --name example.com --version latest",
+        "title": "Create a domain on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#create-domain"]
     },
@@ -355,39 +293,36 @@
       "examples": [{
         "cmd": "",
         "description": "",
-        "title": ""
+        "title": "Delete a domain on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#delete-domain"]
     },
     "describe": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly domain describe --name example.com --version latest",
+        "title": "Show detailed information about a domain on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#get-domain"]
     },
     "list": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly domain list --version latest",
+        "title": "List domains on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#list-domains"]
     },
     "update": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly domain update --name example.com --new-name testing.com --version latest",
+        "title": "Update a domain on a Fastly service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#update-domain"]
     },
     "validate": {
       "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
+        "cmd": "fastly domain validate --name example.com --version latest",
+        "description": "To validate all domains at once replace the --name flag with --all.",
+        "title": "Checks the status of a specific domain's DNS record for a Service Version"
       }],
       "apis": [
         "https://developer.fastly.com/reference/api/services/domain/#check-domains",
@@ -397,1169 +332,474 @@
   },
   "healthcheck": {
     "create": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#create-healthcheck"]
     },
     "delete": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#delete-healthcheck"]
     },
     "describe": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#get-healthcheck"]
     },
     "list": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#list-healthchecks"]
     },
     "update": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/healthcheck/#update-healthcheck"]
     }
   },
   "ip-list": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }],
     "apis": ["https://developer.fastly.com/reference/api/utils/public-ip-list/"]
   },
   "log-tail": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }]
   },
   "logging": {
     "azureblob": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#create-log-azure"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#delete-log-azure"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#get-log-azure"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#list-log-azure"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/azureblob/#update-log-azure"]
       }
     },
     "bigquery": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#create-log-bigquery"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#delete-log-bigquery"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#get-log-bigquery"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#list-log-bigquery"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/bigquery/#update-log-bigquery"]
       }
     },
     "cloudfiles": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#create-log-cloudfiles"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#delete-log-cloudfiles"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#get-log-cloudfiles"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#list-log-cloudfiles"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/cloudfiles/#update-log-cloudfiles"]
       }
     },
     "datadog": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#create-log-datadog"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#delete-log-datadog"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#get-log-datadog"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#list-log-datadog"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/datadog/#update-log-datadog"]
       }
     },
     "digitalocean": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#create-log-digocean"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#delete-log-digocean"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#get-log-digocean"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#list-log-digocean"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/digitalocean/#update-log-digocean"]
       }
     },
     "elasticsearch": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#create-log-elasticsearch"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#delete-log-elasticsearch"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#get-log-elasticsearch"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#list-log-elasticsearch"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/elasticsearch/#update-log-elasticsearch"]
       }
     },
     "ftp": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#create-log-ftp"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#delete-log-ftp"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#get-log-ftp"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#list-log-ftp"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/ftp/#update-log-ftp"]
       }
     },
     "gcs": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#create-log-gcs"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#delete-log-gcs"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#get-log-gcs"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#list-log-gcs"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/gcs/#update-log-gcs"]
       }
     },
     "googlepubsub": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#create-log-gcp-pubsub"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#delete-log-gcp-pubsub"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#get-log-gcp-pubsub"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#list-log-gcp-pubsub"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/google-pubsub/#update-log-gcp-pubsub"]
       }
     },
     "heroku": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#create-log-heroku"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#delete-log-heroku"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#get-log-heroku"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#list-log-heroku"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/heroku/#update-log-heroku"]
       }
     },
     "honeycomb": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#create-log-honeycomb"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#delete-log-honeycomb"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#get-log-honeycomb"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#list-log-honeycomb"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/honeycomb/#update-log-honeycomb"]
       }
     },
     "https": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/https/#create-log-https"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/https/#delete-log-https"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/https/#get-log-https"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/https/#list-log-https"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/https/#update-log-https"]
       }
     },
     "kafka": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#create-log-kafka"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#delete-log-kafka"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#get-log-kafka"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#list-log-kafka"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kafka/#update-log-kafka"]
       }
     },
     "kinesis": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#create-log-kinesis"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#delete-log-kinesis"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#get-log-kinesis"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#list-log-kinesis"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/kinesis/#update-log-kinesis"]
       }
     },
     "logentries": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#create-log-logentries"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#delete-log-logentries"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#get-log-logentries"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#list-log-logentries"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logentries/#update-log-logentries"]
       }
     },
     "loggly": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#create-log-loggly"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#delete-log-loggly"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#get-log-loggly"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#list-log-loggly"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/loggly/#update-log-loggly"]
       }
     },
     "logshuttle": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#create-log-logshuttle"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#delete-log-logshuttle"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#get-log-logshuttle"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#list-log-logshuttle"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/logshuttle/#update-log-logshuttle"]
       }
     },
     "newrelic": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#create-log-newrelic"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#delete-log-newrelic"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#get-log-newrelic"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#list-log-newrelic"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/new-relic/#update-log-newrelic"]
       }
     },
     "openstack": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#get-log-openstack"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#delete-log-openstack"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#get-log-openstack"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#list-log-openstack"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/openstack/#update-log-openstack"]
       }
     },
     "papertrail": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#create-log-papertrail"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#delete-log-papertrail"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#get-log-papertrail"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#list-log-papertrail"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/papertrail/#update-log-papertrail"]
       }
     },
     "s3": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/s3/#create-log-aws-s3"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/s3/#delete-log-aws-s3"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/s3/#get-log-aws-s3"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/s3/#list-log-aws-s3"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/s3/#update-log-aws-s3"]
       }
     },
     "scalyr": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#create-log-scalyr"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#delete-log-scalyr"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#get-log-scalyr"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#list-log-scalyr"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/scalyr/#update-log-scalyr"]
       }
     },
     "sftp": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#create-log-sftp"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#delete-log-sftp"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#get-log-sftp"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#list-log-sftp"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sftp/#update-log-sftp"]
       }
     },
     "splunk": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#create-log-splunk"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#delete-log-splunk"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#get-log-splunk"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#list-log-splunk"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/splunk/#update-log-splunk"]
       }
     },
     "sumologic": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#create-log-sumologic"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#delete-log-sumologic"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#list-log-sumologic"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#list-log-sumologic"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/sumologic/#update-log-sumologic"]
       }
     },
     "syslog": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#create-log-syslog"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#delete-log-syslog"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#get-log-syslog"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#list-log-syslog"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/logging/syslog/#update-log-syslog"]
       }
     }
   },
   "pops": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }],
     "apis": ["https://developer.fastly.com/reference/api/utils/pops/#list-pops"]
   },
   "purge": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }],
     "apis": [
       "https://developer.fastly.com/reference/api/purging/#purge-all",
       "https://developer.fastly.com/reference/api/purging/#bulk-purge-tag",
@@ -1569,19 +809,9 @@
   },
   "search": {
     "create": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/service/#create-service"]
     },
     "delete": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": [
         "https://developer.fastly.com/reference/api/services/service/#get-service-detail",
         "https://developer.fastly.com/reference/api/services/version/#deactivate-service-version",
@@ -1589,163 +819,68 @@
       ]
     },
     "describe": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/service/#get-service-detail"]
     },
     "list": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/service/#list-services"]
     },
     "search": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/service/#search-service"]
     },
     "update": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/service/#update-service"]
     }
   },
   "service-version": {
     "activate": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/version/#activate-service-version"]
     },
     "clone": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/version/#clone-service-version"]
     },
     "deactivate": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/version/#deactivate-service-version"]
     },
     "list": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/version/#list-service-versions"]
     },
     "lock": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/version/#lock-service-version"]
     },
     "update": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/services/version/#update-service-version"]
     }
   },
   "stats": {
     "historical": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-hist-stats-service"]
     },
     "realtime": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/metrics-stats/realtime/#get-stats-last-second"]
     },
     "regional": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-regions"]
     }
   },
   "update": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }]
   },
   "user": {
     "create": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/account/user/#create-user"]
     },
     "delete": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/account/user/#delete-user"]
     },
     "describe": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": [
         "https://developer.fastly.com/reference/api/account/user/#get-current-user",
         "https://developer.fastly.com/reference/api/account/user/#get-user"
       ]
     },
     "list": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": ["https://developer.fastly.com/reference/api/account/customer/#list-users"]
     },
     "update": {
-      "examples": [{
-        "cmd": "",
-        "description": "",
-        "title": ""
-      }],
       "apis": [
         "https://developer.fastly.com/reference/api/account/user/#request-password-reset",
         "https://developer.fastly.com/reference/api/account/user/#update-user"
@@ -1755,52 +890,32 @@
   "vcl": {
     "custom": {
       "create": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#create-custom-vcl"]
       },
       "delete": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#delete-custom-vcl"]
       },
       "describe": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#get-custom-vcl"]
       },
       "list": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#list-custom-vcl"]
       },
       "update": {
-        "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
-        }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/vcl/#update-custom-vcl"]
       }
     },
     "snippet": {
       "create": {
         "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
+          "cmd": "fastly vcl snippet create --name example --content ./example.vcl --type recv --version latest",
+          "description": "The --type flag additionally supports tab completion hints for valid location values.",
+          "title": "Create a snippet using a local file"
+        },
+        {
+          "cmd": "fastly vcl snippet create --name example --content \"$(< example.vcl)\" --type recv --version latest",
+          "description": "The --type flag additionally supports tab completion hints for valid location values.",
+          "title": "Create a snippet using command substitution"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#create-snippet"]
       },
@@ -1808,15 +923,15 @@
         "examples": [{
           "cmd": "",
           "description": "",
-          "title": ""
+          "title": "Delete a specific snippet for a particular service and version"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#delete-snippet"]
       },
       "describe": {
         "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
+          "cmd": "fastly vcl snippet describe --snippet-id 3p8fPcMVB6OqbMxGT83hb9 --dynamic --version latest",
+          "description": "To describe a 'versioned' snippet replace the --snippet-id and --dynamic flags with --name.",
+          "title": "Get the uploaded VCL snippet for a particular service and version"
         }],
         "apis": [
           "https://developer.fastly.com/reference/api/vcl-services/snippet/#get-snippet-dynamic",
@@ -1825,17 +940,16 @@
       },
       "list": {
         "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
+          "cmd": "fastly vcl snippet list --version latest",
+          "title": "List the uploaded VCL snippets for a particular service and version"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#list-snippets"]
       },
       "update": {
         "examples": [{
-          "cmd": "",
-          "description": "",
-          "title": ""
+          "cmd": "fastly vcl snippet update --snippet-id 2k5KYQCSJERvR8aB3cbOdA --dynamic --type deliver --version latest",
+          "description": "To update a 'versioned' snippet replace the --snippet-id and --dynamic flags with --name.",
+          "title": "Update a VCL snippet for a particular service and version"
         }],
         "apis": [
           "https://developer.fastly.com/reference/api/vcl-services/snippet/#update-snippet-dynamic",
@@ -1845,17 +959,7 @@
     }
   },
   "version": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }]
   },
   "whoami": {
-    "examples": [{
-      "cmd": "",
-      "description": "",
-      "title": ""
-    }]
   }
 }

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -2,36 +2,37 @@
   "acl": {
     "create": {
       "examples": [{
-        "cmd": "fastly acl create --name robots --version latest",
-        "title": "Create a new ACL attached to the specified service version"
+        "cmd": "fastly acl create --name robots --version active --autoclone",
+        "description": "Uses the `--version` flag to select the currently active service version and the `--autoclone` flag to enable automate cloning of the service version.",
+        "title": "Create a new ACL attached to the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#create-acl"]
     },
     "delete": {
       "examples": [{
-        "cmd": "fastly acl delete --name robots --version latest",
+        "cmd": "fastly acl delete --name robots --version 1",
         "title": "Delete an ACL from the specified service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#delete-acl"]
     },
     "describe": {
       "examples": [{
-        "cmd": "fastly acl describe --name robots --version latest",
-        "title": "Retrieve a single ACL by name for the version and service"
+        "cmd": "fastly acl describe --name robots --version active",
+        "title": "Retrieve a single ACL by name for the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#get-acl"]
     },
     "list": {
       "examples": [{
-        "cmd": "fastly acl list --version latest",
-        "title": "List ACLs for the version and service"
+        "cmd": "fastly acl list --version 1",
+        "title": "List ACLs for the specified service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#list-acls"]
     },
     "update": {
       "examples": [{
         "cmd": "fastly acl update --name robots --new-name blocklist --version latest",
-        "title": "Update an ACL for a particular service and version"
+        "title": "Update an ACL for the highest numbered existing service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl/#update-acl"]
     }
@@ -39,50 +40,50 @@
   "acl-entry": {
     "create": {
       "examples": [{
-        "cmd": "fastly acl-entry create --acl-id 50CCynNwD3BjaGJjMTFB1j --ip 64.18.0.0",
-        "title": "Add an ACL entry to an ACL"
+        "cmd": "fastly acl-entry create --acl-id SU1Z0isxPaozGVKXdv0eY --ip 192.0.2.0",
+        "title": "Add an ACL entry to the specified ACL"
       },
       {
-        "cmd": "fastly acl-entry create --acl-id 50CCynNwD3BjaGJjMTFB1j --ip 64.18.0.1 --negated",
-        "title": "Add a negated ACL entry to an ACL"
+        "cmd": "fastly acl-entry create --acl-id SU1Z0isxPaozGVKXdv0eY --ip 192.0.2.0 --negated",
+        "title": "Add a negated ACL entry to the specified ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#create-acl-entry"]
     },
     "delete": {
       "examples": [{
-        "cmd": "fastly acl-entry delete --acl-id 50CCynNwD3BjaGJjMTFB1j --id 4DiuYrv9nVoa4HFmQmujT1",
-        "title": "Delete an ACL entry from a specified ACL"
+        "cmd": "fastly acl-entry delete --acl-id SU1Z0isxPaozGVKXdv0eY --id 4DiuYrv9nVoa4HFmQmujT1",
+        "title": "Delete an ACL entry from the specified ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#delete-acl-entry"]
     },
     "describe": {
       "examples": [{
-        "cmd": "fastly acl-entry describe --acl-id 50CCynNwD3BjaGJjMTFB1j --id 4bgjM6X1gb3670gJMEqdKX",
-        "title": "Retrieve a single ACL entry"
+        "cmd": "fastly acl-entry describe --acl-id SU1Z0isxPaozGVKXdv0eY --id x9KzsrACXZv8tPwlEDsKb6",
+        "title": "Retrieve a single ACL entry from the specified ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#get-acl-entry"]
     },
     "list": {
       "examples": [{
-        "cmd": "fastly acl-entry list --acl-id 50CCynNwD3BjaGJjMTFB1j",
-        "title": "List ACLs from a specified ACL"
+        "cmd": "fastly acl-entry list --acl-id SU1Z0isxPaozGVKXdv0eY",
+        "title": "List ACLs from the specified ACL"
       }],
       "apis": ["https://developer.fastly.com/reference/api/acls/acl-entry/#list-acl-entries"]
     },
     "update": {
       "examples": [{
-        "cmd": "fastly acl-entry update --acl-id 50CCynNwD3BjaGJjMTFB1j --id 4bgjM6X1gb3670gJMEqdKX --negated",
-        "title": "Update a specific ACL entry"
+        "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --id x9KzsrACXZv8tPwlEDsKb6 --negated",
+        "title": "Update an ACL entry from the specified ACL"
       },
       {
-        "cmd": "fastly acl-entry update --acl-id 50CCynNwD3BjaGJjMTFB1j --file ./batch.json",
-        "description": "Update multiple ACL entries using JSON batch file. Refer to https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries for example structure.",
-        "title": "Update multiple ACL entries using a local file"
+        "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --file ./batch.json",
+        "description": "Update multiple ACL entries using a [JSON batch file](https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries).",
+        "title": "Update multiple ACL entries from the specified ACL using a local file"
       },
       {
-        "cmd": "fastly acl-entry update --acl-id 50CCynNwD3BjaGJjMTFB1j --file \"$(< batch.json)\"",
-        "description": "Update multiple ACL entries using JSON batch file content passed in using shell command substitution. Refer to https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries for example structure.",
-        "title": "Update multiple ACL entries using command substitution"
+        "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --file \"$(< batch.json)\"",
+        "description": "Update multiple ACL entries using a [JSON batch file](https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries)'s content passed in using shell command sustitution.",
+        "title": "Update multiple ACL entries from the specified ACL using command substitution"
       }],
       "apis": [
         "https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries",
@@ -114,37 +115,37 @@
   "backend": {
     "create": {
       "examples": [{
-        "cmd": "fastly backend create --name example --address example.com --version latest",
-        "description": "Create a backend with a hostname assigned to the --address flag. The --override-host, --ssl-cert-hostname and --ssl-sni-hostname will default to the same hostname assigned to --address.",
-        "title": "Create a backend on a Fastly service version"
+        "cmd": "fastly backend create --name example --address example.com --version active --autoclone",
+        "description": "Create a backend with a hostname assigned to the `--address` flag. The `--override-host`, `--ssl-cert-hostname` and `--ssl-sni-hostname` will default to the same hostname assigned to `--address`.",
+        "title": "Create a backend from the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#create-backend"]
     },
     "delete": {
       "examples": [{
         "cmd": "fastly backend delete --name example --version latest",
-        "title": "Delete a backend on a Fastly service version"
+        "title": "Delete a backend from the highest numbered existing service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#delete-backend"]
     },
     "describe": {
       "examples": [{
-        "cmd": "fastly backend describe --name example --version latest",
-        "title": "Show detailed information about a backend on a Fastly service version"
+        "cmd": "fastly backend describe --name example --version 1",
+        "title": "Show detailed information about a backend on the specified service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#get-backend"]
     },
     "list": {
       "examples": [{
-        "cmd": "fastly backend list --version latest",
-        "title": "List backends on a Fastly service version"
+        "cmd": "fastly backend list --version active",
+        "title": "List backends on the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#list-backends"]
     },
     "update": {
       "examples": [{
         "cmd": "fastly backend update --name example --new-name testing --version latest",
-        "title": "Update a backend on a Fastly service version"
+        "title": "Update a backend on the highest numbered existing service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#update-backend"]
     }
@@ -153,14 +154,14 @@
     "build": {
       "examples": [{
         "cmd": "fastly compute build --skip-verification",
-        "description": "The optional --skip-verification flag will prevent the CLI from validating your local environment has the required language toolchain installed to build your package.",
+        "description": "The optional `--skip-verification` flag will prevent the CLI from validating your local environment has the required language toolchain installed to build your package.",
         "title": "Build a Compute@Edge package locally"
       }]
     },
     "deploy": {
       "examples": [{
         "cmd": "fastly compute deploy --accept-defaults",
-        "description": "The optional --accept-defaults flag accepts default values for all prompts if configured via the fastly.toml `[setup]` section (refer to https://developer.fastly.com/reference/compute/fastly-toml/) and performs a deploy non-interactively",
+        "description": "The optional `--accept-defaults` flag accepts default values for all prompts if configured via the [fastly.toml](https://developer.fastly.com/reference/compute/fastly-toml/) `[setup]` section and performs a deploy non-interactively",
         "title": "Deploy a package to a Fastly Compute@Edge service"
       },
       {
@@ -178,12 +179,12 @@
     "init": {
       "examples": [{
         "cmd": "fastly compute init --name example --language rust",
-        "description": "To initialize a new Compute@Edge package you must select a supported language. The language can be provided using the optional --language flag, which supports tab completion hints, or the flag can be omitted and you'll be prompted interactively. The --name flag can also be omitted, which will result in the CLI prompting you interactively.",
+        "description": "To initialize a new Compute@Edge package you must select a supported language. The language can be provided using the optional `--language` flag, which supports tab completion hints, or the flag can be omitted and you'll be prompted interactively. The `--name` flag can also be omitted, which will result in the CLI prompting you interactively.",
         "title": "Initialize a new Compute@Edge package locally"
       },
       {
         "cmd": "fastly compute init --from=https://fiddle.fastlydemo.net/fiddle/0220c0d2",
-        "description": "Any Compute@Edge examples found on https://developer.fastly.com/solutions/examples/ can be used as a source template for your new package.",
+        "description": "Any [Compute@Edge examples](https://developer.fastly.com/solutions/examples/) can be used as a source template for your new package.",
         "title": "Initialize a new Compute@Edge package locally using a remote package template"
       },
       {
@@ -195,7 +196,7 @@
     "pack": {
       "examples": [{
         "cmd": "fastly compute pack --wasm-binary ./bin/main.wasm",
-        "description": "Write Compute@Edge applications in any WASI-supporting language and use `compute pack` to package the pre-compiled Wasm binary into a supported format. Refer to https://developer.fastly.com/learning/compute/custom/",
+        "description": "Write Compute@Edge applications in [any WASI-supporting language](https://developer.fastly.com/learning/compute/custom/) and use `compute pack` to package the pre-compiled Wasm binary into a supported format.",
         "title": "Package a pre-compiled Wasm binary for a Fastly Compute@Edge service"
       }]
     },
@@ -221,9 +222,9 @@
     },
     "update": {
       "examples": [{
-        "cmd": "fastly compute update --package ./pkg/example.tar.gz --version latest --autoclone",
-        "description": "If unsure the given --version is editable, use --autoclone to automatically clone the version.",
-        "title": "Update a package on a Fastly Compute@Edge service version"
+        "cmd": "fastly compute update --package ./pkg/example.tar.gz --version active --autoclone",
+        "description": "Uses the `--version` flag to select the currently active service version and the `--autoclone` flag to enable automate cloning of the service version.",
+        "title": "Update a package on the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/package/#put-package"]
     },
@@ -284,44 +285,47 @@
   "domain": {
     "create": {
       "examples": [{
-        "cmd": "fastly domain create --name example.com --version latest",
-        "title": "Create a domain on a Fastly service version"
+        "cmd": "fastly domain create --name example.com --version latest --autoclone",
+        "description": "Uses the `--version` flag to dynamically determine the highest numbered existing service version, and the `--autoclone` flag if the latest version is currently 'active'",
+        "title": "Create a domain on the highest numbered existing service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#create-domain"]
     },
     "delete": {
       "examples": [{
-        "cmd": "fastly domain delete --name example.com --version latest",
-        "title": "Delete a domain on a Fastly service version"
+        "cmd": "fastly domain delete --name example.com --version latest --autoclone",
+        "description": "Uses the `--version` flag to dynamically determine the highest numbered existing service version, and the `--autoclone` flag if the latest version is currently 'active'",
+        "title": "Delete a domain from the highest numbered existing service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#delete-domain"]
     },
     "describe": {
       "examples": [{
-        "cmd": "fastly domain describe --name example.com --version latest",
-        "title": "Show detailed information about a domain on a Fastly service version"
+        "cmd": "fastly domain describe --name example.com --version 1",
+        "title": "Show detailed information about a domain on the specified service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#get-domain"]
     },
     "list": {
       "examples": [{
-        "cmd": "fastly domain list --version latest",
-        "title": "List domains on a Fastly service version"
+        "cmd": "fastly domain list --version active",
+        "title": "List domains on the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#list-domains"]
     },
     "update": {
       "examples": [{
-        "cmd": "fastly domain update --name example.com --new-name testing.com --version latest",
-        "title": "Update a domain on a Fastly service version"
+        "cmd": "fastly domain update --name example.com --new-name example.net --version active --autoclone",
+        "description": "Uses the `--version` flag to select the currently active service version and the `--autoclone` flag to enable automate cloning of the service version.",
+        "title": "Update a domain on the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/domain/#update-domain"]
     },
     "validate": {
       "examples": [{
-        "cmd": "fastly domain validate --name example.com --version latest",
-        "description": "To validate all domains at once replace the --name flag with --all.",
-        "title": "Checks the status of a specific domain's DNS record for a Service Version"
+        "cmd": "fastly domain validate --name example.com --version 2",
+        "description": "To validate all domains at once replace the `--name` flag with `--all`.",
+        "title": "Check the status of a specific domain's DNS record for the specified service version"
       }],
       "apis": [
         "https://developer.fastly.com/reference/api/services/domain/#check-domains",
@@ -348,8 +352,6 @@
   },
   "ip-list": {
     "apis": ["https://developer.fastly.com/reference/api/utils/public-ip-list/"]
-  },
-  "log-tail": {
   },
   "logging": {
     "azureblob": {
@@ -861,8 +863,6 @@
       "apis": ["https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-regions"]
     }
   },
-  "update": {
-  },
   "user": {
     "create": {
       "apis": ["https://developer.fastly.com/reference/api/account/user/#create-user"]
@@ -908,28 +908,28 @@
       "create": {
         "examples": [{
           "cmd": "fastly vcl snippet create --name example --content ./example.vcl --type recv --version latest",
-          "description": "The --type flag additionally supports tab completion hints for valid location values.",
-          "title": "Create a snippet using a local file"
+          "description": "The `--type` flag additionally supports tab completion hints for valid location values.",
+          "title": "Create a snippet using a local file for the highest numbered existing service version"
         },
         {
           "cmd": "fastly vcl snippet create --name example --content \"$(< example.vcl)\" --type recv --version latest",
-          "description": "The --type flag additionally supports tab completion hints for valid location values.",
-          "title": "Create a snippet using command substitution"
+          "description": "The `--type` flag additionally supports tab completion hints for valid location values.",
+          "title": "Create a snippet using command substitution for the highest numbered existing service version"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#create-snippet"]
       },
       "delete": {
         "examples": [{
-          "cmd": "fastly vcl snippet delete --name example --version latest",
-          "title": "Delete a specific snippet for a particular service and version"
+          "cmd": "fastly vcl snippet delete --name example --version 1",
+          "title": "Delete a specific snippet from the specified service version"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#delete-snippet"]
       },
       "describe": {
         "examples": [{
-          "cmd": "fastly vcl snippet describe --snippet-id 3p8fPcMVB6OqbMxGT83hb9 --dynamic --version latest",
-          "description": "To describe a 'versioned' snippet replace the --snippet-id and --dynamic flags with --name.",
-          "title": "Get the uploaded VCL snippet for a particular service and version"
+          "cmd": "fastly vcl snippet describe --snippet-id 3p8fPcMVB6OqbMxGT83hb9 --dynamic --version active",
+          "description": "To describe a 'versioned' snippet replace the `--snippet-id` and `--dynamic` flags with `--name`.",
+          "title": "Get the uploaded VCL snippet for the currently active service version"
         }],
         "apis": [
           "https://developer.fastly.com/reference/api/vcl-services/snippet/#get-snippet-dynamic",
@@ -938,16 +938,16 @@
       },
       "list": {
         "examples": [{
-          "cmd": "fastly vcl snippet list --version latest",
-          "title": "List the uploaded VCL snippets for a particular service and version"
+          "cmd": "fastly vcl snippet list --version active",
+          "title": "List the uploaded VCL snippets for the currently active service version"
         }],
         "apis": ["https://developer.fastly.com/reference/api/vcl-services/snippet/#list-snippets"]
       },
       "update": {
         "examples": [{
           "cmd": "fastly vcl snippet update --snippet-id 2k5KYQCSJERvR8aB3cbOdA --dynamic --type deliver --version latest",
-          "description": "To update a 'versioned' snippet replace the --snippet-id and --dynamic flags with --name.",
-          "title": "Update a VCL snippet for a particular service and version"
+          "description": "To update a 'versioned' snippet replace the `--snippet-id` and `--dynamic` flags with `--name`.",
+          "title": "Update a VCL snippet for the highest numbered existing service version"
         }],
         "apis": [
           "https://developer.fastly.com/reference/api/vcl-services/snippet/#update-snippet-dynamic",
@@ -955,9 +955,5 @@
         ]
       }
     }
-  },
-  "version": {
-  },
-  "whoami": {
   }
 }

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -117,7 +117,7 @@
       "examples": [{
         "cmd": "fastly backend create --name example --address example.com --version active --autoclone",
         "description": "Create a backend with a hostname assigned to the `--address` flag. The `--override-host`, `--ssl-cert-hostname` and `--ssl-sni-hostname` will default to the same hostname assigned to `--address`.",
-        "title": "Create a backend from the currently active service version"
+        "title": "Create a backend on the currently active service version"
       }],
       "apis": ["https://developer.fastly.com/reference/api/services/backend/#create-backend"]
     },

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -83,7 +83,7 @@
       {
         "cmd": "fastly acl-entry update --acl-id SU1Z0isxPaozGVKXdv0eY --file \"$(< batch.json)\"",
         "description": "Update multiple ACL entries using a [JSON batch file](https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries)'s content passed in using shell command sustitution.",
-        "title": "Update multiple ACL entries from the specified ACL using command substitution"
+        "title": "Update multiple ACL entries in the specified ACL using command substitution"
       }],
       "apis": [
         "https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries",

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -909,7 +909,7 @@
         "examples": [{
           "cmd": "fastly vcl snippet create --name example --content ./example.vcl --type recv --version latest",
           "description": "The `--type` flag additionally supports tab completion hints for valid location values.",
-          "title": "Create a snippet using a local file for the highest numbered existing service version"
+          "title": "Create a snippet on the highest numbered existing service version, using a local file"
         },
         {
           "cmd": "fastly vcl snippet create --name example --content \"$(< example.vcl)\" --type recv --version latest",

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -4193,7 +4193,7 @@ COMMANDS
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
         --type=TYPE              The location in generated VCL where the snippet
-                                 should be placed (e.g. recv, miss, fetch etc)
+                                 should be placed
         --autoclone              If the selected service version is not
                                  editable, clone it and use the clone.
         --dynamic                Whether the VCL snippet is dynamic or versioned
@@ -4250,7 +4250,7 @@ COMMANDS
                                  then fastly.toml)
     -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
         --type=TYPE              The location in generated VCL where the snippet
-                                 should be placed (e.g. recv, miss, fetch etc)
+                                 should be placed
 
   version
     Display version information for the Fastly CLI

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -403,7 +403,7 @@ type commandJSON struct {
 	Description string        `json:"description"`
 	Flags       []flagJSON    `json:"flags"`
 	Children    []commandJSON `json:"children"`
-	APIs        []string      `json:"apis"`
+	APIs        []string      `json:"apis,omitempty"`
 }
 
 func getGlobalFlagJSON(models []*kingpin.ClauseModel) []flagJSON {

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -439,44 +439,6 @@ func getCommandJSON(models []*kingpin.CmdModel, data commandsMetadata) []command
 
 		segs := strings.Split(m.FullCommand(), " ")
 		data := recurse(m.Depth, segs, data)
-
-		examples, ok := data["examples"]
-		if ok {
-			examples, ok := examples.([]interface{})
-			if ok {
-				for _, example := range examples {
-					e, ok := example.(map[string]interface{})
-					if ok {
-						c, ok := e["cmd"]
-						if ok {
-							c, ok := c.(string)
-							if ok {
-								d, ok := e["description"]
-								if ok {
-									d, ok := d.(string)
-									if ok {
-										t, ok := e["title"]
-										if ok {
-											t, _ := t.(string)
-											if ok {
-												if c != "" && d != "" && t != "" {
-													cmd.Examples = append(cmd.Examples, Example{
-														Cmd:         c,
-														Description: d,
-														Title:       t,
-													})
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
 		apis, ok := data["apis"]
 		if ok {
 			apis, ok := apis.([]interface{})
@@ -489,6 +451,26 @@ func getCommandJSON(models []*kingpin.CmdModel, data commandsMetadata) []command
 				}
 			}
 		}
+
+		examples, ok := data["examples"]
+		if ok {
+			examples, ok := examples.([]interface{})
+			if ok {
+				for _, example := range examples {
+					c := resolveToString(example, "cmd")
+					d := resolveToString(example, "description")
+					t := resolveToString(example, "title")
+					if c != "" && d != "" && t != "" {
+						cmd.Examples = append(cmd.Examples, Example{
+							Cmd:         c,
+							Description: d,
+							Title:       t,
+						})
+					}
+				}
+			}
+		}
+
 		cmds = append(cmds, cmd)
 	}
 	return cmds
@@ -515,6 +497,21 @@ func recurse(n int, segs []string, data commandsMetadata) commandsMetadata {
 		}
 	}
 	return nil
+}
+
+// resolveToString extracts a value from a map as a string
+func resolveToString(i interface{}, key string) string {
+	m, ok := i.(map[string]interface{})
+	if ok {
+		v, ok := m[key]
+		if ok {
+			v, ok := v.(string)
+			if ok {
+				return v
+			}
+		}
+	}
+	return ""
 }
 
 func getFlagJSON(models []*kingpin.ClauseModel) []flagJSON {

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -452,7 +452,7 @@ func getCommandJSON(models []*kingpin.CmdModel, data commandsMetadata) []command
 //
 // NOTE: The `n` arg represents the number of CLI arguments. For example,
 // with `logging kafka create`, the initial function call would be passed n=3.
-// The `segs` arg represents the CLI arguments. While `c` is the map data
+// The `segs` arg represents the CLI arguments. While `data` is the map data
 // structure populated from the metadata.json file.
 //
 // Each recursive call not only decrements the `n` counter but also removes the

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -450,6 +450,14 @@ func getCommandJSON(models []*kingpin.CmdModel, c commands) []commandJSON {
 }
 
 // recurse simplifies the tree style traversal of a complex map.
+//
+// NOTE: The `n` arg represents the number of CLI arguments. For example,
+// with `logging kafka create`, the initial function call would be passed n=3.
+// The `segs` arg represents the CLI arguments. While `c` is the map data
+// structure populated from the metadata.json file.
+//
+// Each recursive call not only decrements the `n` counter but also removes the
+// previous CLI arg, so `segs` becomes shorter on each iteration.
 func recurse(n int, segs []string, c commands) commands {
 	if n == 0 {
 		return c

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -398,9 +398,10 @@ type flagJSON struct {
 	IsBool      bool   `json:"isBool"`
 }
 
+// Example represents a metadata.json command example.
 type Example struct {
 	Cmd         string `json:"cmd"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	Title       string `json:"title"`
 }
 
@@ -460,7 +461,7 @@ func getCommandJSON(models []*kingpin.CmdModel, data commandsMetadata) []command
 					c := resolveToString(example, "cmd")
 					d := resolveToString(example, "description")
 					t := resolveToString(example, "title")
-					if c != "" && d != "" && t != "" {
+					if c != "" && t != "" {
 						cmd.Examples = append(cmd.Examples, Example{
 							Cmd:         c,
 							Description: d,

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -208,15 +208,6 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: args("backend update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone"),
 			API: mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				CloneVersionFn: testutil.CloneVersionResult(4),
-				GetBackendFn:   getBackendError,
-			},
-			WantError: errTest.Error(),
-		},
-		{
-			Args: args("backend update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone"),
-			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -43,6 +43,8 @@ type InitCommand struct {
 	tag              string
 }
 
+var Languages = []string{"rust", "assemblyscript", "javascript", "other"}
+
 // NewInitCommand returns a usable command registered under the parent.
 func NewInitCommand(parent cmd.Registerer, client api.HTTPClient, globals *config.Data, data manifest.Data) *InitCommand {
 	var c InitCommand
@@ -54,7 +56,7 @@ func NewInitCommand(parent cmd.Registerer, client api.HTTPClient, globals *confi
 	c.CmdClause.Flag("description", "Description of the package").Short('d').StringVar(&c.manifest.File.Description)
 	c.CmdClause.Flag("directory", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.dir)
 	c.CmdClause.Flag("author", "Author(s) of the package").Short('a').StringsVar(&c.manifest.File.Authors)
-	c.CmdClause.Flag("language", "Language of the package").Short('l').StringVar(&c.language)
+	c.CmdClause.Flag("language", "Language of the package").Short('l').HintOptions(Languages...).EnumVar(&c.language, Languages...)
 	c.CmdClause.Flag("from", "Git repository URL, or URL referencing a .zip/.tar.gz file, containing a package template").Short('f').StringVar(&c.from)
 	c.CmdClause.Flag("branch", "Git branch name to clone from package template repository").Hidden().StringVar(&c.branch)
 	c.CmdClause.Flag("tag", "Git tag name to clone from package template repository").Hidden().StringVar(&c.tag)

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -78,7 +78,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	text.Output(out, "Press ^C at any time to quit.")
 	text.Break(out)
 
-	cont, err := verifyDirectory(c.skipVerification, out, in)
+	cont, err := verifyDirectory(c.dir, c.skipVerification, out, in)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -199,22 +199,25 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 // verifyDirectory indicates if the user wants to continue with the execution
 // flow when presented with a prompt that suggests the current directory isn't
 // empty.
-func verifyDirectory(skipVerification bool, out io.Writer, in io.Reader) (bool, error) {
+func verifyDirectory(dir string, skipVerification bool, out io.Writer, in io.Reader) (bool, error) {
 	if skipVerification {
 		return true, nil
 	}
 
-	files, err := os.ReadDir(".")
+	if dir == "" {
+		dir = "."
+	}
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return false, err
+	}
+
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}
 
 	if len(files) > 0 {
-		dir, err := os.Getwd()
-		if err != nil {
-			return false, err
-		}
-
 		label := fmt.Sprintf("The current directory isn't empty. Are you sure you want to initialize a Compute@Edge project in %s? [y/N] ", dir)
 		cont, err := text.Input(out, label, in)
 		if err != nil {

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -103,7 +103,7 @@ func (r Rust) SourceDirectory() string { return "src" }
 // additional files to include in the package archive for Rust packages.
 func (r Rust) IncludeFiles() []string { return []string{"Cargo.toml"} }
 
-// Verify implments the Toolchain interface and verifies whether the Rust
+// Verify implements the Toolchain interface and verifies whether the Rust
 // language toolchain is correctly configured on the host.
 //
 // NOTE:

--- a/pkg/commands/vcl/snippet/create.go
+++ b/pkg/commands/vcl/snippet/create.go
@@ -84,7 +84,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out, "Created VCL snippet '%s' (service: %s, version: %d, dynamic: %t, type: %s, priority: %d)", v.Name, v.ServiceID, v.ServiceVersion, c.dynamic.WasSet, c.location, v.Priority)
+	text.Success(out, "Created VCL snippet '%s' (service: %s, version: %d, dynamic: %t, snippet id: %s, type: %s, priority: %d)", v.Name, v.ServiceID, v.ServiceVersion, c.dynamic.WasSet, v.ID, c.location, v.Priority)
 	return nil
 }
 

--- a/pkg/commands/vcl/snippet/create.go
+++ b/pkg/commands/vcl/snippet/create.go
@@ -11,6 +11,8 @@ import (
 	"github.com/fastly/go-fastly/v5/fastly"
 )
 
+var Locations = []string{"init", "recv", "hash", "hit", "miss", "pass", "fetch", "error", "deliver", "log", "none"}
+
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest.Data) *CreateCommand {
 	var c CreateCommand
@@ -24,7 +26,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.RegisterServiceVersionFlag(cmd.ServiceVersionFlagOpts{
 		Dst: &c.serviceVersion.Value,
 	})
-	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed (e.g. recv, miss, fetch etc)").Required().StringVar(&c.location)
+	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed").Required().HintOptions(Locations...).EnumVar(&c.location, Locations...)
 
 	// Optional flags
 	c.RegisterAutoCloneFlag(cmd.AutoCloneFlagOpts{

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -73,11 +73,12 @@ func TestVCLSnippetCreate(t *testing.T) {
 						Priority:       i.Priority,
 						ServiceID:      i.ServiceID,
 						ServiceVersion: i.ServiceVersion,
+						ID:             "123",
 					}, nil
 				},
 			},
 			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 3"),
-			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, type: recv, priority: 0)",
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 		},
 		{
 			Name: "validate CreateSnippet API success for dynamic Snippet",
@@ -94,11 +95,12 @@ func TestVCLSnippetCreate(t *testing.T) {
 						Priority:       i.Priority,
 						ServiceID:      i.ServiceID,
 						ServiceVersion: i.ServiceVersion,
+						ID:             "123",
 					}, nil
 				},
 			},
 			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --dynamic --name foo --service-id 123 --type recv --version 3"),
-			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: true, type: recv, priority: 0)",
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: true, snippet id: 123, type: recv, priority: 0)",
 		},
 		{
 			Name: "validate Priority set",
@@ -115,11 +117,12 @@ func TestVCLSnippetCreate(t *testing.T) {
 						Priority:       i.Priority,
 						ServiceID:      i.ServiceID,
 						ServiceVersion: i.ServiceVersion,
+						ID:             "123",
 					}, nil
 				},
 			},
 			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --priority 1 --service-id 123 --type recv --version 3"),
-			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, type: recv, priority: 1)",
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 1)",
 		},
 		{
 			Name: "validate --autoclone results in cloned service version",
@@ -137,11 +140,12 @@ func TestVCLSnippetCreate(t *testing.T) {
 						Priority:       i.Priority,
 						ServiceID:      i.ServiceID,
 						ServiceVersion: i.ServiceVersion,
+						ID:             "123",
 					}, nil
 				},
 			},
 			Args:       args("vcl snippet create --autoclone --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 1"),
-			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 4, dynamic: false, type: recv, priority: 0)",
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 4, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 		},
 		{
 			Name: "validate CreateSnippet API success with inline Snippet content",
@@ -158,11 +162,12 @@ func TestVCLSnippetCreate(t *testing.T) {
 						Priority:       i.Priority,
 						ServiceID:      i.ServiceID,
 						ServiceVersion: i.ServiceVersion,
+						ID:             "123",
 					}, nil
 				},
 			},
 			Args:       args("vcl snippet create --content inline_vcl --name foo --service-id 123 --type recv --version 3"),
-			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, type: recv, priority: 0)",
+			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 		},
 	}
 

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -36,7 +36,9 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.CmdClause.Flag("priority", "Priority determines execution order. Lower numbers execute first").Short('p').Action(c.priority.Set).IntVar(&c.priority.Value)
 	c.RegisterServiceIDFlag(&c.manifest.Flag.ServiceID)
 	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").Short('i').StringVar(&c.snippetID)
-	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed (e.g. recv, miss, fetch etc)").Action(c.location.Set).StringVar(&c.location.Value)
+
+	// NOTE: Locations is defined in the same snippet package inside create.go
+	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed").HintOptions(Locations...).Action(c.location.Set).EnumVar(&c.location.Value, Locations...)
 
 	return &c
 }


### PR DESCRIPTION
The metadata added in this PR will not be utilised by the CLI itself. It exists to help support documentation across Fastly's developer hub (https://developer.fastly.com/).

## Example

There is a WIP `metadata.json` file included in this PR, which only defines four commands (purposely chosen because they each have different 'levels' to them, such as `pops` being one level, `acl create` being two levels, while `logging bigquery create` is three levels):

> **NOTE**: I've used the initial 'test' commit of the `metadata.json` for my demonstration, as I expect to commit a real version of it shortly (i.e. the final version will list _all_ the commands and include all the relevant API endpoints each command utilises).

The `examples` field can be ignored for now. I've included it for a future iteration that will implement it within the CLI's JSON output. The important field to pay attention to is the `apis` field as this is what we've integrated as part of this PR.

```json
{
  "acl": {
    "create": {
      "examples": [{
        "cmd": "fastly acl create --name=\"foo\"",
        "description": "Create an ACL named \"foo\".",
        "title": "Standard two level command"
      }],
      "apis": [
        "beep",
        "boop"
      ]
    }
  },
  "backend": {
    "create": {
      "examples": [{
        "cmd": "fastly backend create --name=\"foo\"",
        "description": "Create a backend named \"foo\".",
        "title": "Another standard two level command"
      }],
      "apis": [
        "foo",
        "bar"
      ]
    }
  },
  "logging": {
    "bigquery": {
      "create": {
        "examples": [{
          "cmd": "fastly logging bigquery create --name=\"foo\"",
          "description": "Create a bigquery log endpoint named \"foo\".",
          "title": "Three level command"
        }],
        "apis": [
          "foo",
          "bar"
        ]
      }
    }
  },
  "pops": {
    "examples": [{
      "cmd": "fastly pops",
      "description": "List Fastly datacenters.",
      "title": "One level command"
    }],
    "apis": [
      "foo",
      "bar"
    ]
  }
}
```

When running `fastly help --format json` now, it will be built to include the `api` data pulled from the `metadata.json` included in this PR, and will produce the following JSON output:

```
{
  "globalFlags": [
    ...snip...
  ],
  "commands": [
    {
      "name": "acl",
      "description": "Manipulate Fastly ACLs (Access Control Lists)",
      "flags": null,
      "children": [
        {
          "name": "create",
          "description": "Create a new ACL attached to the specified service version",
          "flags": [
            ...snip...
          ],
          "children": null,
          "apis": [
            "beep",
            "boop"
          ]
        },
        ...snip...
      ],
      "apis": []
    },
    ...snip...
    {
      "name": "backend",
      "description": "Manipulate Fastly service version backends",
      "flags": null,
      "children": [
        {
          "name": "create",
          "description": "Create a backend on a Fastly service version",
          "flags": [
            ...snip...
          ],
          "children": null,
          "apis": [
            "foo",
            "bar"
          ]
        },
      ],
      "apis": []
    },
    {
      "name": "logging",
      "description": "Manipulate Fastly service version logging endpoints",
      "flags": null,
      "children": [
        ...snip...
        {
          "name": "bigquery",
          "description": "Manipulate Fastly service version BigQuery logging endpoints",
          "flags": null,
          "children": [
            {
              "name": "create",
              "description": "Create a BigQuery logging endpoint on a Fastly service version",
              "flags": [
                ...snip...
              ],
              "children": null,
              "apis": [
                "foo",
                "bar"
              ]
            },
          ],
          "apis": []
        },
        ...snip...
      ],
      "apis": []
    },
    {
      "name": "pops",
      "description": "List Fastly datacenters",
      "flags": null,
      "children": null,
      "apis": [
        "foo",
        "bar"
      ]
    },
    ...snip...
  ]
}
```

## NOTES

You'll see a few empty `"apis": []` for the various command groups (e.g. `"backends"`, `"logging"` etc). This is because a command group doesn't ever get executed and so has no logic associated with it.