### PR TITLE
Fix `compute init --from` for Windows

### DIFF
--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -566,11 +566,9 @@ func fetchPackageTemplate(
 		return fmt.Errorf("failed to create local %s archive: %w", filename, err)
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
-			errLog.Add(err)
-		}
-	}()
-	defer func() {
+		// NOTE: Later on we rename the file to include an extension and the
+		// following call to os.Remove works still because the `filename` variable
+		// that is still in scope is also updated to include the extension.
 		err := os.Remove(filename)
 		if err != nil {
 			errLog.Add(err)
@@ -583,6 +581,13 @@ func fetchPackageTemplate(
 	if err != nil {
 		errLog.Add(err)
 		return fmt.Errorf("failed to write %s archive to disk: %w", filename, err)
+	}
+
+	// NOTE: We used to `defer` the closing of the file after its creation but
+	// realised that this caused issues on Windows as it was unable to rename the
+	// file as we still have the descriptor `f` open.
+	if err := f.Close(); err != nil {
+		errLog.Add(err)
 	}
 
 	var archive file.Archive


### PR DESCRIPTION
Windows users would see the following error when running `compute init --from <FIDDLE>`:

```
ERROR: rename c6a72613 c6a72613.tgz: The process cannot access the file because it is being used by another process..
```