### PR TITLE
Support `compute build` for 'other' language option using `[scripts.build]`

### DIFF
--- a/cmd/fastly/static/config.toml
+++ b/cmd/fastly/static/config.toml
@@ -14,6 +14,9 @@ wasm_wasi_target = "wasm32-wasi"
 fastly_sys_constraint = ">= 0.3.3"
 rustup_constraint = ">= 1.23.0"
 
+[viceroy]
+ttl = "24h"
+
 [[starter-kits.assemblyscript]]
 name = "Default starter for AssemblyScript"
 description = "A basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
@@ -38,6 +41,3 @@ path = "https://github.com/fastly/compute-starter-kit-rust-default"
 name = "Static content"
 description = "Apply performance, security and usability upgrades to static bucket services such as Google Cloud Storage or AWS S3."
 path = "https://github.com/fastly/compute-starter-kit-rust-static-content"
-
-[viceroy]
-ttl = "24h"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/fastly/go-fastly/v5 v5.0.0
 	github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible
-	github.com/fatih/color v1.12.0
+	github.com/fatih/color v1.13.0
 	github.com/frankban/quicktest v1.13.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/google/go-cmp v0.5.6
@@ -43,7 +43,7 @@ require (
 	github.com/google/jsonapi v0.0.0-20201022225600-f822737867f6 // indirect
 	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
-	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/fastly/go-fastly/v5 v5.0.0 h1:SyYmAARhDQ4GFpcKZ404kumH473nsF8EgBBdY83
 github.com/fastly/go-fastly/v5 v5.0.0/go.mod h1:Hr7UTc2laOUk+jnocgJFIjpE/jqoxR0Oftt0AIeLSzo=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
-github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
-github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/frankban/quicktest v1.13.1 h1:xVm/f9seEhZFL9+n5kv5XLrGwy6elc4V9v/XFY2vmd8=
 github.com/frankban/quicktest v1.13.1/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
@@ -69,8 +69,9 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
-github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
@@ -140,6 +141,7 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b h1:1VkfZQv42XQlA/jchYumAnv1UPo6RgF9rJFkTgZIxO4=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
@@ -167,4 +169,3 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-# forcing CI step 'Install dependencies' to run as we updated how to install deps which results in current hash of go.sum to not be a cache miss and thus dep step isn't run

--- a/pkg/app/metadata.json
+++ b/pkg/app/metadata.json
@@ -153,6 +153,11 @@
   "compute": {
     "build": {
       "examples": [{
+        "cmd": "fastly compute build",
+        "description": "In the `fastly.toml` manifest define a new `[scripts]` table and within it define a `build` key with your Yarn instructions. For example, `build = \"yarn install && yarn build\"`.",
+        "title": "Build a JavaScript Compute@Edge package using Yarn instead of NPM"
+      },
+      {
         "cmd": "fastly compute build --skip-verification",
         "description": "The optional `--skip-verification` flag will prevent the CLI from validating your local environment has the required language toolchain installed to build your package.",
         "title": "Build a Compute@Edge package locally"

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -579,11 +579,13 @@ COMMANDS
   compute build [<flags>]
     Build a Compute@Edge package locally
 
-    --include-source     Include source code in built package
-    --language=LANGUAGE  Language type
-    --name=NAME          Package name
-    --skip-verification  Skip verification steps and force build
-    --timeout=TIMEOUT    Timeout, in seconds, for the build compilation step
+    --accept-custom-build  Do not prompt when project manifest defines
+                           [scripts.build]
+    --include-source       Include source code in built package
+    --language=LANGUAGE    Language type
+    --name=NAME            Package name
+    --skip-verification    Skip verification steps and force build
+    --timeout=TIMEOUT      Timeout, in seconds, for the build compilation step
 
   compute deploy [<flags>]
     Deploy a package to a Fastly Compute@Edge service
@@ -623,26 +625,30 @@ COMMANDS
   compute publish [<flags>]
     Build and deploy a Compute@Edge package to a Fastly service
 
-        --name=NAME              Package name
-        --language=LANGUAGE      Language type
-        --include-source         Include source code in built package
-        --skip-verification      Skip verification steps and force build
-        --timeout=TIMEOUT        Timeout, in seconds, for the build compilation
-                                 step
+        --accept-custom-build    Do not prompt when project manifest defines
+                                 [scripts.build]
         --accept-defaults        Accept default values for all prompts and
                                  perform deploy non-interactively
         --comment=COMMENT        Human-readable comment
         --domain=DOMAIN          The name of the domain associated to the
                                  package
+        --include-source         Include source code in built package
+        --language=LANGUAGE      Language type
+        --name=NAME              Package name
     -p, --package=PACKAGE        Path to a package tar.gz
     -s, --service-id=SERVICE-ID  Service ID (falls back to FASTLY_SERVICE_ID,
                                  then fastly.toml)
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
+        --skip-verification      Skip verification steps and force build
+        --timeout=TIMEOUT        Timeout, in seconds, for the build compilation
+                                 step
 
   compute serve [<flags>]
     Build and run a Compute@Edge package locally
 
+    --accept-custom-build    Do not prompt when project manifest defines
+                             [scripts.build]
     --addr="127.0.0.1:7676"  The IPv4 address and port to listen on
     --env=ENV                The environment configuration to use (e.g. stage)
     --file="bin/main.wasm"   The Wasm file to run

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -174,13 +174,14 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// things. So we should notify the user and confirm they would like to
 	// continue with the build.
 	if !c.Flags.AcceptCustomBuild && language.Name == "other" && toolchain == "custom" {
-		label := fmt.Sprintf("This project has a custom build script defined (%s). Are you sure you want to continue with the build step? [y/N] ", c.Manifest.File.Scripts.Build)
+		label := "This project has a custom build script defined in the fastly.toml manifest. Are you sure you want to continue with the build step? [y/N] "
 		cont, err := text.Input(out, label, in)
 		if err != nil {
 			return fmt.Errorf("error reading input %w", err)
 		}
 		contl := strings.ToLower(cont)
 		if contl != "y" && contl != "yes" {
+			text.Info(out, "Stopping the build process.")
 			return nil
 		}
 	}

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -169,16 +169,18 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 	}
 
+	customBuildMsg := "This project has a custom build script defined in the fastly.toml manifest. "
+
+	if toolchain == "custom" && c.Globals.Flag.Verbose {
+		text.Info(out, fmt.Sprintf("%s\n\n%s\n\n", customBuildMsg, c.Manifest.File.Scripts.Build))
+		customBuildMsg = ""
+	}
+
 	// NOTE: A third-party could share a project with a build command for a
 	// language that wouldn't normally require one (e.g. Rust), and do evil
 	// things. So we should notify the user and confirm they would like to
 	// continue with the build.
-	if !c.Flags.AcceptCustomBuild && toolchain == "custom" {
-		customBuildMsg := "This project has a custom build script defined in the fastly.toml manifest. "
-		if c.Globals.Flag.Verbose {
-			text.Info(out, customBuildMsg)
-			customBuildMsg = ""
-		}
+	if toolchain == "custom" && !c.Flags.AcceptCustomBuild {
 		label := fmt.Sprintf("%sAre you sure you want to continue with the build step? [y/N] ", customBuildMsg)
 		cont, err := text.Input(out, label, in)
 		if err != nil {

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -174,7 +174,12 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// things. So we should notify the user and confirm they would like to
 	// continue with the build.
 	if !c.Flags.AcceptCustomBuild && toolchain == "custom" {
-		label := "This project has a custom build script defined in the fastly.toml manifest. Are you sure you want to continue with the build step? [y/N] "
+		customBuildMsg := "This project has a custom build script defined in the fastly.toml manifest. "
+		if c.Globals.Flag.Verbose {
+			text.Info(out, customBuildMsg)
+			customBuildMsg = ""
+		}
+		label := fmt.Sprintf("%sAre you sure you want to continue with the build step? [y/N] ", customBuildMsg)
 		cont, err := text.Input(out, label, in)
 		if err != nil {
 			return fmt.Errorf("error reading input %w", err)

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -173,7 +173,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// language that wouldn't normally require one (e.g. Rust), and do evil
 	// things. So we should notify the user and confirm they would like to
 	// continue with the build.
-	if !c.Flags.AcceptCustomBuild && language.Name == "other" && toolchain == "custom" {
+	if !c.Flags.AcceptCustomBuild && toolchain == "custom" {
 		label := "This project has a custom build script defined in the fastly.toml manifest. Are you sure you want to continue with the build step? [y/N] "
 		cont, err := text.Input(out, label, in)
 		if err != nil {

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -192,7 +192,8 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			contl := strings.ToLower(cont)
 			if contl != "y" && contl != "yes" {
 				text.Info(out, "Stopping the build process.")
-				return nil
+				text.Break(out)
+				return fsterr.ErrBuildStopped
 			}
 			text.Break(out)
 		}

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -135,6 +135,11 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			IncludeFiles:    []string{"Cargo.toml"},
 			Toolchain:       NewRust(c.client, c.Globals.File.Language.Rust, c.Globals.ErrLog, c.Timeout, c.Manifest.File.Scripts.Build),
 		})
+	case "other":
+		language = NewLanguage(&LanguageOptions{
+			Name:      "other",
+			Toolchain: NewOther(c.Timeout, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
+		})
 	default:
 		return fmt.Errorf("unsupported language %s", lang)
 	}

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -175,7 +175,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	if toolchain == "custom" {
 		if c.Globals.Flag.Verbose || !c.Flags.AcceptCustomBuild {
-			text.Info(out, "This project has a custom build script defined in the fastly.toml manifest.\n")
+			text.Info(out, "This project has a custom build script defined in the fastly.toml manifest:\n")
 			text.Break(out)
 			text.Indent(out, 4, "%s", c.Manifest.File.Scripts.Build)
 		}

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -607,7 +607,7 @@ func TestBuildOther(t *testing.T) {
 			wantOutput: []string{
 				"This project has a custom build script defined in the fastly.toml manifest",
 				"Building package using custom toolchain",
-				"Built package 'test' (pkg/test.tar.gz)",
+				"Built package 'test'",
 			},
 		},
 		{
@@ -623,7 +623,7 @@ func TestBuildOther(t *testing.T) {
 			wantOutput: []string{
 				"This project has a custom build script defined in the fastly.toml manifest",
 				"Building package using custom toolchain",
-				"Built package 'test' (pkg/test.tar.gz)",
+				"Built package 'test'",
 			},
 		},
 		{
@@ -637,7 +637,7 @@ func TestBuildOther(t *testing.T) {
 			build = "echo custom build"`,
 			wantOutput: []string{
 				"Building package using custom toolchain",
-				"Built package 'test' (pkg/test.tar.gz)",
+				"Built package 'test'",
 			},
 			dontWantOutput: []string{
 				"This project has a custom build script defined in the fastly.toml manifest",

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -580,7 +580,20 @@ func TestBuildOther(t *testing.T) {
 		wantRemediationError string
 	}{
 		{
-			name: "Stop build process",
+			name: "no custom build",
+			args: args("compute build --language other"),
+			fastlyManifest: `
+			manifest_version = 2
+			name = "test"
+			language = "other"`,
+			dontWantOutput: []string{
+				"This project has a custom build script defined in the fastly.toml manifest",
+			},
+			wantError:            "error reading custom build instructions from fastly.toml manifest",
+			wantRemediationError: "Add a [scripts.build] setting for your custom build process",
+		},
+		{
+			name: "stop build process",
 			args: args("compute build --language other"),
 			fastlyManifest: `
 			manifest_version = 2
@@ -595,7 +608,7 @@ func TestBuildOther(t *testing.T) {
 			},
 		},
 		{
-			name: "Allow build process",
+			name: "allow build process",
 			args: args("compute build --language other"),
 			fastlyManifest: `
 			manifest_version = 2
@@ -611,7 +624,7 @@ func TestBuildOther(t *testing.T) {
 			},
 		},
 		{
-			name: "Language pulled from manifest",
+			name: "language pulled from manifest",
 			args: args("compute build"),
 			fastlyManifest: `
 			manifest_version = 2
@@ -627,7 +640,7 @@ func TestBuildOther(t *testing.T) {
 			},
 		},
 		{
-			name: "Avoid prompt confirmation",
+			name: "avoid prompt confirmation",
 			args: args("compute build --accept-custom-build --language other"),
 			fastlyManifest: `
 			manifest_version = 2

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -607,6 +607,8 @@ func TestCustomBuild(t *testing.T) {
 				"Are you sure you want to continue with the build step?",
 				"Stopping the build process",
 			},
+			wantError:            "build process stopped by user",
+			wantRemediationError: "Remove or update the custom [scripts.build] in the fastly.toml manifest.",
 		},
 		{
 			name: "allow build process",

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fastly/cli/pkg/api"
@@ -528,6 +529,142 @@ func TestBuildJavaScript(t *testing.T) {
 			testutil.AssertRemediationErrorContains(t, err, testcase.wantRemediationError)
 			if testcase.wantOutputContains != "" {
 				testutil.AssertStringContains(t, stdout.String(), testcase.wantOutputContains)
+			}
+		})
+	}
+}
+
+func TestBuildOther(t *testing.T) {
+	args := testutil.Args
+	if os.Getenv("TEST_COMPUTE_BUILD") == "" {
+		t.Log("skipping test")
+		t.Skip("Set TEST_COMPUTE_BUILD to run this test")
+	}
+
+	// We're going to chdir to a build environment,
+	// so save the PWD to return to, afterwards.
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test environment
+	//
+	// NOTE: Our only requirement is that there be a bin directory. The custom
+	// build script we're using in the test is not going to use any files in the
+	// directory (the script will just `echo` a message).
+	rootdir := testutil.NewEnv(testutil.EnvOpts{
+		T: t,
+		Write: []testutil.FileIO{
+			{Src: "mock content", Dst: "bin/testfile"},
+		},
+	})
+	defer os.RemoveAll(rootdir)
+
+	// Before running the test, chdir into the build environment.
+	// When we're done, chdir back to our original location.
+	// This is so we can reliably copy the testdata/ fixtures.
+	if err := os.Chdir(rootdir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(pwd)
+
+	for _, testcase := range []struct {
+		args                 []string
+		dontWantOutput       []string
+		fastlyManifest       string
+		name                 string
+		stdin                string
+		wantError            string
+		wantOutput           []string
+		wantRemediationError string
+	}{
+		{
+			name: "Stop build process",
+			args: args("compute build --language other"),
+			fastlyManifest: `
+			manifest_version = 2
+			name = "test"
+			language = "other"
+			[scripts]
+			build = "echo custom build"`,
+			stdin: "N",
+			wantOutput: []string{
+				"This project has a custom build script defined in the fastly.toml manifest",
+				"Stopping the build process",
+			},
+		},
+		{
+			name: "Allow build process",
+			args: args("compute build --language other"),
+			fastlyManifest: `
+			manifest_version = 2
+			name = "test"
+			language = "other"
+			[scripts]
+			build = "echo custom build"`,
+			stdin: "Y",
+			wantOutput: []string{
+				"This project has a custom build script defined in the fastly.toml manifest",
+				"Building package using custom toolchain",
+				"Built package 'test' (pkg/test.tar.gz)",
+			},
+		},
+		{
+			name: "Language pulled from manifest",
+			args: args("compute build"),
+			fastlyManifest: `
+			manifest_version = 2
+			name = "test"
+			language = "other"
+			[scripts]
+			build = "echo custom build"`,
+			stdin: "Y",
+			wantOutput: []string{
+				"This project has a custom build script defined in the fastly.toml manifest",
+				"Building package using custom toolchain",
+				"Built package 'test' (pkg/test.tar.gz)",
+			},
+		},
+		{
+			name: "Avoid prompt confirmation",
+			args: args("compute build --accept-custom-build --language other"),
+			fastlyManifest: `
+			manifest_version = 2
+			name = "test"
+			language = "other"
+			[scripts]
+			build = "echo custom build"`,
+			wantOutput: []string{
+				"Building package using custom toolchain",
+				"Built package 'test' (pkg/test.tar.gz)",
+			},
+			dontWantOutput: []string{
+				"This project has a custom build script defined in the fastly.toml manifest",
+			},
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.fastlyManifest != "" {
+				if err := os.WriteFile(filepath.Join(rootdir, manifest.Filename), []byte(testcase.fastlyManifest), 0777); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var stdout bytes.Buffer
+			opts := testutil.NewRunOpts(testcase.args, &stdout)
+			opts.Stdin = strings.NewReader(testcase.stdin) // NOTE: build only has one prompt when dealing with a custom build
+			err = app.Run(opts)
+
+			t.Log(stdout.String())
+
+			testutil.AssertErrorContains(t, err, testcase.wantError)
+			testutil.AssertRemediationErrorContains(t, err, testcase.wantRemediationError)
+			for _, s := range testcase.wantOutput {
+				testutil.AssertStringContains(t, stdout.String(), s)
+			}
+			for _, s := range testcase.dontWantOutput {
+				testutil.AssertStringDoesntContain(t, stdout.String(), s)
 			}
 		})
 	}

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -522,7 +522,7 @@ func manageNoServiceIDFlow(
 		text.Break(out)
 	}
 
-	progress := text.NewProgress(out, verbose)
+	progress := text.ResetProgress(out, verbose)
 
 	// There is no service and so we'll do a one time creation of the service
 	//

--- a/pkg/commands/compute/language_other.go
+++ b/pkg/commands/compute/language_other.go
@@ -1,0 +1,69 @@
+package compute
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	fsterr "github.com/fastly/cli/pkg/errors"
+	fstexec "github.com/fastly/cli/pkg/exec"
+)
+
+// Other implements a Toolchain for languages without official support.
+type Other struct {
+	Shell
+
+	build   string
+	errlog  fsterr.LogInterface
+	timeout int
+}
+
+// NewOther constructs a new unsupported language instance.
+func NewOther(timeout int, build string, errlog fsterr.LogInterface) *Other {
+	return &Other{
+		Shell:   Shell{},
+		build:   build,
+		errlog:  errlog,
+		timeout: timeout,
+	}
+}
+
+// No-op
+func (o Other) Initialize(out io.Writer) error {
+	return nil
+}
+
+// No-op
+func (o Other) Verify(out io.Writer) error {
+	return nil
+}
+
+// Build implements the Toolchain interface and attempts to compile the package
+// source to a Wasm binary.
+func (o Other) Build(out io.Writer, verbose bool) error {
+	if o.build == "" {
+		err := fmt.Errorf("error reading custom build instructions from fastly.toml manifest")
+		o.errlog.Add(err)
+		return fsterr.RemediationError{
+			Inner:       err,
+			Remediation: fsterr.ComputeBuildRemediation,
+		}
+	}
+	cmd, args := o.Shell.Build(o.build)
+
+	s := fstexec.Streaming{
+		Command: cmd,
+		Args:    args,
+		Env:     []string{},
+		Output:  out,
+	}
+	if o.timeout > 0 {
+		s.Timeout = time.Duration(o.timeout) * time.Second
+	}
+	if err := s.Exec(); err != nil {
+		o.errlog.Add(err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -72,19 +72,19 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// Reset the fields on the BuildCommand based on PublishCommand values.
 	if c.includeSrc.WasSet {
-		c.build.IncludeSrc = c.includeSrc.Value
+		c.build.Flags.IncludeSrc = c.includeSrc.Value
 	}
 	if c.lang.WasSet {
-		c.build.Lang = c.lang.Value
+		c.build.Flags.Lang = c.lang.Value
 	}
 	if c.name.WasSet {
-		c.build.PackageName = c.name.Value
+		c.build.Flags.PackageName = c.name.Value
 	}
 	if c.skipVerification.WasSet {
-		c.build.SkipVerification = c.skipVerification.Value
+		c.build.Flags.SkipVerification = c.skipVerification.Value
 	}
 	if c.timeout.WasSet {
-		c.build.Timeout = c.timeout.Value
+		c.build.Flags.Timeout = c.timeout.Value
 	}
 	c.build.Manifest = c.manifest
 

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -89,7 +89,7 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 	}
 
-	progress := text.NewProgress(out, c.Globals.Verbose())
+	progress := text.ResetProgress(out, c.Globals.Verbose())
 
 	bin, err := getViceroy(progress, out, c.viceroyVersioner)
 	if err != nil {

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -121,19 +121,19 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 	// Reset the fields on the BuildCommand based on ServeCommand values.
 	if c.includeSrc.WasSet {
-		c.build.IncludeSrc = c.includeSrc.Value
+		c.build.Flags.IncludeSrc = c.includeSrc.Value
 	}
 	if c.lang.WasSet {
-		c.build.Lang = c.lang.Value
+		c.build.Flags.Lang = c.lang.Value
 	}
 	if c.name.WasSet {
-		c.build.PackageName = c.name.Value
+		c.build.Flags.PackageName = c.name.Value
 	}
 	if c.skipVerification.WasSet {
-		c.build.SkipVerification = c.skipVerification.Value
+		c.build.Flags.SkipVerification = c.skipVerification.Value
 	}
 	if c.timeout.WasSet {
-		c.build.Timeout = c.timeout.Value
+		c.build.Flags.Timeout = c.timeout.Value
 	}
 
 	err := c.build.Exec(in, out)

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -35,11 +35,12 @@ type ServeCommand struct {
 	viceroyVersioner update.Versioner
 
 	// Build fields
-	includeSrc       cmd.OptionalBool
-	lang             cmd.OptionalString
-	name             cmd.OptionalString
-	skipVerification cmd.OptionalBool
-	timeout          cmd.OptionalInt
+	acceptCustomBuild cmd.OptionalBool
+	includeSrc        cmd.OptionalBool
+	lang              cmd.OptionalString
+	name              cmd.OptionalString
+	skipVerification  cmd.OptionalBool
+	timeout           cmd.OptionalInt
 
 	// Serve fields
 	addr      string
@@ -60,6 +61,7 @@ func NewServeCommand(parent cmd.Registerer, globals *config.Data, build *BuildCo
 	c.CmdClause = parent.Command("serve", "Build and run a Compute@Edge package locally")
 	c.manifest = data
 
+	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines [scripts.build]").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
 	c.CmdClause.Flag("addr", "The IPv4 address and port to listen on").Default("127.0.0.1:7676").StringVar(&c.addr)
 	c.CmdClause.Flag("env", "The environment configuration to use (e.g. stage)").Action(c.env.Set).StringVar(&c.env.Value)
 	c.CmdClause.Flag("file", "The Wasm file to run").Default("bin/main.wasm").StringVar(&c.file)
@@ -120,6 +122,9 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 // Build constructs and executes the build logic.
 func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 	// Reset the fields on the BuildCommand based on ServeCommand values.
+	if c.acceptCustomBuild.WasSet {
+		c.build.Flags.AcceptCustomBuild = c.acceptCustomBuild.Value
+	}
 	if c.includeSrc.WasSet {
 		c.build.Flags.IncludeSrc = c.includeSrc.Value
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -92,3 +92,10 @@ var ErrInvalidArchive = RemediationError{
 	Inner:       fmt.Errorf("invalid package archive structure"),
 	Remediation: "Ensure the archive contains all required package files (such as a 'fastly.toml' manifest, and a 'src' folder etc).",
 }
+
+// ErrBuildStopped means the user stopped the build because they were unhappy
+// with the custom build defined in the fastly.toml manifest file.
+var ErrBuildStopped = RemediationError{
+	Inner:       fmt.Errorf("build process stopped by user"),
+	Remediation: "Remove or update the custom [scripts.build] in the fastly.toml manifest.",
+}

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -124,3 +124,10 @@ var ComputeServeRemediation = strings.Join([]string{
 	"The --watch flag enables hot reloading of your project to support a faster feedback loop during local development, and subsequently conflicts with the --skip-build flag which avoids rebuilding your project altogether.",
 	"Remove one of the flags based on the outcome you require.",
 }, " ")
+
+// ComputeBuildRemediation suggests configuring a `[scripts.build]` setting in
+// the fastly.toml manifest.
+var ComputeBuildRemediation = strings.Join([]string{
+	"Add a [scripts.build] setting for your custom build process.",
+	"See more at https://developer.fastly.com/reference/fastly-toml/",
+}, " ")


### PR DESCRIPTION
Currently a project that uses an unsupported C@E language can't use the `compute build` command (which means having to do things like using `compute serve --skip-build`). The new `[scripts.build]` configuration in the fastly.toml manifest helps us to better support `compute build` for unofficial languages.

## EXAMPLE

```toml
[scripts]
build = "mkdir -p bin && tinygo build -target wasi -o bin/main.wasm main.go && fastly compute pack --wasm-binary bin/main.wasm"
```

I was able to run `fastly compute serve` and have it 'build' and 'serve' locally via Viceroy.