### PR TITLE
🦀 Bump Rust toolchain constraint to 1.56.1 for 2021 edition

### DIFF
--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -9,8 +9,8 @@ ttl = "5m"
 
 [language]
   [language.rust]
-  toolchain_version = "1.54.0"
-  toolchain_constraint = ">= 1.54.0"
+  toolchain_version = "1.56.1"
+  toolchain_constraint = ">= 1.56.1"
   wasm_wasi_target = "wasm32-wasi"
   fastly_sys_constraint = ">= 0.3.3"
   rustup_constraint = ">= 1.23.0"


### PR DESCRIPTION
This allows subsequent SDK releases to use Rust 2021 edition. There are some bugs in the lints for 2021 edition compatibility, so we're looking to migrate soon. It's not urgent however, so if this change seems disruptive for any reason, we can hold off on merging this.