### PR TITLE
Display `viceroy --version` if installed

### DIFF
--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -322,7 +322,7 @@ func defineCommands(
 	vclSnippetDescribe := snippet.NewDescribeCommand(vclSnippetCmdRoot.CmdClause, globals, data)
 	vclSnippetList := snippet.NewListCommand(vclSnippetCmdRoot.CmdClause, globals, data)
 	vclSnippetUpdate := snippet.NewUpdateCommand(vclSnippetCmdRoot.CmdClause, globals, data)
-	versionCmdRoot := version.NewRootCommand(app)
+	versionCmdRoot := version.NewRootCommand(app, opts.Versioners.Viceroy)
 	whoamiCmdRoot := whoami.NewRootCommand(app, opts.HTTPClient, globals)
 
 	return []cmd.Command{

--- a/pkg/commands/version/root.go
+++ b/pkg/commands/version/root.go
@@ -3,9 +3,13 @@ package version
 import (
 	"fmt"
 	"io"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/commands/compute"
+	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/useragent"
 	"github.com/fastly/go-fastly/v5/fastly"
@@ -23,11 +27,13 @@ func init() {
 // It should be installed under the primary root command.
 type RootCommand struct {
 	cmd.Base
+	viceroyVersioner update.Versioner
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent cmd.Registerer) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, viceroyVersioner update.Versioner) *RootCommand {
 	var c RootCommand
+	c.viceroyVersioner = viceroyVersioner
 	c.CmdClause = parent.Command("version", "Display version information for the Fastly CLI")
 	return &c
 }
@@ -36,6 +42,19 @@ func NewRootCommand(parent cmd.Registerer) *RootCommand {
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Fastly CLI version %s (%s)\n", revision.AppVersion, revision.GitCommit)
 	fmt.Fprintf(out, "Built with %s\n", revision.GoVersion)
+
+	viceroy := filepath.Join(compute.InstallDir, c.viceroyVersioner.Binary())
+	// gosec flagged this:
+	// G204 (CWE-78): Subprocess launched with variable
+	// Disabling as we lookup the binary in a trusted location. For this to be a
+	// concern the user would need to have an already compromised system where an
+	// attacker could swap the actual viceroy executable for something malicious.
+	/* #nosec */
+	cmd := exec.Command(viceroy, "--version")
+	if stdoutStderr, err := cmd.CombinedOutput(); err == nil {
+		fmt.Fprintf(out, "Viceroy version: %s", stdoutStderr)
+	}
+
 	return nil
 }
 

--- a/pkg/commands/version/version_test.go
+++ b/pkg/commands/version/version_test.go
@@ -2,22 +2,85 @@ package version_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/commands/compute"
+	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/testutil"
 )
 
 func TestVersion(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("skipping test due to unix specific mock shell script")
+	}
+
+	// We're going to chdir to an temp environment,
+	// so save the PWD to return to, afterwards.
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test environment
+	rootdir := testutil.NewEnv(testutil.EnvOpts{
+		T: t,
+		Write: []testutil.FileIO{
+			{Src: `#!/bin/bash
+			echo viceroy 0.0.0`, Dst: "viceroy"},
+		},
+	})
+	defer os.RemoveAll(rootdir)
+
+	// Ensure the viceroy file we created can be executed.
+	//
+	// G302 (CWE-276): Expect file permissions to be 0600 or less
+	// gosec flagged this:
+	// Disabling as this is for test suite purposes only.
+	/* #nosec */
+	err = os.Chmod(filepath.Join(rootdir, "viceroy"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Override the InstallDir where the viceroy binary is looked up.
+	orgInstallDir := compute.InstallDir
+	compute.InstallDir = rootdir
+	defer func() {
+		compute.InstallDir = orgInstallDir
+	}()
+
+	// Before running the test, chdir into the temp environment.
+	// When we're done, chdir back to our original location.
+	// This is so we can reliably assert file structure.
+	if err := os.Chdir(rootdir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(pwd)
+
 	var stdout bytes.Buffer
 	args := testutil.Args("version")
 	opts := testutil.NewRunOpts(args, &stdout)
-	err := app.Run(opts)
+	opts.Versioners = app.Versioners{
+		Viceroy: update.NewGitHub(update.GitHubOpts{
+			Org:    "fastly",
+			Repo:   "viceroy",
+			Binary: "viceroy",
+		}),
+	}
+	err = app.Run(opts)
+
+	t.Log(stdout.String())
+
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, strings.Join([]string{
 		"Fastly CLI version v0.0.0-unknown (unknown)",
 		"Built with go version unknown",
+		"Viceroy version: viceroy 0.0.0",
 		"",
 	}, "\n"), stdout.String())
 }


### PR DESCRIPTION
To aid debugging we will now display the [`viceroy --version`](https://github.com/fastly/viceroy) output when a user executes the `fastly version` command...

```bash
$ fastly version
Fastly CLI version v0.0.0-unknown (unknown)                                                                                                                                                                                                   
Built with go version unknown                                                                                                                                                                                                                 
Viceroy version: viceroy 0.0.0
```