### PR TITLE
Display the requested command in Sentry breadcrumb

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -38,6 +38,7 @@ func main() {
 			`required flag \-\-[^\s]+ not provided`,
 			`error reading service: no service ID found`,
 			`error matching service name with available services`,
+			`open fastly.toml: no such file or directory`,
 		},
 	})
 	if err != nil {

--- a/pkg/errors/log.go
+++ b/pkg/errors/log.go
@@ -129,8 +129,9 @@ ERROR:
 // instrument reports errors to our error analysis platform.
 func instrument(l LogEntries, cmd string) {
 	sentry.AddBreadcrumb(&sentry.Breadcrumb{
-		Message: cmd,
-		Type:    "info",
+		Category: "input",
+		Message:  cmd,
+		Type:     "info",
 	})
 	for _, entry := range l {
 		var (


### PR DESCRIPTION
Prior to this change we didn't actually know the command executed without going backwards through the stack traces. Now we record the requested command as the first step in the breadcrumb...

<img width="1307" alt="Screenshot 2022-01-20 at 14 49 43" src="https://user-images.githubusercontent.com/180050/150362226-c4c7813f-dd6c-4535-ab3d-093234b7199a.png">
