### PR TITLE
Update config `last_checked` field even on config load error

### DIFF
--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -285,7 +285,7 @@ func (f *File) Static() []byte {
 
 // Load gets the configuration file from the CLI API endpoint and encodes it
 // from memory into config.File.
-func (f *File) Load(configEndpoint string, c api.HTTPClient, d time.Duration, fpath string) error {
+func (f *File) Load(configEndpoint string, c api.HTTPClient, d time.Duration, path string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), d)
 	defer cancel()
 
@@ -321,12 +321,12 @@ func (f *File) Load(configEndpoint string, c api.HTTPClient, d time.Duration, fp
 
 	migrateLegacyData(f)
 
-	err = createConfigDir(fpath)
+	err = createConfigDir(path)
 	if err != nil {
 		return err
 	}
 
-	return f.Write(fpath)
+	return f.Write(path)
 }
 
 // migrateLegacyData ensures legacy data is transitioned to config new format.

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -75,6 +75,13 @@ var BugRemediation = strings.Join([]string{
 	"https://github.com/fastly/cli/issues/new?labels=bug&template=bug_report.md",
 }, " ")
 
+// ConfigRemediation informs the user that an error with loading the config
+// isn't a breaking error and the CLI can still be used.
+var ConfigRemediation = strings.Join([]string{
+	"There is a fallback version of the configuration provided with the CLI install",
+	"(see `fastly configure --display`) which enables the CLI to continue to be usable even though the config couldn't be updated.",
+}, " ")
+
 // ServiceIDRemediation suggests provide a service ID via --service-id flag or
 // package manifest.
 var ServiceIDRemediation = strings.Join([]string{


### PR DESCRIPTION
If the user is suffering from https://github.com/fastly/cli/issues/289, then it means after each CLI invocation they'll have to wait N amount of seconds before the command can timeout and display an error.

The fact this happens after _every_ invocation is frustrating as it's unlikely the issue will magically resolve itself on the next time around. So instead we defer retrying the config until the config TTL has expired (default 5mins but can be extended manually).