### PR TITLE
Add `viceroy.ttl` to CLI app config

### DIFF
--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -15,4 +15,7 @@ ttl = "5m"
   fastly_sys_constraint = ">= 0.3.3"
   rustup_constraint = ">= 1.23.0"
 
+[viceroy]
+ttl = "24h"
+
 # starter kits will be appended by devhub build process

--- a/cmd/fastly/static/config.toml
+++ b/cmd/fastly/static/config.toml
@@ -38,3 +38,6 @@ path = "https://github.com/fastly/compute-starter-kit-rust-default"
 name = "Static content"
 description = "Apply performance, security and usability upgrades to static bucket services such as Google Cloud Storage or AWS S3."
 path = "https://github.com/fastly/compute-starter-kit-rust-static-content"
+
+[viceroy]
+ttl = "24h"


### PR DESCRIPTION
An internal publishing flow means changes such as https://github.com/fastly/cli/pull/488 can't be released until the CLI's application configuration is published to https://developer.fastly.com/

This PR adds a new viceroy configuration field that will be used by the aforementioned PR.