### PR TITLE
Make `--name` flag for `service search` command a required flag

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -265,7 +265,7 @@ SUBCOMMANDS
         --per-page=PER-PAGE  Number of records per page
         --sort="created"     Field on which to sort
 
-  service search [<flags>]
+  service search --name=NAME
     Search for a Fastly service by name
 
     -n, --name=NAME  Service name
@@ -4448,7 +4448,7 @@ COMMANDS
         --per-page=PER-PAGE  Number of records per page
         --sort="created"     Field on which to sort
 
-  service search [<flags>]
+  service search --name=NAME
     Search for a Fastly service by name
 
     -n, --name=NAME  Service name

--- a/pkg/commands/service/search.go
+++ b/pkg/commands/service/search.go
@@ -23,7 +23,7 @@ func NewSearchCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.Globals = globals
 	c.manifest = data
 	c.CmdClause = parent.Command("search", "Search for a Fastly service by name")
-	c.CmdClause.Flag("name", "Service name").Short('n').StringVar(&c.Input.Name)
+	c.CmdClause.Flag("name", "Service name").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }
 

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -287,6 +287,10 @@ func TestServiceSearch(t *testing.T) {
 		wantOutput string
 	}{
 		{
+			args:      args("service search"),
+			wantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
 			args:       args("service search --name Foo"),
 			api:        mock.API{SearchServiceFn: searchServiceOK},
 			wantOutput: searchServiceShortOutput,


### PR DESCRIPTION
The `fastly service search` command has a `--name` flag which is currently not a _required_ flag, meaning go-fastly’s own internal logic will reject the request and return an error to say the required field is not set. This error is then propagated into Sentry (which can be quite noisy). 

We already ignore errors reported to Sentry that have a format of `required flag \-\-[^\s]+ not provided` (i.e. ignore any errors reported where a explicitly required flag has not been provided) and so by making the flag required in the CLI argument parser, we can avoid this error from reaching Sentry.