### PR TITLE
create and switch to non-root user within Dockerfile

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -11,6 +11,9 @@ RUN export FASTLY_CLI_VERSION=$(curl --silent https://api.github.com/repos/fastl
 
 RUN tar -xzf fastly.tar.gz --directory /usr/bin && rm fastly.tar.gz
 
+RUN adduser fastly
+USER fastly
+
 WORKDIR /app
 ENTRYPOINT ["/usr/bin/fastly"]
 CMD ["--help"]

--- a/Dockerfile-rust
+++ b/Dockerfile-rust
@@ -15,6 +15,9 @@ RUN export FASTLY_CLI_VERSION=$(curl --silent https://api.github.com/repos/fastl
 
 RUN tar -xzf fastly.tar.gz --directory /usr/bin && rm fastly.tar.gz
 
+RUN adduser fastly
+USER fastly
+
 WORKDIR /app
 ENTRYPOINT ["/usr/bin/fastly"]
 CMD ["--help"]


### PR DESCRIPTION
Tested both containers locally using:

```
docker run -v $PWD:/app -it -p 7676:7676 fastly/cli/<rust|node> compute serve --addr="0.0.0.0:7676"
```