### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile-assemblyscript
+++ b/Dockerfile-assemblyscript
@@ -1,4 +1,4 @@
-FROM node:17
+FROM node:latest
 LABEL maintainer="Fastly OSS <oss@fastly.com>"
 
 RUN apt-get update && apt-get install -y curl jq
@@ -16,4 +16,4 @@ ENTRYPOINT ["/usr/bin/fastly"]
 CMD ["--help"]
 
 # docker build -t fastly/cli/assemblyscript . -f ./Dockerfile-assemblyscript
-# docker run -v $PWD:/app -it fastly/cli/assemblyscript
+# docker run -v $PWD:/app -it -p 7676:7676 fastly/cli/assemblyscript compute serve --addr="0.0.0.0:7676"

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -15,5 +15,5 @@ WORKDIR /app
 ENTRYPOINT ["/usr/bin/fastly"]
 CMD ["--help"]
 
-# docker build -t fastly/cli/assemblyscript . -f ./Dockerfile-assemblyscript
-# docker run -v $PWD:/app -it -p 7676:7676 fastly/cli/assemblyscript compute serve --addr="0.0.0.0:7676"
+# docker build -t fastly/cli/node . -f ./Dockerfile-node
+# docker run -v $PWD:/app -it -p 7676:7676 fastly/cli/node compute serve --addr="0.0.0.0:7676"

--- a/Dockerfile-rust
+++ b/Dockerfile-rust
@@ -20,4 +20,4 @@ ENTRYPOINT ["/usr/bin/fastly"]
 CMD ["--help"]
 
 # docker build -t fastly/cli/rust . -f ./Dockerfile-rust
-# docker run -v $PWD:/app -it fastly/cli/rust
+# docker run -v $PWD:/app -it -p 7676:7676 fastly/cli/rust compute serve --addr="0.0.0.0:7676"


### PR DESCRIPTION
- Updated Node version to `latest` as `compute serve` didn't work with older version of GLIBC. Bumping the Node version provided the updated dependency.

- User @byteshiva identified how to correctly [port forward](https://github.com/fastly/cli/issues/512#issuecomment-1015098637) so I've updated the comments in the Dockerfile to reflect this.

- Renamed the Dockerfile from `-assemblyscript` suffix to `-node` because (from my testing) the Dockerfile works with both AssemblyScript and JavaScript.