### PR TITLE
Sentry notifications

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -33,3 +33,12 @@ jobs:
       env:
         GOVERSION: ${{ env.GOVERSION }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+    - name: Create Sentry release
+      uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      with:
+        environment: 'production'
+        version: '${{ github.ref_name }}'

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -33,9 +33,12 @@ jobs:
       env:
         GOVERSION: ${{ env.GOVERSION }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+    - name: "Generate release commits"
+      id: generate-commits
+      run: ./scripts/release-commits.sh
     - name: Create Sentry release
       run: |
         curl https://sentry.io/api/0/organizations/${{ secrets.SENTRY_ORG }}/releases/ \
          -H 'Authorization: Bearer ${{ secrets.SENTRY_TOKEN }}' \
          -H 'Content-Type: application/json' \
-         -d '{"version":"${{ github.ref_name }}","ref":"${{ github.sha }}","url":"https://github.com/fastly/cli/releases/tag/v${{ github.ref_name }}","projects":["${{ secrets.SENTRY_PROJECT }}"]}'
+         -d '{"version":"${{ github.ref_name }}","ref":"${{ github.sha }}","commits":${{ steps.generate-commits.outputs.commits }},"url":"https://github.com/fastly/cli/releases/tag/v${{ github.ref_name }}","projects":["${{ secrets.SENTRY_PROJECT }}"]}'

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -34,11 +34,8 @@ jobs:
         GOVERSION: ${{ env.GOVERSION }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     - name: Create Sentry release
-      uses: getsentry/action-release@v1
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      with:
-        environment: 'production'
-        version: '${{ github.ref_name }}'
+      run: |
+        curl https://sentry.io/api/0/organizations/${{ secrets.SENTRY_ORG }}/releases/ \
+         -H 'Authorization: Bearer ${{ secrets.SENTRY_TOKEN }}' \
+         -H 'Content-Type: application/json' \
+         -d '{"version":"${{ github.ref_name }}","ref":"${{ github.sha }}","url":"https://github.com/fastly/cli/releases/tag/v${{ github.ref_name }}","projects":["${{ secrets.SENTRY_PROJECT }}"]}'

--- a/scripts/release-commits.sh
+++ b/scripts/release-commits.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# The following `commits` var essentially is an array containing multiple lines
+# of output, specifically one commit SHA per line.
+#
+# The command that generates it looks complex but in essence it's logging a
+# range of commits between the latest commit and the previous tag:
+#
+# git log --<formatting_flags> <prev_tag>..HEAD
+#
+# Broken down further:
+#
+# git rev-list
+#   = get the SHA of the commit before latest tag (the tag that triggered this release)
+#
+# git describe
+#   = get the previous tag
+#
+# git log <prev_tag>..HEAD
+#   = display just the SHAs and stick them in an array
+#
+commits=($(git log --oneline --format=format:%H $(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))..HEAD))
+
+arr="["
+
+for commit in "${commits[@]}"; do
+  arr+="{\"id\":\"$commit\"},"
+done
+
+arr+="]"
+
+# need to remove the last trailing comma as that's invalid json and is what
+# we're ultimately producing this value to be used as.
+#
+# so we do that using sed...
+
+echo "::set-output name=commits::$(echo $arr | sed 's/},]/}]/')"
+
+# example output:
+#
+# ::set-output name=commits::[{"id":"afe0311974601664933a37391a9f78e8e2ee320b"},{"id":"2fc2c62f9a4851a7a54af9c6fe1946f8df0a77a7"},{"id":"151c6edfff93560bcaab28acc0757a01e1eb916f"},]


### PR DESCRIPTION
Sentry recommend using an [internal integration](https://github.com/marketplace/actions/sentry-release#create-a-sentry-internal-integration) over a standard auth token, but there is some red-tape involved with the former and so we're using an auth token (`SENTRY_TOKEN`) instead to trigger a new deploy.