### PR TITLE
Avoid triggering GitHub API rate limit when running Viceroy in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build: config
 	go build ./cmd/fastly
 
 .PHONY: install
-install:
+install: config
 	go install ./cmd/fastly
 
 .PHONY: changelog

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -55,6 +55,7 @@ func Run(opts RunOpts) error {
 	// from a variety of sources, and is provided to each concrete command.
 	globals := config.Data{
 		File:   opts.ConfigFile,
+		Path:   opts.ConfigPath,
 		Env:    opts.Env,
 		Output: opts.Stdout,
 		ErrLog: opts.ErrLog,

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -205,6 +205,8 @@ func getViceroy(progress text.Progress, out io.Writer, versioner update.Versione
 		}
 	}
 
+	// The latest_version value 0.0.0 means the property either has not been set
+	// or is now stale and needs to be refreshed.
 	if latest.String() == "0.0.0" {
 		progress.Step("Checking latest Viceroy release...")
 

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/bep/debounce"
 	"github.com/blang/semver"
+	"github.com/fastly/cli/pkg/check"
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/config"
@@ -91,7 +92,7 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	progress := text.ResetProgress(out, c.Globals.Verbose())
 
-	bin, err := getViceroy(progress, out, c.viceroyVersioner, c.Globals.ErrLog)
+	bin, err := getViceroy(progress, out, c.viceroyVersioner, c.Globals)
 	if err != nil {
 		return err
 	}
@@ -161,14 +162,12 @@ func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 //
 // In the case of a network failure we fallback to the latest installed version of the
 // Viceroy binary as long as one is installed and has the correct permissions.
-func getViceroy(progress text.Progress, out io.Writer, versioner update.Versioner, errLog fsterr.LogInterface) (bin string, err error) {
-	progress.Step("Checking latest Viceroy release...")
-
-	defer func(progress text.Progress) {
+func getViceroy(progress text.Progress, out io.Writer, versioner update.Versioner, cfg *config.Data) (bin string, err error) {
+	defer func() {
 		if err != nil {
 			progress.Fail()
 		}
-	}(progress)
+	}()
 
 	bin = filepath.Join(InstallDir, versioner.Binary())
 
@@ -185,30 +184,59 @@ func getViceroy(progress text.Progress, out io.Writer, versioner update.Versione
 	/* #nosec */
 	cmd := exec.Command(bin, "--version")
 
-	var install bool
+	var install, checkUpdate bool
 
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		errLog.Add(err)
+		cfg.ErrLog.Add(err)
 
 		// We presume an error means Viceroy needs to be installed.
 		install = true
 	}
 
-	latest, err := versioner.LatestVersion(context.Background())
-	if err != nil {
-		errLog.Add(err)
+	viceroy := cfg.File.Viceroy
+	var latest semver.Version
 
-		// When we have an error getting the latest version information for Viceroy
-		// and the user doesn't have a pre-existing install of Viceroy, then we're
-		// forced to return the error.
-		if install {
-			return bin, fsterr.RemediationError{
-				Inner:       fmt.Errorf("error fetching latest version: %w", err),
-				Remediation: fsterr.NetworkRemediation,
-			}
+	// Use latest_version from CLI app config if it's not stale.
+	if viceroy.LastChecked != "" && viceroy.LatestVersion != "" && !check.Stale(viceroy.LastChecked, viceroy.TTL) {
+		latest, err = semver.Parse(viceroy.LatestVersion)
+		if err != nil {
+			return bin, err
 		}
-		return bin, nil
+	}
+
+	if latest.String() == "0.0.0" {
+		progress.Step("Checking latest Viceroy release...")
+
+		latest, err = versioner.LatestVersion(context.Background())
+		if err != nil {
+			cfg.ErrLog.Add(err)
+
+			// When we have an error getting the latest version information for Viceroy
+			// and the user doesn't have a pre-existing install of Viceroy, then we're
+			// forced to return the error.
+			if install {
+				return bin, fsterr.RemediationError{
+					Inner:       fmt.Errorf("error fetching latest version: %w", err),
+					Remediation: fsterr.NetworkRemediation,
+				}
+			}
+			return bin, nil
+		}
+
+		viceroy.LatestVersion = latest.String()
+		viceroy.LastChecked = time.Now().Format(time.RFC3339)
+
+		// Before attempting to write the config data back to disk we need to
+		// ensure we reassign the modified struct which is a copy (not reference).
+		cfg.File.Viceroy = viceroy
+
+		err := cfg.File.Write(cfg.Path)
+		if err != nil {
+			return bin, err
+		}
+
+		checkUpdate = true
 	}
 
 	archiveFormat := ".tar.gz"
@@ -218,21 +246,21 @@ func getViceroy(progress text.Progress, out io.Writer, versioner update.Versione
 	if install {
 		err := installViceroy(progress, versioner, latest, bin)
 		if err != nil {
-			errLog.Add(err)
+			cfg.ErrLog.Add(err)
 			return bin, err
 		}
-	} else {
+	} else if checkUpdate {
 		version := strings.TrimSpace(string(stdoutStderr))
 		err := updateViceroy(progress, version, out, versioner, latest, bin)
 		if err != nil {
-			errLog.Add(err)
+			cfg.ErrLog.Add(err)
 			return bin, err
 		}
 	}
 
 	err = setBinPerms(bin)
 	if err != nil {
-		errLog.Add(err)
+		cfg.ErrLog.Add(err)
 		return bin, err
 	}
 	return bin, nil

--- a/pkg/commands/configure/configure_test.go
+++ b/pkg/commands/configure/configure_test.go
@@ -83,6 +83,11 @@ func TestConfigure(t *testing.T) {
 [user]
   email = "test@example.com"
   token = "abcdef"
+
+[viceroy]
+  last_checked = ""
+  latest_version = ""
+  ttl = ""
 `,
 		},
 		{
@@ -131,6 +136,11 @@ func TestConfigure(t *testing.T) {
 [user]
   email = "test@example.com"
   token = "abcdef"
+
+[viceroy]
+  last_checked = ""
+  latest_version = ""
+  ttl = ""
 `,
 		},
 		{
@@ -176,6 +186,11 @@ func TestConfigure(t *testing.T) {
 [user]
   email = "test@example.com"
   token = "abcdef"
+
+[viceroy]
+  last_checked = ""
+  latest_version = ""
+  ttl = ""
 `,
 		},
 		{
@@ -224,6 +239,11 @@ func TestConfigure(t *testing.T) {
 [user]
   email = "test@example.com"
   token = "1234"
+
+[viceroy]
+  last_checked = ""
+  latest_version = ""
+  ttl = ""
 `,
 		},
 		{
@@ -270,6 +290,11 @@ func TestConfigure(t *testing.T) {
 [user]
   email = "test@example.com"
   token = "hello"
+
+[viceroy]
+  last_checked = ""
+  latest_version = ""
+  ttl = ""
 `,
 		},
 		{
@@ -319,6 +344,11 @@ func TestConfigure(t *testing.T) {
 [user]
   email = "test@example.com"
   token = "new_token"
+
+[viceroy]
+  last_checked = ""
+  latest_version = ""
+  ttl = ""
 `,
 		},
 		{

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -100,6 +100,7 @@ var writeMutex = &sync.Mutex{}
 // command structs, and parsed as flags.
 type Data struct {
 	File   File
+	Path   string
 	Env    Environment
 	Output io.Writer
 	Flag   Flag
@@ -185,6 +186,7 @@ type File struct {
 	Language      Language            `toml:"language"`
 	StarterKits   StarterKitLanguages `toml:"starter-kits"`
 	User          User                `toml:"user"`
+	Viceroy       Viceroy             `toml:"viceroy"`
 
 	// We store off a possible legacy configuration so that we can later extract
 	// the relevant email and token values that may pre-exist.
@@ -212,6 +214,13 @@ type CLI struct {
 type User struct {
 	Token string `toml:"token"`
 	Email string `toml:"email"`
+}
+
+// Viceroy represents viceroy specific configuration.
+type Viceroy struct {
+	LastChecked   string `toml:"last_checked"`
+	LatestVersion string `toml:"latest_version"`
+	TTL           string `toml:"ttl"`
 }
 
 // Language represents C@E language specific configuration.

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -179,12 +179,12 @@ type LegacyFile struct {
 
 // File represents our dynamic application toml configuration.
 type File struct {
+	CLI           CLI                 `toml:"cli"`
 	ConfigVersion int                 `toml:"config_version"`
 	Fastly        Fastly              `toml:"fastly"`
-	CLI           CLI                 `toml:"cli"`
-	User          User                `toml:"user"`
 	Language      Language            `toml:"language"`
 	StarterKits   StarterKitLanguages `toml:"starter-kits"`
+	User          User                `toml:"user"`
 
 	// We store off a possible legacy configuration so that we can later extract
 	// the relevant email and token values that may pre-exist.


### PR DESCRIPTION
**Problem**: When running in CI...

```
fastly compute serve --addr "127.0.0.1":7879 --skip-build
Initializing...
Checking latest Viceroy release...

ERROR: error fetching latest version: 
GET https://api.github.com/repos/fastly/viceroy/releases/latest: 
403 API rate limit exceeded for xx.xxx.xxx.xxx. 

(But here's the good news: Authenticated requests get a higher rate limit. 
Check out the documentation for more details.) [rate reset in 32m07s].
```

**NOTE**: This PR is blocked by https://github.com/fastly/cli/pull/489