### PR TITLE
Fix the `--watch` flag for AssemblyScript

### DIFF
--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -124,21 +124,21 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	case "assemblyscript":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "assemblyscript",
-			SourceDirectory: "assembly",
+			SourceDirectory: ASSourceDirectory,
 			IncludeFiles:    []string{"package.json"},
 			Toolchain:       NewAssemblyScript(c.Flags.Timeout, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
 		})
 	case "javascript":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "javascript",
-			SourceDirectory: "src",
+			SourceDirectory: JSSourceDirectory,
 			IncludeFiles:    []string{"package.json"},
 			Toolchain:       NewJavaScript(c.Flags.Timeout, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
 		})
 	case "rust":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "rust",
-			SourceDirectory: "src",
+			SourceDirectory: RustSourceDirectory,
 			IncludeFiles:    []string{"Cargo.toml"},
 			Toolchain:       NewRust(c.client, c.Globals.File.Language.Rust, c.Globals.ErrLog, c.Flags.Timeout, c.Manifest.File.Scripts.Build),
 		})

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -12,6 +12,9 @@ import (
 	"github.com/fastly/cli/pkg/filesystem"
 )
 
+// ASSourceDirectory represents the source code directory.
+const ASSourceDirectory = "assembly"
+
 // AssemblyScript implements a Toolchain for the AssemblyScript language.
 //
 // NOTE: We embed the JavaScript type as the behaviours across both languages

--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -15,6 +15,9 @@ import (
 	"github.com/fastly/cli/pkg/text"
 )
 
+// JSSourceDirectory represents the source code directory.
+const JSSourceDirectory = "src"
+
 // JsToolchain represents the default JS toolchain.
 const JsToolchain = "npm"
 

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -24,6 +24,9 @@ import (
 	toml "github.com/pelletier/go-toml"
 )
 
+// RustSourceDirectory represents the source code directory.
+const RustSourceDirectory = "src"
+
 // CargoPackage models the package configuration properties of a Rust Cargo
 // package which we are interested in and is embedded within CargoManifest and
 // CargoLock.
@@ -103,10 +106,6 @@ func NewRust(client api.HTTPClient, config config.Rust, errlog fsterr.LogInterfa
 		timeout: timeout,
 	}
 }
-
-// SourceDirectory implements the Toolchain interface and returns the source
-// directory for Rust packages.
-func (r Rust) SourceDirectory() string { return "src" }
 
 // IncludeFiles implements the Toolchain interface and returns a list of
 // additional files to include in the package archive for Rust packages.

--- a/pkg/commands/compute/serve_test.go
+++ b/pkg/commands/compute/serve_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/text"
 )
@@ -42,7 +43,9 @@ func TestGetViceroy(t *testing.T) {
 		DownloadedFile: downloadedFile,
 	}
 
-	_, err := getViceroy(progress, &out, versioner)
+	errlog := fsterr.MockLog{}
+
+	_, err := getViceroy(progress, &out, versioner, errlog)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #476 

**Problem**: When implementing the `--watch` functionality we neglected to notice that the source code directory for AssemblyScript wasn't `src` (as it is with JavaScript and Rust) and so when it came to using the `--watch` flag we had hardcoded `"src"` to be watched.

**Solution**: We inspect the `--language` flag, falling back to the fastly.toml manifest to identify the language and use that information to identify the correct source code directory to watch.

**Screenshots**: The following screenshot shows that the compiled binary now correctly runs the `compute serve --watch` command and will (when an update is made to a file) trigger the hot reload functionality.

<img width="887" alt="Screenshot 2021-12-17 at 17 08 07" src="https://user-images.githubusercontent.com/180050/146581858-5ee1b1d7-92bf-46e2-9ec9-0e380aa547d0.png">