### PR TITLE
Omit unix file perms in messaging

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -129,7 +129,7 @@ func Run(opts RunOpts) error {
 		if fi, err := os.Stat(config.FilePath); err == nil {
 			if mode := fi.Mode().Perm(); mode > config.FilePermissions {
 				text.Warning(opts.Stdout, "Unprotected configuration file.")
-				fmt.Fprintf(opts.Stdout, "Permissions %04o for '%s' are too open\n", mode, config.FilePath)
+				fmt.Fprintf(opts.Stdout, "Permissions for '%s' are too open\n", config.FilePath)
 				fmt.Fprintf(opts.Stdout, "It is recommended that your configuration file is NOT accessible by others.\n")
 				fmt.Fprintln(opts.Stdout)
 			}


### PR DESCRIPTION
Some Windows users were confused by the messaging otherwise.