### PR TITLE
Support `gotest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SHELL := /bin/bash -o pipefail
 # the output is consistent across environments.
 VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 
+# Enables support for tools such as https://github.com/rakyll/gotest
+TEST_COMMAND ?= go test
+
 TESTARGS ?= ./{cmd,pkg}/...
 
 LDFLAGS = -ldflags "\
@@ -51,7 +54,7 @@ staticcheck:
 
 .PHONY: test
 test: config
-	go test -race $(TESTARGS)
+	@$(TEST_COMMAND) -race $(TESTARGS)
 
 .PHONY: build
 build: config


### PR DESCRIPTION
**Before**:

<img width="1112" alt="Screenshot 2022-01-04 at 17 43 34" src="https://user-images.githubusercontent.com/180050/148101250-643a5561-b858-4aad-9b9f-32812ff5d367.png">

**After** (if `gotest` installed and setting `TEST_COMMAND=gotest`):

<img width="1275" alt="Screenshot 2022-01-04 at 17 44 17" src="https://user-images.githubusercontent.com/180050/148101340-e9760832-7e49-4e11-b176-86ea9434d9c6.png">
