### PR TITLE
Implement custom build operation

### DIFF
--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -119,27 +119,27 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Name:            "assemblyscript",
 			SourceDirectory: "assembly",
 			IncludeFiles:    []string{"package.json"},
-			Toolchain:       NewAssemblyScript(c.Timeout),
+			Toolchain:       NewAssemblyScript(c.Timeout, c.Manifest.File.Scripts.Build),
 		})
 	case "javascript":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "javascript",
 			SourceDirectory: "src",
 			IncludeFiles:    []string{"package.json"},
-			Toolchain:       NewJavaScript(c.Timeout),
+			Toolchain:       NewJavaScript(c.Timeout, c.Manifest.File.Scripts.Build),
 		})
 	case "rust":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "rust",
 			SourceDirectory: "src",
 			IncludeFiles:    []string{"Cargo.toml"},
-			Toolchain:       NewRust(c.client, c.Globals, c.Timeout),
+			Toolchain:       NewRust(c.client, c.Globals, c.Timeout, c.Manifest.File.Scripts.Build),
 		})
 	default:
 		return fmt.Errorf("unsupported language %s", lang)
 	}
 
-	if !c.SkipVerification {
+	if c.Manifest.File.Scripts.Build == "" && !c.SkipVerification {
 		progress.Step(fmt.Sprintf("Verifying local %s toolchain...", lang))
 
 		err = language.Verify(progress)
@@ -149,6 +149,10 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			})
 			return err
 		}
+	}
+
+	if c.Manifest.File.Scripts.Build != "" {
+		lang = "custom"
 	}
 
 	progress.Step(fmt.Sprintf("Building package using %s toolchain...", lang))

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -211,7 +211,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	progress.Done()
 
-	text.Success(out, "Built %s package %s (%s)", lang, name, dest)
+	text.Success(out, "Built package '%s' (%s)", name, dest)
 	return nil
 }
 

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -119,21 +119,21 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Name:            "assemblyscript",
 			SourceDirectory: "assembly",
 			IncludeFiles:    []string{"package.json"},
-			Toolchain:       NewAssemblyScript(c.Timeout, c.Manifest.File.Scripts.Build),
+			Toolchain:       NewAssemblyScript(c.Timeout, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
 		})
 	case "javascript":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "javascript",
 			SourceDirectory: "src",
 			IncludeFiles:    []string{"package.json"},
-			Toolchain:       NewJavaScript(c.Timeout, c.Manifest.File.Scripts.Build),
+			Toolchain:       NewJavaScript(c.Timeout, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
 		})
 	case "rust":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "rust",
 			SourceDirectory: "src",
 			IncludeFiles:    []string{"Cargo.toml"},
-			Toolchain:       NewRust(c.client, c.Globals, c.Timeout, c.Manifest.File.Scripts.Build),
+			Toolchain:       NewRust(c.client, c.Globals.File.Language.Rust, c.Globals.ErrLog, c.Timeout, c.Manifest.File.Scripts.Build),
 		})
 	default:
 		return fmt.Errorf("unsupported language %s", lang)

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -253,7 +253,7 @@ func TestBuildRust(t *testing.T) {
 			client: versionClient{
 				fastlyVersions: []string{"0.6.0"},
 			},
-			wantOutputContains: "Built rust package test",
+			wantOutputContains: "Built package 'test'",
 		},
 		{
 			name: "Rust success",
@@ -291,7 +291,7 @@ func TestBuildRust(t *testing.T) {
 			client: versionClient{
 				fastlyVersions: []string{"0.6.0"},
 			},
-			wantOutputContains: "Built rust package test",
+			wantOutputContains: "Built package 'test'",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
@@ -395,7 +395,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 			manifest_version = 2
 			name = "test"
 			language = "assemblyscript"`,
-			wantOutputContains: "Built assemblyscript package test",
+			wantOutputContains: "Built package 'test'",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
@@ -511,7 +511,7 @@ func TestBuildJavaScript(t *testing.T) {
 			manifest_version = 2
 			name = "test"
 			language = "javascript"`,
-			wantOutputContains: "Built javascript package test",
+			wantOutputContains: "Built package 'test'",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/pkg/commands/compute/compute_test.go
+++ b/pkg/commands/compute/compute_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/compute/manifest"
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/config"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/kingpin"
 	"github.com/mholt/archiver/v3"
@@ -393,7 +394,8 @@ func TestGetLatestCrateVersion(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			v, err := compute.GetLatestCrateVersion(testcase.inputClient, "fastly")
+			errlog := fsterr.MockLog{}
+			v, err := compute.GetLatestCrateVersion(testcase.inputClient, "fastly", errlog)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			if err == nil && !v.Equal(testcase.wantVersion) {
 				t.Errorf("wanted version %s, got %s", testcase.wantVersion, v)

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -132,7 +132,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return err
 	}
 
-	languages := NewLanguages(c.Globals.File.StarterKits, c.client, c.Globals)
+	languages := NewLanguages(c.Globals.File.StarterKits, c.client, c.Globals, mf.Scripts.Build)
 	language, err := selectLanguage(c.from, c.language, languages, mf, in, out)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
@@ -185,7 +185,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return err
 	}
 
-	language, err = initializeLanguage(progress, language, languages, mf.Language, wd, c.dir)
+	language, err = initializeLanguage(progress, language, languages, mf.Language, wd, c.dir, mf.Scripts.Build)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return fmt.Errorf("error initializing package: %w", err)
@@ -805,7 +805,7 @@ func updateManifest(
 }
 
 // initializeLanguage for newly cloned package.
-func initializeLanguage(progress text.Progress, language *Language, languages []*Language, name, wd, path string) (*Language, error) {
+func initializeLanguage(progress text.Progress, language *Language, languages []*Language, name, wd, path, build string) (*Language, error) {
 	progress.Step("Initializing package...")
 
 	if wd != path {
@@ -832,7 +832,7 @@ func initializeLanguage(progress text.Progress, language *Language, languages []
 		}
 	}
 
-	if language.Name != "other" {
+	if language.Name != "other" && build == "" {
 		if err := language.Initialize(progress); err != nil {
 			return nil, err
 		}

--- a/pkg/commands/compute/language.go
+++ b/pkg/commands/compute/language.go
@@ -93,8 +93,18 @@ func NewLanguage(options *LanguageOptions) *Language {
 	}
 }
 
+// Shell represents a subprocess shell used by `compute` environment where
+// `[scripts.build]` has been defined within fastly.toml manifest.
 type Shell struct{}
 
+// Build expects a command that can be prefixed with an appropriate subprocess
+// shell.
+//
+// Example:
+// build = "yarn install && yarn build"
+//
+// Should be converted into a command such as (on unix):
+// sh -c "yarn install && yarn build"
 func (s Shell) Build(command string) (cmd string, args []string) {
 	cmd = "sh"
 	args = []string{"-c"}

--- a/pkg/commands/compute/language.go
+++ b/pkg/commands/compute/language.go
@@ -14,25 +14,25 @@ import (
 // NOTE: The 'timeout' value zero is passed into each New<Language> call as it's
 // only useful during the `compute build` phase and is expected to be
 // provided by the user via a flag on the build command.
-func NewLanguages(kits config.StarterKitLanguages, c api.HTTPClient, d *config.Data) []*Language {
+func NewLanguages(kits config.StarterKitLanguages, c api.HTTPClient, d *config.Data, customBuild string) []*Language {
 	return []*Language{
 		NewLanguage(&LanguageOptions{
 			Name:        "rust",
 			DisplayName: "Rust",
 			StarterKits: kits.Rust,
-			Toolchain:   NewRust(c, d, 0),
+			Toolchain:   NewRust(c, d, 0, customBuild),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "assemblyscript",
 			DisplayName: "AssemblyScript (beta)",
 			StarterKits: kits.AssemblyScript,
-			Toolchain:   NewAssemblyScript(0),
+			Toolchain:   NewAssemblyScript(0, customBuild),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "javascript",
 			DisplayName: "JavaScript (beta)",
 			StarterKits: kits.JavaScript,
-			Toolchain:   NewJavaScript(0),
+			Toolchain:   NewJavaScript(0, customBuild),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "other",

--- a/pkg/commands/compute/language.go
+++ b/pkg/commands/compute/language.go
@@ -21,19 +21,19 @@ func NewLanguages(kits config.StarterKitLanguages, c api.HTTPClient, d *config.D
 			Name:        "rust",
 			DisplayName: "Rust",
 			StarterKits: kits.Rust,
-			Toolchain:   NewRust(c, d, 0, customBuild),
+			Toolchain:   NewRust(c, d.File.Language.Rust, d.ErrLog, 0, customBuild),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "assemblyscript",
 			DisplayName: "AssemblyScript (beta)",
 			StarterKits: kits.AssemblyScript,
-			Toolchain:   NewAssemblyScript(0, customBuild),
+			Toolchain:   NewAssemblyScript(0, customBuild, d.ErrLog),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "javascript",
 			DisplayName: "JavaScript (beta)",
 			StarterKits: kits.JavaScript,
-			Toolchain:   NewJavaScript(0, customBuild),
+			Toolchain:   NewJavaScript(0, customBuild, d.ErrLog),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "other",

--- a/pkg/commands/compute/language.go
+++ b/pkg/commands/compute/language.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -90,4 +91,17 @@ func NewLanguage(options *LanguageOptions) *Language {
 		options.IncludeFiles,
 		options.Toolchain,
 	}
+}
+
+type Shell struct{}
+
+func (s Shell) Build(command string) (cmd string, args []string) {
+	cmd = "sh"
+	args = []string{"-c"}
+	if runtime.GOOS == "windows" {
+		cmd = "cmd.exe"
+		args = []string{"/C"}
+	}
+	args = append(args, command)
+	return
 }

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/fastly/cli/pkg/errors"
@@ -17,13 +16,19 @@ import (
 
 // AssemblyScript implements a Toolchain for the AssemblyScript language.
 type AssemblyScript struct {
+	Shell
+
 	build   string
 	timeout int
 }
 
 // NewAssemblyScript constructs a new AssemblyScript.
 func NewAssemblyScript(timeout int, build string) *AssemblyScript {
-	return &AssemblyScript{build, timeout}
+	return &AssemblyScript{
+		Shell:   Shell{},
+		build:   build,
+		timeout: timeout,
+	}
 }
 
 // Verify implements the Toolchain interface and verifies whether the
@@ -181,9 +186,7 @@ func (a AssemblyScript) Build(out io.Writer, verbose bool) error {
 	}
 
 	if a.build != "" {
-		segs := strings.Split(a.build, " ")
-		cmd = segs[0]
-		args = segs[1:]
+		cmd, args = a.Shell.Build(a.build)
 	}
 
 	s := fstexec.Streaming{

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	fstexec "github.com/fastly/cli/pkg/exec"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/text"
@@ -19,14 +19,16 @@ type AssemblyScript struct {
 	Shell
 
 	build   string
+	errlog  fsterr.LogInterface
 	timeout int
 }
 
 // NewAssemblyScript constructs a new AssemblyScript.
-func NewAssemblyScript(timeout int, build string) *AssemblyScript {
+func NewAssemblyScript(timeout int, build string, errlog fsterr.LogInterface) *AssemblyScript {
 	return &AssemblyScript{
 		Shell:   Shell{},
 		build:   build,
+		errlog:  errlog,
 		timeout: timeout,
 	}
 }
@@ -44,7 +46,8 @@ func (a AssemblyScript) Verify(out io.Writer) error {
 
 	p, err := exec.LookPath("npm")
 	if err != nil {
-		return errors.RemediationError{
+		a.errlog.Add(err)
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("`npm` not found in $PATH"),
 			Remediation: fmt.Sprintf("To fix this error, install Node.js and npm by visiting:\n\n\t$ %s", text.Bold("https://nodejs.org/")),
 		}
@@ -57,19 +60,22 @@ func (a AssemblyScript) Verify(out io.Writer) error {
 	// A valid npm package is needed for compilation and to assert whether the
 	// required dependencies are installed locally. Therefore, we first assert
 	// whether one exists in the current $PWD.
-	fpath, err := filepath.Abs("package.json")
+	pkg, err := filepath.Abs("package.json")
 	if err != nil {
+		a.errlog.Add(err)
 		return fmt.Errorf("getting package.json path: %w", err)
 	}
 
-	if !filesystem.FileExists(fpath) {
-		return errors.RemediationError{
+	if !filesystem.FileExists(pkg) {
+		err = fsterr.RemediationError{
 			Inner:       fmt.Errorf("package.json not found"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm init")),
 		}
+		a.errlog.Add(err)
+		return err
 	}
 
-	fmt.Fprintf(out, "Found package.json at %s\n", fpath)
+	fmt.Fprintf(out, "Found package.json at %s\n", pkg)
 
 	// 3) Check if `asc` is installed.
 	//
@@ -77,15 +83,18 @@ func (a AssemblyScript) Verify(out io.Writer) error {
 	// package.json and then whether the binary exists in the npm bin directory.
 	fmt.Fprintf(out, "Checking if AssemblyScript is installed...\n")
 	if !checkPackageDependencyExists("assemblyscript") {
-		return errors.RemediationError{
+		err = fsterr.RemediationError{
 			Inner:       fmt.Errorf("`assemblyscript` not found in package.json"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm install --save-dev assemblyscript")),
 		}
+		a.errlog.Add(err)
+		return err
 	}
 
 	p, err = getNpmBinPath()
 	if err != nil {
-		return errors.RemediationError{
+		a.errlog.Add(err)
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("could not determine npm bin path"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm install --global npm@latest")),
 		}
@@ -93,13 +102,16 @@ func (a AssemblyScript) Verify(out io.Writer) error {
 
 	path, err := exec.LookPath(filepath.Join(p, "asc"))
 	if err != nil {
+		a.errlog.Add(err)
 		return fmt.Errorf("getting asc path: %w", err)
 	}
 	if !filesystem.FileExists(path) {
-		return errors.RemediationError{
+		err = fsterr.RemediationError{
 			Inner:       fmt.Errorf("`asc` binary not found in %s", p),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm install --save-dev assemblyscript")),
 		}
+		a.errlog.Add(err)
+		return err
 	}
 
 	fmt.Fprintf(out, "Found asc at %s\n", path)
@@ -119,10 +131,12 @@ func (a AssemblyScript) Initialize(out io.Writer) error {
 
 	p, err := exec.LookPath("npm")
 	if err != nil {
-		return errors.RemediationError{
+		err = fsterr.RemediationError{
 			Inner:       fmt.Errorf("`npm` not found in $PATH"),
 			Remediation: fmt.Sprintf("To fix this error, install Node.js and npm by visiting:\n\n\t$ %s", text.Bold("https://nodejs.org/")),
 		}
+		a.errlog.Add(err)
+		return err
 	}
 
 	fmt.Fprintf(out, "Found npm at %s\n", p)
@@ -131,19 +145,22 @@ func (a AssemblyScript) Initialize(out io.Writer) error {
 	//
 	// A valid npm package manifest file is needed for the install command to
 	// work. Therefore, we first assert whether one exists in the current $PWD.
-	fpath, err := filepath.Abs("package.json")
+	pkg, err := filepath.Abs("package.json")
 	if err != nil {
+		a.errlog.Add(err)
 		return fmt.Errorf("getting package.json path: %w", err)
 	}
 
-	if !filesystem.FileExists(fpath) {
-		return errors.RemediationError{
+	if !filesystem.FileExists(pkg) {
+		err = fsterr.RemediationError{
 			Inner:       fmt.Errorf("package.json not found"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm init")),
 		}
+		a.errlog.Add(err)
+		return err
 	}
 
-	fmt.Fprintf(out, "Found package.json at %s\n", fpath)
+	fmt.Fprintf(out, "Found package.json at %s\n", pkg)
 	fmt.Fprintf(out, "Installing package dependencies...\n")
 
 	cmd := fstexec.Streaming{
@@ -152,7 +169,10 @@ func (a AssemblyScript) Initialize(out io.Writer) error {
 		Env:     []string{},
 		Output:  out,
 	}
-	return cmd.Exec()
+	if err := cmd.Exec(); err != nil {
+		a.errlog.Add(err)
+	}
+	return nil
 }
 
 // Build implements the Toolchain interface and attempts to compile the package
@@ -161,15 +181,18 @@ func (a AssemblyScript) Build(out io.Writer, verbose bool) error {
 	// Check if bin directory exists and create if not.
 	pwd, err := os.Getwd()
 	if err != nil {
+		a.errlog.Add(err)
 		return fmt.Errorf("getting current working directory: %w", err)
 	}
 	binDir := filepath.Join(pwd, "bin")
 	if err := filesystem.MakeDirectoryIfNotExists(binDir); err != nil {
+		a.errlog.Add(err)
 		return fmt.Errorf("making bin directory: %w", err)
 	}
 
 	npmdir, err := getNpmBinPath()
 	if err != nil {
+		a.errlog.Add(err)
 		return fmt.Errorf("getting npm path: %w", err)
 	}
 
@@ -199,6 +222,7 @@ func (a AssemblyScript) Build(out io.Writer, verbose bool) error {
 		s.Timeout = time.Duration(a.timeout) * time.Second
 	}
 	if err := s.Exec(); err != nil {
+		a.errlog.Add(err)
 		return err
 	}
 

--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -16,13 +16,19 @@ import (
 
 // JavaScript implements a Toolchain for the JavaScript language.
 type JavaScript struct {
+	Shell
+
 	build   string
 	timeout int
 }
 
 // NewJavaScript constructs a new JavaScript.
 func NewJavaScript(timeout int, build string) *JavaScript {
-	return &JavaScript{build, timeout}
+	return &JavaScript{
+		Shell:   Shell{},
+		build:   build,
+		timeout: timeout,
+	}
 }
 
 // Initialize implements the Toolchain interface and initializes a newly cloned
@@ -177,9 +183,7 @@ func (a JavaScript) Build(out io.Writer, verbose bool) error {
 	args := []string{"run", "build"}
 
 	if a.build != "" {
-		segs := strings.Split(a.build, " ")
-		cmd = segs[0]
-		args = segs[1:]
+		cmd, args = a.Shell.Build(a.build)
 	}
 
 	s := fstexec.Streaming{

--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	fstexec "github.com/fastly/cli/pkg/exec"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/text"
@@ -19,14 +19,16 @@ type JavaScript struct {
 	Shell
 
 	build   string
+	errlog  fsterr.LogInterface
 	timeout int
 }
 
 // NewJavaScript constructs a new JavaScript.
-func NewJavaScript(timeout int, build string) *JavaScript {
+func NewJavaScript(timeout int, build string, errlog fsterr.LogInterface) *JavaScript {
 	return &JavaScript{
 		Shell:   Shell{},
 		build:   build,
+		errlog:  errlog,
 		timeout: timeout,
 	}
 }
@@ -43,7 +45,7 @@ func (a JavaScript) Initialize(out io.Writer) error {
 
 	p, err := exec.LookPath("npm")
 	if err != nil {
-		return errors.RemediationError{
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("`npm` not found in $PATH"),
 			Remediation: fmt.Sprintf("To fix this error, install Node.js and npm by visiting:\n\n\t$ %s", text.Bold("https://nodejs.org/")),
 		}
@@ -55,19 +57,19 @@ func (a JavaScript) Initialize(out io.Writer) error {
 	//
 	// A valid npm package manifest file is needed for the install command to
 	// work. Therefore, we first assert whether one exists in the current $PWD.
-	fpath, err := filepath.Abs("package.json")
+	pkg, err := filepath.Abs("package.json")
 	if err != nil {
 		return fmt.Errorf("getting package.json path: %w", err)
 	}
 
-	if !filesystem.FileExists(fpath) {
-		return errors.RemediationError{
+	if !filesystem.FileExists(pkg) {
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("package.json not found"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm init")),
 		}
 	}
 
-	fmt.Fprintf(out, "Found package.json at %s\n", fpath)
+	fmt.Fprintf(out, "Found package.json at %s\n", pkg)
 	fmt.Fprintf(out, "Installing package dependencies...\n")
 
 	cmd := fstexec.Streaming{
@@ -93,7 +95,7 @@ func (a JavaScript) Verify(out io.Writer) error {
 
 	p, err := exec.LookPath("npm")
 	if err != nil {
-		return errors.RemediationError{
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("`npm` not found in $PATH"),
 			Remediation: fmt.Sprintf("To fix this error, install Node.js and npm by visiting:\n\n\t$ %s", text.Bold("https://nodejs.org/")),
 		}
@@ -106,19 +108,19 @@ func (a JavaScript) Verify(out io.Writer) error {
 	// A valid npm package is needed for compilation and to assert whether the
 	// required dependencies are installed locally. Therefore, we first assert
 	// whether one exists in the current $PWD.
-	fpath, err := filepath.Abs("package.json")
+	pkg, err := filepath.Abs("package.json")
 	if err != nil {
 		return fmt.Errorf("getting package.json path: %w", err)
 	}
 
-	if !filesystem.FileExists(fpath) {
-		return errors.RemediationError{
+	if !filesystem.FileExists(pkg) {
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("package.json not found"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm init")),
 		}
 	}
 
-	fmt.Fprintf(out, "Found package.json at %s\n", fpath)
+	fmt.Fprintf(out, "Found package.json at %s\n", pkg)
 
 	// 3) Check if `js-compute-runtime` is installed.
 	//
@@ -127,7 +129,7 @@ func (a JavaScript) Verify(out io.Writer) error {
 	// js-compute-runtime binary exists in the npm bin directory.
 	fmt.Fprintf(out, "Checking if @fastly/js-compute is installed...\n")
 	if !checkPackageDependencyExists("@fastly/js-compute") {
-		return errors.RemediationError{
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("`@fastly/js-compute` not found in package.json"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm install --save-dev @fastly/js-compute")),
 		}
@@ -135,7 +137,7 @@ func (a JavaScript) Verify(out io.Writer) error {
 
 	p, err = getNpmBinPath()
 	if err != nil {
-		return errors.RemediationError{
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("could not determine npm bin path"),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm install --global npm@latest")),
 		}
@@ -146,7 +148,7 @@ func (a JavaScript) Verify(out io.Writer) error {
 		return fmt.Errorf("getting js-compute-runtime path: %w", err)
 	}
 	if !filesystem.FileExists(path) {
-		return errors.RemediationError{
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("`js-compute-runtime` binary not found in %s", p),
 			Remediation: fmt.Sprintf("To fix this error, run the following command:\n\n\t$ %s", text.Bold("npm install --save-dev @fastly/js-compute")),
 		}
@@ -160,14 +162,14 @@ func (a JavaScript) Verify(out io.Writer) error {
 	cmd := exec.Command("npm", "run")
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.RemediationError{
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("%s: %w", pkgErr, err),
 			Remediation: remediation,
 		}
 	}
 
 	if !strings.Contains(string(stdoutStderr), "  build\n") {
-		return errors.RemediationError{
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf(pkgErr),
 			Remediation: remediation,
 		}

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -81,6 +81,8 @@ func (m *CargoMetadata) Read() error {
 
 // Rust implements a Toolchain for the Rust language.
 type Rust struct {
+	Shell
+
 	build   string
 	client  api.HTTPClient
 	config  *config.Data
@@ -90,6 +92,7 @@ type Rust struct {
 // NewRust constructs a new Rust.
 func NewRust(client api.HTTPClient, config *config.Data, timeout int, build string) *Rust {
 	return &Rust{
+		Shell:   Shell{},
 		build:   build,
 		client:  client,
 		config:  config,
@@ -445,9 +448,7 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 	}
 
 	if r.build != "" {
-		segs := strings.Split(r.build, " ")
-		cmd = segs[0]
-		args = segs[1:]
+		cmd, args = r.Shell.Build(r.build)
 	}
 
 	// Execute the `cargo build` commands with the Wasm WASI target, release

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	fstexec "github.com/fastly/cli/pkg/exec"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/text"
@@ -63,17 +63,19 @@ type CargoMetadata struct {
 }
 
 // Read the contents of the Cargo.lock file from filename.
-func (m *CargoMetadata) Read() error {
+func (m *CargoMetadata) Read(errlog fsterr.LogInterface) error {
 	cmd := exec.Command("cargo", "metadata", "--quiet", "--format-version", "1")
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		if len(stdoutStderr) > 0 {
-			return fmt.Errorf("%s", strings.TrimSpace(string(stdoutStderr)))
+			err = fmt.Errorf("%s", strings.TrimSpace(string(stdoutStderr)))
 		}
+		errlog.Add(err)
 		return err
 	}
 	r := bytes.NewReader(stdoutStderr)
 	if err := json.NewDecoder(r).Decode(&m); err != nil {
+		errlog.Add(err)
 		return err
 	}
 	return nil
@@ -85,17 +87,19 @@ type Rust struct {
 
 	build   string
 	client  api.HTTPClient
-	config  *config.Data
+	config  config.Rust
+	errlog  fsterr.LogInterface
 	timeout int
 }
 
 // NewRust constructs a new Rust.
-func NewRust(client api.HTTPClient, config *config.Data, timeout int, build string) *Rust {
+func NewRust(client api.HTTPClient, config config.Rust, errlog fsterr.LogInterface, timeout int, build string) *Rust {
 	return &Rust{
 		Shell:   Shell{},
 		build:   build,
 		client:  client,
 		config:  config,
+		errlog:  errlog,
 		timeout: timeout,
 	}
 }
@@ -123,50 +127,50 @@ func (r Rust) IncludeFiles() []string { return []string{"Cargo.toml"} }
 func (r *Rust) Verify(out io.Writer) (err error) {
 	fmt.Fprintf(out, "Checking if `rustc` is installed...\n")
 
-	err = validateCompilerExists()
+	err = validateCompilerExists(r.errlog)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(out, "Checking the `rustc` version...\n")
 
-	err = validateCompilerVersion(r.config.File.Language.Rust.ToolchainConstraint)
+	err = validateCompilerVersion(r.config.ToolchainConstraint, r.errlog)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(out, "Checking the `wasm32-wasi` target is installed...\n")
 
-	err = validateWasmTarget(r.config.File.Language.Rust.WasmWasiTarget)
+	err = validateWasmTarget(r.config.WasmWasiTarget, r.errlog)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(out, "Checking if `cargo` is installed...\n")
 
-	err = validateCargoExists()
+	err = validateCargoExists(r.errlog)
 	if err != nil {
 		return err
 	}
 
 	// Validate the fastly and fastly-sys crates...
 
-	latestFastlyCrate, err := GetLatestCrateVersion(r.client, "fastly")
+	latestFastlyCrate, err := GetLatestCrateVersion(r.client, "fastly", r.errlog)
 	if err != nil {
 		return fmt.Errorf("error fetching latest `fastly` crate version: %w", err)
 	}
 
 	var metadata CargoMetadata
-	if err := metadata.Read(); err != nil {
+	if err := metadata.Read(r.errlog); err != nil {
 		return fmt.Errorf("error reading cargo metadata: %w", err)
 	}
 
-	err = validateFastlySysCrate(metadata, r.config.File.Language.Rust.FastlySysConstraint, latestFastlyCrate.String())
+	err = validateFastlySysCrate(metadata, r.config.FastlySysConstraint, latestFastlyCrate.String(), r.errlog)
 	if err != nil {
 		return err
 	}
 
-	err = validateFastlyCrate(metadata, latestFastlyCrate, out)
+	err = validateFastlyCrate(metadata, latestFastlyCrate, out, r.errlog)
 	if err != nil {
 		return err
 	}
@@ -175,10 +179,11 @@ func (r *Rust) Verify(out io.Writer) (err error) {
 }
 
 // validateCompilerExists checks if `rustc` is installed.
-func validateCompilerExists() error {
+func validateCompilerExists(errlog fsterr.LogInterface) error {
 	_, err := exec.LookPath("rustc")
 	if err != nil {
-		return errors.RemediationError{
+		errlog.Add(err)
+		return fsterr.RemediationError{
 			Inner:       err,
 			Remediation: "Ensure the `rustc` compiler is installed:\n\n\thttps://www.rust-lang.org/tools/install",
 		}
@@ -187,38 +192,43 @@ func validateCompilerExists() error {
 }
 
 // validateCompilerVersion checks the `rustc` version meets our constraint.
-func validateCompilerVersion(constraint string) error {
-	version, err := rustcVersion()
+func validateCompilerVersion(constraint string, errlog fsterr.LogInterface) error {
+	version, err := rustcVersion(errlog)
 	if err != nil {
 		return err
 	}
 
 	rustcVersion, err := semver.NewVersion(version)
 	if err != nil {
+		errlog.Add(err)
 		return fmt.Errorf("error parsing `%s` output %q into a semver: %w", "rustc --version", version, err)
 	}
 
 	rustcConstraint, err := semver.NewConstraint(constraint)
 	if err != nil {
+		errlog.Add(err)
 		return fmt.Errorf("error parsing rustup constraint: %w", err)
 	}
 
 	if !rustcConstraint.Check(rustcVersion) {
-		return errors.RemediationError{
+		err := fsterr.RemediationError{
 			Inner:       fmt.Errorf("rustc constraint '%s' not met: %s", constraint, version),
 			Remediation: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint (e.g. `channel = \"stable\"`).",
 		}
+		errlog.Add(err)
+		return err
 	}
 
 	return nil
 }
 
 // rustcVersion returns the active rustc compiler version.
-func rustcVersion() (string, error) {
+func rustcVersion(errlog fsterr.LogInterface) (string, error) {
 	cmd := []string{"rustc", "--version"}
 	c := exec.Command(cmd[0], cmd[1:]...) // #nosec G204
 	stdoutStderr, err := c.CombinedOutput()
 	if err != nil {
+		errlog.Add(err)
 		return "", fmt.Errorf("error executing `%s`: %w", strings.Join(cmd, " "), err)
 	}
 
@@ -233,7 +243,9 @@ func rustcVersion() (string, error) {
 	}
 	err = scanner.Err()
 	if line == "" || err != nil {
-		return "", fmt.Errorf("error reading `%s` output: %w", strings.Join(cmd, " "), err)
+		err = fmt.Errorf("error reading `%s` output: %w", strings.Join(cmd, " "), err)
+		errlog.Add(err)
+		return "", err
 	}
 	line = strings.TrimSpace(line)
 
@@ -242,15 +254,19 @@ func rustcVersion() (string, error) {
 	// rustc 1.56.0-nightly (2d2bc94c8 2021-08-15)
 	parts := strings.Split(line, " ")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("error reading `%s` output", strings.Join(cmd, " "))
+		err := fmt.Errorf("error reading `%s` output", strings.Join(cmd, " "))
+		errlog.Add(err)
+		return "", err
 	}
 
 	version := strings.Split(parts[1], "-")
 	if len(version) > 1 {
-		return "", errors.RemediationError{
+		err := fsterr.RemediationError{
 			Inner:       fmt.Errorf("non-stable releases are not supported: %s", parts[1]),
 			Remediation: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint (e.g. `channel = \"stable\"`). Alternatively utilise the CLI's `--force` flag.",
 		}
+		errlog.Add(err)
+		return "", err
 	}
 
 	return version[0], nil
@@ -261,13 +277,14 @@ func rustcVersion() (string, error) {
 // If the user has `rustup` installed then we use it to identify if the target
 // is installed, otherwise we fallback to a low-level check of the target
 // directory using `rustc --print sysroot`.
-func validateWasmTarget(target string) error {
+func validateWasmTarget(target string, errlog fsterr.LogInterface) error {
 	_, err := exec.LookPath("rustup")
 	if err != nil {
-		return rustcSysroot(target)
+		errlog.Add(err)
+		return rustcSysroot(target, errlog)
 	}
 
-	toolchain, err := rustupToolchain()
+	toolchain, err := rustupToolchain(errlog)
 	if err != nil {
 		return err
 	}
@@ -276,6 +293,7 @@ func validateWasmTarget(target string) error {
 	c := exec.Command(cmd[0], cmd[1:]...) // #nosec G204
 	stdoutStderr, err := c.CombinedOutput()
 	if err != nil {
+		errlog.Add(err)
 		return fmt.Errorf("error executing `%s`: %w", strings.Join(cmd, " "), err)
 	}
 
@@ -290,27 +308,31 @@ func validateWasmTarget(target string) error {
 	}
 
 	if !found {
-		return errors.RemediationError{
+		err := fsterr.RemediationError{
 			Inner:       fmt.Errorf("rust target %s not found", target),
 			Remediation: fmt.Sprintf("Run the following command:\n\n\t$ %s\n", text.Bold(fmt.Sprintf("rustup target add %s --toolchain %s", target, toolchain))),
 		}
+		errlog.Add(err)
+		return err
 	}
 
 	return nil
 }
 
 // rustupToolchain returns the active rustup toolchain.
-func rustupToolchain() (string, error) {
+func rustupToolchain(errlog fsterr.LogInterface) (string, error) {
 	cmd := []string{"rustup", "show", "active-toolchain"}
 	c := exec.Command(cmd[0], cmd[1:]...) // #nosec G204
 	stdoutStderr, err := c.CombinedOutput()
 	if err != nil {
+		errlog.Add(err)
 		return "", fmt.Errorf("error executing `%s`: %w", strings.Join(cmd, " "), err)
 	}
 
 	reader := bufio.NewReader(bytes.NewReader(stdoutStderr))
 	line, err := reader.ReadString('\n')
 	if err != nil {
+		errlog.Add(err)
 		return "", fmt.Errorf("error reading `%s` output: %w", strings.Join(cmd, " "), err)
 	}
 
@@ -319,7 +341,9 @@ func rustupToolchain() (string, error) {
 	// 1.54.0-x86_64-apple-darwin (directory override for '/Users/integralist/Code/fastly/cli')
 	parts := strings.Split(line, "-")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("error reading `%s` output", strings.Join(cmd, " "))
+		err := fmt.Errorf("error reading `%s` output", strings.Join(cmd, " "))
+		errlog.Add(err)
+		return "", err
 	}
 
 	return parts[0], nil
@@ -329,18 +353,20 @@ func rustupToolchain() (string, error) {
 // low-level rustc compiler `--print sysroot` flag.
 //
 // This is called only when the user doesn't have `rustup` installed.
-func rustcSysroot(target string) error {
+func rustcSysroot(target string, errlog fsterr.LogInterface) error {
 	cmd := []string{"rustc", "--print", "sysroot"}
 	c := exec.Command(cmd[0], cmd[1:]...) // #nosec G204
 	stdoutStderr, err := c.CombinedOutput()
 	if err != nil {
+		errlog.Add(err)
 		return fmt.Errorf("error executing `%s`: %w", strings.Join(cmd, " "), err)
 	}
 
 	sysroot := strings.TrimSpace(string(stdoutStderr))
 	path := filepath.Join(sysroot, "lib", "rustlib", "wasm32-wasi")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return errors.RemediationError{
+		errlog.Add(err)
+		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("the Rust target directory `%s` doesn't exist", path),
 			Remediation: fmt.Sprintf("Ensure the following target is installed:\n\n\t%s", target),
 		}
@@ -350,10 +376,11 @@ func rustcSysroot(target string) error {
 }
 
 // validateCargoExists checks `cargo` is installed.
-func validateCargoExists() error {
+func validateCargoExists(errlog fsterr.LogInterface) error {
 	_, err := exec.LookPath("cargo")
 	if err != nil {
-		return errors.RemediationError{
+		errlog.Add(err)
+		return fsterr.RemediationError{
 			Inner:       err,
 			Remediation: "Ensure the `cargo` package manager is installed:\n\n\thttps://doc.rust-lang.org/cargo/getting-started/installation.html",
 		}
@@ -367,19 +394,23 @@ func validateCargoExists() error {
 // have to think about and so we don't indicate to the user that we're
 // validating the fastly-sys crate specifically (i.e. we make the messaging
 // generic towards the fastly crate).
-func validateFastlySysCrate(metadata CargoMetadata, constraint string, latestFastlyCrateVersion string) error {
+func validateFastlySysCrate(metadata CargoMetadata, constraint string, latestFastlyCrateVersion string, errlog fsterr.LogInterface) error {
 	fastlySysConstraint, err := semver.NewConstraint(constraint)
 	if err != nil {
+		errlog.Add(err)
 		return fmt.Errorf("error parsing crate constraint: %w", err)
 	}
 
 	fastlySysVersion, err := GetCrateVersionFromMetadata(metadata, "fastly-sys")
 	if err != nil {
+		errlog.Add(err)
 		return newCargoUpdateRemediationErr(err, latestFastlyCrateVersion)
 	}
 
 	if ok := fastlySysConstraint.Check(fastlySysVersion); !ok {
-		return newCargoUpdateRemediationErr(fmt.Errorf("fastly crate not up-to-date"), latestFastlyCrateVersion)
+		err := fmt.Errorf("fastly crate not up-to-date")
+		errlog.Add(err)
+		return newCargoUpdateRemediationErr(err, latestFastlyCrateVersion)
 	}
 
 	return nil
@@ -389,9 +420,10 @@ func validateFastlySysCrate(metadata CargoMetadata, constraint string, latestFas
 //
 // The folllowing logic is an optional upgrade suggestion and so we don't
 // display any up front message to say we're checking the fastly crate.
-func validateFastlyCrate(metadata CargoMetadata, v *semver.Version, out io.Writer) error {
+func validateFastlyCrate(metadata CargoMetadata, v *semver.Version, out io.Writer, errlog fsterr.LogInterface) error {
 	fastlyVersion, err := GetCrateVersionFromMetadata(metadata, "fastly")
 	if err != nil {
+		errlog.Add(err)
 		return newCargoUpdateRemediationErr(err, v.String())
 	}
 
@@ -428,6 +460,7 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 	// Get binary name from Cargo.toml.
 	var m CargoManifest
 	if err := m.Read("Cargo.toml"); err != nil {
+		r.errlog.Add(err)
 		return fmt.Errorf("error reading Cargo.toml manifest: %w", err)
 	}
 	binName := m.Package.Name
@@ -439,7 +472,7 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 		binName,
 		"--release",
 		"--target",
-		r.config.File.Language.Rust.WasmWasiTarget,
+		r.config.WasmWasiTarget,
 		"--color",
 		"always",
 	}
@@ -463,29 +496,34 @@ func (r *Rust) Build(out io.Writer, verbose bool) error {
 		s.Timeout = time.Duration(r.timeout) * time.Second
 	}
 	if err := s.Exec(); err != nil {
+		r.errlog.Add(err)
 		return err
 	}
 
 	// Get working directory.
 	dir, err := os.Getwd()
 	if err != nil {
+		r.errlog.Add(err)
 		return fmt.Errorf("getting current working directory: %w", err)
 	}
 	var metadata CargoMetadata
-	if err := metadata.Read(); err != nil {
+	if err := metadata.Read(r.errlog); err != nil {
+		r.errlog.Add(err)
 		return fmt.Errorf("error reading cargo metadata: %w", err)
 	}
-	src := filepath.Join(metadata.TargetDirectory, r.config.File.Language.Rust.WasmWasiTarget, "release", fmt.Sprintf("%s.wasm", binName))
+	src := filepath.Join(metadata.TargetDirectory, r.config.WasmWasiTarget, "release", fmt.Sprintf("%s.wasm", binName))
 	dst := filepath.Join(dir, "bin", "main.wasm")
 
 	// Check if bin directory exists and create if not.
 	binDir := filepath.Join(dir, "bin")
 	if err := filesystem.MakeDirectoryIfNotExists(binDir); err != nil {
+		r.errlog.Add(err)
 		return fmt.Errorf("creating bin directory: %w", err)
 	}
 
 	err = filesystem.CopyFile(src, dst)
 	if err != nil {
+		r.errlog.Add(err)
 		return fmt.Errorf("copying wasm binary: %w", err)
 	}
 
@@ -504,32 +542,37 @@ type CargoCrateVersions struct {
 
 // GetLatestCrateVersion fetches all versions of a given Rust crate from the
 // crates.io HTTP API and returns the latest valid semver version.
-func GetLatestCrateVersion(client api.HTTPClient, name string) (*semver.Version, error) {
+func GetLatestCrateVersion(client api.HTTPClient, name string, errlog fsterr.LogInterface) (*semver.Version, error) {
 	url := fmt.Sprintf("https://crates.io/api/v1/crates/%s/versions", name)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
+		errlog.Add(err)
 		return nil, err
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
+		errlog.Add(err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		errlog.Add(err)
 		return nil, fmt.Errorf("error fetching latest crate version: %s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		errlog.Add(err)
 		return nil, err
 	}
 
 	crate := CargoCrateVersions{}
 	err = json.Unmarshal(body, &crate)
 	if err != nil {
+		errlog.Add(err)
 		return nil, err
 	}
 
@@ -586,8 +629,8 @@ func GetCrateVersionFromMetadata(metadata CargoMetadata, crate string) (*semver.
 // newCargoUpdateRemediationErr constructs a new RemediationError which wraps a
 // cargo error and suggests to update the fastly crate to a specified version as
 // its remediation message.
-func newCargoUpdateRemediationErr(err error, version string) errors.RemediationError {
-	return errors.RemediationError{
+func newCargoUpdateRemediationErr(err error, version string) fsterr.RemediationError {
+	return fsterr.RemediationError{
 		Inner: err,
 		Remediation: fmt.Sprintf(
 			"To fix this error, edit %s with:\n\n\t %s\n\nAnd then run the following command:\n\n\t$ %s\n",

--- a/pkg/commands/compute/manifest/manifest.go
+++ b/pkg/commands/compute/manifest/manifest.go
@@ -206,6 +206,7 @@ type File struct {
 	LocalServer     LocalServer `toml:"local_server,omitempty"`
 	ManifestVersion Version     `toml:"manifest_version"`
 	Name            string      `toml:"name"`
+	Scripts         Scripts     `toml:"scripts,omitempty"`
 	ServiceID       string      `toml:"service_id"`
 	Setup           Setup       `toml:"setup,omitempty"`
 
@@ -213,6 +214,11 @@ type File struct {
 	exists    bool
 	output    io.Writer
 	readError error
+}
+
+// Scripts represents custom operations.
+type Scripts struct {
+	Build string `toml:"build,omitempty"`
 }
 
 // Setup represents a set of service configuration that works with the code in

--- a/pkg/errors/log.go
+++ b/pkg/errors/log.go
@@ -31,6 +31,13 @@ type LogInterface interface {
 	Persist(logPath string, args []string) error
 }
 
+// MockLog is a no-op Log type.
+type MockLog struct{}
+
+func (ml MockLog) Add(err error)                                        {}
+func (ml MockLog) AddWithContext(err error, ctx map[string]interface{}) {}
+func (ml MockLog) Persist(logPath string, args []string) error          { return nil }
+
 // Log is the primary interface for consumers.
 var Log = new(LogEntries)
 


### PR DESCRIPTION
This feature allows a user to override the default verification and build steps within the CLI with whatever toolchain the user wishes to use.

For example, to avoid using NPM as the default toolchain for a JavaScript project you can set in `fastly.toml`:

```toml
[scripts]
build = "yarn run build"
```

## Example

I tested this by copying https://github.com/fastly/compute-starter-kit-javascript-default and then modifying the `fastly.toml` to include:

```toml
[scripts]
build = "yarn install && yarn run build"
```