### PR TITLE
OAuth Support

### DIFF
--- a/.tmpl/test.go
+++ b/.tmpl/test.go
@@ -76,7 +76,7 @@ func TestCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -145,7 +145,7 @@ func TestDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -201,7 +201,7 @@ func TestDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -266,7 +266,7 @@ func TestList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -332,7 +332,7 @@ func TestUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/.tmpl/test.go
+++ b/.tmpl/test.go
@@ -76,7 +76,7 @@ func TestCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -145,7 +145,7 @@ func TestDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -201,7 +201,7 @@ func TestDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -266,7 +266,7 @@ func TestList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -332,7 +332,7 @@ func TestUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ fastly:
 
 # useful for attaching a debugger such as https://github.com/go-delve/delve
 debug:
-	@go build -gcflags="all=-N -l" -o "fastly" ./cmd/fastly
+	@go build -gcflags="all=-N -l" $(LDFLAGS) -o "fastly" ./cmd/fastly
 
 .PHONY: all
 all: config tidy fmt vet staticcheck gosec test build install
@@ -63,11 +63,11 @@ test: config
 
 .PHONY: build
 build: config
-	go build ./cmd/fastly
+	go build $(LDFLAGS) ./cmd/fastly
 
 .PHONY: install
 install: config
-	go install ./cmd/fastly
+	go install $(LDFLAGS) ./cmd/fastly
 
 .PHONY: changelog
 changelog:

--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -166,15 +166,15 @@ Compatibility and versioning information for the Fastly CLI is being updated in 
 
 	// Main is basically just a shim to call Run, so we do that here.
 	opts := app.RunOpts{
-		APIClient:  clientFactory,
-		Args:       args,
-		ConfigFile: file,
-		ConfigPath: config.FilePath,
-		Env:        env,
-		ErrLog:     fsterr.Log,
-		HTTPClient: httpClient,
-		Stdin:      in,
-		Stdout:     out,
+		ClientFactory: clientFactory,
+		Args:          args,
+		ConfigFile:    file,
+		ConfigPath:    config.FilePath,
+		Env:           env,
+		ErrLog:        fsterr.Log,
+		HTTPClient:    httpClient,
+		Stdin:         in,
+		Stdout:        out,
 		Versioners: app.Versioners{
 			CLI:     versionerCLI,
 			Viceroy: versionerViceroy,

--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -167,6 +167,7 @@ Compatibility and versioning information for the Fastly CLI is being updated in 
 	// Main is basically just a shim to call Run, so we do that here.
 	opts := app.RunOpts{
 		Args:          args,
+		AuthService:   "https://developer.fastly.com/auth/login",
 		ClientFactory: clientFactory,
 		ConfigFile:    file,
 		ConfigPath:    config.FilePath,

--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -166,8 +166,8 @@ Compatibility and versioning information for the Fastly CLI is being updated in 
 
 	// Main is basically just a shim to call Run, so we do that here.
 	opts := app.RunOpts{
-		ClientFactory: clientFactory,
 		Args:          args,
+		ClientFactory: clientFactory,
 		ConfigFile:    file,
 		ConfigPath:    config.FilePath,
 		Env:           env,

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/nicksnyder/go-i18n v1.10.1 // indirect
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/segmentio/textio v1.2.0
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	golang.org/x/sys v0.0.0-20211103235746-7861aae1554b // indirect
@@ -45,7 +46,6 @@ require (
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/peterhellberg/link v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/peterhellberg/link v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/pierrec/lz4/v4 v4.1.8 h1:ieHkV+i2BRzngO4Wd/3HGowuZStgq6QkPsD1eolNAO4=
 github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -290,6 +292,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -6,14 +6,12 @@ import (
 	"github.com/fastly/go-fastly/v6/fastly"
 )
 
-// APIClientFactory creates a Fastly API client (modeled as an api.Interface)
+// ClientFactory creates a Fastly API client (modeled as an api.Interface)
 // from a user-provided API token. It exists as a type in order to parameterize
 // the Run helper with it: in the real CLI, we can use NewClient from the Fastly
 // API client library via RealClient; in tests, we can provide a mock API
 // interface via MockClient.
-//
-// TODO: Rename to ClientFactory.
-type APIClientFactory func(token, endpoint string) (Interface, error)
+type ClientFactory func(token, endpoint string) (Interface, error)
 
 // HTTPClient models a concrete http.Client. It's a consumer contract for some
 // commands which need to make direct HTTP requests to the API, because the

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -6,6 +6,15 @@ import (
 	"github.com/fastly/go-fastly/v6/fastly"
 )
 
+// APIClientFactory creates a Fastly API client (modeled as an api.Interface)
+// from a user-provided API token. It exists as a type in order to parameterize
+// the Run helper with it: in the real CLI, we can use NewClient from the Fastly
+// API client library via RealClient; in tests, we can provide a mock API
+// interface via MockClient.
+//
+// TODO: Rename to ClientFactory.
+type APIClientFactory func(token, endpoint string) (Interface, error)
+
 // HTTPClient models a concrete http.Client. It's a consumer contract for some
 // commands which need to make direct HTTP requests to the API, because the
 // official Fastly client library lacks certain endpoints, so we call the API

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -17,6 +17,8 @@ type HTTPClient interface {
 // Interface models the methods of the Fastly API client that we use.
 // It exists to allow for easier testing, in combination with Mock.
 type Interface interface {
+	Get(p string, ro *fastly.RequestOptions) (*http.Response, error)
+
 	AllIPs() (v4, v6 fastly.IPAddrs, err error)
 	AllDatacenters() (datacenters []fastly.Datacenter, err error)
 

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/acl"
 	"github.com/fastly/cli/pkg/commands/aclentry"
@@ -98,7 +97,7 @@ func defineCommands(
 	computeServe := compute.NewServeCommand(computeCmdRoot.CmdClause, globals, computeBuild, opts.Versioners.Viceroy, data)
 	computeUpdate := compute.NewUpdateCommand(computeCmdRoot.CmdClause, globals, data)
 	computeValidate := compute.NewValidateCommand(computeCmdRoot.CmdClause, globals)
-	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, api.ClientFactory(opts.ClientFactory), globals)
+	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, opts.ClientFactory, globals)
 	dictionaryCmdRoot := dictionary.NewRootCommand(app, globals)
 	dictionaryCreate := dictionary.NewCreateCommand(dictionaryCmdRoot.CmdClause, globals, data)
 	dictionaryDelete := dictionary.NewDeleteCommand(dictionaryCmdRoot.CmdClause, globals, data)

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -98,7 +98,7 @@ func defineCommands(
 	computeServe := compute.NewServeCommand(computeCmdRoot.CmdClause, globals, computeBuild, opts.Versioners.Viceroy, data)
 	computeUpdate := compute.NewUpdateCommand(computeCmdRoot.CmdClause, globals, data)
 	computeValidate := compute.NewValidateCommand(computeCmdRoot.CmdClause, globals)
-	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, api.APIClientFactory(opts.APIClient), globals)
+	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, api.ClientFactory(opts.APIClient), globals)
 	dictionaryCmdRoot := dictionary.NewRootCommand(app, globals)
 	dictionaryCreate := dictionary.NewCreateCommand(dictionaryCmdRoot.CmdClause, globals, data)
 	dictionaryDelete := dictionary.NewDeleteCommand(dictionaryCmdRoot.CmdClause, globals, data)

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -98,7 +98,7 @@ func defineCommands(
 	computeServe := compute.NewServeCommand(computeCmdRoot.CmdClause, globals, computeBuild, opts.Versioners.Viceroy, data)
 	computeUpdate := compute.NewUpdateCommand(computeCmdRoot.CmdClause, globals, data)
 	computeValidate := compute.NewValidateCommand(computeCmdRoot.CmdClause, globals)
-	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, api.ClientFactory(opts.APIClient), globals)
+	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, api.ClientFactory(opts.ClientFactory), globals)
 	dictionaryCmdRoot := dictionary.NewRootCommand(app, globals)
 	dictionaryCreate := dictionary.NewCreateCommand(dictionaryCmdRoot.CmdClause, globals, data)
 	dictionaryDelete := dictionary.NewDeleteCommand(dictionaryCmdRoot.CmdClause, globals, data)

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/acl"
 	"github.com/fastly/cli/pkg/commands/aclentry"
@@ -97,7 +98,7 @@ func defineCommands(
 	computeServe := compute.NewServeCommand(computeCmdRoot.CmdClause, globals, computeBuild, opts.Versioners.Viceroy, data)
 	computeUpdate := compute.NewUpdateCommand(computeCmdRoot.CmdClause, globals, data)
 	computeValidate := compute.NewValidateCommand(computeCmdRoot.CmdClause, globals)
-	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, configure.APIClientFactory(opts.APIClient), globals)
+	configureCmdRoot := configure.NewRootCommand(app, opts.ConfigPath, api.APIClientFactory(opts.APIClient), globals)
 	dictionaryCmdRoot := dictionary.NewRootCommand(app, globals)
 	dictionaryCreate := dictionary.NewCreateCommand(dictionaryCmdRoot.CmdClause, globals, data)
 	dictionaryDelete := dictionary.NewDeleteCommand(dictionaryCmdRoot.CmdClause, globals, data)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -29,7 +29,7 @@ type Versioners struct {
 
 // RunOpts represent arguments to Run()
 type RunOpts struct {
-	APIClient  APIClientFactory
+	APIClient  api.APIClientFactory
 	Args       []string
 	ConfigFile config.File
 	ConfigPath string
@@ -183,13 +183,6 @@ func Run(opts RunOpts) error {
 
 	return command.Exec(opts.Stdin, opts.Stdout)
 }
-
-// APIClientFactory creates a Fastly API client (modeled as an api.Interface)
-// from a user-provided API token. It exists as a type in order to parameterize
-// the Run helper with it: in the real CLI, we can use NewClient from the Fastly
-// API client library via RealClient; in tests, we can provide a mock API
-// interface via MockClient.
-type APIClientFactory func(token, endpoint string) (api.Interface, error)
 
 // FastlyAPIClient is a ClientFactory that returns a real Fastly API client
 // using the provided token and endpoint.

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -151,7 +151,7 @@ func Run(opts RunOpts) error {
 	}
 
 	if auth.Required(name, token, tSource, opts.Stdout) {
-		token, err = auth.Init(opts.Stdout)
+		token, err = auth.Init(opts.Stdin, opts.Stdout)
 		if err != nil {
 			return err
 		}

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -78,7 +78,7 @@ func Run(opts RunOpts) error {
 	// error states and output control flow.
 	app.Terminate(nil)
 
-	// WARNING: kingping has no way of decorating flags as being "global"
+	// WARNING: kingpin has no way of decorating flags as being "global"
 	// therefore if you add/remove a global flag you will also need to update
 	// the globalFlag map in pkg/app/usage.go which is used for usage rendering.
 	tokenHelp := fmt.Sprintf("Fastly API token (or via %s)", env.Token)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -151,7 +151,7 @@ func Run(opts RunOpts) error {
 	}
 
 	if auth.Required(name, token, tSource, opts.Stdout) {
-		token, err = auth.Init(opts.Stdin, opts.Stdout)
+		token, err = auth.Init(opts.Stdin, opts.Stdout, auth.Browser)
 		if err != nil {
 			return err
 		}

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -149,6 +149,11 @@ func Run(opts RunOpts) error {
 		}
 	}
 
+	// NOTE: The globals variable is passed as a reference earlier in this
+	// function flow, but doesn't get utilised until after command.Exec (below)
+	// has identified the relevant command to execute. This provides us the
+	// opportunity to assign a working API client instance that depends on data
+	// not available earlier in the flow.
 	globals.APIClient, err = opts.APIClient(token, endpoint)
 	if err != nil {
 		globals.ErrLog.Add(err)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -29,7 +29,7 @@ type Versioners struct {
 
 // RunOpts represent arguments to Run()
 type RunOpts struct {
-	APIClient  api.APIClientFactory
+	APIClient  api.ClientFactory
 	Args       []string
 	ConfigFile config.File
 	ConfigPath string

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/fastly/cli/pkg/api"
+	"github.com/fastly/cli/pkg/auth"
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/commands/version"
 	"github.com/fastly/cli/pkg/config"
@@ -134,6 +135,13 @@ func Run(opts RunOpts) error {
 				fmt.Fprintf(opts.Stdout, "It is recommended that your configuration file is NOT accessible by others.\n")
 				fmt.Fprintln(opts.Stdout)
 			}
+		}
+	}
+
+	if auth.Required(name, token, source, opts.Stdout) {
+		err = auth.Init(opts.Stdout)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -30,6 +30,7 @@ type Versioners struct {
 // RunOpts represent arguments to Run()
 type RunOpts struct {
 	Args          []string
+	AuthService   string
 	ClientFactory api.ClientFactory
 	ConfigFile    config.File
 	ConfigPath    string
@@ -151,7 +152,7 @@ func Run(opts RunOpts) error {
 	}
 
 	if auth.Required(name, token, tSource, opts.Stdout) {
-		token, err = auth.Init(opts.Stdin, opts.Stdout, auth.Browser)
+		token, err = auth.Init(opts.Stdin, opts.Stdout, auth.Browser, opts.AuthService)
 		if err != nil {
 			return err
 		}

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -151,7 +151,7 @@ func Run(opts RunOpts) error {
 		}
 	}
 
-	if auth.Required(name, token, tSource, opts.Stdout) {
+	if auth.Required(name, token, endpoint, tSource, opts.Stdout, opts.ClientFactory) {
 		token, err = auth.Init(opts.Stdin, opts.Stdout, auth.Browser, opts.AuthService)
 		if err != nil {
 			return err
@@ -192,6 +192,5 @@ func Run(opts RunOpts) error {
 // FastlyAPIClient is a ClientFactory that returns a real Fastly API client
 // using the provided token and endpoint.
 func FastlyAPIClient(token, endpoint string) (api.Interface, error) {
-	client, err := fastly.NewClientForEndpoint(token, endpoint)
-	return client, err
+	return fastly.NewClientForEndpoint(token, endpoint)
 }

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -29,16 +29,16 @@ type Versioners struct {
 
 // RunOpts represent arguments to Run()
 type RunOpts struct {
-	APIClient  api.ClientFactory
-	Args       []string
-	ConfigFile config.File
-	ConfigPath string
-	Env        config.Environment
-	ErrLog     errors.LogInterface
-	HTTPClient api.HTTPClient
-	Stdin      io.Reader
-	Stdout     io.Writer
-	Versioners Versioners
+	ClientFactory api.ClientFactory
+	Args          []string
+	ConfigFile    config.File
+	ConfigPath    string
+	Env           config.Environment
+	ErrLog        errors.LogInterface
+	HTTPClient    api.HTTPClient
+	Stdin         io.Reader
+	Stdout        io.Writer
+	Versioners    Versioners
 }
 
 // Run constructs the application including all of the subcommands, parses the
@@ -155,7 +155,7 @@ func Run(opts RunOpts) error {
 		if err != nil {
 			return err
 		}
-		err = auth.PersistToken(token, globals.Path, endpoint, &globals.File, opts.APIClient)
+		err = auth.PersistToken(token, globals.Path, endpoint, &globals.File, opts.ClientFactory)
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func Run(opts RunOpts) error {
 	// has identified the relevant command to execute. This provides us the
 	// opportunity to assign a working API client instance that depends on data
 	// not available earlier in the flow.
-	globals.APIClient, err = opts.APIClient(token, endpoint)
+	globals.APIClient, err = opts.ClientFactory(token, endpoint)
 	if err != nil {
 		globals.ErrLog.Add(err)
 		return fmt.Errorf("error constructing Fastly API client: %w", err)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -29,8 +29,8 @@ type Versioners struct {
 
 // RunOpts represent arguments to Run()
 type RunOpts struct {
-	ClientFactory api.ClientFactory
 	Args          []string
+	ClientFactory api.ClientFactory
 	ConfigFile    config.File
 	ConfigPath    string
 	Env           config.Environment

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -4394,9 +4394,10 @@ COMMANDS
                                    format_version default. Can be none or
                                    waf_debug
 
-  pops
+  pops [<flags>]
     List Fastly datacenters
 
+    -j, --json  Render output as JSON
 
   purge [<flags>]
     Invalidate objects in the Fastly cache

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1052,9 +1052,10 @@ COMMANDS
         --initial=INITIAL        When loading a config, the initial number of
                                  probes to be seen as OK
 
-  ip-list
+  ip-list [<flags>]
     List Fastly's public IPs
 
+    -j, --json  Render output as JSON
 
   log-tail [<flags>]
     Tail Compute@Edge logs

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -204,7 +204,7 @@ func processCommandInput(
 	globals *config.Data,
 	commands []cmd.Command) (command cmd.Command, cmdName string, err error) {
 	// As the `help` command model gets privately added as a side-effect of
-	// kingping.Parse, we cannot add the `--format json` flag to the model.
+	// kingpin.Parse, we cannot add the `--format json` flag to the model.
 	// Therefore, we have to manually parse the args slice here to check for the
 	// existence of `help --format json`, if present we print usage JSON and
 	// exit early.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v6/fastly"
+	"github.com/pkg/browser"
+)
+
+// ignoreCommands represents commands that do not require a token.
+var ignoreCommands = []string{"configure", "ip-list", "update", "version"}
+
+// App is the authentication service responsible for authenticating the user
+// and returning a short-lived access token.
+var App = "https://developer-auth.edgecompute.app"
+
+// Required determines if the OAuth flow is required.
+func Required(cmd, token string, s config.Source, stdout io.Writer) (required bool) {
+	for _, name := range ignoreCommands {
+		if cmd == name {
+			return false
+		}
+	}
+
+	// No token is defined so yes we require the OAuth flow.
+	if s == config.SourceUndefined {
+		return true
+	}
+
+	if s == config.SourceFile {
+		apiClient, _ := fastly.NewClient(token)
+		if status, err := ValidateToken(token, apiClient); err != nil {
+			text.Info(stdout, "We were not able to validate your access token.")
+			required = true
+		} else {
+			switch status {
+			case http.StatusUnauthorized:
+				text.Info(stdout, "Your access token has expired.")
+				required = true
+			case http.StatusForbidden:
+				text.Warning(stdout, "Your access token is invalid.")
+				required = true
+			case http.StatusOK:
+				// The token was validated successfully so no OAuth flow required.
+			}
+		}
+	}
+
+	return required
+}
+
+// Init starts the OAuth flow.
+//
+// NOTE: This function blocks the command execution until a token has been
+// pulled from the relevant channel.
+func Init(stdout io.Writer) error {
+	text.Info(stdout, "We are about to initialise a new OAuth flow.")
+
+	token := make(chan string)
+	port := make(chan int)
+
+	go ListenAndServe(port, token)
+
+	p := <-port
+	callback := fmt.Sprintf("http://127.0.0.1:%d/auth-callback", p)
+	url := fmt.Sprintf("%s?redirect_uri=%s", App, callback)
+	err := browser.OpenURL(url)
+	if err != nil {
+		return err
+	}
+
+	t := <-token
+	if t == "" {
+		return errors.New("no token received from authentication service")
+	}
+	fmt.Printf("token received: %s\n", t)
+	return nil
+}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -17,7 +17,7 @@ var ignoreCommands = []string{"configure", "ip-list", "update", "version"}
 
 // App is the authentication service responsible for authenticating the user
 // and returning a short-lived access token.
-var App = "https://developer-auth.edgecompute.app"
+var App = "https://developer.fastly.com"
 
 // Required determines if the OAuth flow is required.
 func Required(cmd, token string, s config.Source, stdout io.Writer) (required bool) {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -9,7 +9,6 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v6/fastly"
-	"github.com/pkg/browser"
 )
 
 // ignoreCommands represents commands that do not require a token.
@@ -59,7 +58,7 @@ func Required(cmd, token string, s config.Source, stdout io.Writer) (required bo
 //
 // NOTE: This function blocks the command execution until a token has been
 // pulled from the relevant channel.
-func Init(stdin io.Reader, stdout io.Writer) (string, error) {
+func Init(stdin io.Reader, stdout io.Writer, o Opener) (string, error) {
 	text.Break(stdout)
 	text.Output(stdout, "We are about to initialise a new authentication flow, which requires the CLI to open your web browser for you.")
 	text.Break(stdout)
@@ -82,7 +81,7 @@ func Init(stdin io.Reader, stdout io.Writer) (string, error) {
 	path := "/auth/login"
 	callback := fmt.Sprintf("http://127.0.0.1:%d/auth-callback", p)
 	url := fmt.Sprintf("%s%s?redirect_uri=%s", App, path, callback)
-	err = browser.OpenURL(url)
+	err = o(url)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -54,11 +54,11 @@ func Required(cmd, token string, s config.Source, stdout io.Writer) (required bo
 	return required
 }
 
-// Init starts the OAuth flow.
+// Init starts the OAuth flow and returns a new access token.
 //
 // NOTE: This function blocks the command execution until a token has been
 // pulled from the relevant channel.
-func Init(stdout io.Writer) error {
+func Init(stdout io.Writer) (string, error) {
 	text.Info(stdout, "We are about to initialise a new OAuth flow.")
 
 	token := make(chan string)
@@ -71,13 +71,13 @@ func Init(stdout io.Writer) error {
 	url := fmt.Sprintf("%s?redirect_uri=%s", App, callback)
 	err := browser.OpenURL(url)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	t := <-token
 	if t == "" {
-		return errors.New("no token received from authentication service")
+		return t, errors.New("no token received from authentication service")
 	}
-	fmt.Printf("token received: %s\n", t)
-	return nil
+
+	return t, nil
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -79,8 +79,9 @@ func Init(stdin io.Reader, stdout io.Writer) (string, error) {
 	go ListenAndServe(port, token)
 
 	p := <-port
+	path := "/auth/login"
 	callback := fmt.Sprintf("http://127.0.0.1:%d/auth-callback", p)
-	url := fmt.Sprintf("%s?redirect_uri=%s", App, callback)
+	url := fmt.Sprintf("%s%s?redirect_uri=%s", App, path, callback)
 	err = browser.OpenURL(url)
 	if err != nil {
 		return "", err

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -14,10 +14,6 @@ import (
 // ignoreCommands represents commands that do not require a token.
 var ignoreCommands = []string{"configure", "ip-list", "update", "version"}
 
-// App is the authentication service responsible for authenticating the user
-// and returning a short-lived access token.
-var App = "https://developer.fastly.com"
-
 // Required determines if the OAuth flow is required.
 func Required(cmd, token string, s config.Source, stdout io.Writer) (required bool) {
 	for _, name := range ignoreCommands {
@@ -58,7 +54,7 @@ func Required(cmd, token string, s config.Source, stdout io.Writer) (required bo
 //
 // NOTE: This function blocks the command execution until a token has been
 // pulled from the relevant channel.
-func Init(stdin io.Reader, stdout io.Writer, o Opener) (string, error) {
+func Init(stdin io.Reader, stdout io.Writer, o Opener, authService string) (string, error) {
 	text.Break(stdout)
 	text.Output(stdout, "We are about to initialise a new authentication flow, which requires the CLI to open your web browser for you.")
 	text.Break(stdout)
@@ -78,9 +74,8 @@ func Init(stdin io.Reader, stdout io.Writer, o Opener) (string, error) {
 	go ListenAndServe(port, token)
 
 	p := <-port
-	path := "/auth/login"
 	callback := fmt.Sprintf("http://127.0.0.1:%d/auth-callback", p)
-	url := fmt.Sprintf("%s%s?redirect_uri=%s", App, path, callback)
+	url := fmt.Sprintf("%s?redirect_uri=%s", authService, callback)
 	err = o(url)
 	if err != nil {
 		return "", err

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -47,6 +47,7 @@ func Required(cmd, token string, s config.Source, stdout io.Writer) (required bo
 		}
 	}
 
+	// False (no authentication flow required).
 	return required
 }
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -2,18 +2,54 @@ package auth_test
 
 import (
 	"bytes"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/auth"
 	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v6/fastly"
 )
 
-// m represents a basic fastly.toml manifest.
-const m = `name = "authentication"
-manifest_version = 2`
+// TestAuthSuccess validates we're able to initialise the authentication flow
+// and to get a new access token returned and persisted to disk.
+func TestAuthSuccess(t *testing.T) {
+	wd, root := createTestEnvironment(t)
+	defer os.RemoveAll(root)
+	defer os.Chdir(wd)
+
+	var stdout bytes.Buffer
+	args := testutil.Args("pops")
+	opts := testutil.NewRunOpts(args, &stdout)
+	opts.ConfigPath = filepath.Join(root, manifest.Filename)
+	opts.ClientFactory = mock.ClientFactory(mockAPI)
+	opts.Stdin = strings.NewReader("y") // Authorise opening of web browser.
+
+	auth.Browser = mockBrowser()
+
+	err := app.Run(opts)
+	if err != nil {
+		t.Log(stdout.String())
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(opts.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("data: %+v\n", string(data))
+}
+
+// TODO: Validate --token isn't persisted.
+// TODO: Validate migration scenario (e.g. invalidate an old long-lived token by checking its expiry)
 
 // createTestEnvironment creates a temp directory to run our integration tests
 // within, along with a simple fastly.toml manifest.
@@ -37,24 +73,71 @@ func createTestEnvironment(t *testing.T) (wd, root string) {
 	return wd, root
 }
 
-// TestAuthSuccess validates we're able to initialise the authentication flow
-// and to get a new access token returned and persisted to disk.
-func TestAuthSuccess(t *testing.T) {
-	wd, root := createTestEnvironment(t)
-	defer os.RemoveAll(root)
-	defer os.Chdir(wd)
+// m represents a basic fastly.toml manifest.
+const m = `name = "authentication"
+manifest_version = 2`
 
-	var stdout bytes.Buffer
-	args := testutil.Args("pops")
-	opts := testutil.NewRunOpts(args, &stdout)
-	opts.Stdin = strings.NewReader("y") // Authorise opening of web browser.
+// mockAPI represents the expected API calls to be made.
+var mockAPI = mock.API{
+	GetTokenSelfFn: func() (*fastly.Token, error) {
+		return &fastly.Token{UserID: "123"}, nil
+	},
+	GetUserFn: func(*fastly.GetUserInput) (*fastly.User, error) {
+		return &fastly.User{
+			Login: "test@example.com",
+		}, nil
+	},
+	AllDatacentersFn: func() ([]fastly.Datacenter, error) {
+		return []fastly.Datacenter{}, nil
+	},
+}
 
-	err := app.Run(opts)
-	if err != nil {
-		t.Log(stdout.String())
-		t.Fatal(err)
+// mockBrowser mocks the behaviour for opening a web browser.
+//
+// NOTE:
+// A local HTTP server that handles /auth/login will be started.
+// The auth.App value will point to the local server.
+//
+// NOTE:
+// The returned Opener type will be parsed an arg that will point to the local
+// server, along with a callback query param. The function will make a request
+// to the URL for which the local server will 302 to the CLI local server's
+// /auth-callback endpoint (passing along a mock token).
+func mockBrowser() auth.Opener {
+	go listenAndServe()
+
+	return func(url string) error {
+		go http.Get(url)
+		return nil
 	}
 }
 
-// TODO: Validate --token isn't persisted.
-// TODO: Validate migration scenario (e.g. invalidate an old long-lived token by checking its expiry)
+// listenAndServe listens on a random TCP network port and then calls Serve with
+// custom handler type to handle requests on incoming connections.
+func listenAndServe() {
+	local := "127.0.0.1"
+	l, err := net.Listen("tcp", local+":0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	auth.App = fmt.Sprintf("http://%s:%d", local, l.Addr().(*net.TCPAddr).Port)
+
+	defer l.Close()
+	http.Serve(l, authServer{})
+}
+
+// authServer represents a mock Authentication HTTP Server.
+//
+// NOTE: The handler will redirect to the CLI local server, which will cause
+// the CLI flow to unblock as a token will be passed through via a query param.
+type authServer struct{}
+
+func (s authServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/auth/login":
+		uri := r.URL.Query().Get("redirect_uri")
+		url := fmt.Sprintf("%s?access_token=123", uri)
+		http.Redirect(w, r, url, http.StatusFound)
+	}
+}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/auth"
+	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
@@ -43,11 +44,17 @@ func TestAuthSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(opts.ConfigPath)
+	var f config.File
+	err = f.Read(opts.ConfigPath, opts.Stdin, opts.Stdout)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("data: %+v\n", string(data))
+
+	wantToken := "123"
+	wantEmail := "test@example.com"
+	if f.User.Token != wantToken || f.User.Email != wantEmail {
+		t.Errorf("want token '%s', have '%s' | want email '%s', have '%s'", wantToken, f.User.Token, wantEmail, f.User.Email)
+	}
 }
 
 // TODO: Validate --token isn't persisted.

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -23,7 +23,7 @@ import (
 // TestAuthSuccess validates we're able to initialise the authentication flow
 // and to get a new access token returned and persisted to disk.
 func TestAuthSuccess(t *testing.T) {
-	wd, root := createTestEnvironment(ConfigDefault, t)
+	wd, root := createTestEnvironment(t)
 	defer os.RemoveAll(root)
 	defer os.Chdir(wd)
 
@@ -35,7 +35,8 @@ func TestAuthSuccess(t *testing.T) {
 	opts.Stdin = strings.NewReader("y") // Authorise opening of web browser.
 
 	endpoint := make(chan string)
-	auth.Browser = mockBrowser(endpoint)
+	generatedToken := "123"
+	auth.Browser = mockBrowser(endpoint, generatedToken)
 	opts.AuthService = <-endpoint
 
 	err := app.Run(opts)
@@ -44,6 +45,9 @@ func TestAuthSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	wantOutput := "We are about to initialise a new authentication flow"
+	testutil.AssertStringContains(t, stdout.String(), wantOutput)
+
 	var f config.File
 	err = f.Read(opts.ConfigPath, opts.Stdin, opts.Stdout)
 	if err != nil {
@@ -51,9 +55,12 @@ func TestAuthSuccess(t *testing.T) {
 	}
 
 	wantToken := "123"
+	if f.User.Token != wantToken {
+		t.Errorf("want token '%s', have '%s'", wantToken, f.User.Token)
+	}
 	wantEmail := "test@example.com"
-	if f.User.Token != wantToken || f.User.Email != wantEmail {
-		t.Errorf("want token '%s', have '%s' | want email '%s', have '%s'", wantToken, f.User.Token, wantEmail, f.User.Email)
+	if f.User.Email != wantEmail {
+		t.Errorf("want email '%s', have '%s'", wantEmail, f.User.Email)
 	}
 }
 
@@ -61,7 +68,7 @@ func TestAuthSuccess(t *testing.T) {
 // authentication flow being initialised, as well as the token not being
 // persisted to disk.
 func TestAuthTokenFlag(t *testing.T) {
-	wd, root := createTestEnvironment(ConfigDefault, t)
+	wd, root := createTestEnvironment(t)
 	defer os.RemoveAll(root)
 	defer os.Chdir(wd)
 
@@ -72,7 +79,8 @@ func TestAuthTokenFlag(t *testing.T) {
 	opts.ClientFactory = mock.ClientFactory(mockAPISuccess)
 
 	endpoint := make(chan string)
-	auth.Browser = mockBrowser(endpoint)
+	generatedToken := "123"
+	auth.Browser = mockBrowser(endpoint, generatedToken)
 	opts.AuthService = <-endpoint
 
 	err := app.Run(opts)
@@ -81,38 +89,138 @@ func TestAuthTokenFlag(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	wantToIgnore := "We are about to initialise a new authentication flow"
+	testutil.AssertStringDoesntContain(t, stdout.String(), wantToIgnore)
+
 	var f config.File
 	err = f.Read(opts.ConfigPath, opts.Stdin, opts.Stdout)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if f.User.Token != "" || f.User.Email != "" {
-		t.Errorf("want no token, have '%s' | want no email, have '%s'", f.User.Token, f.User.Email)
+	if f.User.Token != "" {
+		t.Errorf("want no token, have '%s'", f.User.Token)
+	}
+	if f.User.Email != "" {
+		t.Errorf("want no email, have '%s'", f.User.Email)
 	}
 }
 
-// TODO: Validate migration scenario (e.g. invalidate an old long-lived token by checking its expiry)
+// TestAuthMigration validates we're able to initialise the authentication flow
+// and to get a new access token returned and persisted to disk, which replaces
+// a pre-existing long-lived token (from before the CLI supported OAuth).
+func TestAuthMigration(t *testing.T) {
+	wd, root := createTestEnvironment(t)
+	defer os.RemoveAll(root)
+	defer os.Chdir(wd)
 
-// createTestEnvironment creates a temp directory to run our integration tests
-// within, along with a simple fastly.toml manifest.
-func createTestEnvironment(c Config, t *testing.T) (wd, root string) {
+	var stdout bytes.Buffer
+	args := testutil.Args("pops")
+	opts := testutil.NewRunOpts(args, &stdout)
+	opts.ConfigFile = config.File{
+		User: config.User{
+			Token: "123",
+		},
+	}
+	opts.ConfigPath = filepath.Join(root, manifest.Filename)
+	opts.ClientFactory = mock.ClientFactory(mockAPIMigration)
+	opts.Stdin = strings.NewReader("y") // Authorise opening of web browser.
+
+	endpoint := make(chan string)
+	generatedToken := "456"
+	auth.Browser = mockBrowser(endpoint, generatedToken)
+	opts.AuthService = <-endpoint
+
+	err := app.Run(opts)
+	if err != nil {
+		t.Log(stdout.String())
+		t.Fatal(err)
+	}
+
+	wantOutput := "Your current access token has no expiration and will be replaced with a short-lived token"
+	testutil.AssertStringContains(t, stdout.String(), wantOutput)
+
+	wantOutput = "We are about to initialise a new authentication flow"
+	testutil.AssertStringContains(t, stdout.String(), wantOutput)
+
+	var f config.File
+	err = f.Read(opts.ConfigPath, opts.Stdin, opts.Stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantToken := "456" // token in config was 123 and should be replaced
+	if f.User.Token != wantToken {
+		t.Errorf("want token '%s', have '%s'", wantToken, f.User.Token)
+	}
+	wantEmail := "test@example.com"
+	if f.User.Email != wantEmail {
+		t.Errorf("want email '%s', have '%s'", wantEmail, f.User.Email)
+	}
+}
+
+// TestAuthTokenExpired validates we're able to initialise the authentication
+// flow and to get a new access token returned and persisted to disk, which
+// replaces a previously generated token that has since expired.
+func TestAuthTokenExpired(t *testing.T) {
+	wd, root := createTestEnvironment(t)
+	defer os.RemoveAll(root)
+	defer os.Chdir(wd)
+
+	var stdout bytes.Buffer
+	args := testutil.Args("pops")
+	opts := testutil.NewRunOpts(args, &stdout)
+	opts.ConfigFile = config.File{
+		User: config.User{
+			Token: "123",
+		},
+	}
+	opts.ConfigPath = filepath.Join(root, manifest.Filename)
+	opts.ClientFactory = mock.ClientFactory(mockAPITokenExpired)
+	opts.Stdin = strings.NewReader("y") // Authorise opening of web browser.
+
+	endpoint := make(chan string)
+	generatedToken := "456"
+	auth.Browser = mockBrowser(endpoint, generatedToken)
+	opts.AuthService = <-endpoint
+
+	err := app.Run(opts)
+	if err != nil {
+		t.Log(stdout.String())
+		t.Fatal(err)
+	}
+
+	wantOutput := "Your access token has expired"
+	testutil.AssertStringContains(t, stdout.String(), wantOutput)
+
+	wantOutput = "We are about to initialise a new authentication flow"
+	testutil.AssertStringContains(t, stdout.String(), wantOutput)
+
+	var f config.File
+	err = f.Read(opts.ConfigPath, opts.Stdin, opts.Stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantToken := "456" // token in config was 123 and should be replaced
+	if f.User.Token != wantToken {
+		t.Errorf("want token '%s', have '%s'", wantToken, f.User.Token)
+	}
+	wantEmail := "test@example.com"
+	if f.User.Email != wantEmail {
+		t.Errorf("want email '%s', have '%s'", wantEmail, f.User.Email)
+	}
+}
+
+// createTestEnvironment creates a temp directory to run our integration tests.
+func createTestEnvironment(t *testing.T) (wd, root string) {
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m := mDefault
-	switch c {
-	case ConfigUser:
-		m = fmt.Sprintf("%s%s", mDefault, mUser)
-	}
-
 	root = testutil.NewEnv(testutil.EnvOpts{
 		T: t,
-		Write: []testutil.FileIO{
-			{Src: m, Dst: manifest.Filename},
-		},
 	})
 
 	if err := os.Chdir(root); err != nil {
@@ -122,30 +230,66 @@ func createTestEnvironment(c Config, t *testing.T) (wd, root string) {
 	return wd, root
 }
 
-// Config is a base for the different environment configuration variants.
-//
-// NOTE: We're using an enum to allow for future flexibility.
-type Config int64
-
-const (
-	ConfigDefault Config = iota
-	ConfigUser
-)
-
-// mDefault represents a basic fastly.toml manifest.
-const mDefault = `name = "authentication"
-manifest_version = 2`
-
-// mUser represents a user extension to the fastly.toml manifest.
-const mUser = `
-[user]
-  email = "test@example.com"
-  token = "123"`
-
-// mockAPISuccess represents the expected API calls to be made.
+// mockAPISuccess represents the expected API calls to be made for a
+// successful token generation using the new CLI OAuth flow.
 var mockAPISuccess = mock.API{
 	GetTokenSelfFn: func() (*fastly.Token, error) {
 		return &fastly.Token{UserID: "123"}, nil
+	},
+	GetUserFn: func(*fastly.GetUserInput) (*fastly.User, error) {
+		return &fastly.User{
+			Login: "test@example.com",
+		}, nil
+	},
+	AllDatacentersFn: func() ([]fastly.Datacenter, error) {
+		return []fastly.Datacenter{}, nil
+	},
+}
+
+// mockAPIMigration represents the expected API calls to be made for a
+// successful migration from a long-lived token to short-lived tokens generated
+// via the new CLI OAuth flow.
+//
+// NOTE: GetTokenSelf is effectively called twice, once at the start of the
+// command execution to validate if the current token is valid and again before
+// persisting the generated short-lived token to disk. We'll use the same token
+// data for both calls but this isn't a problem.
+//
+// NOTE: For the sake of the 'migration' scenario, we'll not set an Expiry,
+// which means the test output will show an appropriate messaging.
+var mockAPIMigration = mock.API{
+	GetTokenSelfFn: func() (*fastly.Token, error) {
+		return &fastly.Token{UserID: "456"}, nil
+	},
+	GetUserFn: func(*fastly.GetUserInput) (*fastly.User, error) {
+		return &fastly.User{
+			Login: "test@example.com",
+		}, nil
+	},
+	AllDatacentersFn: func() ([]fastly.Datacenter, error) {
+		return []fastly.Datacenter{}, nil
+	},
+}
+
+// mockAPITokenExpired represents the expected API calls to be made for a
+// successful update from an existing generated token that has expired to a
+// newly generated token via the new CLI OAuth flow.
+//
+// NOTE: GetTokenSelf is effectively called twice, once at the start of the
+// command execution to validate if the current token is valid and again before
+// persisting the generated short-lived token to disk. We'll use the same token
+// data for both calls but this isn't a problem.
+//
+// NOTE: For the sake of the 'expiry' scenario, we'll not set an Expiry,
+// which means the test output will show an appropriate messaging.
+var mockAPITokenExpired = mock.API{
+	GetTokenSelfFn: func() (*fastly.Token, error) {
+		t := testutil.Date
+
+		return &fastly.Token{
+			UserID:    "456",
+			ExpiresAt: &t,
+		}, nil
 	},
 	GetUserFn: func(*fastly.GetUserInput) (*fastly.User, error) {
 		return &fastly.User{
@@ -168,8 +312,8 @@ var mockAPISuccess = mock.API{
 // server, along with a callback query param. The function will make a request
 // to the URL for which the local server will 302 to the CLI local server's
 // /auth-callback endpoint (passing along a mock token).
-func mockBrowser(endpoint chan string) auth.Opener {
-	go listenAndServe(endpoint)
+func mockBrowser(endpoint chan string, token string) auth.Opener {
+	go listenAndServe(endpoint, token)
 
 	return func(url string) error {
 		go http.Get(url)
@@ -182,7 +326,7 @@ func mockBrowser(endpoint chan string) auth.Opener {
 //
 // NOTE: This function is expected to be called asynchronously, hence a channel
 // is provided for synchronised communication.
-func listenAndServe(endpoint chan string) {
+func listenAndServe(endpoint chan string, token string) {
 	local := "127.0.0.1"
 	l, err := net.Listen("tcp", local+":0")
 	if err != nil {
@@ -192,20 +336,22 @@ func listenAndServe(endpoint chan string) {
 	endpoint <- fmt.Sprintf("http://%s:%d/auth/login", local, l.Addr().(*net.TCPAddr).Port)
 
 	defer l.Close()
-	http.Serve(l, authServer{})
+	http.Serve(l, authServer{token: token})
 }
 
 // authServer represents a mock Authentication HTTP Server.
 //
 // NOTE: The handler will redirect to the CLI local server, which will cause
 // the CLI flow to unblock as a token will be passed through via a query param.
-type authServer struct{}
+type authServer struct {
+	token string
+}
 
 func (s authServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/auth/login":
 		uri := r.URL.Query().Get("redirect_uri")
-		url := fmt.Sprintf("%s?access_token=123", uri)
+		url := fmt.Sprintf("%s?access_token=%s", uri, s.token)
 		http.Redirect(w, r, url, http.StatusFound)
 	}
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,60 @@
+package auth_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/testutil"
+)
+
+// m represents a basic fastly.toml manifest.
+const m = `name = "authentication"
+manifest_version = 2`
+
+// createTestEnvironment creates a temp directory to run our integration tests
+// within, along with a simple fastly.toml manifest.
+func createTestEnvironment(t *testing.T) (wd, root string) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root = testutil.NewEnv(testutil.EnvOpts{
+		T: t,
+		Write: []testutil.FileIO{
+			{Src: m, Dst: manifest.Filename},
+		},
+	})
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	return wd, root
+}
+
+// TestAuthSuccess validates we're able to initialise the authentication flow
+// and to get a new access token returned and persisted to disk.
+func TestAuthSuccess(t *testing.T) {
+	wd, root := createTestEnvironment(t)
+	defer os.RemoveAll(root)
+	defer os.Chdir(wd)
+
+	var stdout bytes.Buffer
+	args := testutil.Args("pops")
+	opts := testutil.NewRunOpts(args, &stdout)
+	opts.Stdin = strings.NewReader("y") // Authorise opening of web browser.
+
+	err := app.Run(opts)
+	if err != nil {
+		t.Log(stdout.String())
+		t.Fatal(err)
+	}
+}
+
+// TODO: Validate --token isn't persisted.
+// TODO: Validate migration scenario (e.g. invalidate an old long-lived token by checking its expiry)

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -13,7 +13,7 @@ import (
 // NOTE: This function is expected to be called asynchronously, hence channels
 // are provided for synchronised communication.
 func ListenAndServe(port chan int, token chan string) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -50,8 +50,6 @@ func (s Server) authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	t := r.URL.Query().Get("access_token")
 	if t == "" {
 		// TODO: Handle `auth_error` query param!
-		// TODO: Check --token doesn't get persisted to disk!
-		// TODO: Invalidate old token by checking its expiry is set to never expire (migration scenario for someone with long lived token in their config).
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "unable to parse an authentication token")
 	}

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -45,4 +45,6 @@ func (s Server) authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "unable to parse an authentication token")
 	}
 	s.token <- t
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "Authentication complete. You may close this browser tab and return to your terminal.")
 }

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -5,7 +5,15 @@ import (
 	"log"
 	"net"
 	"net/http"
+
+	"github.com/pkg/browser"
 )
+
+// Opener represents something that can open a URL.
+type Opener func(string) error
+
+// Browser is the default implementation of an Opener.
+var Browser Opener = browser.OpenURL
 
 // ListenAndServe listens on a random TCP network port and then calls Serve with
 // custom handler type to handle requests on incoming connections.
@@ -43,7 +51,7 @@ func (s Server) authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	if t == "" {
 		// TODO: Handle `auth_error` query param!
 		// TODO: Check --token doesn't get persisted to disk!
-		// TODO: Invalidate old token by checking its expiry is set to never expire.
+		// TODO: Invalidate old token by checking its expiry is set to never expire (migration scenario for someone with long lived token in their config).
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "unable to parse an authentication token")
 	}

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -39,7 +39,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // NOTE: authCallbackHandler is expected to be provided with a token query.
 func (s Server) authCallbackHandler(w http.ResponseWriter, r *http.Request) {
-	t := r.URL.Query().Get("token")
+	t := r.URL.Query().Get("access_token")
 	if t == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "unable to parse an authentication token")

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+)
+
+// ListenAndServe listens on a random TCP network port and then calls Serve with
+// custom handler type to handle requests on incoming connections.
+//
+// NOTE: This function is expected to be called asynchronously, hence channels
+// are provided for synchronised communication.
+func ListenAndServe(port chan int, token chan string) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+	port <- l.Addr().(*net.TCPAddr).Port
+	http.Serve(l, Server{token})
+}
+
+// Server represents a HTTP Server.
+type Server struct {
+	token chan string
+}
+
+func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/auth-callback":
+		s.authCallbackHandler(w, r)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "No page found for: %s\n", r.URL)
+	}
+}
+
+// NOTE: authCallbackHandler is expected to be provided with a token query.
+func (s Server) authCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	t := r.URL.Query().Get("token")
+	if t == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, "unable to parse an authentication token")
+	}
+	s.token <- t
+}

--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -41,6 +41,9 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s Server) authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	t := r.URL.Query().Get("access_token")
 	if t == "" {
+		// TODO: Handle `auth_error` query param!
+		// TODO: Check --token doesn't get persisted to disk!
+		// TODO: Invalidate old token by checking its expiry is set to never expire.
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "unable to parse an authentication token")
 	}

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,9 +1,12 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/fastly/cli/pkg/api"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/go-fastly/v6/fastly"
 )
 
 // ValidateToken retrieves the given token data and returns.
@@ -16,4 +19,32 @@ func ValidateToken(token string, apiClient api.Interface) (status int, err error
 	} else {
 		return resp.StatusCode, nil
 	}
+}
+
+// PersistToken stores the access token and user email in the local config.
+func PersistToken(token, cfgPath, apiEndpoint string, cfg *config.File, cf api.ClientFactory) error {
+	c, err := cf(token, apiEndpoint)
+	if err != nil {
+		return fmt.Errorf("error constructing Fastly API client: %w", err)
+	}
+
+	ts, err := c.GetTokenSelf()
+	if err != nil {
+		return fmt.Errorf("error validating token: %w", err)
+	}
+	u, err := c.GetUser(&fastly.GetUserInput{
+		ID: ts.UserID,
+	})
+	if err != nil {
+		return fmt.Errorf("error fetching token user: %w", err)
+	}
+
+	cfg.User.Email = u.Login
+	cfg.User.Token = token
+	err = cfg.Write(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,0 +1,19 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/fastly/cli/pkg/api"
+)
+
+// ValidateToken retrieves the given token data and returns.
+//
+// NOTE: We don't use the SDK GetTokenSelf method because it returns data and
+// not the response, meaning we can't inspect the status code returned.
+func ValidateToken(token string, apiClient api.Interface) (status int, err error) {
+	if resp, err := apiClient.Get("/tokens/self", nil); err != nil {
+		return http.StatusInternalServerError, err
+	} else {
+		return resp.StatusCode, nil
+	}
+}

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -86,7 +86,7 @@ func TestACLCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -160,7 +160,7 @@ func TestACLDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -221,7 +221,7 @@ func TestACLDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -286,7 +286,7 @@ func TestACLList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -375,7 +375,7 @@ func TestACLUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -86,7 +86,7 @@ func TestACLCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -160,7 +160,7 @@ func TestACLDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -221,7 +221,7 @@ func TestACLDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -286,7 +286,7 @@ func TestACLList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -375,7 +375,7 @@ func TestACLUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package acl_test
 
 import (
@@ -15,17 +18,17 @@ func TestACLCreate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("acl create --version 3"),
+			Args:      args("acl create --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("acl create --name foo"),
+			Args:      args("acl create --name foo --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl create --name foo --version 3"),
+			Args:      args("acl create --name foo --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -33,7 +36,7 @@ func TestACLCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("acl create --name foo --service-id 123 --version 1"),
+			Args:      args("acl create --name foo --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -44,7 +47,7 @@ func TestACLCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("acl create --name foo --service-id 123 --version 3"),
+			Args:      args("acl create --name foo --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -60,7 +63,7 @@ func TestACLCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("acl create --name foo --service-id 123 --version 3"),
+			Args:       args("acl create --name foo --service-id 123 --version 3 --token 123"),
 			WantOutput: "Created ACL 'foo' (id: 456, service: 123, version: 3)",
 		},
 		{
@@ -77,7 +80,7 @@ func TestACLCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("acl create --autoclone --name foo --service-id 123 --version 1"),
+			Args:       args("acl create --autoclone --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Created ACL 'foo' (id: 456, service: 123, version: 4)",
 		},
 	}
@@ -99,17 +102,17 @@ func TestACLDelete(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("acl delete --version 3"),
+			Args:      args("acl delete --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("acl delete --name foobar"),
+			Args:      args("acl delete --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl delete --name foobar --version 3"),
+			Args:      args("acl delete --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -117,7 +120,7 @@ func TestACLDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("acl delete --name foobar --service-id 123 --version 1"),
+			Args:      args("acl delete --name foobar --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -128,7 +131,7 @@ func TestACLDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Args:      args("acl delete --name foobar --service-id 123 --version 3"),
+			Args:      args("acl delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -139,7 +142,7 @@ func TestACLDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("acl delete --name foobar --service-id 123 --version 3"),
+			Args:       args("acl delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "Deleted ACL 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -151,7 +154,7 @@ func TestACLDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("acl delete --autoclone --name foo --service-id 123 --version 1"),
+			Args:       args("acl delete --autoclone --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Deleted ACL 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -173,17 +176,17 @@ func TestACLDescribe(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("acl describe --version 3"),
+			Args:      args("acl describe --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("acl describe --name foobar"),
+			Args:      args("acl describe --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl describe --name foobar --version 3"),
+			Args:      args("acl describe --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -194,7 +197,7 @@ func TestACLDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("acl describe --name foobar --service-id 123 --version 3"),
+			Args:      args("acl describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -203,7 +206,7 @@ func TestACLDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetACLFn:       getACL,
 			},
-			Args:       args("acl describe --name foobar --service-id 123 --version 3"),
+			Args:       args("acl describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -212,7 +215,7 @@ func TestACLDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetACLFn:       getACL,
 			},
-			Args:       args("acl describe --name foobar --service-id 123 --version 1"),
+			Args:       args("acl describe --name foobar --service-id 123 --version 1 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
@@ -234,12 +237,12 @@ func TestACLList(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("acl list"),
+			Args:      args("acl list --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl list --version 3"),
+			Args:      args("acl list --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -250,7 +253,7 @@ func TestACLList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("acl list --service-id 123 --version 3"),
+			Args:      args("acl list --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -259,7 +262,7 @@ func TestACLList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListACLsFn:     listACLs,
 			},
-			Args:       args("acl list --service-id 123 --version 3"),
+			Args:       args("acl list --service-id 123 --version 3 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME  ID\n123         3        foo   456\n123         3        bar   789\n",
 		},
 		{
@@ -268,7 +271,7 @@ func TestACLList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListACLsFn:     listACLs,
 			},
-			Args:       args("acl list --service-id 123 --version 1"),
+			Args:       args("acl list --service-id 123 --version 1 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME  ID\n123         1        foo   456\n123         1        bar   789\n",
 		},
 		{
@@ -277,8 +280,8 @@ func TestACLList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListACLsFn:     listACLs,
 			},
-			Args:       args("acl list --service-id 123 --verbose --version 1"),
-			WantOutput: "Fastly API token not provided\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nID: 789\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
+			Args:       args("acl list --service-id 123 --verbose --version 1 --token 123"),
+			WantOutput: "Fastly API token provided via --token\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nID: 789\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
@@ -299,22 +302,22 @@ func TestACLUpdate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("acl update --new-name beepboop --version 3"),
+			Args:      args("acl update --new-name beepboop --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --new-name flag",
-			Args:      args("acl update --name foobar --version 3"),
+			Args:      args("acl update --name foobar --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --new-name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("acl update --name foobar --new-name beepboop"),
+			Args:      args("acl update --name foobar --new-name beepboop --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl update --name foobar --new-name beepboop --version 3"),
+			Args:      args("acl update --name foobar --new-name beepboop --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -322,7 +325,7 @@ func TestACLUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("acl update --name foobar --new-name beepboop --service-id 123 --version 1"),
+			Args:      args("acl update --name foobar --new-name beepboop --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -333,7 +336,7 @@ func TestACLUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("acl update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			Args:      args("acl update --name foobar --new-name beepboop --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -349,7 +352,7 @@ func TestACLUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("acl update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			Args:       args("acl update --name foobar --new-name beepboop --service-id 123 --version 3 --token 123"),
 			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 3)",
 		},
 		{
@@ -366,7 +369,7 @@ func TestACLUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("acl update --autoclone --name foobar --new-name beepboop --service-id 123 --version 1"),
+			Args:       args("acl update --autoclone --name foobar --new-name beepboop --service-id 123 --version 1 --token 123"),
 			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 4)",
 		},
 	}

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -75,7 +75,7 @@ func TestACLEntryCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -127,7 +127,7 @@ func TestACLEntryDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -177,7 +177,7 @@ func TestACLEntryDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -322,7 +322,7 @@ func TestACLEntryList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -448,7 +448,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -75,7 +75,7 @@ func TestACLEntryCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -127,7 +127,7 @@ func TestACLEntryDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -177,7 +177,7 @@ func TestACLEntryDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -322,7 +322,7 @@ func TestACLEntryList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -448,7 +448,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package aclentry_test
 
 import (
@@ -15,17 +18,17 @@ func TestACLEntryCreate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Args:      args("acl-entry create --ip 127.0.0.1"),
+			Args:      args("acl-entry create --ip 127.0.0.1 --token 123"),
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --ip flag",
-			Args:      args("acl-entry create --acl-id 123"),
+			Args:      args("acl-entry create --acl-id 123 --token 123"),
 			WantError: "error parsing arguments: required flag --ip not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl-entry create --acl-id 123 --ip 127.0.0.1"),
+			Args:      args("acl-entry create --acl-id 123 --ip 127.0.0.1 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -35,7 +38,7 @@ func TestACLEntryCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("acl-entry create --acl-id 123 --ip 127.0.0.1 --service-id 123"),
+			Args:      args("acl-entry create --acl-id 123 --ip 127.0.0.1 --service-id 123 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -50,7 +53,7 @@ func TestACLEntryCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("acl-entry create --acl-id 123 --ip 127.0.0.1 --service-id 123"),
+			Args:       args("acl-entry create --acl-id 123 --ip 127.0.0.1 --service-id 123 --token 123"),
 			WantOutput: "Created ACL entry '456' (ip: 127.0.0.1, negated: false, service: 123)",
 		},
 		{
@@ -66,7 +69,7 @@ func TestACLEntryCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("acl-entry create --acl-id 123 --ip 127.0.0.1 --negated --service-id 123"),
+			Args:       args("acl-entry create --acl-id 123 --ip 127.0.0.1 --negated --service-id 123 --token 123"),
 			WantOutput: "Created ACL entry '456' (ip: 127.0.0.1, negated: true, service: 123)",
 		},
 	}
@@ -88,17 +91,17 @@ func TestACLEntryDelete(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Args:      args("acl-entry delete --id 456"),
+			Args:      args("acl-entry delete --id 456 --token 123"),
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --id flag",
-			Args:      args("acl-entry delete --acl-id 123"),
+			Args:      args("acl-entry delete --acl-id 123 --token 123"),
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl-entry delete --acl-id 123 --id 456"),
+			Args:      args("acl-entry delete --acl-id 123 --id 456 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -108,7 +111,7 @@ func TestACLEntryDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Args:      args("acl-entry delete --acl-id 123 --id 456 --service-id 123"),
+			Args:      args("acl-entry delete --acl-id 123 --id 456 --service-id 123 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -118,7 +121,7 @@ func TestACLEntryDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("acl-entry delete --acl-id 123 --id 456 --service-id 123"),
+			Args:       args("acl-entry delete --acl-id 123 --id 456 --service-id 123 --token 123"),
 			WantOutput: "Deleted ACL entry '456' (service: 123)",
 		},
 	}
@@ -140,17 +143,17 @@ func TestACLEntryDescribe(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Args:      args("acl-entry describe --id 456"),
+			Args:      args("acl-entry describe --id 456 --token 123"),
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --id flag",
-			Args:      args("acl-entry describe --acl-id 123"),
+			Args:      args("acl-entry describe --acl-id 123 --token 123"),
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl-entry describe --acl-id 123 --id 456"),
+			Args:      args("acl-entry describe --acl-id 123 --id 456 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -160,7 +163,7 @@ func TestACLEntryDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("acl-entry describe --acl-id 123 --id 456 --service-id 123"),
+			Args:      args("acl-entry describe --acl-id 123 --id 456 --service-id 123 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -168,7 +171,7 @@ func TestACLEntryDescribe(t *testing.T) {
 			API: mock.API{
 				GetACLEntryFn: getACLEntry,
 			},
-			Args:       args("acl-entry describe --acl-id 123 --id 456 --service-id 123"),
+			Args:       args("acl-entry describe --acl-id 123 --id 456 --service-id 123 --token 123"),
 			WantOutput: "\nService ID: 123\nACL ID: 123\nID: 456\nIP: 127.0.0.1\nSubnet: 0\nNegated: false\nComment: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
@@ -252,12 +255,12 @@ func TestACLEntryList(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Args:      args("acl-entry list"),
+			Args:      args("acl-entry list --token 123"),
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl-entry list --acl-id 123"),
+			Args:      args("acl-entry list --acl-id 123 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -267,7 +270,7 @@ func TestACLEntryList(t *testing.T) {
 					return &mockACLPaginator{returnErr: true}
 				},
 			},
-			Args:      args("acl-entry list --acl-id 123 --service-id 123"),
+			Args:      args("acl-entry list --acl-id 123 --service-id 123 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		// NOTE: Our mock paginator defines two ACL entries, and so even when
@@ -279,7 +282,7 @@ func TestACLEntryList(t *testing.T) {
 					return &mockACLPaginator{numOfPages: i.PerPage, maxPages: 2}
 				},
 			},
-			Args:       args("acl-entry list --acl-id 123 --per-page 1 --service-id 123"),
+			Args:       args("acl-entry list --acl-id 123 --per-page 1 --service-id 123 --token 123"),
 			WantOutput: listACLEntriesOutput,
 		},
 		// In the following test, we set --page 1 and as there's only one record
@@ -291,7 +294,7 @@ func TestACLEntryList(t *testing.T) {
 					return &mockACLPaginator{count: i.Page - 1, requestedPage: i.Page, numOfPages: i.PerPage, maxPages: 2}
 				},
 			},
-			Args:       args("acl-entry list --acl-id 123 --page 1 --per-page 1 --service-id 123"),
+			Args:       args("acl-entry list --acl-id 123 --page 1 --per-page 1 --service-id 123 --token 123"),
 			WantOutput: listACLEntriesOutputPageOne,
 		},
 		// In the following test, we set --page 2 and as there's only one record
@@ -303,7 +306,7 @@ func TestACLEntryList(t *testing.T) {
 					return &mockACLPaginator{count: i.Page - 1, requestedPage: i.Page, numOfPages: i.PerPage, maxPages: 2}
 				},
 			},
-			Args:       args("acl-entry list --acl-id 123 --page 2 --per-page 1 --service-id 123"),
+			Args:       args("acl-entry list --acl-id 123 --page 2 --per-page 1 --service-id 123 --token 123"),
 			WantOutput: listACLEntriesOutputPageTwo,
 		},
 		{
@@ -313,7 +316,7 @@ func TestACLEntryList(t *testing.T) {
 					return &mockACLPaginator{numOfPages: i.PerPage, maxPages: 2}
 				},
 			},
-			Args:       args("acl-entry list --acl-id 123 --per-page 1 --service-id 123 --verbose"),
+			Args:       args("acl-entry list --acl-id 123 --per-page 1 --service-id 123 --verbose --token 123"),
 			WantOutput: listACLEntriesOutputVerbose,
 		},
 	}
@@ -343,7 +346,7 @@ var listACLEntriesOutputPageTwo = `SERVICE ID  ID   IP         SUBNET  NEGATED
 123         789  127.0.0.2  0       true
 `
 
-var listACLEntriesOutputVerbose = `Fastly API token not provided
+var listACLEntriesOutputVerbose = `Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 
@@ -375,17 +378,17 @@ func TestACLEntryUpdate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Args:      args("acl-entry update"),
+			Args:      args("acl-entry update --token 123"),
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("acl-entry update --acl-id 123"),
+			Args:      args("acl-entry update --acl-id 123 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate missing --id flag for single entry update",
-			Args:      args("acl-entry update --acl-id 123 --service-id 123"),
+			Args:      args("acl-entry update --acl-id 123 --service-id 123 --token 123"),
 			WantError: "no ID found",
 		},
 		{
@@ -395,7 +398,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("acl-entry update --acl-id 123 --id 456 --service-id 123"),
+			Args:      args("acl-entry update --acl-id 123 --id 456 --service-id 123 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -405,7 +408,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Args:      args(`acl-entry update --acl-id 123 --file {"foo":"bar"} --id 456 --service-id 123`),
+			Args:      args(`acl-entry update --acl-id 123 --file {"foo":"bar"} --id 456 --service-id 123 --token 123`),
 			WantError: "missing 'entries'",
 		},
 		{
@@ -415,7 +418,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Args:      args(`acl-entry update --acl-id 123 --file {"entries":[]} --id 456 --service-id 123`),
+			Args:      args(`acl-entry update --acl-id 123 --file {"entries":[]} --id 456 --service-id 123 --token 123`),
 			WantError: "missing 'entries'",
 		},
 		{
@@ -425,7 +428,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("acl-entry update --acl-id 123 --file testdata/batch.json --id 456 --service-id 123"),
+			Args:       args("acl-entry update --acl-id 123 --file testdata/batch.json --id 456 --service-id 123 --token 123"),
 			WantOutput: "Updated 3 ACL entries (service: 123)",
 		},
 		// NOTE: When specifying JSON inline be sure not to have any spaces, and don't
@@ -439,7 +442,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args(`acl-entry update --acl-id 123 --file {"entries":[{"op":"create","ip":"127.0.0.1","subnet":8},{"op":"update"},{"op":"upsert"}]} --id 456 --service-id 123`),
+			Args:       args(`acl-entry update --acl-id 123 --file {"entries":[{"op":"create","ip":"127.0.0.1","subnet":8},{"op":"update"},{"op":"upsert"}]} --id 456 --service-id 123 --token 123`),
 			WantOutput: "Updated 3 ACL entries (service: 123)",
 		},
 	}

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -74,7 +74,7 @@ func TestCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -171,7 +171,7 @@ func TestDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -211,7 +211,7 @@ func TestDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -314,7 +314,7 @@ func TestList(t *testing.T) {
 			}
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package authtoken_test
 
 import (
@@ -7,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/fastly/cli/pkg/app"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -18,13 +20,8 @@ func TestCreate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --password flag",
-			Args:      args("auth-token create"),
+			Args:      args("auth-token create --token 123"),
 			WantError: "error parsing arguments: required flag --password not provided",
-		},
-		{
-			Name:      "validate missing --token flag",
-			Args:      args("auth-token create --password secure"),
-			WantError: errors.ErrNoToken.Inner.Error(),
 		},
 		{
 			Name: "validate CreateToken API error",
@@ -85,11 +82,6 @@ func TestCreate(t *testing.T) {
 func TestDelete(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
-		{
-			Name:      "validate missing --token flag",
-			Args:      args("auth-token delete"),
-			WantError: errors.ErrNoToken.Inner.Error(),
-		},
 		{
 			Name:      "validate missing optional flags",
 			Args:      args("auth-token delete --token 123"),
@@ -183,11 +175,6 @@ func TestDescribe(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Name:      "validate missing --token flag",
-			Args:      args("auth-token describe"),
-			WantError: errors.ErrNoToken.Inner.Error(),
-		},
-		{
 			Name: "validate GetTokenSelf API error",
 			API: mock.API{
 				GetTokenSelfFn: func() (*fastly.Token, error) {
@@ -226,13 +213,6 @@ func TestList(t *testing.T) {
 		SetEnv bool
 	}
 	scenarios := []ts{
-		{
-			TestScenario: testutil.TestScenario{
-				Name:      "validate missing --token flag",
-				Args:      args("auth-token list"),
-				WantError: errors.ErrNoToken.Inner.Error(),
-			},
-		},
 		{
 			TestScenario: testutil.TestScenario{
 				Name: "validate ListTokens API error",

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -74,7 +74,7 @@ func TestCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -171,7 +171,7 @@ func TestDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -211,7 +211,7 @@ func TestDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -314,7 +314,7 @@ func TestList(t *testing.T) {
 			}
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/authtoken/create.go
+++ b/pkg/commands/authtoken/create.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -60,11 +59,6 @@ type CreateCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	input := c.constructInput()
 
 	r, err := c.Globals.APIClient.CreateToken(input)

--- a/pkg/commands/authtoken/delete.go
+++ b/pkg/commands/authtoken/delete.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -39,11 +38,6 @@ type DeleteCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	if !c.current && c.file == "" && c.id == "" {
 		return fmt.Errorf("error parsing arguments: must provide either the --current, --file or --id flag")
 	}

--- a/pkg/commands/authtoken/describe.go
+++ b/pkg/commands/authtoken/describe.go
@@ -38,10 +38,6 @@ type DescribeCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return fsterr.ErrNoToken
-	}
 	if c.Globals.Verbose() && c.json {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}

--- a/pkg/commands/authtoken/list.go
+++ b/pkg/commands/authtoken/list.go
@@ -46,10 +46,6 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return fsterr.ErrNoToken
-	}
 	if c.Globals.Verbose() && c.json {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -105,7 +105,7 @@ func TestBackendCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -185,7 +185,7 @@ func TestBackendList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			if testcase.WantError == "" {
@@ -223,7 +223,7 @@ func TestBackendDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertString(t, testcase.WantOutput, stdout.String())
@@ -263,7 +263,7 @@ func TestBackendUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -301,7 +301,7 @@ func TestBackendDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -105,7 +105,7 @@ func TestBackendCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -185,7 +185,7 @@ func TestBackendList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			if testcase.WantError == "" {
@@ -223,7 +223,7 @@ func TestBackendDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertString(t, testcase.WantOutput, stdout.String())
@@ -263,7 +263,7 @@ func TestBackendUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -301,7 +301,7 @@ func TestBackendDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package compute_test
 
 import (
@@ -51,14 +54,14 @@ func TestBuildRust(t *testing.T) {
 	}{
 		{
 			name:                 "no fastly.toml manifest",
-			args:                 args("compute build"),
+			args:                 args("compute build --token 123"),
 			client:               versionClient{fastlyVersions: []string{"0.0.0"}},
 			wantError:            "error reading package manifest",
 			wantRemediationError: "Run `fastly compute init` to ensure a correctly configured manifest.",
 		},
 		{
 			name: "empty language",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"`,
@@ -67,7 +70,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "empty name",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			language = "rust"`,
@@ -76,7 +79,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "unknown language",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -86,7 +89,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "error reading cargo metadata",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -110,7 +113,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "fastly-sys crate not found",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -149,7 +152,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "fastly-sys crate out-of-date",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -184,7 +187,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "rust toolchain does not match the constraint",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -221,7 +224,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "fastly crate prerelease",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -259,7 +262,7 @@ func TestBuildRust(t *testing.T) {
 		},
 		{
 			name: "Rust success",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
@@ -361,13 +364,13 @@ func TestBuildAssemblyScript(t *testing.T) {
 	}{
 		{
 			name:                 "no fastly.toml manifest",
-			args:                 args("compute build"),
+			args:                 args("compute build --token 123"),
 			wantError:            "error reading package manifest",
 			wantRemediationError: "Run `fastly compute init` to ensure a correctly configured manifest.",
 		},
 		{
 			name: "empty language",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"`,
@@ -375,7 +378,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 		},
 		{
 			name: "empty name",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			language = "assemblyscript"`,
@@ -383,7 +386,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 		},
 		{
 			name: "unknown language",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -392,7 +395,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 		},
 		{
 			name: "AssemblyScript success",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -487,13 +490,13 @@ func TestBuildJavaScript(t *testing.T) {
 	}{
 		{
 			name:                 "no fastly.toml manifest",
-			args:                 args("compute build"),
+			args:                 args("compute build --token 123"),
 			wantError:            "error reading package manifest",
 			wantRemediationError: "Run `fastly compute init` to ensure a correctly configured manifest.",
 		},
 		{
 			name: "empty language",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"`,
@@ -501,7 +504,7 @@ func TestBuildJavaScript(t *testing.T) {
 		},
 		{
 			name: "empty name",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			language = "javascript"`,
@@ -509,7 +512,7 @@ func TestBuildJavaScript(t *testing.T) {
 		},
 		{
 			name: "JavaScript success",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -518,7 +521,7 @@ func TestBuildJavaScript(t *testing.T) {
 		},
 		{
 			name: "JavaScript compilation error",
-			args: args("compute build --verbose"),
+			args: args("compute build --verbose --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -604,7 +607,7 @@ func TestCustomBuild(t *testing.T) {
 	}{
 		{
 			name: "no custom build",
-			args: args("compute build --language other"),
+			args: args("compute build --language other --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -617,7 +620,7 @@ func TestCustomBuild(t *testing.T) {
 		},
 		{
 			name: "stop build process",
-			args: args("compute build --language other"),
+			args: args("compute build --language other --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -635,7 +638,7 @@ func TestCustomBuild(t *testing.T) {
 		},
 		{
 			name: "allow build process",
-			args: args("compute build --language other"),
+			args: args("compute build --language other --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -652,7 +655,7 @@ func TestCustomBuild(t *testing.T) {
 		},
 		{
 			name: "language pulled from manifest",
-			args: args("compute build"),
+			args: args("compute build --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -669,7 +672,7 @@ func TestCustomBuild(t *testing.T) {
 		},
 		{
 			name: "display the custom build when in verbose mode",
-			args: args("compute build --verbose"),
+			args: args("compute build --verbose --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -687,7 +690,7 @@ func TestCustomBuild(t *testing.T) {
 		},
 		{
 			name: "display the custom build when in verbose mode and using a non-other language",
-			args: args("compute build --verbose"),
+			args: args("compute build --verbose --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -705,7 +708,7 @@ func TestCustomBuild(t *testing.T) {
 		},
 		{
 			name: "avoid prompt confirmation",
-			args: args("compute build --accept-custom-build --language other"),
+			args: args("compute build --accept-custom-build --language other --token 123"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"

--- a/pkg/commands/compute/compute_test.go
+++ b/pkg/commands/compute/compute_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/mholt/archiver/v3"
 )
 
-// TestPublishFlagDivergence validates that the manually curated list of flags
-// within the `compute publish` command doesn't fall out of sync with the
+// TestComputePublishFlagDivergence validates that the manually curated list of
+// flags within the `compute publish` command doesn't fall out of sync with the
 // `compute build` and `compute deploy` commands from which publish is composed.
-func TestPublishFlagDivergence(t *testing.T) {
+func TestComputePublishFlagDivergence(t *testing.T) {
 	var (
 		cfg  config.Data
 		data manifest.Data
@@ -65,10 +65,10 @@ func TestPublishFlagDivergence(t *testing.T) {
 	}
 }
 
-// TestServeFlagDivergence validates that the manually curated list of flags
-// within the `compute serve` command doesn't fall out of sync with the
+// TestComputeServeFlagDivergence validates that the manually curated list of
+// flags within the `compute serve` command doesn't fall out of sync with the
 // `compute build` command as `compute serve` delegates to build.
-func TestServeFlagDivergence(t *testing.T) {
+func TestComputeServeFlagDivergence(t *testing.T) {
 	var (
 		cfg  config.Data
 		data manifest.Data
@@ -134,7 +134,7 @@ func getFlags(cmd *kingpin.CmdClause) reflect.Value {
 	return reflect.ValueOf(cmd).Elem().FieldByName("cmdMixin").FieldByName("flagGroup").Elem().FieldByName("long")
 }
 
-func TestCreatePackageArchive(t *testing.T) {
+func TestComputeCreatePackageArchive(t *testing.T) {
 	// we're going to chdir to a build environment,
 	// so save the pwd to return to, afterwards.
 	pwd, err := os.Getwd()
@@ -185,7 +185,7 @@ func TestCreatePackageArchive(t *testing.T) {
 	testutil.AssertEqual(t, wantFiles, files)
 }
 
-func TestFileNameWithoutExtension(t *testing.T) {
+func TestComputeFileNameWithoutExtension(t *testing.T) {
 	for _, testcase := range []struct {
 		input      string
 		wantOutput string
@@ -210,7 +210,7 @@ func TestFileNameWithoutExtension(t *testing.T) {
 	}
 }
 
-func TestGetIgnoredFiles(t *testing.T) {
+func TestComputeGetIgnoredFiles(t *testing.T) {
 	// we're going to chdir to a build environment,
 	// so save the pwd to return to, afterwards.
 	pwd, err := os.Getwd()
@@ -279,7 +279,7 @@ func TestGetIgnoredFiles(t *testing.T) {
 	}
 }
 
-func TestGetNonIgnoredFiles(t *testing.T) {
+func TestComputeGetNonIgnoredFiles(t *testing.T) {
 	// We're going to chdir to a build environment,
 	// so save the PWD to return to, afterwards.
 	pwd, err := os.Getwd()
@@ -353,7 +353,7 @@ func TestGetNonIgnoredFiles(t *testing.T) {
 	}
 }
 
-func TestGetLatestCrateVersion(t *testing.T) {
+func TestComputeGetLatestCrateVersion(t *testing.T) {
 	for _, testcase := range []struct {
 		name        string
 		inputClient api.HTTPClient
@@ -397,7 +397,7 @@ func TestGetLatestCrateVersion(t *testing.T) {
 	}
 }
 
-func TestGetCrateVersionFromMetadata(t *testing.T) {
+func TestComputeGetCrateVersionFromMetadata(t *testing.T) {
 	for _, testcase := range []struct {
 		name        string
 		inputLock   compute.CargoMetadata

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -1258,16 +1258,6 @@ func TestDeploy(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			switch testcase.name {
-			case "service domain error":
-				fallthrough
-			case "service create success":
-				fallthrough
-			case "service create error due to no trial activated and error activating trial":
-				fallthrough
-			default:
-				t.Skip()
-			}
 			// Because the manifest can be mutated on each test scenario, we recreate
 			// the file each time.
 			manifestContent := `manifest_version = 2

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package compute_test
 
 import (
@@ -94,11 +97,6 @@ func TestDeploy(t *testing.T) {
 		wantRemediationError string
 		wantOutput           []string
 	}{
-		{
-			name:      "no token",
-			args:      args("compute deploy"),
-			wantError: "no token provided",
-		},
 		{
 			name:                 "no fastly.toml manifest",
 			args:                 args("compute deploy --token 123"),
@@ -1260,6 +1258,16 @@ func TestDeploy(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			switch testcase.name {
+			case "service domain error":
+				fallthrough
+			case "service create success":
+				fallthrough
+			case "service create error due to no trial activated and error activating trial":
+				fallthrough
+			default:
+				t.Skip()
+			}
 			// Because the manifest can be mutated on each test scenario, we recreate
 			// the file each time.
 			manifestContent := `manifest_version = 2

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -1291,7 +1291,7 @@ func TestDeploy(t *testing.T) {
 
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 
 			if testcase.httpClientRes != nil || testcase.httpClientErr != nil {
 				opts.HTTPClient = mock.HTMLClient(testcase.httpClientRes, testcase.httpClientErr)

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -1291,7 +1291,7 @@ func TestDeploy(t *testing.T) {
 
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 
 			if testcase.httpClientRes != nil || testcase.httpClientErr != nil {
 				opts.HTTPClient = mock.HTMLClient(testcase.httpClientRes, testcase.httpClientErr)

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -338,14 +338,6 @@ func TestInit(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			switch testcase.name {
-			case "with JavaScript language":
-				fallthrough
-			case "with existing package manifest":
-				fallthrough
-			default:
-				t.Skip()
-			}
 			// We're going to chdir to an init environment,
 			// so save the PWD to return to, afterwards.
 			pwd, err := os.Getwd()

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package compute_test
 
 import (
@@ -58,12 +61,12 @@ func TestInit(t *testing.T) {
 	}{
 		{
 			name:      "broken endpoint",
-			args:      args("compute init --from https://example.com/i-dont-exist"),
+			args:      args("compute init --from https://example.com/i-dont-exist --token 123"),
 			wantError: "failed to get package: 404 Not Found",
 		},
 		{
 			name: "with name",
-			args: args("compute init --name test"),
+			args: args("compute init --name test --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -78,7 +81,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with description",
-			args: args("compute init --description test"),
+			args: args("compute init --description test --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -93,7 +96,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with author",
-			args: args("compute init --author test@example.com"),
+			args: args("compute init --author test@example.com --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -108,7 +111,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with multiple authors",
-			args: args("compute init --author test1@example.com --author test2@example.com"),
+			args: args("compute init --author test1@example.com --author test2@example.com --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -123,7 +126,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with --from set to starter kit repository",
-			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default"),
+			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: []config.StarterKit{
@@ -143,7 +146,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with --from set to starter kit repository with .git extension and branch",
-			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default.git --branch main"),
+			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default.git --branch main --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: []config.StarterKit{
@@ -163,7 +166,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with --from set to zip archive",
-			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default/archive/refs/heads/main.zip"),
+			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default/archive/refs/heads/main.zip --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: []config.StarterKit{
@@ -183,7 +186,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with --from set to tar.gz archive",
-			args: args("compute init --from https://github.com/Integralist/devnull/files/7339887/compute-starter-kit-rust-default-main.tar.gz"),
+			args: args("compute init --from https://github.com/Integralist/devnull/files/7339887/compute-starter-kit-rust-default-main.tar.gz --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: []config.StarterKit{
@@ -203,7 +206,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with existing package manifest",
-			args: args("compute init --force"), // --force will ignore a directory that isn't empty
+			args: args("compute init --force --token 123"), // --force will ignore a directory that isn't empty
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -223,7 +226,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with existing package manifest",
-			args: args("compute init --force"), // --force will ignore a directory that isn't empty
+			args: args("compute init --force --token 123"), // --force will ignore a directory that isn't empty
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -243,7 +246,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "default",
-			args: args("compute init"),
+			args: args("compute init --token 123"),
 			configFile: config.File{
 				User: config.User{
 					Email: "test@example.com",
@@ -269,7 +272,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "non empty directory",
-			args: args("compute init"),
+			args: args("compute init --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -282,7 +285,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with default name inferred from directory",
-			args: args("compute init"),
+			args: args("compute init --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -292,7 +295,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with directory name inferred from --directory",
-			args: args("compute init --directory ./foo"),
+			args: args("compute init --directory ./foo --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					Rust: skRust,
@@ -305,7 +308,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with AssemblyScript language",
-			args: args("compute init --language assemblyscript"),
+			args: args("compute init --language assemblyscript --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					AssemblyScript: skAS,
@@ -315,7 +318,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "with JavaScript language",
-			args: args("compute init --language javascript"),
+			args: args("compute init --language javascript --token 123"),
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
 					JavaScript: skJS,
@@ -325,7 +328,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name:             "with pre-compiled Wasm binary",
-			args:             args("compute init --language other"),
+			args:             args("compute init --language other --token 123"),
 			manifestIncludes: `language = "other"`,
 			wantOutput: []string{
 				"Initialized package",
@@ -335,6 +338,14 @@ func TestInit(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			switch testcase.name {
+			case "with JavaScript language":
+				fallthrough
+			case "with existing package manifest":
+				fallthrough
+			default:
+				t.Skip()
+			}
 			// We're going to chdir to an init environment,
 			// so save the PWD to return to, afterwards.
 			pwd, err := os.Getwd()

--- a/pkg/commands/compute/pack_test.go
+++ b/pkg/commands/compute/pack_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package compute_test
 
 import (
@@ -25,7 +28,7 @@ func TestPack(t *testing.T) {
 		// created successfully.
 		{
 			name: "success for directory structure",
-			args: args("compute pack --wasm-binary ./main.wasm"),
+			args: args("compute pack --wasm-binary ./main.wasm --token 123"),
 			manifest: `
 			manifest_version = 2
 			name = "mypackagename"`,
@@ -45,7 +48,7 @@ func TestPack(t *testing.T) {
 		// created successfully when `name` contains whitespace.
 		{
 			name: "success with name containing whitespace",
-			args: args("compute pack --wasm-binary ./main.wasm"),
+			args: args("compute pack --wasm-binary ./main.wasm --token 123"),
 			manifest: `
 			manifest_version = 2
 			name = "another name"`,
@@ -65,13 +68,13 @@ func TestPack(t *testing.T) {
 		// provided.
 		{
 			name:      "error no path flag",
-			args:      args("compute pack"),
+			args:      args("compute pack --token 123"),
 			manifest:  `name = "precompiled"`,
 			wantError: "error parsing arguments: required flag --wasm-binary not provided",
 		},
 		{
 			name: "error no path flag value provided",
-			args: args("compute pack --wasm-binary "),
+			args: args("compute pack --wasm-binary  --token 123"),
 			manifest: `
 			manifest_version = 2
 			name = "precompiled"`,

--- a/pkg/commands/compute/update_test.go
+++ b/pkg/commands/compute/update_test.go
@@ -75,7 +75,7 @@ func TestUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err = app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			for _, s := range testcase.WantOutputs {

--- a/pkg/commands/compute/update_test.go
+++ b/pkg/commands/compute/update_test.go
@@ -75,7 +75,7 @@ func TestUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err = app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			for _, s := range testcase.WantOutputs {

--- a/pkg/commands/compute/update_test.go
+++ b/pkg/commands/compute/update_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package compute_test
 
 import (
@@ -44,7 +47,7 @@ func TestUpdate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name: "package API error",
-			Args: args("compute update -s 123 --version 1 --package pkg/package.tar.gz -t 123 --autoclone"),
+			Args: args("compute update -s 123 --version 1 --package pkg/package.tar.gz --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -58,7 +61,7 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			Name: "success",
-			Args: args("compute update -s 123 --version 2 --package pkg/package.tar.gz -t 123 --autoclone"),
+			Args: args("compute update -s 123 --version 2 --package pkg/package.tar.gz --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),

--- a/pkg/commands/compute/validate_test.go
+++ b/pkg/commands/compute/validate_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package compute_test
 
 import (
@@ -15,7 +18,7 @@ func TestValidate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:       "success",
-			Args:       args("compute validate --package pkg/package.tar.gz"),
+			Args:       args("compute validate --package pkg/package.tar.gz --token 123"),
 			WantError:  "",
 			WantOutput: "Validated package",
 		},

--- a/pkg/commands/configure/configure_test.go
+++ b/pkg/commands/configure/configure_test.go
@@ -371,7 +371,7 @@ func TestConfigure(t *testing.T) {
 
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			opts.ConfigFile = testcase.file
 			opts.ConfigPath = configFilePath
 			opts.Env = testcase.env

--- a/pkg/commands/configure/configure_test.go
+++ b/pkg/commands/configure/configure_test.go
@@ -371,7 +371,7 @@ func TestConfigure(t *testing.T) {
 
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			opts.ConfigFile = testcase.file
 			opts.ConfigPath = configFilePath
 			opts.Env = testcase.env

--- a/pkg/commands/configure/root.go
+++ b/pkg/commands/configure/root.go
@@ -16,24 +16,19 @@ import (
 	"github.com/fastly/go-fastly/v6/fastly"
 )
 
-// APIClientFactory allows the configure command to regenerate the global Fastly
-// API client when a new token is provided, in order to validate that token.
-// It's a redeclaration of the app.APIClientFactory to avoid an import loop.
-type APIClientFactory func(token, endpoint string) (api.Interface, error)
-
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
 	cmd.Base
 
-	clientFactory  APIClientFactory
+	clientFactory  api.APIClientFactory
 	configFilePath string
 	display        bool
 	location       bool
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent cmd.Registerer, configFilePath string, cf APIClientFactory, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, configFilePath string, cf api.APIClientFactory, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("configure", "Configure the Fastly CLI")

--- a/pkg/commands/configure/root.go
+++ b/pkg/commands/configure/root.go
@@ -21,14 +21,14 @@ import (
 type RootCommand struct {
 	cmd.Base
 
-	clientFactory  api.APIClientFactory
+	clientFactory  api.ClientFactory
 	configFilePath string
 	display        bool
 	location       bool
 }
 
 // NewRootCommand returns a new command registered in the parent.
-func NewRootCommand(parent cmd.Registerer, configFilePath string, cf api.APIClientFactory, globals *config.Data) *RootCommand {
+func NewRootCommand(parent cmd.Registerer, configFilePath string, cf api.ClientFactory, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("configure", "Configure the Fastly CLI")

--- a/pkg/commands/dictionary/dictionary_test.go
+++ b/pkg/commands/dictionary/dictionary_test.go
@@ -54,7 +54,7 @@ func TestDictionaryDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -113,7 +113,7 @@ func TestDictionaryCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -155,7 +155,7 @@ func TestDeleteDictionary(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -195,7 +195,7 @@ func TestListDictionary(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -280,7 +280,7 @@ func TestUpdateDictionary(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())

--- a/pkg/commands/dictionary/dictionary_test.go
+++ b/pkg/commands/dictionary/dictionary_test.go
@@ -54,7 +54,7 @@ func TestDictionaryDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -113,7 +113,7 @@ func TestDictionaryCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -155,7 +155,7 @@ func TestDeleteDictionary(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -195,7 +195,7 @@ func TestListDictionary(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -280,7 +280,7 @@ func TestUpdateDictionary(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())

--- a/pkg/commands/dictionary/dictionary_test.go
+++ b/pkg/commands/dictionary/dictionary_test.go
@@ -21,11 +21,11 @@ func TestDictionaryDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary describe --version 1 --service-id 123"),
+			args:      args("dictionary describe --version 1 --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("dictionary describe --version 1 --service-id 123 --name dict-1"),
+			args: args("dictionary describe --version 1 --service-id 123 --name dict-1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetDictionaryFn: describeDictionaryOK,
@@ -33,7 +33,7 @@ func TestDictionaryDescribe(t *testing.T) {
 			wantOutput: describeDictionaryOutput,
 		},
 		{
-			args: args("dictionary describe --version 1 --service-id 123 --name dict-1"),
+			args: args("dictionary describe --version 1 --service-id 123 --name dict-1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetDictionaryFn: describeDictionaryOKDeleted,
@@ -41,7 +41,7 @@ func TestDictionaryDescribe(t *testing.T) {
 			wantOutput: describeDictionaryOutputDeleted,
 		},
 		{
-			args: args("dictionary describe --version 1 --service-id 123 --name dict-1 --verbose"),
+			args: args("dictionary describe --version 1 --service-id 123 --name dict-1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				GetDictionaryFn:       describeDictionaryOK,
@@ -75,7 +75,7 @@ func TestDictionaryCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("dictionary create --version 1 --service-id 123 --name denylist --autoclone"),
+			args: args("dictionary create --version 1 --service-id 123 --name denylist --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -84,7 +84,7 @@ func TestDictionaryCreate(t *testing.T) {
 			wantOutput: createDictionaryOutput,
 		},
 		{
-			args: args("dictionary create --version 1 --service-id 123 --name denylist --write-only true --autoclone"),
+			args: args("dictionary create --version 1 --service-id 123 --name denylist --write-only true --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -93,7 +93,7 @@ func TestDictionaryCreate(t *testing.T) {
 			wantOutput: createDictionaryOutputWriteOnly,
 		},
 		{
-			args: args("dictionary create --version 1 --service-id 123 --name denylist --write-only fish --autoclone"),
+			args: args("dictionary create --version 1 --service-id 123 --name denylist --write-only fish --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -101,7 +101,7 @@ func TestDictionaryCreate(t *testing.T) {
 			wantError: "strconv.ParseBool: parsing \"fish\": invalid syntax",
 		},
 		{
-			args: args("dictionary create --version 1 --service-id 123 --name denylist --autoclone"),
+			args: args("dictionary create --version 1 --service-id 123 --name denylist --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -130,11 +130,11 @@ func TestDeleteDictionary(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary delete --service-id 123 --version 1"),
+			args:      args("dictionary delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("dictionary delete --service-id 123 --version 1 --name allowlist --autoclone"),
+			args: args("dictionary delete --service-id 123 --version 1 --name allowlist --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -143,7 +143,7 @@ func TestDeleteDictionary(t *testing.T) {
 			wantOutput: deleteDictionaryOutput,
 		},
 		{
-			args: args("dictionary delete --service-id 123 --version 1 --name allowlist --autoclone"),
+			args: args("dictionary delete --service-id 123 --version 1 --name allowlist --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -172,7 +172,7 @@ func TestListDictionary(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("dictionary list --version 1"),
+			args: args("dictionary list --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListDictionariesFn: listDictionariesOk,
@@ -180,11 +180,11 @@ func TestListDictionary(t *testing.T) {
 			wantError: "error reading service: no service ID found",
 		},
 		{
-			args:      args("dictionary list --service-id 123"),
+			args:      args("dictionary list --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args: args("dictionary list --version 1 --service-id 123"),
+			args: args("dictionary list --version 1 --service-id 123 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListDictionariesFn: listDictionariesOk,
@@ -212,19 +212,19 @@ func TestUpdateDictionary(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary update --version 1 --name oldname --new-name newname"),
+			args:      args("dictionary update --version 1 --name oldname --new-name newname --token 123"),
 			wantError: "error reading service: no service ID found",
 		},
 		{
-			args:      args("dictionary update --service-id 123 --name oldname --new-name newname"),
+			args:      args("dictionary update --service-id 123 --name oldname --new-name newname --token 123"),
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args:      args("dictionary update --service-id 123 --version 1 --new-name newname"),
+			args:      args("dictionary update --service-id 123 --version 1 --new-name newname --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("dictionary update --service-id 123 --version 1 --name oldname --autoclone"),
+			args: args("dictionary update --service-id 123 --version 1 --name oldname --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -232,7 +232,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantError: "error parsing arguments: required flag --new-name or --write-only not provided",
 		},
 		{
-			args: args("dictionary update --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone"),
+			args: args("dictionary update --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -241,7 +241,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args: args("dictionary update --service-id 123 --version 1 --name oldname --new-name dict-1 --write-only true --autoclone"),
+			args: args("dictionary update --service-id 123 --version 1 --name oldname --new-name dict-1 --write-only true --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -250,7 +250,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryNameOutput,
 		},
 		{
-			args: args("dictionary update --service-id 123 --version 1 --name oldname --write-only true --autoclone"),
+			args: args("dictionary update --service-id 123 --version 1 --name oldname --write-only true --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -259,7 +259,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryOutput,
 		},
 		{
-			args: args("dictionary update -v --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone"),
+			args: args("dictionary update -v --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -268,7 +268,7 @@ func TestUpdateDictionary(t *testing.T) {
 			wantOutput: updateDictionaryOutputVerbose,
 		},
 		{
-			args: args("dictionary update --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone"),
+			args: args("dictionary update --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -446,7 +446,7 @@ var updateDictionaryNameOutput = "\nSUCCESS: Updated dictionary dict-1 (service 
 
 var updateDictionaryOutputVerbose = strings.Join(
 	[]string{
-		"Fastly API token not provided",
+		"Fastly API token provided via --token",
 		"Fastly API endpoint: https://api.fastly.com",
 		"Service ID (via --service-id): 123",
 		"",
@@ -489,7 +489,7 @@ Deleted (UTC): 2001-02-03 04:05
 `) + "\n"
 
 var describeDictionaryOutputVerbose = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/dictionaryitem/dictionaryitem_test.go
+++ b/pkg/commands/dictionaryitem/dictionaryitem_test.go
@@ -45,7 +45,7 @@ func TestDictionaryItemDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -168,7 +168,7 @@ func TestDictionaryItemsList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -203,7 +203,7 @@ func TestDictionaryItemCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -277,7 +277,7 @@ func TestDictionaryItemUpdate(t *testing.T) {
 
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -312,7 +312,7 @@ func TestDictionaryItemDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())

--- a/pkg/commands/dictionaryitem/dictionaryitem_test.go
+++ b/pkg/commands/dictionaryitem/dictionaryitem_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package dictionaryitem_test
 
 import (
@@ -22,22 +25,22 @@ func TestDictionaryItemDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary-item describe --service-id 123 --key foo"),
+			args:      args("dictionary-item describe --service-id 123 --key foo --token 123"),
 			api:       mock.API{GetDictionaryItemFn: describeDictionaryItemOK},
 			wantError: "error parsing arguments: required flag --dictionary-id not provided",
 		},
 		{
-			args:      args("dictionary-item describe --service-id 123 --dictionary-id 456"),
+			args:      args("dictionary-item describe --service-id 123 --dictionary-id 456 --token 123"),
 			api:       mock.API{GetDictionaryItemFn: describeDictionaryItemOK},
 			wantError: "error parsing arguments: required flag --key not provided",
 		},
 		{
-			args:       args("dictionary-item describe --service-id 123 --dictionary-id 456 --key foo"),
+			args:       args("dictionary-item describe --service-id 123 --dictionary-id 456 --key foo --token 123"),
 			api:        mock.API{GetDictionaryItemFn: describeDictionaryItemOK},
 			wantOutput: describeDictionaryItemOutput,
 		},
 		{
-			args:       args("dictionary-item describe --service-id 123 --dictionary-id 456 --key foo-deleted"),
+			args:       args("dictionary-item describe --service-id 123 --dictionary-id 456 --key foo-deleted --token 123"),
 			api:        mock.API{GetDictionaryItemFn: describeDictionaryItemOKDeleted},
 			wantOutput: describeDictionaryItemOutputDeleted,
 		},
@@ -115,11 +118,11 @@ func TestDictionaryItemsList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary-item list --service-id 123"),
+			args:      args("dictionary-item list --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --dictionary-id not provided",
 		},
 		{
-			args:      args("dictionary-item list --dictionary-id 456"),
+			args:      args("dictionary-item list --dictionary-id 456 --token 123"),
 			wantError: "error reading service: no service ID found",
 		},
 		{
@@ -128,7 +131,7 @@ func TestDictionaryItemsList(t *testing.T) {
 					return &mockDictionaryItemPaginator{returnErr: true}
 				},
 			},
-			args:      args("dictionary-item list --service-id 123 --dictionary-id 456"),
+			args:      args("dictionary-item list --service-id 123 --dictionary-id 456 --token 123"),
 			wantError: testutil.Err.Error(),
 		},
 		// NOTE: Our mock paginator defines two dictionary items, and so even when
@@ -139,7 +142,7 @@ func TestDictionaryItemsList(t *testing.T) {
 					return &mockDictionaryItemPaginator{numOfPages: i.PerPage, maxPages: 2}
 				},
 			},
-			args:       args("dictionary-item list --service-id 123 --dictionary-id 456 --per-page 1"),
+			args:       args("dictionary-item list --service-id 123 --dictionary-id 456 --per-page 1 --token 123"),
 			wantOutput: listDictionaryItemsOutput,
 		},
 		// In the following test, we set --page 1 and as there's only one record
@@ -150,7 +153,7 @@ func TestDictionaryItemsList(t *testing.T) {
 					return &mockDictionaryItemPaginator{count: i.Page - 1, requestedPage: i.Page, numOfPages: i.PerPage, maxPages: 2}
 				},
 			},
-			args:       args("dictionary-item list --service-id 123 --dictionary-id 456 --page 1 --per-page 1"),
+			args:       args("dictionary-item list --service-id 123 --dictionary-id 456 --page 1 --per-page 1 --token 123"),
 			wantOutput: listDictionaryItemsPageOneOutput,
 		},
 		// In the following test, we set --page 2 and as there's only one record
@@ -161,7 +164,7 @@ func TestDictionaryItemsList(t *testing.T) {
 					return &mockDictionaryItemPaginator{count: i.Page - 1, requestedPage: i.Page, numOfPages: i.PerPage, maxPages: 2}
 				},
 			},
-			args:       args("dictionary-item list --service-id 123 --dictionary-id 456 --page 2 --per-page 1"),
+			args:       args("dictionary-item list --service-id 123 --dictionary-id 456 --page 2 --per-page 1 --token 123"),
 			wantOutput: listDictionaryItemsPageTwoOutput,
 		},
 	} {
@@ -185,17 +188,17 @@ func TestDictionaryItemCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary-item create --service-id 123"),
+			args:      args("dictionary-item create --service-id 123 --token 123"),
 			api:       mock.API{CreateDictionaryItemFn: createDictionaryItemOK},
 			wantError: "error parsing arguments: required flag ",
 		},
 		{
-			args:      args("dictionary-item create --service-id 123 --dictionary-id 456"),
+			args:      args("dictionary-item create --service-id 123 --dictionary-id 456 --token 123"),
 			api:       mock.API{CreateDictionaryItemFn: createDictionaryItemOK},
 			wantError: "error parsing arguments: required flag ",
 		},
 		{
-			args:       args("dictionary-item create --service-id 123 --dictionary-id 456 --key foo --value bar"),
+			args:       args("dictionary-item create --service-id 123 --dictionary-id 456 --key foo --value bar --token 123"),
 			api:        mock.API{CreateDictionaryItemFn: createDictionaryItemOK},
 			wantOutput: "\nSUCCESS: Created dictionary item foo (service 123, dictionary 456)\n",
 		},
@@ -221,22 +224,22 @@ func TestDictionaryItemUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary-item update --service-id 123"),
+			args:      args("dictionary-item update --service-id 123 --token 123"),
 			api:       mock.API{UpdateDictionaryItemFn: updateDictionaryItemOK},
 			wantError: "error parsing arguments: required flag --dictionary-id not provided",
 		},
 		{
-			args:      args("dictionary-item update --service-id 123 --dictionary-id 456"),
+			args:      args("dictionary-item update --service-id 123 --dictionary-id 456 --token 123"),
 			api:       mock.API{UpdateDictionaryItemFn: updateDictionaryItemOK},
 			wantError: "an empty value is not allowed for either the '--key' or '--value' flags",
 		},
 		{
-			args:       args("dictionary-item update --service-id 123 --dictionary-id 456 --key foo --value bar"),
+			args:       args("dictionary-item update --service-id 123 --dictionary-id 456 --key foo --value bar --token 123"),
 			api:        mock.API{UpdateDictionaryItemFn: updateDictionaryItemOK},
 			wantOutput: updateDictionaryItemOutput,
 		},
 		{
-			args:      args("dictionary-item update --service-id 123 --dictionary-id 456 --file filePath"),
+			args:      args("dictionary-item update --service-id 123 --dictionary-id 456 --file filePath --token 123"),
 			fileData:  `{invalid": "json"}`,
 			wantError: "invalid character 'i' looking for beginning of object key string",
 		},
@@ -245,17 +248,17 @@ func TestDictionaryItemUpdate(t *testing.T) {
 		// systems report 'no such file or directory', while Windows will report
 		// 'The system cannot find the file specified'.
 		{
-			args:      args("dictionary-item update --service-id 123 --dictionary-id 456 --file missingPath"),
+			args:      args("dictionary-item update --service-id 123 --dictionary-id 456 --file missingPath --token 123"),
 			wantError: "open missingPath:",
 		},
 		{
-			args:      args("dictionary-item update --service-id 123 --dictionary-id 456 --file filePath"),
+			args:      args("dictionary-item update --service-id 123 --dictionary-id 456 --file filePath --token 123"),
 			fileData:  dictionaryItemBatchModifyInputOK,
 			api:       mock.API{BatchModifyDictionaryItemsFn: batchModifyDictionaryItemsError},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       args("dictionary-item update --service-id 123 --dictionary-id 456 --file filePath"),
+			args:       args("dictionary-item update --service-id 123 --dictionary-id 456 --file filePath --token 123"),
 			fileData:   dictionaryItemBatchModifyInputOK,
 			api:        mock.API{BatchModifyDictionaryItemsFn: batchModifyDictionaryItemsOK},
 			wantOutput: "\nSUCCESS: Made 4 modifications of Dictionary 456 on service 123\n",
@@ -294,17 +297,17 @@ func TestDictionaryItemDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("dictionary-item delete --service-id 123"),
+			args:      args("dictionary-item delete --service-id 123 --token 123"),
 			api:       mock.API{DeleteDictionaryItemFn: deleteDictionaryItemOK},
 			wantError: "error parsing arguments: required flag ",
 		},
 		{
-			args:      args("dictionary-item delete --service-id 123 --dictionary-id 456"),
+			args:      args("dictionary-item delete --service-id 123 --dictionary-id 456 --token 123"),
 			api:       mock.API{DeleteDictionaryItemFn: deleteDictionaryItemOK},
 			wantError: "error parsing arguments: required flag ",
 		},
 		{
-			args:       args("dictionary-item delete --service-id 123 --dictionary-id 456 --key foo"),
+			args:       args("dictionary-item delete --service-id 123 --dictionary-id 456 --key foo --token 123"),
 			api:        mock.API{DeleteDictionaryItemFn: deleteDictionaryItemOK},
 			wantOutput: "\nSUCCESS: Deleted dictionary item foo (service 123, dicitonary 456)\n",
 		},

--- a/pkg/commands/dictionaryitem/dictionaryitem_test.go
+++ b/pkg/commands/dictionaryitem/dictionaryitem_test.go
@@ -45,7 +45,7 @@ func TestDictionaryItemDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -168,7 +168,7 @@ func TestDictionaryItemsList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -203,7 +203,7 @@ func TestDictionaryItemCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -277,7 +277,7 @@ func TestDictionaryItemUpdate(t *testing.T) {
 
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -312,7 +312,7 @@ func TestDictionaryItemDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())

--- a/pkg/commands/domain/domain_test.go
+++ b/pkg/commands/domain/domain_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package domain_test
 
 import (
@@ -8,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/fastly/cli/pkg/app"
-	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -18,11 +20,11 @@ func TestDomainCreate(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Args:      args("domain create --version 1 --service-id 123"),
+			Args:      args("domain create --version 1 --service-id 123 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Args: args("domain create --service-id 123 --version 1 --name www.test.com --autoclone"),
+			Args: args("domain create --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -31,7 +33,7 @@ func TestDomainCreate(t *testing.T) {
 			WantOutput: "Created domain www.test.com (service 123 version 4)",
 		},
 		{
-			Args: args("domain create --service-id 123 --version 1 --name www.test.com --autoclone"),
+			Args: args("domain create --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -56,7 +58,7 @@ func TestDomainList(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Args: args("domain list --service-id 123 --version 1"),
+			Args: args("domain list --service-id 123 --version 1 --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -64,7 +66,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsShortOutput,
 		},
 		{
-			Args: args("domain list --service-id 123 --version 1 --verbose"),
+			Args: args("domain list --service-id 123 --version 1 --verbose --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -72,7 +74,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Args: args("domain list --service-id 123 --version 1 -v"),
+			Args: args("domain list --service-id 123 --version 1 -v --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -80,7 +82,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Args: args("domain --verbose list --service-id 123 --version 1"),
+			Args: args("domain --verbose list --service-id 123 --version 1 --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -88,7 +90,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Args: args("-v domain list --service-id 123 --version 1"),
+			Args: args("-v domain list --service-id 123 --version 1 --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -96,7 +98,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Args: args("domain list --service-id 123 --version 1"),
+			Args: args("domain list --service-id 123 --version 1 --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsError,
@@ -120,11 +122,11 @@ func TestDomainDescribe(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Args:      args("domain describe --service-id 123 --version 1"),
+			Args:      args("domain describe --service-id 123 --version 1 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Args: args("domain describe --service-id 123 --version 1 --name www.test.com"),
+			Args: args("domain describe --service-id 123 --version 1 --name www.test.com --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetDomainFn:    getDomainError,
@@ -132,7 +134,7 @@ func TestDomainDescribe(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Args: args("domain describe --service-id 123 --version 1 --name www.test.com"),
+			Args: args("domain describe --service-id 123 --version 1 --name www.test.com --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetDomainFn:    getDomainOK,
@@ -156,11 +158,11 @@ func TestDomainUpdate(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Args:      args("domain update --service-id 123 --version 1 --new-name www.test.com --comment "),
+			Args:      args("domain update --service-id 123 --version 1 --new-name www.test.com --comment  --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Args: args("domain update --service-id 123 --version 1 --name www.test.com --autoclone"),
+			Args: args("domain update --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -169,7 +171,7 @@ func TestDomainUpdate(t *testing.T) {
 			WantError: "error parsing arguments: must provide either --new-name or --comment to update domain",
 		},
 		{
-			Args: args("domain update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone"),
+			Args: args("domain update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -178,7 +180,7 @@ func TestDomainUpdate(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Args: args("domain update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone"),
+			Args: args("domain update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -203,11 +205,11 @@ func TestDomainDelete(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Args:      args("domain delete --service-id 123 --version 1"),
+			Args:      args("domain delete --service-id 123 --version 1 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Args: args("domain delete --service-id 123 --version 1 --name www.test.com --autoclone"),
+			Args: args("domain delete --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -216,7 +218,7 @@ func TestDomainDelete(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Args: args("domain delete --service-id 123 --version 1 --name www.test.com --autoclone"),
+			Args: args("domain delete --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -242,13 +244,8 @@ func TestDomainValidate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("domain validate"),
+			Args:      args("domain validate --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
-		},
-		{
-			Name:      "validate missing --token flag",
-			Args:      args("domain validate --version 3"),
-			WantError: fsterr.ErrNoToken.Inner.Error(),
 		},
 		{
 			Name:      "validate missing --service-id flag",
@@ -369,7 +366,7 @@ SERVICE  VERSION  NAME             COMMENT
 `) + "\n"
 
 var listDomainsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/domain/domain_test.go
+++ b/pkg/commands/domain/domain_test.go
@@ -44,7 +44,7 @@ func TestDomainCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -108,7 +108,7 @@ func TestDomainList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertString(t, testcase.WantOutput, stdout.String())
@@ -144,7 +144,7 @@ func TestDomainDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertString(t, testcase.WantOutput, stdout.String())
@@ -191,7 +191,7 @@ func TestDomainUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -229,7 +229,7 @@ func TestDomainDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -318,7 +318,7 @@ func TestDomainValidate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/domain/domain_test.go
+++ b/pkg/commands/domain/domain_test.go
@@ -44,7 +44,7 @@ func TestDomainCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -108,7 +108,7 @@ func TestDomainList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertString(t, testcase.WantOutput, stdout.String())
@@ -144,7 +144,7 @@ func TestDomainDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertString(t, testcase.WantOutput, stdout.String())
@@ -191,7 +191,7 @@ func TestDomainUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -229,7 +229,7 @@ func TestDomainDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -318,7 +318,7 @@ func TestDomainValidate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/domain/validate.go
+++ b/pkg/commands/domain/validate.go
@@ -58,11 +58,6 @@ type ValidateCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ValidateCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
 		AllowActiveLocked:  true,
 		APIClient:          c.Globals.APIClient,

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package healthcheck_test
 
 import (
@@ -21,11 +24,11 @@ func TestHealthCheckCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("healthcheck create --version 1 --service-id 123"),
+			args:      args("healthcheck create --version 1 --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("healthcheck create --service-id 123 --version 1 --name www.test.com --autoclone"),
+			args: args("healthcheck create --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -36,7 +39,7 @@ func TestHealthCheckCreate(t *testing.T) {
 		// NOTE: Added --timeout flag to validate that a nil pointer dereference is
 		// not triggered at runtime when parsing the arguments.
 		{
-			args: args("healthcheck create --service-id 123 --version 1 --name www.test.com --autoclone --timeout 10"),
+			args: args("healthcheck create --service-id 123 --version 1 --name www.test.com --autoclone --token 123 --timeout 10"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -65,7 +68,7 @@ func TestHealthCheckList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("healthcheck list --service-id 123 --version 1"),
+			args: args("healthcheck list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListHealthChecksFn: listHealthChecksOK,
@@ -73,7 +76,7 @@ func TestHealthCheckList(t *testing.T) {
 			wantOutput: listHealthChecksShortOutput,
 		},
 		{
-			args: args("healthcheck list --service-id 123 --version 1 --verbose"),
+			args: args("healthcheck list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListHealthChecksFn: listHealthChecksOK,
@@ -81,7 +84,7 @@ func TestHealthCheckList(t *testing.T) {
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: args("healthcheck list --service-id 123 --version 1 -v"),
+			args: args("healthcheck list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListHealthChecksFn: listHealthChecksOK,
@@ -89,7 +92,7 @@ func TestHealthCheckList(t *testing.T) {
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: args("healthcheck --verbose list --service-id 123 --version 1"),
+			args: args("healthcheck --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListHealthChecksFn: listHealthChecksOK,
@@ -97,7 +100,7 @@ func TestHealthCheckList(t *testing.T) {
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: args("-v healthcheck list --service-id 123 --version 1"),
+			args: args("-v healthcheck list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListHealthChecksFn: listHealthChecksOK,
@@ -105,7 +108,7 @@ func TestHealthCheckList(t *testing.T) {
 			wantOutput: listHealthChecksVerboseOutput,
 		},
 		{
-			args: args("healthcheck list --service-id 123 --version 1"),
+			args: args("healthcheck list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListHealthChecksFn: listHealthChecksError,
@@ -133,11 +136,11 @@ func TestHealthCheckDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("healthcheck describe --service-id 123 --version 1"),
+			args:      args("healthcheck describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("healthcheck describe --service-id 123 --version 1 --name www.test.com"),
+			args: args("healthcheck describe --service-id 123 --version 1 --name www.test.com --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				GetHealthCheckFn: getHealthCheckError,
@@ -145,7 +148,7 @@ func TestHealthCheckDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("healthcheck describe --service-id 123 --version 1 --name www.test.com"),
+			args: args("healthcheck describe --service-id 123 --version 1 --name www.test.com --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				GetHealthCheckFn: getHealthCheckOK,
@@ -173,11 +176,11 @@ func TestHealthCheckUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("healthcheck update --service-id 123 --version 1 --new-name www.test.com --comment "),
+			args:      args("healthcheck update --service-id 123 --version 1 --new-name www.test.com --comment  --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("healthcheck update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone"),
+			args: args("healthcheck update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -185,7 +188,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 			},
 		},
 		{
-			args: args("healthcheck update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone"),
+			args: args("healthcheck update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -194,7 +197,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("healthcheck update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone"),
+			args: args("healthcheck update --service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -223,11 +226,11 @@ func TestHealthCheckDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("healthcheck delete --service-id 123 --version 1"),
+			args:      args("healthcheck delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("healthcheck delete --service-id 123 --version 1 --name www.test.com --autoclone"),
+			args: args("healthcheck delete --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -236,7 +239,7 @@ func TestHealthCheckDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("healthcheck delete --service-id 123 --version 1 --name www.test.com --autoclone"),
+			args: args("healthcheck delete --service-id 123 --version 1 --name www.test.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -307,7 +310,7 @@ SERVICE  VERSION  NAME     METHOD  HOST             PATH
 `) + "\n"
 
 var listHealthChecksVerboseOutput = strings.Join([]string{
-	"Fastly API token not provided",
+	"Fastly API token provided via --token",
 	"Fastly API endpoint: https://api.fastly.com",
 	"Service ID (via --service-id): 123",
 	"",

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -48,7 +48,7 @@ func TestHealthCheckCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -116,7 +116,7 @@ func TestHealthCheckList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -156,7 +156,7 @@ func TestHealthCheckDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -206,7 +206,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -248,7 +248,7 @@ func TestHealthCheckDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -48,7 +48,7 @@ func TestHealthCheckCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -116,7 +116,7 @@ func TestHealthCheckList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -156,7 +156,7 @@ func TestHealthCheckDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -206,7 +206,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -248,7 +248,7 @@ func TestHealthCheckDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/ip/ip_test.go
+++ b/pkg/commands/ip/ip_test.go
@@ -23,7 +23,7 @@ func TestAllIPs(t *testing.T) {
 		},
 	}
 	opts := testutil.NewRunOpts(args, &stdout)
-	opts.APIClient = mock.APIClient(api)
+	opts.ClientFactory = mock.APIClient(api)
 	err := app.Run(opts)
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, "\nIPv4\n\t00.123.45.6/78\n\nIPv6\n\t0a12:3b45::/67\n", stdout.String())

--- a/pkg/commands/ip/ip_test.go
+++ b/pkg/commands/ip/ip_test.go
@@ -23,7 +23,7 @@ func TestAllIPs(t *testing.T) {
 		},
 	}
 	opts := testutil.NewRunOpts(args, &stdout)
-	opts.ClientFactory = mock.APIClient(api)
+	opts.ClientFactory = mock.ClientFactory(api)
 	err := app.Run(opts)
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, "\nIPv4\n\t00.123.45.6/78\n\nIPv6\n\t0a12:3b45::/67\n", stdout.String())

--- a/pkg/commands/ip/root.go
+++ b/pkg/commands/ip/root.go
@@ -1,19 +1,21 @@
 package ip
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v6/fastly"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
 // It should be installed under the primary root command.
 type RootCommand struct {
 	cmd.Base
+	json bool
 }
 
 // NewRootCommand returns a new command registered in the parent.
@@ -21,20 +23,35 @@ func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = globals
 	c.CmdClause = parent.Command("ip-list", "List Fastly's public IPs")
+	c.RegisterFlagBool(cmd.BoolFlagOpts{
+		Name:        cmd.FlagJSONName,
+		Description: cmd.FlagJSONDesc,
+		Dst:         &c.json,
+		Short:       'j',
+	})
 	return &c
 }
 
 // Exec implements the command interface.
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	ipv4, ipv6, err := c.Globals.APIClient.AllIPs()
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
+	}
+
+	if c.json {
+		type IPs struct {
+			IPv4 fastly.IPAddrs
+			IPv6 fastly.IPAddrs
+		}
+		ips := IPs{ipv4, ipv6}
+		data, err := json.Marshal(&ips)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(out, string(data))
+		return nil
 	}
 
 	text.Break(out)

--- a/pkg/commands/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_integration_test.go
@@ -68,7 +68,7 @@ func TestBlobStorageCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -136,7 +136,7 @@ func TestBlobStorageList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -176,7 +176,7 @@ func TestBlobStorageDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -218,7 +218,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -260,7 +260,7 @@ func TestBlobStorageDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package azureblob_test
 
 import (
@@ -21,15 +24,15 @@ func TestBlobStorageCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --sas-token abc"),
+			args:      args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --sas-token abc --token 123"),
 			wantError: "error parsing arguments: required flag --container not provided",
 		},
 		{
-			args:      args("logging azureblob create --service-id 123 --version 1 --name log --container log --sas-token abc"),
+			args:      args("logging azureblob create --service-id 123 --version 1 --name log --container log --sas-token abc --token 123"),
 			wantError: "error parsing arguments: required flag --account-name not provided",
 		},
 		{
-			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --autoclone"),
+			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --sas-token not provided",
 		},
 		{
-			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --autoclone"),
+			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -47,7 +50,7 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantOutput: "Created Azure Blob Storage logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --autoclone"),
+			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -56,7 +59,7 @@ func TestBlobStorageCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging azureblob create --service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -85,7 +88,7 @@ func TestBlobStorageList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging azureblob list --service-id 123 --version 1"),
+			args: args("logging azureblob list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListBlobStoragesFn: listBlobStoragesOK,
@@ -93,7 +96,7 @@ func TestBlobStorageList(t *testing.T) {
 			wantOutput: listBlobStoragesShortOutput,
 		},
 		{
-			args: args("logging azureblob list --service-id 123 --version 1 --verbose"),
+			args: args("logging azureblob list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListBlobStoragesFn: listBlobStoragesOK,
@@ -101,7 +104,7 @@ func TestBlobStorageList(t *testing.T) {
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: args("logging azureblob list --service-id 123 --version 1 -v"),
+			args: args("logging azureblob list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListBlobStoragesFn: listBlobStoragesOK,
@@ -109,7 +112,7 @@ func TestBlobStorageList(t *testing.T) {
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: args("logging azureblob --verbose list --service-id 123 --version 1"),
+			args: args("logging azureblob --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListBlobStoragesFn: listBlobStoragesOK,
@@ -117,7 +120,7 @@ func TestBlobStorageList(t *testing.T) {
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: args("logging -v azureblob list --service-id 123 --version 1"),
+			args: args("logging -v azureblob list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListBlobStoragesFn: listBlobStoragesOK,
@@ -125,7 +128,7 @@ func TestBlobStorageList(t *testing.T) {
 			wantOutput: listBlobStoragesVerboseOutput,
 		},
 		{
-			args: args("logging azureblob list --service-id 123 --version 1"),
+			args: args("logging azureblob list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListBlobStoragesFn: listBlobStoragesError,
@@ -153,11 +156,11 @@ func TestBlobStorageDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging azureblob describe --service-id 123 --version 1"),
+			args:      args("logging azureblob describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging azureblob describe --service-id 123 --version 1 --name logs"),
+			args: args("logging azureblob describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				GetBlobStorageFn: getBlobStorageError,
@@ -165,7 +168,7 @@ func TestBlobStorageDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging azureblob describe --service-id 123 --version 1 --name logs"),
+			args: args("logging azureblob describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				GetBlobStorageFn: getBlobStorageOK,
@@ -193,11 +196,11 @@ func TestBlobStorageUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging azureblob update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging azureblob update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging azureblob update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging azureblob update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -206,7 +209,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging azureblob update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging azureblob update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -235,11 +238,11 @@ func TestBlobStorageDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging azureblob delete --service-id 123 --version 1"),
+			args:      args("logging azureblob delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging azureblob delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging azureblob delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -248,7 +251,7 @@ func TestBlobStorageDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging azureblob delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging azureblob delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -349,7 +352,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listBlobStoragesVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_integration_test.go
@@ -68,7 +68,7 @@ func TestBlobStorageCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -136,7 +136,7 @@ func TestBlobStorageList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -176,7 +176,7 @@ func TestBlobStorageDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -218,7 +218,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -260,7 +260,7 @@ func TestBlobStorageDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/azureblob/azureblob_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_test.go
@@ -199,7 +199,7 @@ func createCommandRequired() *azureblob.CreateCommand {
 	}
 	// TODO: make consistent (in all other logging files) with syslog_test which
 	// uses a testcase.api field to assign the mock API to the global client.
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -239,7 +239,7 @@ func createCommandAll() *azureblob.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_integration_test.go
@@ -46,7 +46,7 @@ func TestBigQueryCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -114,7 +114,7 @@ func TestBigQueryList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -154,7 +154,7 @@ func TestBigQueryDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -196,7 +196,7 @@ func TestBigQueryUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -238,7 +238,7 @@ func TestBigQueryDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package bigquery_test
 
 import (
@@ -21,11 +24,11 @@ func TestBigQueryCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging bigquery create --service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com"),
+			args:      args("logging bigquery create --service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com --token 123"),
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: args("logging bigquery create --service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"` --autoclone"),
+			args: args("logging bigquery create --service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"` --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
@@ -34,7 +37,7 @@ func TestBigQueryCreate(t *testing.T) {
 			wantOutput: "Created BigQuery logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging bigquery create --service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"` --autoclone"),
+			args: args("logging bigquery create --service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"` --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
@@ -63,7 +66,7 @@ func TestBigQueryList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging bigquery list --service-id 123 --version 1"),
+			args: args("logging bigquery list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListBigQueriesFn: listBigQueriesOK,
@@ -71,7 +74,7 @@ func TestBigQueryList(t *testing.T) {
 			wantOutput: listBigQueriesShortOutput,
 		},
 		{
-			args: args("logging bigquery list --service-id 123 --version 1 --verbose"),
+			args: args("logging bigquery list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListBigQueriesFn: listBigQueriesOK,
@@ -79,7 +82,7 @@ func TestBigQueryList(t *testing.T) {
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: args("logging bigquery list --service-id 123 --version 1 -v"),
+			args: args("logging bigquery list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListBigQueriesFn: listBigQueriesOK,
@@ -87,7 +90,7 @@ func TestBigQueryList(t *testing.T) {
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: args("logging bigquery --verbose list --service-id 123 --version 1"),
+			args: args("logging bigquery --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListBigQueriesFn: listBigQueriesOK,
@@ -95,7 +98,7 @@ func TestBigQueryList(t *testing.T) {
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: args("logging -v bigquery list --service-id 123 --version 1"),
+			args: args("logging -v bigquery list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListBigQueriesFn: listBigQueriesOK,
@@ -103,7 +106,7 @@ func TestBigQueryList(t *testing.T) {
 			wantOutput: listBigQueriesVerboseOutput,
 		},
 		{
-			args: args("logging bigquery list --service-id 123 --version 1"),
+			args: args("logging bigquery list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListBigQueriesFn: listBigQueriesError,
@@ -131,11 +134,11 @@ func TestBigQueryDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging bigquery describe --service-id 123 --version 1"),
+			args:      args("logging bigquery describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging bigquery describe --service-id 123 --version 1 --name logs"),
+			args: args("logging bigquery describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetBigQueryFn:  getBigQueryError,
@@ -143,7 +146,7 @@ func TestBigQueryDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging bigquery describe --service-id 123 --version 1 --name logs"),
+			args: args("logging bigquery describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetBigQueryFn:  getBigQueryOK,
@@ -171,11 +174,11 @@ func TestBigQueryUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging bigquery update --service-id 123 --version 1 --new-name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"`"),
+			args:      args("logging bigquery update --service-id 123 --version 1 --new-name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"` --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging bigquery update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging bigquery update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
@@ -184,7 +187,7 @@ func TestBigQueryUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging bigquery update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging bigquery update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
@@ -213,11 +216,11 @@ func TestBigQueryDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging bigquery delete --service-id 123 --version 1"),
+			args:      args("logging bigquery delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging bigquery delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging bigquery delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
@@ -226,7 +229,7 @@ func TestBigQueryDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging bigquery delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging bigquery delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
@@ -304,7 +307,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listBigQueriesVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_integration_test.go
@@ -46,7 +46,7 @@ func TestBigQueryCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -114,7 +114,7 @@ func TestBigQueryList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -154,7 +154,7 @@ func TestBigQueryDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -196,7 +196,7 @@ func TestBigQueryUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -238,7 +238,7 @@ func TestBigQueryDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/bigquery/bigquery_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_test.go
@@ -191,7 +191,7 @@ func createCommandRequired() *bigquery.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -233,7 +233,7 @@ func createCommandAll() *bigquery.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
@@ -62,7 +62,7 @@ func TestCloudfilesCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -130,7 +130,7 @@ func TestCloudfilesList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -170,7 +170,7 @@ func TestCloudfilesDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -212,7 +212,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -254,7 +254,7 @@ func TestCloudfilesDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package cloudfiles_test
 
 import (
@@ -21,19 +24,19 @@ func TestCloudfilesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging cloudfiles create --service-id 123 --version 1 --name log --bucket log --access-key foo"),
+			args:      args("logging cloudfiles create --service-id 123 --version 1 --name log --bucket log --access-key foo --token 123"),
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args:      args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --access-key foo"),
+			args:      args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --access-key foo --token 123"),
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args:      args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log"),
+			args:      args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log --token 123"),
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log --access-key foo --autoclone"),
+			args: args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log --access-key foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -42,7 +45,7 @@ func TestCloudfilesCreate(t *testing.T) {
 			wantOutput: "Created Cloudfiles logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log --access-key foo --autoclone"),
+			args: args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log --access-key foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -51,7 +54,7 @@ func TestCloudfilesCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log --access-key foo --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging cloudfiles create --service-id 123 --version 1 --name log --user username --bucket log --access-key foo --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -79,7 +82,7 @@ func TestCloudfilesList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging cloudfiles list --service-id 123 --version 1"),
+			args: args("logging cloudfiles list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListCloudfilesFn: listCloudfilesOK,
@@ -87,7 +90,7 @@ func TestCloudfilesList(t *testing.T) {
 			wantOutput: listCloudfilesShortOutput,
 		},
 		{
-			args: args("logging cloudfiles list --service-id 123 --version 1 --verbose"),
+			args: args("logging cloudfiles list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListCloudfilesFn: listCloudfilesOK,
@@ -95,7 +98,7 @@ func TestCloudfilesList(t *testing.T) {
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: args("logging cloudfiles list --service-id 123 --version 1 -v"),
+			args: args("logging cloudfiles list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListCloudfilesFn: listCloudfilesOK,
@@ -103,7 +106,7 @@ func TestCloudfilesList(t *testing.T) {
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: args("logging cloudfiles --verbose list --service-id 123 --version 1"),
+			args: args("logging cloudfiles --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListCloudfilesFn: listCloudfilesOK,
@@ -111,7 +114,7 @@ func TestCloudfilesList(t *testing.T) {
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: args("logging -v cloudfiles list --service-id 123 --version 1"),
+			args: args("logging -v cloudfiles list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListCloudfilesFn: listCloudfilesOK,
@@ -119,7 +122,7 @@ func TestCloudfilesList(t *testing.T) {
 			wantOutput: listCloudfilesVerboseOutput,
 		},
 		{
-			args: args("logging cloudfiles list --service-id 123 --version 1"),
+			args: args("logging cloudfiles list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListCloudfilesFn: listCloudfilesError,
@@ -147,11 +150,11 @@ func TestCloudfilesDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging cloudfiles describe --service-id 123 --version 1"),
+			args:      args("logging cloudfiles describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging cloudfiles describe --service-id 123 --version 1 --name logs"),
+			args: args("logging cloudfiles describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetCloudfilesFn: getCloudfilesError,
@@ -159,7 +162,7 @@ func TestCloudfilesDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging cloudfiles describe --service-id 123 --version 1 --name logs"),
+			args: args("logging cloudfiles describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetCloudfilesFn: getCloudfilesOK,
@@ -187,11 +190,11 @@ func TestCloudfilesUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging cloudfiles update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging cloudfiles update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging cloudfiles update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging cloudfiles update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -200,7 +203,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging cloudfiles update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging cloudfiles update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -229,11 +232,11 @@ func TestCloudfilesDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging cloudfiles delete --service-id 123 --version 1"),
+			args:      args("logging cloudfiles delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging cloudfiles delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging cloudfiles delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -242,7 +245,7 @@ func TestCloudfilesDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging cloudfiles delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging cloudfiles delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -335,7 +338,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listCloudfilesVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
@@ -62,7 +62,7 @@ func TestCloudfilesCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -130,7 +130,7 @@ func TestCloudfilesList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -170,7 +170,7 @@ func TestCloudfilesDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -212,7 +212,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -254,7 +254,7 @@ func TestCloudfilesDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_test.go
@@ -199,7 +199,7 @@ func createCommandRequired() *cloudfiles.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -239,7 +239,7 @@ func createCommandAll() *cloudfiles.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/logging/datadog/datadog_integration_test.go
@@ -46,7 +46,7 @@ func TestDatadogCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -114,7 +114,7 @@ func TestDatadogList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -154,7 +154,7 @@ func TestDatadogDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -196,7 +196,7 @@ func TestDatadogUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -238,7 +238,7 @@ func TestDatadogDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/logging/datadog/datadog_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package datadog_test
 
 import (
@@ -21,11 +24,11 @@ func TestDatadogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging datadog create --service-id 123 --version 1 --name log"),
+			args:      args("logging datadog create --service-id 123 --version 1 --name log --token 123"),
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: args("logging datadog create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging datadog create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -34,7 +37,7 @@ func TestDatadogCreate(t *testing.T) {
 			wantOutput: "Created Datadog logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging datadog create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging datadog create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -63,7 +66,7 @@ func TestDatadogList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging datadog list --service-id 123 --version 1"),
+			args: args("logging datadog list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDatadogFn:  listDatadogsOK,
@@ -71,7 +74,7 @@ func TestDatadogList(t *testing.T) {
 			wantOutput: listDatadogsShortOutput,
 		},
 		{
-			args: args("logging datadog list --service-id 123 --version 1 --verbose"),
+			args: args("logging datadog list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDatadogFn:  listDatadogsOK,
@@ -79,7 +82,7 @@ func TestDatadogList(t *testing.T) {
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: args("logging datadog list --service-id 123 --version 1 -v"),
+			args: args("logging datadog list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDatadogFn:  listDatadogsOK,
@@ -87,7 +90,7 @@ func TestDatadogList(t *testing.T) {
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: args("logging datadog --verbose list --service-id 123 --version 1"),
+			args: args("logging datadog --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDatadogFn:  listDatadogsOK,
@@ -95,7 +98,7 @@ func TestDatadogList(t *testing.T) {
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: args("logging -v datadog list --service-id 123 --version 1"),
+			args: args("logging -v datadog list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDatadogFn:  listDatadogsOK,
@@ -103,7 +106,7 @@ func TestDatadogList(t *testing.T) {
 			wantOutput: listDatadogsVerboseOutput,
 		},
 		{
-			args: args("logging datadog list --service-id 123 --version 1"),
+			args: args("logging datadog list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDatadogFn:  listDatadogsError,
@@ -131,11 +134,11 @@ func TestDatadogDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging datadog describe --service-id 123 --version 1"),
+			args:      args("logging datadog describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging datadog describe --service-id 123 --version 1 --name logs"),
+			args: args("logging datadog describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetDatadogFn:   getDatadogError,
@@ -143,7 +146,7 @@ func TestDatadogDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging datadog describe --service-id 123 --version 1 --name logs"),
+			args: args("logging datadog describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetDatadogFn:   getDatadogOK,
@@ -171,11 +174,11 @@ func TestDatadogUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging datadog update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging datadog update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging datadog update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging datadog update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -184,7 +187,7 @@ func TestDatadogUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging datadog update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging datadog update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -213,11 +216,11 @@ func TestDatadogDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging datadog delete --service-id 123 --version 1"),
+			args:      args("logging datadog delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging datadog delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging datadog delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -226,7 +229,7 @@ func TestDatadogDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging datadog delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging datadog delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -303,7 +306,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listDatadogsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/logging/datadog/datadog_integration_test.go
@@ -46,7 +46,7 @@ func TestDatadogCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -114,7 +114,7 @@ func TestDatadogList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -154,7 +154,7 @@ func TestDatadogDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -196,7 +196,7 @@ func TestDatadogUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -238,7 +238,7 @@ func TestDatadogDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/datadog/datadog_test.go
+++ b/pkg/commands/logging/datadog/datadog_test.go
@@ -179,7 +179,7 @@ func createCommandOK() *datadog.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -222,7 +222,7 @@ func createCommandRequired() *datadog.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
@@ -74,7 +74,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestDigitalOceanList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package digitalocean_test
 
 import (
@@ -21,7 +24,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging digitalocean create --service-id 123 --version 1 --name log --access-key foo --secret-key abc --autoclone"),
+			args: args("logging digitalocean create --service-id 123 --version 1 --name log --access-key foo --secret-key abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --secret-key abc --autoclone"),
+			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --secret-key abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --autoclone"),
+			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --autoclone"),
+			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersions,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
@@ -54,7 +57,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 			wantOutput: "Created DigitalOcean Spaces logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --autoclone"),
+			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersions,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
@@ -63,7 +66,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging digitalocean create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -91,7 +94,7 @@ func TestDigitalOceanList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging digitalocean list --service-id 123 --version 1"),
+			args: args("logging digitalocean list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListDigitalOceansFn: listDigitalOceansOK,
@@ -99,7 +102,7 @@ func TestDigitalOceanList(t *testing.T) {
 			wantOutput: listDigitalOceansShortOutput,
 		},
 		{
-			args: args("logging digitalocean list --service-id 123 --version 1 --verbose"),
+			args: args("logging digitalocean list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListDigitalOceansFn: listDigitalOceansOK,
@@ -107,7 +110,7 @@ func TestDigitalOceanList(t *testing.T) {
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: args("logging digitalocean list --service-id 123 --version 1 -v"),
+			args: args("logging digitalocean list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListDigitalOceansFn: listDigitalOceansOK,
@@ -115,7 +118,7 @@ func TestDigitalOceanList(t *testing.T) {
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: args("logging digitalocean --verbose list --service-id 123 --version 1"),
+			args: args("logging digitalocean --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListDigitalOceansFn: listDigitalOceansOK,
@@ -123,7 +126,7 @@ func TestDigitalOceanList(t *testing.T) {
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: args("logging -v digitalocean list --service-id 123 --version 1"),
+			args: args("logging -v digitalocean list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListDigitalOceansFn: listDigitalOceansOK,
@@ -131,7 +134,7 @@ func TestDigitalOceanList(t *testing.T) {
 			wantOutput: listDigitalOceansVerboseOutput,
 		},
 		{
-			args: args("logging digitalocean list --service-id 123 --version 1"),
+			args: args("logging digitalocean list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListDigitalOceansFn: listDigitalOceansError,
@@ -159,11 +162,11 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging digitalocean describe --service-id 123 --version 1"),
+			args:      args("logging digitalocean describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging digitalocean describe --service-id 123 --version 1 --name logs"),
+			args: args("logging digitalocean describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				GetDigitalOceanFn: getDigitalOceanError,
@@ -171,7 +174,7 @@ func TestDigitalOceanDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging digitalocean describe --service-id 123 --version 1 --name logs"),
+			args: args("logging digitalocean describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				GetDigitalOceanFn: getDigitalOceanOK,
@@ -199,11 +202,11 @@ func TestDigitalOceanUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging digitalocean update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging digitalocean update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging digitalocean update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging digitalocean update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersions,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
@@ -212,7 +215,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging digitalocean update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging digitalocean update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersions,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
@@ -241,11 +244,11 @@ func TestDigitalOceanDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging digitalocean delete --service-id 123 --version 1"),
+			args:      args("logging digitalocean delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging digitalocean delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging digitalocean delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersions,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
@@ -254,7 +257,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging digitalocean delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging digitalocean delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:       testutil.ListVersions,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
@@ -347,7 +350,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listDigitalOceansVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
@@ -74,7 +74,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestDigitalOceanList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/digitalocean/digitalocean_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_test.go
@@ -199,7 +199,7 @@ func createCommandRequired() *digitalocean.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -239,7 +239,7 @@ func createCommandAll() *digitalocean.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
@@ -58,7 +58,7 @@ func TestElasticsearchCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestElasticsearchList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestElasticsearchDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestElasticsearchUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestElasticsearchDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
@@ -58,7 +58,7 @@ func TestElasticsearchCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestElasticsearchList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestElasticsearchDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestElasticsearchUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestElasticsearchDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package elasticsearch_test
 
 import (
@@ -21,7 +24,7 @@ func TestElasticsearchCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --index logs --autoclone"),
+			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --index logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestElasticsearchCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestElasticsearchCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --index not provided",
 		},
 		{
-			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --index logs --url example.com --autoclone"),
+			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --index logs --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
@@ -46,7 +49,7 @@ func TestElasticsearchCreate(t *testing.T) {
 			wantOutput: "Created Elasticsearch logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --index logs --url example.com --autoclone"),
+			args: args("logging elasticsearch create --service-id 123 --version 1 --name log --index logs --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
@@ -75,7 +78,7 @@ func TestElasticsearchList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging elasticsearch list --service-id 123 --version 1"),
+			args: args("logging elasticsearch list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListElasticsearchFn: listElasticsearchsOK,
@@ -83,7 +86,7 @@ func TestElasticsearchList(t *testing.T) {
 			wantOutput: listElasticsearchsShortOutput,
 		},
 		{
-			args: args("logging elasticsearch list --service-id 123 --version 1 --verbose"),
+			args: args("logging elasticsearch list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListElasticsearchFn: listElasticsearchsOK,
@@ -91,7 +94,7 @@ func TestElasticsearchList(t *testing.T) {
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: args("logging elasticsearch list --service-id 123 --version 1 -v"),
+			args: args("logging elasticsearch list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListElasticsearchFn: listElasticsearchsOK,
@@ -99,7 +102,7 @@ func TestElasticsearchList(t *testing.T) {
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: args("logging elasticsearch --verbose list --service-id 123 --version 1"),
+			args: args("logging elasticsearch --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListElasticsearchFn: listElasticsearchsOK,
@@ -107,7 +110,7 @@ func TestElasticsearchList(t *testing.T) {
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: args("logging -v elasticsearch list --service-id 123 --version 1"),
+			args: args("logging -v elasticsearch list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListElasticsearchFn: listElasticsearchsOK,
@@ -115,7 +118,7 @@ func TestElasticsearchList(t *testing.T) {
 			wantOutput: listElasticsearchsVerboseOutput,
 		},
 		{
-			args: args("logging elasticsearch list --service-id 123 --version 1"),
+			args: args("logging elasticsearch list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				ListElasticsearchFn: listElasticsearchsError,
@@ -143,11 +146,11 @@ func TestElasticsearchDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging elasticsearch describe --service-id 123 --version 1"),
+			args:      args("logging elasticsearch describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging elasticsearch describe --service-id 123 --version 1 --name logs"),
+			args: args("logging elasticsearch describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				GetElasticsearchFn: getElasticsearchError,
@@ -155,7 +158,7 @@ func TestElasticsearchDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging elasticsearch describe --service-id 123 --version 1 --name logs"),
+			args: args("logging elasticsearch describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				GetElasticsearchFn: getElasticsearchOK,
@@ -183,11 +186,11 @@ func TestElasticsearchUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging elasticsearch update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging elasticsearch update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging elasticsearch update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging elasticsearch update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
@@ -196,7 +199,7 @@ func TestElasticsearchUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging elasticsearch update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging elasticsearch update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
@@ -225,11 +228,11 @@ func TestElasticsearchDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging elasticsearch delete --service-id 123 --version 1"),
+			args:      args("logging elasticsearch delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging elasticsearch delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging elasticsearch delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
@@ -238,7 +241,7 @@ func TestElasticsearchDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging elasticsearch delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging elasticsearch delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
@@ -343,7 +346,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listElasticsearchsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_test.go
@@ -198,7 +198,7 @@ func createCommandRequired() *elasticsearch.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -237,7 +237,7 @@ func createCommandAll() *elasticsearch.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/logging/ftp/ftp_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package ftp_test
 
 import (
@@ -21,7 +24,7 @@ func TestFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging ftp create --service-id 123 --version 1 --name log --user anonymous --password foo@example.com --autoclone"),
+			args: args("logging ftp create --service-id 123 --version 1 --name log --user anonymous --password foo@example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestFTPCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --password foo@example.com --autoclone"),
+			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --password foo@example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestFTPCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --autoclone"),
+			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestFTPCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --password not provided",
 		},
 		{
-			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --compression-codec zstd --autoclone"),
+			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --compression-codec zstd --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -54,7 +57,7 @@ func TestFTPCreate(t *testing.T) {
 			wantOutput: "Created FTP logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --autoclone"),
+			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -63,7 +66,7 @@ func TestFTPCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging ftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -91,7 +94,7 @@ func TestFTPList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging ftp list --service-id 123 --version 1"),
+			args: args("logging ftp list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListFTPsFn:     listFTPsOK,
@@ -99,7 +102,7 @@ func TestFTPList(t *testing.T) {
 			wantOutput: listFTPsShortOutput,
 		},
 		{
-			args: args("logging ftp list --service-id 123 --version 1 --verbose"),
+			args: args("logging ftp list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListFTPsFn:     listFTPsOK,
@@ -107,7 +110,7 @@ func TestFTPList(t *testing.T) {
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: args("logging ftp list --service-id 123 --version 1 -v"),
+			args: args("logging ftp list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListFTPsFn:     listFTPsOK,
@@ -115,7 +118,7 @@ func TestFTPList(t *testing.T) {
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: args("logging ftp --verbose list --service-id 123 --version 1"),
+			args: args("logging ftp --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListFTPsFn:     listFTPsOK,
@@ -123,7 +126,7 @@ func TestFTPList(t *testing.T) {
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: args("logging -v ftp list --service-id 123 --version 1"),
+			args: args("logging -v ftp list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListFTPsFn:     listFTPsOK,
@@ -131,7 +134,7 @@ func TestFTPList(t *testing.T) {
 			wantOutput: listFTPsVerboseOutput,
 		},
 		{
-			args: args("logging ftp list --service-id 123 --version 1"),
+			args: args("logging ftp list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListFTPsFn:     listFTPsError,
@@ -159,11 +162,11 @@ func TestFTPDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging ftp describe --service-id 123 --version 1"),
+			args:      args("logging ftp describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging ftp describe --service-id 123 --version 1 --name logs"),
+			args: args("logging ftp describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetFTPFn:       getFTPError,
@@ -171,7 +174,7 @@ func TestFTPDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging ftp describe --service-id 123 --version 1 --name logs"),
+			args: args("logging ftp describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetFTPFn:       getFTPOK,
@@ -199,11 +202,11 @@ func TestFTPUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging ftp update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging ftp update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging ftp update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging ftp update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -212,7 +215,7 @@ func TestFTPUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging ftp update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging ftp update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -241,11 +244,11 @@ func TestFTPDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging ftp delete --service-id 123 --version 1"),
+			args:      args("logging ftp delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging ftp delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging ftp delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -254,7 +257,7 @@ func TestFTPDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging ftp delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging ftp delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -343,7 +346,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listFTPsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/logging/ftp/ftp_integration_test.go
@@ -74,7 +74,7 @@ func TestFTPCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestFTPList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestFTPDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestFTPUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestFTPDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/logging/ftp/ftp_integration_test.go
@@ -74,7 +74,7 @@ func TestFTPCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestFTPList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestFTPDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestFTPUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestFTPDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/ftp/ftp_test.go
+++ b/pkg/commands/logging/ftp/ftp_test.go
@@ -195,7 +195,7 @@ func createCommandRequired() *ftp.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -235,7 +235,7 @@ func createCommandAll() *ftp.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package gcs_test
 
 import (
@@ -21,7 +24,7 @@ func TestGCSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging gcs create --service-id 123 --version 1 --name log --user foo@example.com --secret-key foo --autoclone"),
+			args: args("logging gcs create --service-id 123 --version 1 --name log --user foo@example.com --secret-key foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestGCSCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --secret-key foo --autoclone"),
+			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --secret-key foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestGCSCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --autoclone"),
+			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestGCSCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --autoclone"),
+			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -54,7 +57,7 @@ func TestGCSCreate(t *testing.T) {
 			wantOutput: "Created GCS logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --autoclone"),
+			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -63,7 +66,7 @@ func TestGCSCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -91,7 +94,7 @@ func TestGCSList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging gcs list --service-id 123 --version 1"),
+			args: args("logging gcs list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListGCSsFn:     listGCSsOK,
@@ -99,7 +102,7 @@ func TestGCSList(t *testing.T) {
 			wantOutput: listGCSsShortOutput,
 		},
 		{
-			args: args("logging gcs list --service-id 123 --version 1 --verbose"),
+			args: args("logging gcs list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListGCSsFn:     listGCSsOK,
@@ -107,7 +110,7 @@ func TestGCSList(t *testing.T) {
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: args("logging gcs list --service-id 123 --version 1 -v"),
+			args: args("logging gcs list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListGCSsFn:     listGCSsOK,
@@ -115,7 +118,7 @@ func TestGCSList(t *testing.T) {
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: args("logging gcs --verbose list --service-id 123 --version 1"),
+			args: args("logging gcs --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListGCSsFn:     listGCSsOK,
@@ -123,7 +126,7 @@ func TestGCSList(t *testing.T) {
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: args("logging -v gcs list --service-id 123 --version 1"),
+			args: args("logging -v gcs list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListGCSsFn:     listGCSsOK,
@@ -131,7 +134,7 @@ func TestGCSList(t *testing.T) {
 			wantOutput: listGCSsVerboseOutput,
 		},
 		{
-			args: args("logging gcs list --service-id 123 --version 1"),
+			args: args("logging gcs list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListGCSsFn:     listGCSsError,
@@ -159,11 +162,11 @@ func TestGCSDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging gcs describe --service-id 123 --version 1"),
+			args:      args("logging gcs describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging gcs describe --service-id 123 --version 1 --name logs"),
+			args: args("logging gcs describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetGCSFn:       getGCSError,
@@ -171,7 +174,7 @@ func TestGCSDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging gcs describe --service-id 123 --version 1 --name logs"),
+			args: args("logging gcs describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetGCSFn:       getGCSOK,
@@ -199,11 +202,11 @@ func TestGCSUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging gcs update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging gcs update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging gcs update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging gcs update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -212,7 +215,7 @@ func TestGCSUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging gcs update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging gcs update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -241,11 +244,11 @@ func TestGCSDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging gcs delete --service-id 123 --version 1"),
+			args:      args("logging gcs delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging gcs delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging gcs delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -254,7 +257,7 @@ func TestGCSDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging gcs delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging gcs delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -340,7 +343,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listGCSsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -74,7 +74,7 @@ func TestGCSCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestGCSList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestGCSDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestGCSUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestGCSDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -74,7 +74,7 @@ func TestGCSCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestGCSList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestGCSDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestGCSUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestGCSDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/gcs/gcs_test.go
+++ b/pkg/commands/logging/gcs/gcs_test.go
@@ -193,7 +193,7 @@ func createCommandRequired() *gcs.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -233,7 +233,7 @@ func createCommandAll() *gcs.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
@@ -74,7 +74,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestGooglePubSubList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestGooglePubSubUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestGooglePubSubDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
@@ -74,7 +74,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestGooglePubSubList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestGooglePubSubUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestGooglePubSubDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package googlepubsub_test
 
 import (
@@ -21,7 +24,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --secret-key secret --project-id project --topic topic --autoclone"),
+			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --secret-key secret --project-id project --topic topic --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --project-id project --topic topic --autoclone"),
+			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --project-id project --topic topic --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --topic topic --autoclone"),
+			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --topic topic --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --project-id not provided",
 		},
 		{
-			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --autoclone"),
+			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -53,7 +56,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --topic topic --autoclone"),
+			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --topic topic --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -62,7 +65,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 			wantOutput: "Created Google Cloud Pub/Sub logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --topic topic --autoclone"),
+			args: args("logging googlepubsub create --service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --topic topic --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -91,7 +94,7 @@ func TestGooglePubSubList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging googlepubsub list --service-id 123 --version 1"),
+			args: args("logging googlepubsub list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListPubsubsFn:  listGooglePubSubsOK,
@@ -99,7 +102,7 @@ func TestGooglePubSubList(t *testing.T) {
 			wantOutput: listGooglePubSubsShortOutput,
 		},
 		{
-			args: args("logging googlepubsub list --service-id 123 --version 1 --verbose"),
+			args: args("logging googlepubsub list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListPubsubsFn:  listGooglePubSubsOK,
@@ -107,7 +110,7 @@ func TestGooglePubSubList(t *testing.T) {
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: args("logging googlepubsub list --service-id 123 --version 1 -v"),
+			args: args("logging googlepubsub list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListPubsubsFn:  listGooglePubSubsOK,
@@ -115,7 +118,7 @@ func TestGooglePubSubList(t *testing.T) {
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: args("logging googlepubsub --verbose list --service-id 123 --version 1"),
+			args: args("logging googlepubsub --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListPubsubsFn:  listGooglePubSubsOK,
@@ -123,7 +126,7 @@ func TestGooglePubSubList(t *testing.T) {
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: args("logging -v googlepubsub list --service-id 123 --version 1"),
+			args: args("logging -v googlepubsub list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListPubsubsFn:  listGooglePubSubsOK,
@@ -131,7 +134,7 @@ func TestGooglePubSubList(t *testing.T) {
 			wantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
-			args: args("logging googlepubsub list --service-id 123 --version 1"),
+			args: args("logging googlepubsub list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListPubsubsFn:  listGooglePubSubsError,
@@ -159,11 +162,11 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging googlepubsub describe --service-id 123 --version 1"),
+			args:      args("logging googlepubsub describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging googlepubsub describe --service-id 123 --version 1 --name logs"),
+			args: args("logging googlepubsub describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetPubsubFn:    getGooglePubSubError,
@@ -171,7 +174,7 @@ func TestGooglePubSubDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging googlepubsub describe --service-id 123 --version 1 --name logs"),
+			args: args("logging googlepubsub describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetPubsubFn:    getGooglePubSubOK,
@@ -199,11 +202,11 @@ func TestGooglePubSubUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging googlepubsub update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging googlepubsub update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging googlepubsub update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging googlepubsub update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -212,7 +215,7 @@ func TestGooglePubSubUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging googlepubsub update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging googlepubsub update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -241,11 +244,11 @@ func TestGooglePubSubDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging googlepubsub delete --service-id 123 --version 1"),
+			args:      args("logging googlepubsub delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging googlepubsub delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging googlepubsub delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -254,7 +257,7 @@ func TestGooglePubSubDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging googlepubsub delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging googlepubsub delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -338,7 +341,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listGooglePubSubsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_test.go
@@ -186,7 +186,7 @@ func createCommandRequired() *googlepubsub.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -227,7 +227,7 @@ func createCommandAll() *googlepubsub.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/logging/heroku/heroku_integration_test.go
@@ -58,7 +58,7 @@ func TestHerokuCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestHerokuList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestHerokuDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestHerokuUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestHerokuDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/logging/heroku/heroku_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package heroku_test
 
 import (
@@ -21,7 +24,7 @@ func TestHerokuCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging heroku create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging heroku create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestHerokuCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: args("logging heroku create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging heroku create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestHerokuCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: args("logging heroku create --service-id 123 --version 1 --name log --auth-token abc --url example.com --autoclone"),
+			args: args("logging heroku create --service-id 123 --version 1 --name log --auth-token abc --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -46,7 +49,7 @@ func TestHerokuCreate(t *testing.T) {
 			wantOutput: "Created Heroku logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging heroku create --service-id 123 --version 1 --name log --auth-token abc --url example.com --autoclone"),
+			args: args("logging heroku create --service-id 123 --version 1 --name log --auth-token abc --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -75,7 +78,7 @@ func TestHerokuList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging heroku list --service-id 123 --version 1"),
+			args: args("logging heroku list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHerokusFn:  listHerokusOK,
@@ -83,7 +86,7 @@ func TestHerokuList(t *testing.T) {
 			wantOutput: listHerokusShortOutput,
 		},
 		{
-			args: args("logging heroku list --service-id 123 --version 1 --verbose"),
+			args: args("logging heroku list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHerokusFn:  listHerokusOK,
@@ -91,7 +94,7 @@ func TestHerokuList(t *testing.T) {
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: args("logging heroku list --service-id 123 --version 1 -v"),
+			args: args("logging heroku list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHerokusFn:  listHerokusOK,
@@ -99,7 +102,7 @@ func TestHerokuList(t *testing.T) {
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: args("logging heroku --verbose list --service-id 123 --version 1"),
+			args: args("logging heroku --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHerokusFn:  listHerokusOK,
@@ -107,7 +110,7 @@ func TestHerokuList(t *testing.T) {
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: args("logging -v heroku list --service-id 123 --version 1"),
+			args: args("logging -v heroku list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHerokusFn:  listHerokusOK,
@@ -115,7 +118,7 @@ func TestHerokuList(t *testing.T) {
 			wantOutput: listHerokusVerboseOutput,
 		},
 		{
-			args: args("logging heroku list --service-id 123 --version 1"),
+			args: args("logging heroku list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHerokusFn:  listHerokusError,
@@ -143,11 +146,11 @@ func TestHerokuDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging heroku describe --service-id 123 --version 1"),
+			args:      args("logging heroku describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging heroku describe --service-id 123 --version 1 --name logs"),
+			args: args("logging heroku describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetHerokuFn:    getHerokuError,
@@ -155,7 +158,7 @@ func TestHerokuDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging heroku describe --service-id 123 --version 1 --name logs"),
+			args: args("logging heroku describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetHerokuFn:    getHerokuOK,
@@ -183,11 +186,11 @@ func TestHerokuUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging heroku update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging heroku update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging heroku update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging heroku update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -196,7 +199,7 @@ func TestHerokuUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging heroku update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging heroku update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -225,11 +228,11 @@ func TestHerokuDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging heroku delete --service-id 123 --version 1"),
+			args:      args("logging heroku delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging heroku delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging heroku delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -238,7 +241,7 @@ func TestHerokuDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging heroku delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging heroku delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -315,7 +318,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listHerokusVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/logging/heroku/heroku_integration_test.go
@@ -58,7 +58,7 @@ func TestHerokuCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestHerokuList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestHerokuDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestHerokuUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestHerokuDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/heroku/heroku_test.go
+++ b/pkg/commands/logging/heroku/heroku_test.go
@@ -180,7 +180,7 @@ func createCommandRequired() *heroku.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -219,7 +219,7 @@ func createCommandAll() *heroku.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
@@ -58,7 +58,7 @@ func TestHoneycombCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestHoneycombList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestHoneycombDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestHoneycombUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestHoneycombDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
@@ -58,7 +58,7 @@ func TestHoneycombCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestHoneycombList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestHoneycombDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestHoneycombUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestHoneycombDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package honeycomb_test
 
 import (
@@ -21,7 +24,7 @@ func TestHoneycombCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging honeycomb create --service-id 123 --version 1 --name log --dataset log --autoclone"),
+			args: args("logging honeycomb create --service-id 123 --version 1 --name log --dataset log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestHoneycombCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: args("logging honeycomb create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging honeycomb create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestHoneycombCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --dataset not provided",
 		},
 		{
-			args: args("logging honeycomb create --service-id 123 --version 1 --name log --auth-token abc --dataset log --autoclone"),
+			args: args("logging honeycomb create --service-id 123 --version 1 --name log --auth-token abc --dataset log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -46,7 +49,7 @@ func TestHoneycombCreate(t *testing.T) {
 			wantOutput: "Created Honeycomb logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging honeycomb create --service-id 123 --version 1 --name log --auth-token abc --dataset log --autoclone"),
+			args: args("logging honeycomb create --service-id 123 --version 1 --name log --auth-token abc --dataset log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -75,7 +78,7 @@ func TestHoneycombList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging honeycomb list --service-id 123 --version 1"),
+			args: args("logging honeycomb list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListHoneycombsFn: listHoneycombsOK,
@@ -83,7 +86,7 @@ func TestHoneycombList(t *testing.T) {
 			wantOutput: listHoneycombsShortOutput,
 		},
 		{
-			args: args("logging honeycomb list --service-id 123 --version 1 --verbose"),
+			args: args("logging honeycomb list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListHoneycombsFn: listHoneycombsOK,
@@ -91,7 +94,7 @@ func TestHoneycombList(t *testing.T) {
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args: args("logging honeycomb list --service-id 123 --version 1 -v"),
+			args: args("logging honeycomb list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListHoneycombsFn: listHoneycombsOK,
@@ -99,7 +102,7 @@ func TestHoneycombList(t *testing.T) {
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args: args("logging honeycomb --verbose list --service-id 123 --version 1"),
+			args: args("logging honeycomb --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListHoneycombsFn: listHoneycombsOK,
@@ -107,7 +110,7 @@ func TestHoneycombList(t *testing.T) {
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args: args("logging -v honeycomb list --service-id 123 --version 1"),
+			args: args("logging -v honeycomb list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListHoneycombsFn: listHoneycombsOK,
@@ -115,7 +118,7 @@ func TestHoneycombList(t *testing.T) {
 			wantOutput: listHoneycombsVerboseOutput,
 		},
 		{
-			args: args("logging honeycomb list --service-id 123 --version 1"),
+			args: args("logging honeycomb list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListHoneycombsFn: listHoneycombsError,
@@ -143,11 +146,11 @@ func TestHoneycombDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging honeycomb describe --service-id 123 --version 1"),
+			args:      args("logging honeycomb describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging honeycomb describe --service-id 123 --version 1 --name logs"),
+			args: args("logging honeycomb describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetHoneycombFn: getHoneycombError,
@@ -155,7 +158,7 @@ func TestHoneycombDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging honeycomb describe --service-id 123 --version 1 --name logs"),
+			args: args("logging honeycomb describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetHoneycombFn: getHoneycombOK,
@@ -183,11 +186,11 @@ func TestHoneycombUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging honeycomb update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging honeycomb update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging honeycomb update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging honeycomb update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -196,7 +199,7 @@ func TestHoneycombUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging honeycomb update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging honeycomb update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -225,11 +228,11 @@ func TestHoneycombDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging honeycomb delete --service-id 123 --version 1"),
+			args:      args("logging honeycomb delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging honeycomb delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging honeycomb delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -238,7 +241,7 @@ func TestHoneycombDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging honeycomb delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging honeycomb delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -315,7 +318,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listHoneycombsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/honeycomb/honeycomb_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_test.go
@@ -179,7 +179,7 @@ func createCommandRequired() *honeycomb.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -218,7 +218,7 @@ func createCommandAll() *honeycomb.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -50,7 +50,7 @@ func TestHTTPSCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestHTTPSList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestHTTPSDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestHTTPSUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestHTTPSDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -50,7 +50,7 @@ func TestHTTPSCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestHTTPSList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestHTTPSDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestHTTPSUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestHTTPSDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package https_test
 
 import (
@@ -21,7 +24,7 @@ func TestHTTPSCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging https create --service-id 123 --version 1 --name log --autoclone"),
+			args: args("logging https create --service-id 123 --version 1 --name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestHTTPSCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: args("logging https create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging https create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestHTTPSCreate(t *testing.T) {
 			wantOutput: "Created HTTPS logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging https create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging https create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -67,7 +70,7 @@ func TestHTTPSList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging https list --service-id 123 --version 1"),
+			args: args("logging https list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHTTPSFn:    listHTTPSsOK,
@@ -75,7 +78,7 @@ func TestHTTPSList(t *testing.T) {
 			wantOutput: listHTTPSsShortOutput,
 		},
 		{
-			args: args("logging https list --service-id 123 --version 1 --verbose"),
+			args: args("logging https list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHTTPSFn:    listHTTPSsOK,
@@ -83,7 +86,7 @@ func TestHTTPSList(t *testing.T) {
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: args("logging https list --service-id 123 --version 1 -v"),
+			args: args("logging https list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHTTPSFn:    listHTTPSsOK,
@@ -91,7 +94,7 @@ func TestHTTPSList(t *testing.T) {
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: args("logging https --verbose list --service-id 123 --version 1"),
+			args: args("logging https --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHTTPSFn:    listHTTPSsOK,
@@ -99,7 +102,7 @@ func TestHTTPSList(t *testing.T) {
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: args("logging -v https list --service-id 123 --version 1"),
+			args: args("logging -v https list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHTTPSFn:    listHTTPSsOK,
@@ -107,7 +110,7 @@ func TestHTTPSList(t *testing.T) {
 			wantOutput: listHTTPSsVerboseOutput,
 		},
 		{
-			args: args("logging https list --service-id 123 --version 1"),
+			args: args("logging https list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListHTTPSFn:    listHTTPSsError,
@@ -135,11 +138,11 @@ func TestHTTPSDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging https describe --service-id 123 --version 1"),
+			args:      args("logging https describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging https describe --service-id 123 --version 1 --name logs"),
+			args: args("logging https describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetHTTPSFn:     getHTTPSError,
@@ -147,7 +150,7 @@ func TestHTTPSDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging https describe --service-id 123 --version 1 --name logs"),
+			args: args("logging https describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetHTTPSFn:     getHTTPSOK,
@@ -175,11 +178,11 @@ func TestHTTPSUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging https update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging https update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging https update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging https update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -188,7 +191,7 @@ func TestHTTPSUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging https update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging https update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -217,11 +220,11 @@ func TestHTTPSDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging https delete --service-id 123 --version 1"),
+			args:      args("logging https delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging https delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging https delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -230,7 +233,7 @@ func TestHTTPSDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging https delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging https delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -341,7 +344,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listHTTPSsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/https/https_test.go
+++ b/pkg/commands/logging/https/https_test.go
@@ -201,7 +201,7 @@ func createCommandRequired() *https.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -239,7 +239,7 @@ func createCommandAll() *https.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/logging/kafka/kafka_integration_test.go
@@ -58,7 +58,7 @@ func TestKafkaCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestKafkaList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestKafkaDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -217,7 +217,7 @@ func TestKafkaUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -259,7 +259,7 @@ func TestKafkaDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/logging/kafka/kafka_integration_test.go
@@ -58,7 +58,7 @@ func TestKafkaCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestKafkaList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestKafkaDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -217,7 +217,7 @@ func TestKafkaUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -259,7 +259,7 @@ func TestKafkaDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/logging/kafka/kafka_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package kafka_test
 
 import (
@@ -21,7 +24,7 @@ func TestKafkaCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging kafka create --service-id 123 --version 1 --name log --brokers 127.0.0.1127.0.0.2 --autoclone"),
+			args: args("logging kafka create --service-id 123 --version 1 --name log --brokers 127.0.0.1127.0.0.2 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestKafkaCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --topic not provided",
 		},
 		{
-			args: args("logging kafka create --service-id 123 --version 1 --name log --topic logs --autoclone"),
+			args: args("logging kafka create --service-id 123 --version 1 --name log --topic logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestKafkaCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --brokers not provided",
 		},
 		{
-			args: args("logging kafka create --service-id 123 --version 1 --name log --topic logs --brokers 127.0.0.1127.0.0.2 --parse-log-keyvals --max-batch-size 1024 --use-sasl --auth-method plain --username user --password password --autoclone"),
+			args: args("logging kafka create --service-id 123 --version 1 --name log --topic logs --brokers 127.0.0.1127.0.0.2 --parse-log-keyvals --max-batch-size 1024 --use-sasl --auth-method plain --username user --password password --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -46,7 +49,7 @@ func TestKafkaCreate(t *testing.T) {
 			wantOutput: "Created Kafka logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging kafka create --service-id 123 --version 1 --name log --topic logs --brokers 127.0.0.1127.0.0.2 --autoclone"),
+			args: args("logging kafka create --service-id 123 --version 1 --name log --topic logs --brokers 127.0.0.1127.0.0.2 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -75,7 +78,7 @@ func TestKafkaList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging kafka list --service-id 123 --version 1"),
+			args: args("logging kafka list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKafkasFn:   listKafkasOK,
@@ -83,7 +86,7 @@ func TestKafkaList(t *testing.T) {
 			wantOutput: listKafkasShortOutput,
 		},
 		{
-			args: args("logging kafka list --service-id 123 --version 1 --verbose"),
+			args: args("logging kafka list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKafkasFn:   listKafkasOK,
@@ -91,7 +94,7 @@ func TestKafkaList(t *testing.T) {
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: args("logging kafka list --service-id 123 --version 1 -v"),
+			args: args("logging kafka list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKafkasFn:   listKafkasOK,
@@ -99,7 +102,7 @@ func TestKafkaList(t *testing.T) {
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: args("logging kafka --verbose list --service-id 123 --version 1"),
+			args: args("logging kafka --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKafkasFn:   listKafkasOK,
@@ -107,7 +110,7 @@ func TestKafkaList(t *testing.T) {
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: args("logging -v kafka list --service-id 123 --version 1"),
+			args: args("logging -v kafka list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKafkasFn:   listKafkasOK,
@@ -115,7 +118,7 @@ func TestKafkaList(t *testing.T) {
 			wantOutput: listKafkasVerboseOutput,
 		},
 		{
-			args: args("logging kafka list --service-id 123 --version 1"),
+			args: args("logging kafka list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKafkasFn:   listKafkasError,
@@ -143,11 +146,11 @@ func TestKafkaDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging kafka describe --service-id 123 --version 1"),
+			args:      args("logging kafka describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging kafka describe --service-id 123 --version 1 --name logs"),
+			args: args("logging kafka describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetKafkaFn:     getKafkaError,
@@ -155,7 +158,7 @@ func TestKafkaDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging kafka describe --service-id 123 --version 1 --name logs"),
+			args: args("logging kafka describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetKafkaFn:     getKafkaOK,
@@ -183,11 +186,11 @@ func TestKafkaUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging kafka update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging kafka update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging kafka update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging kafka update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -196,7 +199,7 @@ func TestKafkaUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging kafka update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging kafka update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -205,7 +208,7 @@ func TestKafkaUpdate(t *testing.T) {
 			wantOutput: "Updated Kafka logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging kafka update --service-id 123 --version 1 --name logs --new-name log --parse-log-keyvals --max-batch-size 1024 --use-sasl --auth-method plain --username user --password password --autoclone"),
+			args: args("logging kafka update --service-id 123 --version 1 --name logs --new-name log --parse-log-keyvals --max-batch-size 1024 --use-sasl --auth-method plain --username user --password password --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -234,11 +237,11 @@ func TestKafkaDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging kafka delete --service-id 123 --version 1"),
+			args:      args("logging kafka delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging kafka delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging kafka delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -247,7 +250,7 @@ func TestKafkaDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging kafka delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging kafka delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -361,7 +364,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listKafkasVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/kafka/kafka_test.go
+++ b/pkg/commands/logging/kafka/kafka_test.go
@@ -346,7 +346,7 @@ func createCommandRequired() *kafka.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -385,7 +385,7 @@ func createCommandAll() *kafka.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -435,7 +435,7 @@ func createCommandSASL(authMethod, user, password string) *kafka.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -480,7 +480,7 @@ func createCommandNoSASL(authMethod, user, password string) *kafka.CreateCommand
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_integration_test.go
@@ -108,7 +108,7 @@ func TestKinesisCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -176,7 +176,7 @@ func TestKinesisList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -216,7 +216,7 @@ func TestKinesisDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -258,7 +258,7 @@ func TestKinesisUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -300,7 +300,7 @@ func TestKinesisDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package kinesis_test
 
 import (
@@ -21,7 +24,7 @@ func TestKinesisCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --access-key foo --region us-east-1 --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --access-key foo --region us-east-1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --secret-key bar --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --secret-key bar --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --secret-key bar --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --secret-key bar --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -53,7 +56,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -61,7 +64,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --secret-key bar --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --secret-key bar --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -69,7 +72,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --access-key foo --secret-key bar --region us-east-1 --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --access-key foo --secret-key bar --region us-east-1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -78,7 +81,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantOutput: "Created Kinesis logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --access-key foo --secret-key bar --region us-east-1 --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log --stream-name log --access-key foo --secret-key bar --region us-east-1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -87,7 +90,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log2 --stream-name log --region us-east-1 --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log2 --stream-name log --region us-east-1 --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -96,7 +99,7 @@ func TestKinesisCreate(t *testing.T) {
 			wantOutput: "Created Kinesis logging endpoint log2 (service 123 version 4)",
 		},
 		{
-			args: args("logging kinesis create --service-id 123 --version 1 --name log2 --stream-name log --region us-east-1 --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone"),
+			args: args("logging kinesis create --service-id 123 --version 1 --name log2 --stream-name log --region us-east-1 --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -125,7 +128,7 @@ func TestKinesisList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging kinesis list --service-id 123 --version 1"),
+			args: args("logging kinesis list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKinesisFn:  listKinesesOK,
@@ -133,7 +136,7 @@ func TestKinesisList(t *testing.T) {
 			wantOutput: listKinesesShortOutput,
 		},
 		{
-			args: args("logging kinesis list --service-id 123 --version 1 --verbose"),
+			args: args("logging kinesis list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKinesisFn:  listKinesesOK,
@@ -141,7 +144,7 @@ func TestKinesisList(t *testing.T) {
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: args("logging kinesis list --service-id 123 --version 1 -v"),
+			args: args("logging kinesis list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKinesisFn:  listKinesesOK,
@@ -149,7 +152,7 @@ func TestKinesisList(t *testing.T) {
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: args("logging kinesis --verbose list --service-id 123 --version 1"),
+			args: args("logging kinesis --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKinesisFn:  listKinesesOK,
@@ -157,7 +160,7 @@ func TestKinesisList(t *testing.T) {
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: args("logging -v kinesis list --service-id 123 --version 1"),
+			args: args("logging -v kinesis list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKinesisFn:  listKinesesOK,
@@ -165,7 +168,7 @@ func TestKinesisList(t *testing.T) {
 			wantOutput: listKinesesVerboseOutput,
 		},
 		{
-			args: args("logging kinesis list --service-id 123 --version 1"),
+			args: args("logging kinesis list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListKinesisFn:  listKinesesError,
@@ -193,11 +196,11 @@ func TestKinesisDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging kinesis describe --service-id 123 --version 1"),
+			args:      args("logging kinesis describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging kinesis describe --service-id 123 --version 1 --name logs"),
+			args: args("logging kinesis describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetKinesisFn:   getKinesisError,
@@ -205,7 +208,7 @@ func TestKinesisDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging kinesis describe --service-id 123 --version 1 --name logs"),
+			args: args("logging kinesis describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetKinesisFn:   getKinesisOK,
@@ -233,11 +236,11 @@ func TestKinesisUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging kinesis update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging kinesis update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging kinesis update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging kinesis update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -246,7 +249,7 @@ func TestKinesisUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging kinesis update --service-id 123 --version 1 --name logs --new-name log --region us-west-1 --autoclone"),
+			args: args("logging kinesis update --service-id 123 --version 1 --name logs --new-name log --region us-west-1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -275,11 +278,11 @@ func TestKinesisDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging kinesis delete --service-id 123 --version 1"),
+			args:      args("logging kinesis delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging kinesis delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging kinesis delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -288,7 +291,7 @@ func TestKinesisDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging kinesis delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging kinesis delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -364,7 +367,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listKinesesVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_integration_test.go
@@ -108,7 +108,7 @@ func TestKinesisCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -176,7 +176,7 @@ func TestKinesisList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -216,7 +216,7 @@ func TestKinesisDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -258,7 +258,7 @@ func TestKinesisUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -300,7 +300,7 @@ func TestKinesisDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/kinesis/kinesis_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_test.go
@@ -197,7 +197,7 @@ func createCommandRequired() *kinesis.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -237,7 +237,7 @@ func createCommandRequiredIAMRole() *kinesis.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -276,7 +276,7 @@ func createCommandAll() *kinesis.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/logentries/logentries_integration_test.go
+++ b/pkg/commands/logging/logentries/logentries_integration_test.go
@@ -42,7 +42,7 @@ func TestLogentriesCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -110,7 +110,7 @@ func TestLogentriesList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -150,7 +150,7 @@ func TestLogentriesDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -192,7 +192,7 @@ func TestLogentriesUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -234,7 +234,7 @@ func TestLogentriesDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/logentries/logentries_integration_test.go
+++ b/pkg/commands/logging/logentries/logentries_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package logentries_test
 
 import (
@@ -21,7 +24,7 @@ func TestLogentriesCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging logentries create --service-id 123 --version 1 --name log --port 20000 --autoclone"),
+			args: args("logging logentries create --service-id 123 --version 1 --name log --port 20000 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -30,7 +33,7 @@ func TestLogentriesCreate(t *testing.T) {
 			wantOutput: "Created Logentries logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging logentries create --service-id 123 --version 1 --name log --port 20000 --autoclone"),
+			args: args("logging logentries create --service-id 123 --version 1 --name log --port 20000 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -59,7 +62,7 @@ func TestLogentriesList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging logentries list --service-id 123 --version 1"),
+			args: args("logging logentries list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListLogentriesFn: listLogentriesOK,
@@ -67,7 +70,7 @@ func TestLogentriesList(t *testing.T) {
 			wantOutput: listLogentriesShortOutput,
 		},
 		{
-			args: args("logging logentries list --service-id 123 --version 1 --verbose"),
+			args: args("logging logentries list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListLogentriesFn: listLogentriesOK,
@@ -75,7 +78,7 @@ func TestLogentriesList(t *testing.T) {
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: args("logging logentries list --service-id 123 --version 1 -v"),
+			args: args("logging logentries list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListLogentriesFn: listLogentriesOK,
@@ -83,7 +86,7 @@ func TestLogentriesList(t *testing.T) {
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: args("logging logentries --verbose list --service-id 123 --version 1"),
+			args: args("logging logentries --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListLogentriesFn: listLogentriesOK,
@@ -91,7 +94,7 @@ func TestLogentriesList(t *testing.T) {
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: args("logging -v logentries list --service-id 123 --version 1"),
+			args: args("logging -v logentries list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListLogentriesFn: listLogentriesOK,
@@ -99,7 +102,7 @@ func TestLogentriesList(t *testing.T) {
 			wantOutput: listLogentriesVerboseOutput,
 		},
 		{
-			args: args("logging logentries list --service-id 123 --version 1"),
+			args: args("logging logentries list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListLogentriesFn: listLogentriesError,
@@ -127,11 +130,11 @@ func TestLogentriesDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging logentries describe --service-id 123 --version 1"),
+			args:      args("logging logentries describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging logentries describe --service-id 123 --version 1 --name logs"),
+			args: args("logging logentries describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetLogentriesFn: getLogentriesError,
@@ -139,7 +142,7 @@ func TestLogentriesDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging logentries describe --service-id 123 --version 1 --name logs"),
+			args: args("logging logentries describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetLogentriesFn: getLogentriesOK,
@@ -167,11 +170,11 @@ func TestLogentriesUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging logentries update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging logentries update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging logentries update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging logentries update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -180,7 +183,7 @@ func TestLogentriesUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging logentries update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging logentries update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -209,11 +212,11 @@ func TestLogentriesDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging logentries delete --service-id 123 --version 1"),
+			args:      args("logging logentries delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging logentries delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging logentries delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -222,7 +225,7 @@ func TestLogentriesDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging logentries delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging logentries delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -298,7 +301,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listLogentriesVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/logentries/logentries_integration_test.go
+++ b/pkg/commands/logging/logentries/logentries_integration_test.go
@@ -42,7 +42,7 @@ func TestLogentriesCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -110,7 +110,7 @@ func TestLogentriesList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -150,7 +150,7 @@ func TestLogentriesDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -192,7 +192,7 @@ func TestLogentriesUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -234,7 +234,7 @@ func TestLogentriesDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/logentries/logentries_test.go
+++ b/pkg/commands/logging/logentries/logentries_test.go
@@ -182,7 +182,7 @@ func createCommandOK() *logentries.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -227,7 +227,7 @@ func createCommandRequired() *logentries.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/logging/loggly/loggly_integration_test.go
@@ -50,7 +50,7 @@ func TestLogglyCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestLogglyList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestLogglyDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestLogglyUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestLogglyDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/logging/loggly/loggly_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package loggly_test
 
 import (
@@ -21,7 +24,7 @@ func TestLogglyCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging loggly create --service-id 123 --version 1 --name log --autoclone"),
+			args: args("logging loggly create --service-id 123 --version 1 --name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestLogglyCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: args("logging loggly create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging loggly create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestLogglyCreate(t *testing.T) {
 			wantOutput: "Created Loggly logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging loggly create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging loggly create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -67,7 +70,7 @@ func TestLogglyList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging loggly list --service-id 123 --version 1"),
+			args: args("logging loggly list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListLogglyFn:   listLogglysOK,
@@ -75,7 +78,7 @@ func TestLogglyList(t *testing.T) {
 			wantOutput: listLogglysShortOutput,
 		},
 		{
-			args: args("logging loggly list --service-id 123 --version 1 --verbose"),
+			args: args("logging loggly list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListLogglyFn:   listLogglysOK,
@@ -83,7 +86,7 @@ func TestLogglyList(t *testing.T) {
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: args("logging loggly list --service-id 123 --version 1 -v"),
+			args: args("logging loggly list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListLogglyFn:   listLogglysOK,
@@ -91,7 +94,7 @@ func TestLogglyList(t *testing.T) {
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: args("logging loggly --verbose list --service-id 123 --version 1"),
+			args: args("logging loggly --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListLogglyFn:   listLogglysOK,
@@ -99,7 +102,7 @@ func TestLogglyList(t *testing.T) {
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: args("logging -v loggly list --service-id 123 --version 1"),
+			args: args("logging -v loggly list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListLogglyFn:   listLogglysOK,
@@ -107,7 +110,7 @@ func TestLogglyList(t *testing.T) {
 			wantOutput: listLogglysVerboseOutput,
 		},
 		{
-			args: args("logging loggly list --service-id 123 --version 1"),
+			args: args("logging loggly list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListLogglyFn:   listLogglysError,
@@ -135,11 +138,11 @@ func TestLogglyDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging loggly describe --service-id 123 --version 1"),
+			args:      args("logging loggly describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging loggly describe --service-id 123 --version 1 --name logs"),
+			args: args("logging loggly describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetLogglyFn:    getLogglyError,
@@ -147,7 +150,7 @@ func TestLogglyDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging loggly describe --service-id 123 --version 1 --name logs"),
+			args: args("logging loggly describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetLogglyFn:    getLogglyOK,
@@ -175,11 +178,11 @@ func TestLogglyUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging loggly update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging loggly update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging loggly update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging loggly update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -188,7 +191,7 @@ func TestLogglyUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging loggly update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging loggly update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -217,11 +220,11 @@ func TestLogglyDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging loggly delete --service-id 123 --version 1"),
+			args:      args("logging loggly delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging loggly delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging loggly delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -230,7 +233,7 @@ func TestLogglyDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging loggly delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging loggly delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -305,7 +308,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listLogglysVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/logging/loggly/loggly_integration_test.go
@@ -50,7 +50,7 @@ func TestLogglyCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestLogglyList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestLogglyDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestLogglyUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestLogglyDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/loggly/loggly_test.go
+++ b/pkg/commands/logging/loggly/loggly_test.go
@@ -177,7 +177,7 @@ func createCommandOK() *loggly.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -219,7 +219,7 @@ func createCommandRequired() *loggly.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package logshuttle_test
 
 import (
@@ -21,7 +24,7 @@ func TestLogshuttleCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging logshuttle create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging logshuttle create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestLogshuttleCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: args("logging logshuttle create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging logshuttle create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestLogshuttleCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: args("logging logshuttle create --service-id 123 --version 1 --name log --url example.com --auth-token abc --autoclone"),
+			args: args("logging logshuttle create --service-id 123 --version 1 --name log --url example.com --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -46,7 +49,7 @@ func TestLogshuttleCreate(t *testing.T) {
 			wantOutput: "Created Logshuttle logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging logshuttle create --service-id 123 --version 1 --name log --url example.com --auth-token abc --autoclone"),
+			args: args("logging logshuttle create --service-id 123 --version 1 --name log --url example.com --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -75,7 +78,7 @@ func TestLogshuttleList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging logshuttle list --service-id 123 --version 1"),
+			args: args("logging logshuttle list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListLogshuttlesFn: listLogshuttlesOK,
@@ -83,7 +86,7 @@ func TestLogshuttleList(t *testing.T) {
 			wantOutput: listLogshuttlesShortOutput,
 		},
 		{
-			args: args("logging logshuttle list --service-id 123 --version 1 --verbose"),
+			args: args("logging logshuttle list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListLogshuttlesFn: listLogshuttlesOK,
@@ -91,7 +94,7 @@ func TestLogshuttleList(t *testing.T) {
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: args("logging logshuttle list --service-id 123 --version 1 -v"),
+			args: args("logging logshuttle list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListLogshuttlesFn: listLogshuttlesOK,
@@ -99,7 +102,7 @@ func TestLogshuttleList(t *testing.T) {
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: args("logging logshuttle --verbose list --service-id 123 --version 1"),
+			args: args("logging logshuttle --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListLogshuttlesFn: listLogshuttlesOK,
@@ -107,7 +110,7 @@ func TestLogshuttleList(t *testing.T) {
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: args("logging -v logshuttle list --service-id 123 --version 1"),
+			args: args("logging -v logshuttle list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListLogshuttlesFn: listLogshuttlesOK,
@@ -115,7 +118,7 @@ func TestLogshuttleList(t *testing.T) {
 			wantOutput: listLogshuttlesVerboseOutput,
 		},
 		{
-			args: args("logging logshuttle list --service-id 123 --version 1"),
+			args: args("logging logshuttle list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListLogshuttlesFn: listLogshuttlesError,
@@ -143,11 +146,11 @@ func TestLogshuttleDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging logshuttle describe --service-id 123 --version 1"),
+			args:      args("logging logshuttle describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging logshuttle describe --service-id 123 --version 1 --name logs"),
+			args: args("logging logshuttle describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetLogshuttleFn: getLogshuttleError,
@@ -155,7 +158,7 @@ func TestLogshuttleDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging logshuttle describe --service-id 123 --version 1 --name logs"),
+			args: args("logging logshuttle describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetLogshuttleFn: getLogshuttleOK,
@@ -183,11 +186,11 @@ func TestLogshuttleUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging logshuttle update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging logshuttle update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging logshuttle update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging logshuttle update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -196,7 +199,7 @@ func TestLogshuttleUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging logshuttle update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging logshuttle update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -225,11 +228,11 @@ func TestLogshuttleDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging logshuttle delete --service-id 123 --version 1"),
+			args:      args("logging logshuttle delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging logshuttle delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging logshuttle delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -238,7 +241,7 @@ func TestLogshuttleDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging logshuttle delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging logshuttle delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -315,7 +318,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listLogshuttlesVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
@@ -58,7 +58,7 @@ func TestLogshuttleCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestLogshuttleList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestLogshuttleDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestLogshuttleUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestLogshuttleDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
@@ -58,7 +58,7 @@ func TestLogshuttleCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -126,7 +126,7 @@ func TestLogshuttleList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -166,7 +166,7 @@ func TestLogshuttleDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -208,7 +208,7 @@ func TestLogshuttleUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -250,7 +250,7 @@ func TestLogshuttleDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/logshuttle/logshuttle_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_test.go
@@ -180,7 +180,7 @@ func createCommandRequired() *logshuttle.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -219,7 +219,7 @@ func createCommandAll() *logshuttle.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/logging/newrelic/newrelic_test.go
@@ -89,7 +89,7 @@ func TestNewRelicCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -163,7 +163,7 @@ func TestNewRelicDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -224,7 +224,7 @@ func TestNewRelicDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -289,7 +289,7 @@ func TestNewRelicList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -371,7 +371,7 @@ func TestNewRelicUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/logging/newrelic/newrelic_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package newrelic_test
 
 import (
@@ -15,22 +18,22 @@ func TestNewRelicCreate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("logging newrelic create --key abc --version 3"),
+			Args:      args("logging newrelic create --key abc --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --key flag",
-			Args:      args("logging newrelic create --name foo --version 3"),
+			Args:      args("logging newrelic create --name foo --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --key not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("logging newrelic create --key abc --name foo"),
+			Args:      args("logging newrelic create --key abc --name foo --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("logging newrelic create --key abc --name foo --version 3"),
+			Args:      args("logging newrelic create --key abc --name foo --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -38,7 +41,7 @@ func TestNewRelicCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("logging newrelic create --key abc --name foo --service-id 123 --version 1"),
+			Args:      args("logging newrelic create --key abc --name foo --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -49,7 +52,7 @@ func TestNewRelicCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("logging newrelic create --key abc --name foo --service-id 123 --version 3"),
+			Args:      args("logging newrelic create --key abc --name foo --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -64,7 +67,7 @@ func TestNewRelicCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("logging newrelic create --key abc --name foo --service-id 123 --version 3"),
+			Args:       args("logging newrelic create --key abc --name foo --service-id 123 --version 3 --token 123"),
 			WantOutput: "Created New Relic logging endpoint 'foo' (service: 123, version: 3)",
 		},
 		{
@@ -80,7 +83,7 @@ func TestNewRelicCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("logging newrelic create --autoclone --key abc --name foo --service-id 123 --version 1"),
+			Args:       args("logging newrelic create --autoclone --key abc --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Created New Relic logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -102,17 +105,17 @@ func TestNewRelicDelete(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("logging newrelic delete --version 3"),
+			Args:      args("logging newrelic delete --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("logging newrelic delete --name foobar"),
+			Args:      args("logging newrelic delete --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("logging newrelic delete --name foobar --version 3"),
+			Args:      args("logging newrelic delete --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -120,7 +123,7 @@ func TestNewRelicDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("logging newrelic delete --name foobar --service-id 123 --version 1"),
+			Args:      args("logging newrelic delete --name foobar --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -131,7 +134,7 @@ func TestNewRelicDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Args:      args("logging newrelic delete --name foobar --service-id 123 --version 3"),
+			Args:      args("logging newrelic delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -142,7 +145,7 @@ func TestNewRelicDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("logging newrelic delete --name foobar --service-id 123 --version 3"),
+			Args:       args("logging newrelic delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "Deleted New Relic logging endpoint 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -154,7 +157,7 @@ func TestNewRelicDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("logging newrelic delete --autoclone --name foo --service-id 123 --version 1"),
+			Args:       args("logging newrelic delete --autoclone --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Deleted New Relic logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -176,17 +179,17 @@ func TestNewRelicDescribe(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("logging newrelic describe --version 3"),
+			Args:      args("logging newrelic describe --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("logging newrelic describe --name foobar"),
+			Args:      args("logging newrelic describe --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("logging newrelic describe --name foobar --version 3"),
+			Args:      args("logging newrelic describe --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -197,7 +200,7 @@ func TestNewRelicDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("logging newrelic describe --name foobar --service-id 123 --version 3"),
+			Args:      args("logging newrelic describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -206,7 +209,7 @@ func TestNewRelicDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetNewRelicFn:  getNewRelic,
 			},
-			Args:       args("logging newrelic describe --name foobar --service-id 123 --version 3"),
+			Args:       args("logging newrelic describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nToken: abc\nFormat: \nFormat Version: 0\nPlacement: \nRegion: \nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -215,7 +218,7 @@ func TestNewRelicDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetNewRelicFn:  getNewRelic,
 			},
-			Args:       args("logging newrelic describe --name foobar --service-id 123 --version 1"),
+			Args:       args("logging newrelic describe --name foobar --service-id 123 --version 1 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nToken: abc\nFormat: \nFormat Version: 0\nPlacement: \nRegion: \nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
@@ -237,12 +240,12 @@ func TestNewRelicList(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("logging newrelic list"),
+			Args:      args("logging newrelic list --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("logging newrelic list --version 3"),
+			Args:      args("logging newrelic list --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -253,7 +256,7 @@ func TestNewRelicList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("logging newrelic list --service-id 123 --version 3"),
+			Args:      args("logging newrelic list --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -262,7 +265,7 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListNewRelicFn: listNewRelic,
 			},
-			Args:       args("logging newrelic list --service-id 123 --version 3"),
+			Args:       args("logging newrelic list --service-id 123 --version 3 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME\n123         3        foo\n123         3        bar\n",
 		},
 		{
@@ -271,7 +274,7 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListNewRelicFn: listNewRelic,
 			},
-			Args:       args("logging newrelic list --service-id 123 --version 1"),
+			Args:       args("logging newrelic list --service-id 123 --version 1 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME\n123         1        foo\n123         1        bar\n",
 		},
 		{
@@ -280,8 +283,8 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListNewRelicFn: listNewRelic,
 			},
-			Args:       args("logging newrelic list --service-id 123 --verbose --version 1"),
-			WantOutput: "Fastly API token not provided\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
+			Args:       args("logging newrelic list --service-id 123 --verbose --version 1 --token 123"),
+			WantOutput: "Fastly API token provided via --token\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
@@ -302,17 +305,17 @@ func TestNewRelicUpdate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("logging newrelic update --service-id 123 --version 3"),
+			Args:      args("logging newrelic update --service-id 123 --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("logging newrelic update --name foobar --service-id 123"),
+			Args:      args("logging newrelic update --name foobar --service-id 123 --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("logging newrelic update --name foobar --version 3"),
+			Args:      args("logging newrelic update --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -320,7 +323,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("logging newrelic update --name foobar --service-id 123 --version 1"),
+			Args:      args("logging newrelic update --name foobar --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -331,7 +334,7 @@ func TestNewRelicUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("logging newrelic update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			Args:      args("logging newrelic update --name foobar --new-name beepboop --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -346,7 +349,7 @@ func TestNewRelicUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("logging newrelic update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			Args:       args("logging newrelic update --name foobar --new-name beepboop --service-id 123 --version 3 --token 123"),
 			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 3)",
 		},
 		{
@@ -362,7 +365,7 @@ func TestNewRelicUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("logging newrelic update --autoclone --name foobar --new-name beepboop --service-id 123 --version 1"),
+			Args:       args("logging newrelic update --autoclone --name foobar --new-name beepboop --service-id 123 --version 1 --token 123"),
 			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
 		},
 	}

--- a/pkg/commands/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/logging/newrelic/newrelic_test.go
@@ -89,7 +89,7 @@ func TestNewRelicCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -163,7 +163,7 @@ func TestNewRelicDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -224,7 +224,7 @@ func TestNewRelicDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -289,7 +289,7 @@ func TestNewRelicList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -371,7 +371,7 @@ func TestNewRelicUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/logging/openstack/openstack_integration_test.go
@@ -82,7 +82,7 @@ func TestOpenstackCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -150,7 +150,7 @@ func TestOpenstackList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -190,7 +190,7 @@ func TestOpenstackDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -232,7 +232,7 @@ func TestOpenstackUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -274,7 +274,7 @@ func TestOpenstackDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/logging/openstack/openstack_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package openstack_test
 
 import (
@@ -21,7 +24,7 @@ func TestOpenstackCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging openstack create --service-id 123 --version 1 --name log --access-key foo --user user --url https://example.com --autoclone"),
+			args: args("logging openstack create --service-id 123 --version 1 --name log --access-key foo --user user --url https://example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestOpenstackCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --bucket not provided",
 		},
 		{
-			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --user user --url https://example.com --autoclone"),
+			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --user user --url https://example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestOpenstackCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --url https://example.com --autoclone"),
+			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --url https://example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestOpenstackCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --autoclone"),
+			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -53,7 +56,7 @@ func TestOpenstackCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --autoclone"),
+			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -62,7 +65,7 @@ func TestOpenstackCreate(t *testing.T) {
 			wantOutput: "Created OpenStack logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --autoclone"),
+			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -71,7 +74,7 @@ func TestOpenstackCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging openstack create --service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -99,7 +102,7 @@ func TestOpenstackList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging openstack list --service-id 123 --version 1"),
+			args: args("logging openstack list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListOpenstacksFn: listOpenstacksOK,
@@ -107,7 +110,7 @@ func TestOpenstackList(t *testing.T) {
 			wantOutput: listOpenstacksShortOutput,
 		},
 		{
-			args: args("logging openstack list --service-id 123 --version 1 --verbose"),
+			args: args("logging openstack list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListOpenstacksFn: listOpenstacksOK,
@@ -115,7 +118,7 @@ func TestOpenstackList(t *testing.T) {
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: args("logging openstack list --service-id 123 --version 1 -v"),
+			args: args("logging openstack list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListOpenstacksFn: listOpenstacksOK,
@@ -123,7 +126,7 @@ func TestOpenstackList(t *testing.T) {
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: args("logging openstack --verbose list --service-id 123 --version 1"),
+			args: args("logging openstack --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListOpenstacksFn: listOpenstacksOK,
@@ -131,7 +134,7 @@ func TestOpenstackList(t *testing.T) {
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: args("logging -v openstack list --service-id 123 --version 1"),
+			args: args("logging -v openstack list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListOpenstacksFn: listOpenstacksOK,
@@ -139,7 +142,7 @@ func TestOpenstackList(t *testing.T) {
 			wantOutput: listOpenstacksVerboseOutput,
 		},
 		{
-			args: args("logging openstack list --service-id 123 --version 1"),
+			args: args("logging openstack list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListOpenstacksFn: listOpenstacksError,
@@ -167,11 +170,11 @@ func TestOpenstackDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging openstack describe --service-id 123 --version 1"),
+			args:      args("logging openstack describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging openstack describe --service-id 123 --version 1 --name logs"),
+			args: args("logging openstack describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetOpenstackFn: getOpenstackError,
@@ -179,7 +182,7 @@ func TestOpenstackDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging openstack describe --service-id 123 --version 1 --name logs"),
+			args: args("logging openstack describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetOpenstackFn: getOpenstackOK,
@@ -207,11 +210,11 @@ func TestOpenstackUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging openstack update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging openstack update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging openstack update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging openstack update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -220,7 +223,7 @@ func TestOpenstackUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging openstack update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging openstack update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -249,11 +252,11 @@ func TestOpenstackDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging openstack delete --service-id 123 --version 1"),
+			args:      args("logging openstack delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging openstack delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging openstack delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -262,7 +265,7 @@ func TestOpenstackDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging openstack delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging openstack delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -357,7 +360,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listOpenstacksVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/logging/openstack/openstack_integration_test.go
@@ -82,7 +82,7 @@ func TestOpenstackCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -150,7 +150,7 @@ func TestOpenstackList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -190,7 +190,7 @@ func TestOpenstackDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -232,7 +232,7 @@ func TestOpenstackUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -274,7 +274,7 @@ func TestOpenstackDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/openstack/openstack_test.go
+++ b/pkg/commands/logging/openstack/openstack_test.go
@@ -199,7 +199,7 @@ func createCommandRequired() *openstack.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -240,7 +240,7 @@ func createCommandAll() *openstack.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_integration_test.go
@@ -50,7 +50,7 @@ func TestPapertrailCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestPapertrailList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestPapertrailDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestPapertrailUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestPapertrailDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_integration_test.go
@@ -50,7 +50,7 @@ func TestPapertrailCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestPapertrailList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestPapertrailDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestPapertrailUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestPapertrailDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package papertrail_test
 
 import (
@@ -21,7 +24,7 @@ func TestPapertrailCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging papertrail create --service-id 123 --version 1 --name log --autoclone"),
+			args: args("logging papertrail create --service-id 123 --version 1 --name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestPapertrailCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: args("logging papertrail create --service-id 123 --version 1 --name log --address example.com:123 --autoclone"),
+			args: args("logging papertrail create --service-id 123 --version 1 --name log --address example.com:123 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestPapertrailCreate(t *testing.T) {
 			wantOutput: "Created Papertrail logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging papertrail create --service-id 123 --version 1 --name log --address example.com:123 --autoclone"),
+			args: args("logging papertrail create --service-id 123 --version 1 --name log --address example.com:123 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -67,7 +70,7 @@ func TestPapertrailList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging papertrail list --service-id 123 --version 1"),
+			args: args("logging papertrail list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListPapertrailsFn: listPapertrailsOK,
@@ -75,7 +78,7 @@ func TestPapertrailList(t *testing.T) {
 			wantOutput: listPapertrailsShortOutput,
 		},
 		{
-			args: args("logging papertrail list --service-id 123 --version 1 --verbose"),
+			args: args("logging papertrail list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListPapertrailsFn: listPapertrailsOK,
@@ -83,7 +86,7 @@ func TestPapertrailList(t *testing.T) {
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: args("logging papertrail list --service-id 123 --version 1 -v"),
+			args: args("logging papertrail list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListPapertrailsFn: listPapertrailsOK,
@@ -91,7 +94,7 @@ func TestPapertrailList(t *testing.T) {
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: args("logging papertrail --verbose list --service-id 123 --version 1"),
+			args: args("logging papertrail --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListPapertrailsFn: listPapertrailsOK,
@@ -99,7 +102,7 @@ func TestPapertrailList(t *testing.T) {
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: args("logging -v papertrail list --service-id 123 --version 1"),
+			args: args("logging -v papertrail list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListPapertrailsFn: listPapertrailsOK,
@@ -107,7 +110,7 @@ func TestPapertrailList(t *testing.T) {
 			wantOutput: listPapertrailsVerboseOutput,
 		},
 		{
-			args: args("logging papertrail list --service-id 123 --version 1"),
+			args: args("logging papertrail list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ListPapertrailsFn: listPapertrailsError,
@@ -135,11 +138,11 @@ func TestPapertrailDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging papertrail describe --service-id 123 --version 1"),
+			args:      args("logging papertrail describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging papertrail describe --service-id 123 --version 1 --name logs"),
+			args: args("logging papertrail describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetPapertrailFn: getPapertrailError,
@@ -147,7 +150,7 @@ func TestPapertrailDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging papertrail describe --service-id 123 --version 1 --name logs"),
+			args: args("logging papertrail describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetPapertrailFn: getPapertrailOK,
@@ -175,11 +178,11 @@ func TestPapertrailUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging papertrail update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging papertrail update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging papertrail update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging papertrail update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -188,7 +191,7 @@ func TestPapertrailUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging papertrail update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging papertrail update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -217,11 +220,11 @@ func TestPapertrailDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging papertrail delete --service-id 123 --version 1"),
+			args:      args("logging papertrail delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging papertrail delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging papertrail delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -230,7 +233,7 @@ func TestPapertrailDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging papertrail delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging papertrail delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -302,7 +305,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listPapertrailsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/papertrail/papertrail_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_test.go
@@ -179,7 +179,7 @@ func createCommandRequired() *papertrail.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -217,7 +217,7 @@ func createCommandAll() *papertrail.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/s3/s3_integration_test.go
+++ b/pkg/commands/logging/s3/s3_integration_test.go
@@ -116,7 +116,7 @@ func TestS3Create(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -184,7 +184,7 @@ func TestS3List(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestS3Describe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -275,7 +275,7 @@ func TestS3Update(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -317,7 +317,7 @@ func TestS3Delete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/s3/s3_integration_test.go
+++ b/pkg/commands/logging/s3/s3_integration_test.go
@@ -116,7 +116,7 @@ func TestS3Create(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -184,7 +184,7 @@ func TestS3List(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestS3Describe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -275,7 +275,7 @@ func TestS3Update(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -317,7 +317,7 @@ func TestS3Delete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/s3/s3_integration_test.go
+++ b/pkg/commands/logging/s3/s3_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package s3_test
 
 import (
@@ -21,7 +24,7 @@ func TestS3Create(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestS3Create(t *testing.T) {
 			wantError: "error parsing arguments: the --access-key and --secret-key flags or the --iam-role flag must be provided",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestS3Create(t *testing.T) {
 			wantError: "error parsing arguments: required flag --secret-key not provided",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --secret-key bar --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --secret-key bar --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestS3Create(t *testing.T) {
 			wantError: "error parsing arguments: required flag --access-key not provided",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --secret-key bar --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --secret-key bar --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -53,7 +56,7 @@ func TestS3Create(t *testing.T) {
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -61,7 +64,7 @@ func TestS3Create(t *testing.T) {
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -69,7 +72,7 @@ func TestS3Create(t *testing.T) {
 			wantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -78,7 +81,7 @@ func TestS3Create(t *testing.T) {
 			wantOutput: "Created S3 logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -87,7 +90,7 @@ func TestS3Create(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log2 --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log2 --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -96,7 +99,7 @@ func TestS3Create(t *testing.T) {
 			wantOutput: "Created S3 logging endpoint log2 (service 123 version 4)",
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log2 --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log2 --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -105,7 +108,7 @@ func TestS3Create(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging s3 create --service-id 123 --version 1 --name log --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -133,7 +136,7 @@ func TestS3List(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging s3 list --service-id 123 --version 1"),
+			args: args("logging s3 list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListS3sFn:      listS3sOK,
@@ -141,7 +144,7 @@ func TestS3List(t *testing.T) {
 			wantOutput: listS3sShortOutput,
 		},
 		{
-			args: args("logging s3 list --service-id 123 --version 1 --verbose"),
+			args: args("logging s3 list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListS3sFn:      listS3sOK,
@@ -149,7 +152,7 @@ func TestS3List(t *testing.T) {
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: args("logging s3 list --service-id 123 --version 1 -v"),
+			args: args("logging s3 list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListS3sFn:      listS3sOK,
@@ -157,7 +160,7 @@ func TestS3List(t *testing.T) {
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: args("logging s3 --verbose list --service-id 123 --version 1"),
+			args: args("logging s3 --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListS3sFn:      listS3sOK,
@@ -165,7 +168,7 @@ func TestS3List(t *testing.T) {
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: args("logging -v s3 list --service-id 123 --version 1"),
+			args: args("logging -v s3 list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListS3sFn:      listS3sOK,
@@ -173,7 +176,7 @@ func TestS3List(t *testing.T) {
 			wantOutput: listS3sVerboseOutput,
 		},
 		{
-			args: args("logging s3 list --service-id 123 --version 1"),
+			args: args("logging s3 list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListS3sFn:      listS3sError,
@@ -201,11 +204,11 @@ func TestS3Describe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging s3 describe --service-id 123 --version 1"),
+			args:      args("logging s3 describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging s3 describe --service-id 123 --version 1 --name logs"),
+			args: args("logging s3 describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetS3Fn:        getS3Error,
@@ -213,7 +216,7 @@ func TestS3Describe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging s3 describe --service-id 123 --version 1 --name logs"),
+			args: args("logging s3 describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetS3Fn:        getS3OK,
@@ -241,11 +244,11 @@ func TestS3Update(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging s3 update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging s3 update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging s3 update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging s3 update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -254,7 +257,7 @@ func TestS3Update(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging s3 update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging s3 update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -263,7 +266,7 @@ func TestS3Update(t *testing.T) {
 			wantOutput: "Updated S3 logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging s3 update --service-id 123 --version 1 --name logs --access-key foo --secret-key bar --iam-role  --autoclone"),
+			args: args("logging s3 update --service-id 123 --version 1 --name logs --access-key foo --secret-key bar --iam-role  --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -292,11 +295,11 @@ func TestS3Delete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging s3 delete --service-id 123 --version 1"),
+			args:      args("logging s3 delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging s3 delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging s3 delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -305,7 +308,7 @@ func TestS3Delete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging s3 delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging s3 delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -401,7 +404,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listS3sVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/s3/s3_test.go
+++ b/pkg/commands/logging/s3/s3_test.go
@@ -216,7 +216,7 @@ func createCommandRequired() *s3.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -256,7 +256,7 @@ func createCommandRequiredIAMRole() *s3.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -295,7 +295,7 @@ func createCommandAll() *s3.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_integration_test.go
@@ -67,7 +67,7 @@ func TestScalyrCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -135,7 +135,7 @@ func TestScalyrList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -175,7 +175,7 @@ func TestScalyrDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -217,7 +217,7 @@ func TestScalyrUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -259,7 +259,7 @@ func TestScalyrDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_integration_test.go
@@ -67,7 +67,7 @@ func TestScalyrCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -135,7 +135,7 @@ func TestScalyrList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -175,7 +175,7 @@ func TestScalyrDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -217,7 +217,7 @@ func TestScalyrUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -259,7 +259,7 @@ func TestScalyrDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package scalyr_test
 
 import (
@@ -22,7 +25,7 @@ func TestScalyrCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging scalyr create --service-id 123 --version 1 --auth-token abc --autoclone"),
+			args: args("logging scalyr create --service-id 123 --version 1 --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -30,7 +33,7 @@ func TestScalyrCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging scalyr create --service-id 123 --version 1 --name log --autoclone"),
+			args: args("logging scalyr create --service-id 123 --version 1 --name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestScalyrCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --auth-token not provided",
 		},
 		{
-			args: args("logging scalyr create --name log --service-id  --version 1 --auth-token abc --autoclone"),
+			args: args("logging scalyr create --name log --service-id  --version 1 --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -46,7 +49,7 @@ func TestScalyrCreate(t *testing.T) {
 			wantError: fsterrs.ErrNoServiceID.Error(),
 		},
 		{
-			args: args("logging scalyr create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging scalyr create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -55,7 +58,7 @@ func TestScalyrCreate(t *testing.T) {
 			wantOutput: "Created Scalyr logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging scalyr create --service-id 123 --version 1 --name log --auth-token abc --autoclone"),
+			args: args("logging scalyr create --service-id 123 --version 1 --name log --auth-token abc --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -84,7 +87,7 @@ func TestScalyrList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging scalyr list --service-id 123 --version 1"),
+			args: args("logging scalyr list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListScalyrsFn:  listScalyrsOK,
@@ -92,7 +95,7 @@ func TestScalyrList(t *testing.T) {
 			wantOutput: listScalyrsShortOutput,
 		},
 		{
-			args: args("logging scalyr list --service-id 123 --version 1 --verbose"),
+			args: args("logging scalyr list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListScalyrsFn:  listScalyrsOK,
@@ -100,7 +103,7 @@ func TestScalyrList(t *testing.T) {
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: args("logging scalyr list --service-id 123 --version 1 -v"),
+			args: args("logging scalyr list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListScalyrsFn:  listScalyrsOK,
@@ -108,7 +111,7 @@ func TestScalyrList(t *testing.T) {
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: args("logging scalyr --verbose list --service-id 123 --version 1"),
+			args: args("logging scalyr --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListScalyrsFn:  listScalyrsOK,
@@ -116,7 +119,7 @@ func TestScalyrList(t *testing.T) {
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: args("logging -v scalyr list --service-id 123 --version 1"),
+			args: args("logging -v scalyr list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListScalyrsFn:  listScalyrsOK,
@@ -124,7 +127,7 @@ func TestScalyrList(t *testing.T) {
 			wantOutput: listScalyrsVerboseOutput,
 		},
 		{
-			args: args("logging scalyr list --service-id 123 --version 1"),
+			args: args("logging scalyr list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListScalyrsFn:  listScalyrsError,
@@ -152,11 +155,11 @@ func TestScalyrDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging scalyr describe --service-id 123 --version 1"),
+			args:      args("logging scalyr describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging scalyr describe --service-id 123 --version 1 --name logs"),
+			args: args("logging scalyr describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetScalyrFn:    getScalyrError,
@@ -164,7 +167,7 @@ func TestScalyrDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging scalyr describe --service-id 123 --version 1 --name logs"),
+			args: args("logging scalyr describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetScalyrFn:    getScalyrOK,
@@ -192,11 +195,11 @@ func TestScalyrUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging scalyr update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging scalyr update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging scalyr update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging scalyr update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -205,7 +208,7 @@ func TestScalyrUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging scalyr update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging scalyr update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -234,11 +237,11 @@ func TestScalyrDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging scalyr delete --service-id 123 --version 1"),
+			args:      args("logging scalyr delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging scalyr delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging scalyr delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -247,7 +250,7 @@ func TestScalyrDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging scalyr delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging scalyr delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -346,7 +349,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listScalyrsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/scalyr/scalyr_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_test.go
@@ -179,7 +179,7 @@ func createCommandRequired() *scalyr.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -217,7 +217,7 @@ func createCommandAll() *scalyr.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/logging/sftp/sftp_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package sftp_test
 
 import (
@@ -21,7 +24,7 @@ func TestSFTPCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging sftp create --service-id 123 --version 1 --name log --user user --ssh-known-hosts knownHosts() --port 80 --autoclone"),
+			args: args("logging sftp create --service-id 123 --version 1 --name log --user user --ssh-known-hosts knownHosts() --port 80 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestSFTPCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --ssh-known-hosts knownHosts() --port 80 --autoclone"),
+			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --ssh-known-hosts knownHosts() --port 80 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -37,7 +40,7 @@ func TestSFTPCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --user not provided",
 		},
 		{
-			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user user --port 80 --autoclone"),
+			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user user --port 80 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -45,7 +48,7 @@ func TestSFTPCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --ssh-known-hosts not provided",
 		},
 		{
-			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user user --ssh-known-hosts knownHosts() --port 80 --autoclone"),
+			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user user --ssh-known-hosts knownHosts() --port 80 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -54,7 +57,7 @@ func TestSFTPCreate(t *testing.T) {
 			wantOutput: "Created SFTP logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user user --ssh-known-hosts knownHosts() --port 80 --autoclone"),
+			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user user --ssh-known-hosts knownHosts() --port 80 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -63,7 +66,7 @@ func TestSFTPCreate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --ssh-known-hosts knownHosts() --port 80 --compression-codec zstd --gzip-level 9 --autoclone"),
+			args: args("logging sftp create --service-id 123 --version 1 --name log --address example.com --user anonymous --ssh-known-hosts knownHosts() --port 80 --compression-codec zstd --gzip-level 9 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -91,7 +94,7 @@ func TestSFTPList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging sftp list --service-id 123 --version 1"),
+			args: args("logging sftp list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSFTPsFn:    listSFTPsOK,
@@ -99,7 +102,7 @@ func TestSFTPList(t *testing.T) {
 			wantOutput: listSFTPsShortOutput,
 		},
 		{
-			args: args("logging sftp list --service-id 123 --version 1 --verbose"),
+			args: args("logging sftp list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSFTPsFn:    listSFTPsOK,
@@ -107,7 +110,7 @@ func TestSFTPList(t *testing.T) {
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: args("logging sftp list --service-id 123 --version 1 -v"),
+			args: args("logging sftp list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSFTPsFn:    listSFTPsOK,
@@ -115,7 +118,7 @@ func TestSFTPList(t *testing.T) {
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: args("logging sftp --verbose list --service-id 123 --version 1"),
+			args: args("logging sftp --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSFTPsFn:    listSFTPsOK,
@@ -123,7 +126,7 @@ func TestSFTPList(t *testing.T) {
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: args("logging -v sftp list --service-id 123 --version 1"),
+			args: args("logging -v sftp list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSFTPsFn:    listSFTPsOK,
@@ -131,7 +134,7 @@ func TestSFTPList(t *testing.T) {
 			wantOutput: listSFTPsVerboseOutput,
 		},
 		{
-			args: args("logging sftp list --service-id 123 --version 1"),
+			args: args("logging sftp list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSFTPsFn:    listSFTPsError,
@@ -159,11 +162,11 @@ func TestSFTPDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging sftp describe --service-id 123 --version 1"),
+			args:      args("logging sftp describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging sftp describe --service-id 123 --version 1 --name logs"),
+			args: args("logging sftp describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSFTPFn:      getSFTPError,
@@ -171,7 +174,7 @@ func TestSFTPDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging sftp describe --service-id 123 --version 1 --name logs"),
+			args: args("logging sftp describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSFTPFn:      getSFTPOK,
@@ -199,11 +202,11 @@ func TestSFTPUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging sftp update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging sftp update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging sftp update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging sftp update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -212,7 +215,7 @@ func TestSFTPUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging sftp update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging sftp update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -241,11 +244,11 @@ func TestSFTPDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging sftp delete --service-id 123 --version 1"),
+			args:      args("logging sftp delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging sftp delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging sftp delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -254,7 +257,7 @@ func TestSFTPDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging sftp delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging sftp delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -352,7 +355,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listSFTPsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/logging/sftp/sftp_integration_test.go
@@ -74,7 +74,7 @@ func TestSFTPCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestSFTPList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestSFTPDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestSFTPUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestSFTPDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/logging/sftp/sftp_integration_test.go
@@ -74,7 +74,7 @@ func TestSFTPCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -142,7 +142,7 @@ func TestSFTPList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -182,7 +182,7 @@ func TestSFTPDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -224,7 +224,7 @@ func TestSFTPUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -266,7 +266,7 @@ func TestSFTPDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/sftp/sftp_test.go
+++ b/pkg/commands/logging/sftp/sftp_test.go
@@ -202,7 +202,7 @@ func createCommandRequired() *sftp.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -242,7 +242,7 @@ func createCommandAll() *sftp.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/logging/splunk/splunk_integration_test.go
@@ -50,7 +50,7 @@ func TestSplunkCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestSplunkList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestSplunkDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestSplunkUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestSplunkDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/logging/splunk/splunk_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package splunk_test
 
 import (
@@ -21,7 +24,7 @@ func TestSplunkCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging splunk create --service-id 123 --version 1 --name log --autoclone"),
+			args: args("logging splunk create --service-id 123 --version 1 --name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestSplunkCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: args("logging splunk create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging splunk create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestSplunkCreate(t *testing.T) {
 			wantOutput: "Created Splunk logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging splunk create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging splunk create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -67,7 +70,7 @@ func TestSplunkList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging splunk list --service-id 123 --version 1"),
+			args: args("logging splunk list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSplunksFn:  listSplunksOK,
@@ -75,7 +78,7 @@ func TestSplunkList(t *testing.T) {
 			wantOutput: listSplunksShortOutput,
 		},
 		{
-			args: args("logging splunk list --service-id 123 --version 1 --verbose"),
+			args: args("logging splunk list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSplunksFn:  listSplunksOK,
@@ -83,7 +86,7 @@ func TestSplunkList(t *testing.T) {
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: args("logging splunk list --service-id 123 --version 1 -v"),
+			args: args("logging splunk list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSplunksFn:  listSplunksOK,
@@ -91,7 +94,7 @@ func TestSplunkList(t *testing.T) {
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: args("logging splunk --verbose list --service-id 123 --version 1"),
+			args: args("logging splunk --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSplunksFn:  listSplunksOK,
@@ -99,7 +102,7 @@ func TestSplunkList(t *testing.T) {
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: args("logging -v splunk list --service-id 123 --version 1"),
+			args: args("logging -v splunk list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSplunksFn:  listSplunksOK,
@@ -107,7 +110,7 @@ func TestSplunkList(t *testing.T) {
 			wantOutput: listSplunksVerboseOutput,
 		},
 		{
-			args: args("logging splunk list --service-id 123 --version 1"),
+			args: args("logging splunk list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSplunksFn:  listSplunksError,
@@ -135,11 +138,11 @@ func TestSplunkDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging splunk describe --service-id 123 --version 1"),
+			args:      args("logging splunk describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging splunk describe --service-id 123 --version 1 --name logs"),
+			args: args("logging splunk describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSplunkFn:    getSplunkError,
@@ -147,7 +150,7 @@ func TestSplunkDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging splunk describe --service-id 123 --version 1 --name logs"),
+			args: args("logging splunk describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSplunkFn:    getSplunkOK,
@@ -175,11 +178,11 @@ func TestSplunkUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging splunk update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging splunk update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging splunk update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging splunk update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -188,7 +191,7 @@ func TestSplunkUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging splunk update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging splunk update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -217,11 +220,11 @@ func TestSplunkDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging splunk delete --service-id 123 --version 1"),
+			args:      args("logging splunk delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging splunk delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging splunk delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -230,7 +233,7 @@ func TestSplunkDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging splunk delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging splunk delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -310,7 +313,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listSplunksVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/logging/splunk/splunk_integration_test.go
@@ -50,7 +50,7 @@ func TestSplunkCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestSplunkList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestSplunkDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestSplunkUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestSplunkDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/splunk/splunk_test.go
+++ b/pkg/commands/logging/splunk/splunk_test.go
@@ -187,7 +187,7 @@ func createCommandRequired() *splunk.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -225,7 +225,7 @@ func createCommandAll() *splunk.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package sumologic_test
 
 import (
@@ -21,7 +24,7 @@ func TestSumologicCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging sumologic create --service-id 123 --version 1 --name log --autoclone"),
+			args: args("logging sumologic create --service-id 123 --version 1 --name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestSumologicCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --url not provided",
 		},
 		{
-			args: args("logging sumologic create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging sumologic create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestSumologicCreate(t *testing.T) {
 			wantOutput: "Created Sumologic logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging sumologic create --service-id 123 --version 1 --name log --url example.com --autoclone"),
+			args: args("logging sumologic create --service-id 123 --version 1 --name log --url example.com --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -67,7 +70,7 @@ func TestSumologicList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging sumologic list --service-id 123 --version 1"),
+			args: args("logging sumologic list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListSumologicsFn: listSumologicsOK,
@@ -75,7 +78,7 @@ func TestSumologicList(t *testing.T) {
 			wantOutput: listSumologicsShortOutput,
 		},
 		{
-			args: args("logging sumologic list --service-id 123 --version 1 --verbose"),
+			args: args("logging sumologic list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListSumologicsFn: listSumologicsOK,
@@ -83,7 +86,7 @@ func TestSumologicList(t *testing.T) {
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: args("logging sumologic list --service-id 123 --version 1 -v"),
+			args: args("logging sumologic list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListSumologicsFn: listSumologicsOK,
@@ -91,7 +94,7 @@ func TestSumologicList(t *testing.T) {
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: args("logging sumologic --verbose list --service-id 123 --version 1"),
+			args: args("logging sumologic --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListSumologicsFn: listSumologicsOK,
@@ -99,7 +102,7 @@ func TestSumologicList(t *testing.T) {
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: args("logging -v sumologic list --service-id 123 --version 1"),
+			args: args("logging -v sumologic list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListSumologicsFn: listSumologicsOK,
@@ -107,7 +110,7 @@ func TestSumologicList(t *testing.T) {
 			wantOutput: listSumologicsVerboseOutput,
 		},
 		{
-			args: args("logging sumologic list --service-id 123 --version 1"),
+			args: args("logging sumologic list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListSumologicsFn: listSumologicsError,
@@ -135,11 +138,11 @@ func TestSumologicDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging sumologic describe --service-id 123 --version 1"),
+			args:      args("logging sumologic describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging sumologic describe --service-id 123 --version 1 --name logs"),
+			args: args("logging sumologic describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSumologicFn: getSumologicError,
@@ -147,7 +150,7 @@ func TestSumologicDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging sumologic describe --service-id 123 --version 1 --name logs"),
+			args: args("logging sumologic describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSumologicFn: getSumologicOK,
@@ -175,11 +178,11 @@ func TestSumologicUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging sumologic update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging sumologic update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging sumologic update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging sumologic update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -188,7 +191,7 @@ func TestSumologicUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging sumologic update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging sumologic update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -217,11 +220,11 @@ func TestSumologicDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging sumologic delete --service-id 123 --version 1"),
+			args:      args("logging sumologic delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging sumologic delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging sumologic delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -230,7 +233,7 @@ func TestSumologicDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging sumologic delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging sumologic delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -302,7 +305,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listSumologicsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_integration_test.go
@@ -50,7 +50,7 @@ func TestSumologicCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestSumologicList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestSumologicDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestSumologicUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestSumologicDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_integration_test.go
@@ -50,7 +50,7 @@ func TestSumologicCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestSumologicList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestSumologicDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestSumologicUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestSumologicDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/sumologic/sumologic_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_test.go
@@ -179,7 +179,7 @@ func createCommandOK() *sumologic.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -222,7 +222,7 @@ func createCommandRequired() *sumologic.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/logging/syslog/syslog_integration_test.go
@@ -50,7 +50,7 @@ func TestSyslogCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestSyslogList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestSyslogDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestSyslogUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestSyslogDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/logging/syslog/syslog_integration_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package syslog_test
 
 import (
@@ -21,7 +24,7 @@ func TestSyslogCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging syslog create --service-id 123 --version 1 --name log --autoclone"),
+			args: args("logging syslog create --service-id 123 --version 1 --name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +32,7 @@ func TestSyslogCreate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --address not provided",
 		},
 		{
-			args: args("logging syslog create --service-id 123 --version 1 --name log --address 127.0.0.1 --autoclone"),
+			args: args("logging syslog create --service-id 123 --version 1 --name log --address 127.0.0.1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -38,7 +41,7 @@ func TestSyslogCreate(t *testing.T) {
 			wantOutput: "Created Syslog logging endpoint log (service 123 version 4)",
 		},
 		{
-			args: args("logging syslog create --service-id 123 --version 1 --name log --address 127.0.0.1 --autoclone"),
+			args: args("logging syslog create --service-id 123 --version 1 --name log --address 127.0.0.1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -67,7 +70,7 @@ func TestSyslogList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("logging syslog list --service-id 123 --version 1"),
+			args: args("logging syslog list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSyslogsFn:  listSyslogsOK,
@@ -75,7 +78,7 @@ func TestSyslogList(t *testing.T) {
 			wantOutput: listSyslogsShortOutput,
 		},
 		{
-			args: args("logging syslog list --service-id 123 --version 1 --verbose"),
+			args: args("logging syslog list --service-id 123 --version 1 --verbose --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSyslogsFn:  listSyslogsOK,
@@ -83,7 +86,7 @@ func TestSyslogList(t *testing.T) {
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args: args("logging syslog list --service-id 123 --version 1 -v"),
+			args: args("logging syslog list --service-id 123 --version 1 -v --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSyslogsFn:  listSyslogsOK,
@@ -91,7 +94,7 @@ func TestSyslogList(t *testing.T) {
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args: args("logging syslog --verbose list --service-id 123 --version 1"),
+			args: args("logging syslog --verbose list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSyslogsFn:  listSyslogsOK,
@@ -99,7 +102,7 @@ func TestSyslogList(t *testing.T) {
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args: args("logging -v syslog list --service-id 123 --version 1"),
+			args: args("logging -v syslog list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSyslogsFn:  listSyslogsOK,
@@ -107,7 +110,7 @@ func TestSyslogList(t *testing.T) {
 			wantOutput: listSyslogsVerboseOutput,
 		},
 		{
-			args: args("logging syslog list --service-id 123 --version 1"),
+			args: args("logging syslog list --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListSyslogsFn:  listSyslogsError,
@@ -135,11 +138,11 @@ func TestSyslogDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging syslog describe --service-id 123 --version 1"),
+			args:      args("logging syslog describe --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging syslog describe --service-id 123 --version 1 --name logs"),
+			args: args("logging syslog describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSyslogFn:    getSyslogError,
@@ -147,7 +150,7 @@ func TestSyslogDescribe(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging syslog describe --service-id 123 --version 1 --name logs"),
+			args: args("logging syslog describe --service-id 123 --version 1 --name logs --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetSyslogFn:    getSyslogOK,
@@ -175,11 +178,11 @@ func TestSyslogUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging syslog update --service-id 123 --version 1 --new-name log"),
+			args:      args("logging syslog update --service-id 123 --version 1 --new-name log --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging syslog update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging syslog update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -188,7 +191,7 @@ func TestSyslogUpdate(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging syslog update --service-id 123 --version 1 --name logs --new-name log --autoclone"),
+			args: args("logging syslog update --service-id 123 --version 1 --name logs --new-name log --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -217,11 +220,11 @@ func TestSyslogDelete(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("logging syslog delete --service-id 123 --version 1"),
+			args:      args("logging syslog delete --service-id 123 --version 1 --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args: args("logging syslog delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging syslog delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -230,7 +233,7 @@ func TestSyslogDelete(t *testing.T) {
 			wantError: errTest.Error(),
 		},
 		{
-			args: args("logging syslog delete --service-id 123 --version 1 --name logs --autoclone"),
+			args: args("logging syslog delete --service-id 123 --version 1 --name logs --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -320,7 +323,7 @@ SERVICE  VERSION  NAME
 `) + "\n"
 
 var listSyslogsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/logging/syslog/syslog_integration_test.go
@@ -50,7 +50,7 @@ func TestSyslogCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -118,7 +118,7 @@ func TestSyslogList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -158,7 +158,7 @@ func TestSyslogDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -200,7 +200,7 @@ func TestSyslogUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -242,7 +242,7 @@ func TestSyslogDelete(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/logging/syslog/syslog_test.go
+++ b/pkg/commands/logging/syslog/syslog_test.go
@@ -193,7 +193,7 @@ func createCommandRequired() *syslog.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")
@@ -231,7 +231,7 @@ func createCommandAll() *syslog.CreateCommand {
 		Env:    config.Environment{},
 		Output: &b,
 	}
-	globals.APIClient, _ = mock.APIClient(mock.API{
+	globals.APIClient, _ = mock.ClientFactory(mock.API{
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint")

--- a/pkg/commands/pop/pop_test.go
+++ b/pkg/commands/pop/pop_test.go
@@ -32,7 +32,7 @@ func TestAllDatacenters(t *testing.T) {
 		},
 	}
 	opts := testutil.NewRunOpts(args, &stdout)
-	opts.APIClient = mock.APIClient(api)
+	opts.ClientFactory = mock.APIClient(api)
 	err := app.Run(opts)
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, "\nNAME    CODE  GROUP  SHIELD  COORDINATES\nFoobar  FBR   Bar    Baz     {Latitude:1 Longtitude:2 X:3 Y:4}\n", stdout.String())

--- a/pkg/commands/pop/pop_test.go
+++ b/pkg/commands/pop/pop_test.go
@@ -32,7 +32,7 @@ func TestAllDatacenters(t *testing.T) {
 		},
 	}
 	opts := testutil.NewRunOpts(args, &stdout)
-	opts.ClientFactory = mock.APIClient(api)
+	opts.ClientFactory = mock.ClientFactory(api)
 	err := app.Run(opts)
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, "\nNAME    CODE  GROUP  SHIELD  COORDINATES\nFoobar  FBR   Bar    Baz     {Latitude:1 Longtitude:2 X:3 Y:4}\n", stdout.String())

--- a/pkg/commands/purge/purge_test.go
+++ b/pkg/commands/purge/purge_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package purge_test
 
 import (
@@ -14,11 +17,6 @@ import (
 func TestPurgeAll(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
-		{
-			Name:      "validate missing token",
-			Args:      args("purge --all"),
-			WantError: "no token provided",
-		},
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      args("purge --all --token 123"),
@@ -69,11 +67,6 @@ func TestPurgeKeys(t *testing.T) {
 	var keys []string
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
-		{
-			Name:      "validate missing token",
-			Args:      args("purge --file ./testdata/keys"),
-			WantError: "no token provided",
-		},
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      args("purge --file ./testdata/keys --token 123"),
@@ -142,11 +135,6 @@ func TestPurgeKey(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Name:      "validate missing token",
-			Args:      args("purge --key foobar"),
-			WantError: "no token provided",
-		},
-		{
 			Name:      "validate missing --service-id flag",
 			Args:      args("purge --key foobar --token 123"),
 			WantError: "error reading service: no service ID found",
@@ -204,11 +192,6 @@ func TestPurgeKey(t *testing.T) {
 func TestPurgeURL(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
-		{
-			Name:      "validate missing token",
-			Args:      args("purge --url https://example.com"),
-			WantError: "no token provided",
-		},
 		{
 			Name: "validate Purge API error",
 			API: mock.API{

--- a/pkg/commands/purge/purge_test.go
+++ b/pkg/commands/purge/purge_test.go
@@ -57,7 +57,7 @@ func TestPurgeAll(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -112,7 +112,7 @@ func TestPurgeKeys(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -193,7 +193,7 @@ func TestPurgeKey(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -251,7 +251,7 @@ func TestPurgeURL(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/purge/purge_test.go
+++ b/pkg/commands/purge/purge_test.go
@@ -57,7 +57,7 @@ func TestPurgeAll(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -112,7 +112,7 @@ func TestPurgeKeys(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -193,7 +193,7 @@ func TestPurgeKey(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -251,7 +251,7 @@ func TestPurgeURL(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/purge/root.go
+++ b/pkg/commands/purge/root.go
@@ -61,11 +61,6 @@ type RootCommand struct {
 
 // Exec implements the command interface.
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	serviceID, source, flag, err := cmd.ServiceID(c.serviceName, c.manifest, c.Globals.APIClient, c.Globals.ErrLog)
 	if err != nil {
 		return err

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -63,7 +63,7 @@ func TestServiceCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -215,7 +215,7 @@ func TestServiceList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -270,7 +270,7 @@ func TestServiceDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -309,7 +309,7 @@ func TestServiceSearch(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -372,7 +372,7 @@ func TestServiceUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -456,7 +456,7 @@ func TestServiceDelete(t *testing.T) {
 
 			var stdout bytes.Buffer
 			runOpts := testutil.NewRunOpts(testcase.args, &stdout)
-			runOpts.ClientFactory = mock.APIClient(testcase.api)
+			runOpts.ClientFactory = mock.ClientFactory(testcase.api)
 			runErr := app.Run(runOpts)
 			testutil.AssertErrorContains(t, runErr, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -63,7 +63,7 @@ func TestServiceCreate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -215,7 +215,7 @@ func TestServiceList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -270,7 +270,7 @@ func TestServiceDescribe(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -309,7 +309,7 @@ func TestServiceSearch(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -372,7 +372,7 @@ func TestServiceUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -456,7 +456,7 @@ func TestServiceDelete(t *testing.T) {
 
 			var stdout bytes.Buffer
 			runOpts := testutil.NewRunOpts(testcase.args, &stdout)
-			runOpts.APIClient = mock.APIClient(testcase.api)
+			runOpts.ClientFactory = mock.APIClient(testcase.api)
 			runErr := app.Run(runOpts)
 			testutil.AssertErrorContains(t, runErr, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package service_test
 
 import (
@@ -25,37 +28,37 @@ func TestServiceCreate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("service create"),
+			args:      args("service create --token 123"),
 			api:       mock.API{CreateServiceFn: createServiceOK},
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:       args("service create --name Foo"),
+			args:       args("service create --name Foo --token 123"),
 			api:        mock.API{CreateServiceFn: createServiceOK},
 			wantOutput: "Created service 12345",
 		},
 		{
-			args:       args("service create -n=Foo"),
+			args:       args("service create -n=Foo --token 123"),
 			api:        mock.API{CreateServiceFn: createServiceOK},
 			wantOutput: "Created service 12345",
 		},
 		{
-			args:       args("service create --name Foo --type wasm"),
+			args:       args("service create --name Foo --type wasm --token 123"),
 			api:        mock.API{CreateServiceFn: createServiceOK},
 			wantOutput: "Created service 12345",
 		},
 		{
-			args:       args("service create --name Foo --type wasm --comment Hello"),
+			args:       args("service create --name Foo --type wasm --comment Hello --token 123"),
 			api:        mock.API{CreateServiceFn: createServiceOK},
 			wantOutput: "Created service 12345",
 		},
 		{
-			args:       args("service create -n Foo --comment Hello"),
+			args:       args("service create -n Foo --comment Hello --token 123"),
 			api:        mock.API{CreateServiceFn: createServiceOK},
 			wantOutput: "Created service 12345",
 		},
 		{
-			args:      args("service create -n Foo"),
+			args:      args("service create -n Foo --token 123"),
 			api:       mock.API{CreateServiceFn: createServiceError},
 			wantError: errTest.Error(),
 		},
@@ -166,7 +169,7 @@ func TestServiceList(t *testing.T) {
 					return &mockServicesPaginator{returnErr: true}
 				},
 			},
-			args:      args("service list"),
+			args:      args("service list --token 123"),
 			wantError: testutil.Err.Error(),
 		},
 		// NOTE: Our mock paginator defines three services, and so even when setting
@@ -177,7 +180,7 @@ func TestServiceList(t *testing.T) {
 					return &mockServicesPaginator{numOfPages: i.PerPage, maxPages: 3}
 				},
 			},
-			args:       args("service list --per-page 1"),
+			args:       args("service list --per-page 1 --token 123"),
 			wantOutput: listServicesShortOutput,
 		},
 		// In the following test, we set --page 1 and as there's only one record
@@ -188,7 +191,7 @@ func TestServiceList(t *testing.T) {
 					return &mockServicesPaginator{count: i.Page - 1, requestedPage: i.Page, numOfPages: i.PerPage, maxPages: 3}
 				},
 			},
-			args:       args("service list --page 1 --per-page 1"),
+			args:       args("service list --page 1 --per-page 1 --token 123"),
 			wantOutput: listServicesShortOutputPageOne,
 		},
 		// In the following test, we set --page 2 and as there's only one record
@@ -199,7 +202,7 @@ func TestServiceList(t *testing.T) {
 					return &mockServicesPaginator{count: i.Page - 1, requestedPage: i.Page, numOfPages: i.PerPage, maxPages: 3}
 				},
 			},
-			args:       args("service list --page 2 --per-page 1"),
+			args:       args("service list --page 2 --per-page 1 --token 123"),
 			wantOutput: listServicesShortOutputPageTwo,
 		},
 		{
@@ -208,7 +211,7 @@ func TestServiceList(t *testing.T) {
 					return &mockServicesPaginator{maxPages: 3}
 				},
 			},
-			args:       args("service list --verbose"),
+			args:       args("service list --verbose --token 123"),
 			wantOutput: listServicesVerboseOutput,
 		},
 	} {
@@ -232,37 +235,37 @@ func TestServiceDescribe(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("service describe"),
+			args:      args("service describe --token 123"),
 			api:       mock.API{GetServiceDetailsFn: describeServiceOK},
 			wantError: "error reading service: no service ID found",
 		},
 		{
-			args:       args("service describe --service-id 123"),
+			args:       args("service describe --service-id 123 --token 123"),
 			api:        mock.API{GetServiceDetailsFn: describeServiceOK},
 			wantOutput: describeServiceShortOutput,
 		},
 		{
-			args:       args("service describe --service-id 123 --verbose"),
+			args:       args("service describe --service-id 123 --verbose --token 123"),
 			api:        mock.API{GetServiceDetailsFn: describeServiceOK},
 			wantOutput: describeServiceVerboseOutput,
 		},
 		{
-			args:       args("service describe --service-id 123 -v"),
+			args:       args("service describe --service-id 123 -v --token 123"),
 			api:        mock.API{GetServiceDetailsFn: describeServiceOK},
 			wantOutput: describeServiceVerboseOutput,
 		},
 		{
-			args:       args("service --verbose describe --service-id 123"),
+			args:       args("service --verbose describe --service-id 123 --token 123"),
 			api:        mock.API{GetServiceDetailsFn: describeServiceOK},
 			wantOutput: describeServiceVerboseOutput,
 		},
 		{
-			args:       args("-v service describe --service-id 123"),
+			args:       args("-v service describe --service-id 123 --token 123"),
 			api:        mock.API{GetServiceDetailsFn: describeServiceOK},
 			wantOutput: describeServiceVerboseOutput,
 		},
 		{
-			args:      args("service describe --service-id 123"),
+			args:      args("service describe --service-id 123 --token 123"),
 			api:       mock.API{GetServiceDetailsFn: describeServiceError},
 			wantError: errTest.Error(),
 		},
@@ -287,21 +290,21 @@ func TestServiceSearch(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("service search"),
+			args:      args("service search --token 123"),
 			wantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			args:       args("service search --name Foo"),
+			args:       args("service search --name Foo --token 123"),
 			api:        mock.API{SearchServiceFn: searchServiceOK},
 			wantOutput: searchServiceShortOutput,
 		},
 		{
-			args:       args("service search --name Foo -v"),
+			args:       args("service search --name Foo -v --token 123"),
 			api:        mock.API{SearchServiceFn: searchServiceOK},
 			wantOutput: searchServiceVerboseOutput,
 		},
 		{
-			args:      args("service search --name"),
+			args:      args("service search --name --token 123"),
 			api:       mock.API{SearchServiceFn: searchServiceOK},
 			wantError: "error parsing arguments: expected argument for flag '--name'",
 		},
@@ -326,7 +329,7 @@ func TestServiceUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("service update"),
+			args: args("service update --token 123"),
 			api: mock.API{
 				GetServiceFn:    getServiceOK,
 				UpdateServiceFn: updateServiceOK,
@@ -334,37 +337,37 @@ func TestServiceUpdate(t *testing.T) {
 			wantError: "error reading service: no service ID found",
 		},
 		{
-			args:      args("service update --service-id 12345"),
+			args:      args("service update --service-id 12345 --token 123"),
 			api:       mock.API{UpdateServiceFn: updateServiceOK},
 			wantError: "error parsing arguments: must provide either --name or --comment to update service",
 		},
 		{
-			args:       args("service update --service-id 12345 --name Foo"),
+			args:       args("service update --service-id 12345 --name Foo --token 123"),
 			api:        mock.API{UpdateServiceFn: updateServiceOK},
 			wantOutput: "Updated service 12345",
 		},
 		{
-			args:       args("service update --service-id 12345 -n=Foo"),
+			args:       args("service update --service-id 12345 -n=Foo --token 123"),
 			api:        mock.API{UpdateServiceFn: updateServiceOK},
 			wantOutput: "Updated service 12345",
 		},
 		{
-			args:       args("service update --service-id 12345 --name Foo"),
+			args:       args("service update --service-id 12345 --name Foo --token 123"),
 			api:        mock.API{UpdateServiceFn: updateServiceOK},
 			wantOutput: "Updated service 12345",
 		},
 		{
-			args:       args("service update --service-id 12345 --name Foo --comment Hello"),
+			args:       args("service update --service-id 12345 --name Foo --comment Hello --token 123"),
 			api:        mock.API{UpdateServiceFn: updateServiceOK},
 			wantOutput: "Updated service 12345",
 		},
 		{
-			args:       args("service update --service-id 12345 -n Foo --comment Hello"),
+			args:       args("service update --service-id 12345 -n Foo --comment Hello --token 123"),
 			api:        mock.API{UpdateServiceFn: updateServiceOK},
 			wantOutput: "Updated service 12345",
 		},
 		{
-			args:      args("service update --service-id 12345 -n Foo"),
+			args:      args("service update --service-id 12345 -n Foo --token 123"),
 			api:       mock.API{UpdateServiceFn: updateServiceError},
 			wantError: errTest.Error(),
 		},
@@ -393,32 +396,32 @@ func TestServiceDelete(t *testing.T) {
 		expectEmptyServiceID bool
 	}{
 		{
-			args:      args("service delete"),
+			args:      args("service delete --token 123"),
 			api:       mock.API{DeleteServiceFn: deleteServiceOK},
 			manifest:  "fastly-no-serviceid.toml",
 			wantError: "error reading service: no service ID found",
 		},
 		{
-			args:                 args("service delete"),
+			args:                 args("service delete --token 123"),
 			api:                  mock.API{DeleteServiceFn: deleteServiceOK},
 			manifest:             "fastly-valid.toml",
 			wantOutput:           "Deleted service ID 123",
 			expectEmptyServiceID: true,
 		},
 		{
-			args:       args("service delete --service-id 001"),
+			args:       args("service delete --service-id 001 --token 123"),
 			api:        mock.API{DeleteServiceFn: deleteServiceOK},
 			wantOutput: "Deleted service ID 001",
 		},
 		{
-			args:                 args("service delete --service-id 001"),
+			args:                 args("service delete --service-id 001 --token 123"),
 			api:                  mock.API{DeleteServiceFn: deleteServiceOK},
 			manifest:             "fastly-valid.toml",
 			wantOutput:           "Deleted service ID 001",
 			expectEmptyServiceID: false,
 		},
 		{
-			args:      args("service delete --service-id 001"),
+			args:      args("service delete --service-id 001 --token 123"),
 			api:       mock.API{DeleteServiceFn: deleteServiceError},
 			manifest:  "fastly-valid.toml",
 			wantError: errTest.Error(),
@@ -518,7 +521,7 @@ Bar   456  wasm  1               2015-03-14 12:59
 `) + "\n"
 
 var listServicesVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service 1/3
 	ID: 123
@@ -664,7 +667,7 @@ Versions: 2
 `) + "\n"
 
 var describeServiceVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 
@@ -773,7 +776,7 @@ Versions: 2
 `) + "\n"
 
 var searchServiceVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 ID: 123
 Name: Foo

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -47,7 +47,7 @@ func TestVersionClone(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -97,7 +97,7 @@ func TestVersionList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -143,7 +143,7 @@ func TestVersionUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -193,7 +193,7 @@ func TestVersionActivate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -241,7 +241,7 @@ func TestVersionDeactivate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -281,7 +281,7 @@ func TestVersionLock(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package serviceversion_test
 
 import (
@@ -20,15 +23,15 @@ func TestVersionClone(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("service-version clone --version 1"),
+			args:      args("service-version clone --version 1 --token 123"),
 			wantError: "error reading service: no service ID found",
 		},
 		{
-			args:      args("service-version clone --service-id 123"),
+			args:      args("service-version clone --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args: args("service-version clone --service-id 123 --version 1"),
+			args: args("service-version clone --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -36,7 +39,7 @@ func TestVersionClone(t *testing.T) {
 			wantOutput: "Cloned service 123 version 1 to version 4",
 		},
 		{
-			args: args("service-version clone --service-id 456 --version 1"),
+			args: args("service-version clone --service-id 456 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionError,
@@ -64,32 +67,32 @@ func TestVersionList(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       args("service-version list --service-id 123"),
+			args:       args("service-version list --service-id 123 --token 123"),
 			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsShortOutput,
 		},
 		{
-			args:       args("service-version list --service-id 123 --verbose"),
+			args:       args("service-version list --service-id 123 --verbose --token 123"),
 			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
-			args:       args("service-version list --service-id 123 -v"),
+			args:       args("service-version list --service-id 123 -v --token 123"),
 			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
-			args:       args("service-version --verbose list --service-id 123"),
+			args:       args("service-version --verbose list --service-id 123 --token 123"),
 			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
-			args:       args("-v service-version list --service-id 123"),
+			args:       args("-v service-version list --service-id 123 --token 123"),
 			api:        mock.API{ListVersionsFn: testutil.ListVersions},
 			wantOutput: listVersionsVerboseOutput,
 		},
 		{
-			args:      args("service-version list --service-id 123"),
+			args:      args("service-version list --service-id 123 --token 123"),
 			api:       mock.API{ListVersionsFn: testutil.ListVersionsError},
 			wantError: testutil.Err.Error(),
 		},
@@ -114,7 +117,7 @@ func TestVersionUpdate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args: args("service-version update --service-id 123 --version 1 --comment foo --autoclone"),
+			args: args("service-version update --service-id 123 --version 1 --comment foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -123,7 +126,7 @@ func TestVersionUpdate(t *testing.T) {
 			wantOutput: "Updated service 123 version 4",
 		},
 		{
-			args: args("service-version update --service-id 123 --version 1 --autoclone"),
+			args: args("service-version update --service-id 123 --version 1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -131,7 +134,7 @@ func TestVersionUpdate(t *testing.T) {
 			wantError: "error parsing arguments: required flag --comment not provided",
 		},
 		{
-			args: args("service-version update --service-id 123 --version 1 --comment foo --autoclone"),
+			args: args("service-version update --service-id 123 --version 1 --comment foo --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -160,11 +163,11 @@ func TestVersionActivate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("service-version activate --service-id 123"),
+			args:      args("service-version activate --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args: args("service-version activate --service-id 123 --version 1 --autoclone"),
+			args: args("service-version activate --service-id 123 --version 1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -173,7 +176,7 @@ func TestVersionActivate(t *testing.T) {
 			wantError: testutil.Err.Error(),
 		},
 		{
-			args: args("service-version activate --service-id 123 --version 1 --autoclone"),
+			args: args("service-version activate --service-id 123 --version 1 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -182,7 +185,7 @@ func TestVersionActivate(t *testing.T) {
 			wantOutput: "Activated service 123 version 4",
 		},
 		{
-			args: args("service-version activate --service-id 123 --version 3 --autoclone"),
+			args: args("service-version activate --service-id 123 --version 3 --autoclone --token 123"),
 			api: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ActivateVersionFn: activateVersionOK,
@@ -210,11 +213,11 @@ func TestVersionDeactivate(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("service-version deactivate --service-id 123"),
+			args:      args("service-version deactivate --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args: args("service-version deactivate --service-id 123 --version 1"),
+			args: args("service-version deactivate --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				DeactivateVersionFn: deactivateVersionOK,
@@ -222,7 +225,7 @@ func TestVersionDeactivate(t *testing.T) {
 			wantOutput: "Deactivated service 123 version 1",
 		},
 		{
-			args: args("service-version deactivate --service-id 123 --version 3"),
+			args: args("service-version deactivate --service-id 123 --version 3 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				DeactivateVersionFn: deactivateVersionOK,
@@ -230,7 +233,7 @@ func TestVersionDeactivate(t *testing.T) {
 			wantOutput: "Deactivated service 123 version 3",
 		},
 		{
-			args: args("service-version deactivate --service-id 123 --version 3"),
+			args: args("service-version deactivate --service-id 123 --version 3 --token 123"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				DeactivateVersionFn: deactivateVersionError,
@@ -258,11 +261,11 @@ func TestVersionLock(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:      args("service-version lock --service-id 123"),
+			args:      args("service-version lock --service-id 123 --token 123"),
 			wantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			args: args("service-version lock --service-id 123 --version 1"),
+			args: args("service-version lock --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				LockVersionFn:  lockVersionOK,
@@ -270,7 +273,7 @@ func TestVersionLock(t *testing.T) {
 			wantOutput: "Locked service 123 version 1",
 		},
 		{
-			args: args("service-version lock --service-id 123 --version 1"),
+			args: args("service-version lock --service-id 123 --version 1 --token 123"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				LockVersionFn:  lockVersionError,
@@ -297,7 +300,7 @@ NUMBER  ACTIVE  LAST EDITED (UTC)
 `) + "\n"
 
 var listVersionsVerboseOutput = strings.TrimSpace(`
-Fastly API token not provided
+Fastly API token provided via --token
 Fastly API endpoint: https://api.fastly.com
 Service ID (via --service-id): 123
 

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -47,7 +47,7 @@ func TestVersionClone(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -97,7 +97,7 @@ func TestVersionList(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertString(t, testcase.wantOutput, stdout.String())
@@ -143,7 +143,7 @@ func TestVersionUpdate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -193,7 +193,7 @@ func TestVersionActivate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -241,7 +241,7 @@ func TestVersionDeactivate(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
@@ -281,7 +281,7 @@ func TestVersionLock(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/stats/historical_test.go
+++ b/pkg/commands/stats/historical_test.go
@@ -39,7 +39,7 @@ func TestHistorical(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/stats/historical_test.go
+++ b/pkg/commands/stats/historical_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package stats_test
 
 import (
@@ -21,17 +24,17 @@ func TestHistorical(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       args("stats historical --service-id=123"),
+			args:       args("stats historical --service-id=123 --token 123"),
 			api:        mock.API{GetStatsJSONFn: getStatsJSONOK},
 			wantOutput: historicalOK,
 		},
 		{
-			args:      args("stats historical --service-id=123"),
+			args:      args("stats historical --service-id=123 --token 123"),
 			api:       mock.API{GetStatsJSONFn: getStatsJSONError},
 			wantError: errTest.Error(),
 		},
 		{
-			args:       args("stats historical --service-id=123 --format=json"),
+			args:       args("stats historical --service-id=123 --format=json --token 123"),
 			api:        mock.API{GetStatsJSONFn: getStatsJSONOK},
 			wantOutput: historicalJSONOK,
 		},

--- a/pkg/commands/stats/historical_test.go
+++ b/pkg/commands/stats/historical_test.go
@@ -39,7 +39,7 @@ func TestHistorical(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/stats/regions_test.go
+++ b/pkg/commands/stats/regions_test.go
@@ -34,7 +34,7 @@ func TestRegions(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.ClientFactory(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/stats/regions_test.go
+++ b/pkg/commands/stats/regions_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package stats_test
 
 import (
@@ -21,12 +24,12 @@ func TestRegions(t *testing.T) {
 		wantOutput string
 	}{
 		{
-			args:       args("stats regions"),
+			args:       args("stats regions --token 123"),
 			api:        mock.API{GetRegionsFn: getRegionsOK},
 			wantOutput: "foo\nbar\nbaz\n",
 		},
 		{
-			args:      args("stats regions"),
+			args:      args("stats regions --token 123"),
 			api:       mock.API{GetRegionsFn: getRegionsError},
 			wantError: errTest.Error(),
 		},

--- a/pkg/commands/stats/regions_test.go
+++ b/pkg/commands/stats/regions_test.go
@@ -34,7 +34,7 @@ func TestRegions(t *testing.T) {
 		t.Run(strings.Join(testcase.args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.api)
+			opts.ClientFactory = mock.APIClient(testcase.api)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)

--- a/pkg/commands/user/create.go
+++ b/pkg/commands/user/create.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -40,11 +39,6 @@ type CreateCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	input := c.constructInput()
 
 	r, err := c.Globals.APIClient.CreateUser(input)

--- a/pkg/commands/user/delete.go
+++ b/pkg/commands/user/delete.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -31,11 +30,6 @@ type DeleteCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	input := c.constructInput()
 
 	err := c.Globals.APIClient.DeleteUser(input)

--- a/pkg/commands/user/describe.go
+++ b/pkg/commands/user/describe.go
@@ -40,11 +40,6 @@ type DescribeCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	if c.current {
 		r, err := c.Globals.APIClient.GetCurrentUser()
 		if err != nil {

--- a/pkg/commands/user/list.go
+++ b/pkg/commands/user/list.go
@@ -45,10 +45,6 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return fsterr.ErrNoToken
-	}
 	if c.Globals.Verbose() && c.json {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}

--- a/pkg/commands/user/update.go
+++ b/pkg/commands/user/update.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -41,11 +40,6 @@ type UpdateCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	_, s := c.Globals.Token()
-	if s == config.SourceUndefined {
-		return errors.ErrNoToken
-	}
-
 	if c.reset {
 		input, err := c.constructInputReset()
 		if err != nil {

--- a/pkg/commands/user/user_test.go
+++ b/pkg/commands/user/user_test.go
@@ -59,7 +59,7 @@ func TestCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -106,7 +106,7 @@ func TestDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -169,7 +169,7 @@ func TestDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -222,7 +222,7 @@ func TestList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -308,7 +308,7 @@ func TestUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/user/user_test.go
+++ b/pkg/commands/user/user_test.go
@@ -59,7 +59,7 @@ func TestCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -106,7 +106,7 @@ func TestDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -169,7 +169,7 @@ func TestDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -222,7 +222,7 @@ func TestList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -308,7 +308,7 @@ func TestUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/user/user_test.go
+++ b/pkg/commands/user/user_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package user_test
 
 import (
@@ -6,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/fastly/cli/pkg/app"
-	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/go-fastly/v6/fastly"
@@ -17,18 +19,13 @@ func TestCreate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --login flag",
-			Args:      args("user create --name foobar"),
+			Args:      args("user create --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --login not provided",
 		},
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("user create --login foo@example.com"),
+			Args:      args("user create --login foo@example.com --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
-		},
-		{
-			Name:      "validate missing --token flag",
-			Args:      args("user create --login foo@example.com --name foobar"),
-			WantError: errors.ErrNoToken.Inner.Error(),
 		},
 		{
 			Name: "validate CreateUser API error",
@@ -72,13 +69,8 @@ func TestDelete(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --id flag",
-			Args:      args("user delete"),
+			Args:      args("user delete --token 123"),
 			WantError: "error parsing arguments: required flag --id not provided",
-		},
-		{
-			Name:      "validate missing --token flag",
-			Args:      args("user delete --id foo123"),
-			WantError: errors.ErrNoToken.Inner.Error(),
 		},
 		{
 			Name: "validate DeleteUser API error",
@@ -117,11 +109,6 @@ func TestDelete(t *testing.T) {
 func TestDescribe(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
-		{
-			Name:      "validate missing --token flag",
-			Args:      args("user describe"),
-			WantError: errors.ErrNoToken.Inner.Error(),
-		},
 		{
 			Name:      "validate missing --id flag",
 			Args:      args("user describe --token 123"),
@@ -181,11 +168,6 @@ func TestList(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
 		{
-			Name:      "validate missing --token flag",
-			Args:      args("user list --customer-id abc"),
-			WantError: errors.ErrNoToken.Inner.Error(),
-		},
-		{
 			Name:      "validate missing --customer-id flag",
 			Args:      args("user list --token 123"),
 			WantError: "error reading customer ID: no customer ID found",
@@ -233,11 +215,6 @@ func TestList(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
-		{
-			Name:      "validate missing --token flag",
-			Args:      args("user update --id 123"),
-			WantError: errors.ErrNoToken.Inner.Error(),
-		},
 		{
 			Name:      "validate missing --id flag",
 			Args:      args("user update --token 123"),

--- a/pkg/commands/vcl/custom/custom_test.go
+++ b/pkg/commands/vcl/custom/custom_test.go
@@ -140,7 +140,7 @@ func TestVCLCustomCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -215,7 +215,7 @@ func TestVCLCustomDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -276,7 +276,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -341,7 +341,7 @@ func TestVCLCustomList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -451,7 +451,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/vcl/custom/custom_test.go
+++ b/pkg/commands/vcl/custom/custom_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package custom_test
 
 import (
@@ -16,22 +19,22 @@ func TestVCLCustomCreate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --content flag",
-			Args:      args("vcl custom create --name foo --version 3"),
+			Args:      args("vcl custom create --name foo --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --content not provided",
 		},
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("vcl custom create --content /path/to/example.vcl --version 3"),
+			Args:      args("vcl custom create --content /path/to/example.vcl --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl custom create --content /path/to/example.vcl --name foo"),
+			Args:      args("vcl custom create --content /path/to/example.vcl --name foo --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl custom create --content /path/to/example.vcl --name foo --version 3"),
+			Args:      args("vcl custom create --content /path/to/example.vcl --name foo --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -39,7 +42,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl custom create --content ./testdata/example.vcl --name foo --service-id 123 --version 1"),
+			Args:      args("vcl custom create --content ./testdata/example.vcl --name foo --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -50,7 +53,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl custom create --content ./testdata/example.vcl --name foo --service-id 123 --version 3"),
+			Args:      args("vcl custom create --content ./testdata/example.vcl --name foo --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -70,7 +73,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom create --content ./testdata/example.vcl --name foo --service-id 123 --version 3"),
+			Args:       args("vcl custom create --content ./testdata/example.vcl --name foo --service-id 123 --version 3 --token 123"),
 			WantOutput: "Created custom VCL 'foo' (service: 123, version: 3, main: false)",
 		},
 		{
@@ -90,7 +93,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom create --content ./testdata/example.vcl --main --name foo --service-id 123 --version 3"),
+			Args:       args("vcl custom create --content ./testdata/example.vcl --main --name foo --service-id 123 --version 3 --token 123"),
 			WantOutput: "Created custom VCL 'foo' (service: 123, version: 3, main: true)",
 		},
 		{
@@ -111,7 +114,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom create --autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1"),
+			Args:       args("vcl custom create --autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Created custom VCL 'foo' (service: 123, version: 4, main: false)",
 		},
 		{
@@ -131,7 +134,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom create --content inline_vcl --name foo --service-id 123 --version 3"),
+			Args:       args("vcl custom create --content inline_vcl --name foo --service-id 123 --version 3 --token 123"),
 			WantOutput: "Created custom VCL 'foo' (service: 123, version: 3, main: false)",
 		},
 	}
@@ -154,17 +157,17 @@ func TestVCLCustomDelete(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("vcl custom delete --version 3"),
+			Args:      args("vcl custom delete --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl custom delete --name foobar"),
+			Args:      args("vcl custom delete --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl custom delete --name foobar --version 3"),
+			Args:      args("vcl custom delete --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -172,7 +175,7 @@ func TestVCLCustomDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl custom delete --name foobar --service-id 123 --version 1"),
+			Args:      args("vcl custom delete --name foobar --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -183,7 +186,7 @@ func TestVCLCustomDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Args:      args("vcl custom delete --name foobar --service-id 123 --version 3"),
+			Args:      args("vcl custom delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -194,7 +197,7 @@ func TestVCLCustomDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("vcl custom delete --name foobar --service-id 123 --version 3"),
+			Args:       args("vcl custom delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "Deleted custom VCL 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -206,7 +209,7 @@ func TestVCLCustomDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("vcl custom delete --autoclone --name foo --service-id 123 --version 1"),
+			Args:       args("vcl custom delete --autoclone --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Deleted custom VCL 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -228,17 +231,17 @@ func TestVCLCustomDescribe(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("vcl custom describe --version 3"),
+			Args:      args("vcl custom describe --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl custom describe --name foobar"),
+			Args:      args("vcl custom describe --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl custom describe --name foobar --version 3"),
+			Args:      args("vcl custom describe --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -249,7 +252,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl custom describe --name foobar --service-id 123 --version 3"),
+			Args:      args("vcl custom describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -258,7 +261,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetVCLFn:       getVCL,
 			},
-			Args:       args("vcl custom describe --name foobar --service-id 123 --version 3"),
+			Args:       args("vcl custom describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -267,7 +270,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetVCLFn:       getVCL,
 			},
-			Args:       args("vcl custom describe --name foobar --service-id 123 --version 1"),
+			Args:       args("vcl custom describe --name foobar --service-id 123 --version 1 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
@@ -289,12 +292,12 @@ func TestVCLCustomList(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl custom list"),
+			Args:      args("vcl custom list --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl custom list --version 3"),
+			Args:      args("vcl custom list --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -305,7 +308,7 @@ func TestVCLCustomList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl custom list --service-id 123 --version 3"),
+			Args:      args("vcl custom list --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -314,7 +317,7 @@ func TestVCLCustomList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListVCLsFn:     listVCLs,
 			},
-			Args:       args("vcl custom list --service-id 123 --version 3"),
+			Args:       args("vcl custom list --service-id 123 --version 3 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME  MAIN\n123         3        foo   true\n123         3        bar   false\n",
 		},
 		{
@@ -323,7 +326,7 @@ func TestVCLCustomList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListVCLsFn:     listVCLs,
 			},
-			Args:       args("vcl custom list --service-id 123 --version 1"),
+			Args:       args("vcl custom list --service-id 123 --version 1 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME  MAIN\n123         1        foo   true\n123         1        bar   false\n",
 		},
 		{
@@ -332,8 +335,8 @@ func TestVCLCustomList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListVCLsFn:     listVCLs,
 			},
-			Args:       args("vcl custom list --service-id 123 --verbose --version 1"),
-			WantOutput: "Fastly API token not provided\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nMain: false\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
+			Args:       args("vcl custom list --service-id 123 --verbose --version 1 --token 123"),
+			WantOutput: "Fastly API token provided via --token\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nMain: false\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
@@ -355,17 +358,17 @@ func TestVCLCustomUpdate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("vcl custom update --version 3"),
+			Args:      args("vcl custom update --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl custom update --name foobar"),
+			Args:      args("vcl custom update --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl custom update --name foobar --version 3"),
+			Args:      args("vcl custom update --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -373,7 +376,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl custom update --name foobar --service-id 123 --version 1"),
+			Args:      args("vcl custom update --name foobar --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -384,7 +387,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl custom update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			Args:      args("vcl custom update --name foobar --new-name beepboop --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -401,7 +404,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom update --name foobar --new-name beepboop --service-id 123 --version 3"),
+			Args:       args("vcl custom update --name foobar --new-name beepboop --service-id 123 --version 3 --token 123"),
 			WantOutput: "Updated custom VCL 'beepboop' (previously: 'foobar', service: 123, version: 3)",
 		},
 		{
@@ -421,7 +424,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom update --content updated --name foobar --service-id 123 --version 3"),
+			Args:       args("vcl custom update --content updated --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "Updated custom VCL 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -442,7 +445,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl custom update --autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1"),
+			Args:       args("vcl custom update --autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Updated custom VCL 'foo' (service: 123, version: 4)",
 		},
 	}

--- a/pkg/commands/vcl/custom/custom_test.go
+++ b/pkg/commands/vcl/custom/custom_test.go
@@ -140,7 +140,7 @@ func TestVCLCustomCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -215,7 +215,7 @@ func TestVCLCustomDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -276,7 +276,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -341,7 +341,7 @@ func TestVCLCustomList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -451,7 +451,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -171,7 +171,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -246,7 +246,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -327,7 +327,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -392,7 +392,7 @@ func TestVCLSnippetList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -532,7 +532,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.ClientFactory = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.ClientFactory(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -171,7 +171,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -246,7 +246,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -327,7 +327,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -392,7 +392,7 @@ func TestVCLSnippetList(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
@@ -532,7 +532,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			var stdout bytes.Buffer
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
-			opts.APIClient = mock.APIClient(testcase.API)
+			opts.ClientFactory = mock.APIClient(testcase.API)
 			err := app.Run(opts)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package snippet_test
 
 import (
@@ -16,27 +19,27 @@ func TestVCLSnippetCreate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --content flag",
-			Args:      args("vcl snippet create --name foo --type recv --version 3"),
+			Args:      args("vcl snippet create --name foo --type recv --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --content not provided",
 		},
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("vcl snippet create --content /path/to/snippet.vcl --type recv --version 3"),
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --type recv --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --type flag",
-			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --version 3"),
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --type not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --type recv"),
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --type recv --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --type recv --version 3"),
+			Args:      args("vcl snippet create --content /path/to/snippet.vcl --name foo --type recv --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -44,7 +47,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet create --content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 1"),
+			Args:      args("vcl snippet create --content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -55,7 +58,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl snippet create --content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 3"),
+			Args:      args("vcl snippet create --content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -76,7 +79,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 3"),
+			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 3 --token 123"),
 			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 		},
 		{
@@ -97,7 +100,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --dynamic --name foo --service-id 123 --type recv --version 3"),
+			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --dynamic --name foo --service-id 123 --type recv --version 3 --token 123"),
 			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: true, snippet id: 123, type: recv, priority: 0)",
 		},
 		{
@@ -119,7 +122,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --priority 1 --service-id 123 --type recv --version 3"),
+			Args:       args("vcl snippet create --content ./testdata/snippet.vcl --name foo --priority 1 --service-id 123 --type recv --version 3 --token 123"),
 			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 1)",
 		},
 		{
@@ -141,7 +144,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet create --autoclone --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 1"),
+			Args:       args("vcl snippet create --autoclone --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 1 --token 123"),
 			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 4, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 		},
 		{
@@ -162,7 +165,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet create --content inline_vcl --name foo --service-id 123 --type recv --version 3"),
+			Args:       args("vcl snippet create --content inline_vcl --name foo --service-id 123 --type recv --version 3 --token 123"),
 			WantOutput: "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 		},
 	}
@@ -185,17 +188,17 @@ func TestVCLSnippetDelete(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --name flag",
-			Args:      args("vcl snippet delete --version 3"),
+			Args:      args("vcl snippet delete --version 3 --token 123"),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl snippet delete --name foobar"),
+			Args:      args("vcl snippet delete --name foobar --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl snippet delete --name foobar --version 3"),
+			Args:      args("vcl snippet delete --name foobar --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -203,7 +206,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet delete --name foobar --service-id 123 --version 1"),
+			Args:      args("vcl snippet delete --name foobar --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -214,7 +217,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Args:      args("vcl snippet delete --name foobar --service-id 123 --version 3"),
+			Args:      args("vcl snippet delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -225,7 +228,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("vcl snippet delete --name foobar --service-id 123 --version 3"),
+			Args:       args("vcl snippet delete --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "Deleted VCL snippet 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -237,7 +240,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Args:       args("vcl snippet delete --autoclone --name foo --service-id 123 --version 1"),
+			Args:       args("vcl snippet delete --autoclone --name foo --service-id 123 --version 1 --token 123"),
 			WantOutput: "Deleted VCL snippet 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -259,12 +262,12 @@ func TestVCLSnippetDescribe(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl snippet describe"),
+			Args:      args("vcl snippet describe --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl snippet describe --version 3"),
+			Args:      args("vcl snippet describe --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -272,7 +275,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet describe --service-id 123 --version 3"),
+			Args:      args("vcl snippet describe --service-id 123 --version 3 --token 123"),
 			WantError: "error parsing arguments: must provide --name with a versioned VCL snippet",
 		},
 		{
@@ -280,7 +283,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet describe --dynamic --service-id 123 --version 3"),
+			Args:      args("vcl snippet describe --dynamic --service-id 123 --version 3 --token 123"),
 			WantError: "error parsing arguments: must provide --snippet-id with a dynamic VCL snippet",
 		},
 		{
@@ -291,7 +294,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl snippet describe --name foobar --service-id 123 --version 3"),
+			Args:      args("vcl snippet describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -300,7 +303,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetSnippetFn:   getSnippet,
 			},
-			Args:       args("vcl snippet describe --name foobar --service-id 123 --version 3"),
+			Args:       args("vcl snippet describe --name foobar --service-id 123 --version 3 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -309,7 +312,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetSnippetFn:   getSnippet,
 			},
-			Args:       args("vcl snippet describe --name foobar --service-id 123 --version 1"),
+			Args:       args("vcl snippet describe --name foobar --service-id 123 --version 1 --token 123"),
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -318,7 +321,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				GetDynamicSnippetFn: getDynamicSnippet,
 			},
-			Args:       args("vcl snippet describe --dynamic --service-id 123 --snippet-id 456 --version 3"),
+			Args:       args("vcl snippet describe --dynamic --service-id 123 --snippet-id 456 --version 3 --token 123"),
 			WantOutput: "\nService ID: 123\nID: 456\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
@@ -340,12 +343,12 @@ func TestVCLSnippetList(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl snippet list"),
+			Args:      args("vcl snippet list --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl snippet list --version 3"),
+			Args:      args("vcl snippet list --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -356,7 +359,7 @@ func TestVCLSnippetList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl snippet list --service-id 123 --version 3"),
+			Args:      args("vcl snippet list --service-id 123 --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -365,7 +368,7 @@ func TestVCLSnippetList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListSnippetsFn: listSnippets,
 			},
-			Args:       args("vcl snippet list --service-id 123 --version 3"),
+			Args:       args("vcl snippet list --service-id 123 --version 3 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC  SNIPPET ID\n123         3        foo   true     abc\n123         3        bar   false    abc\n",
 		},
 		{
@@ -374,7 +377,7 @@ func TestVCLSnippetList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListSnippetsFn: listSnippets,
 			},
-			Args:       args("vcl snippet list --service-id 123 --version 1"),
+			Args:       args("vcl snippet list --service-id 123 --version 1 --token 123"),
 			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC  SNIPPET ID\n123         1        foo   true     abc\n123         1        bar   false    abc\n",
 		},
 		{
@@ -383,8 +386,8 @@ func TestVCLSnippetList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListSnippetsFn: listSnippets,
 			},
-			Args:       args("vcl snippet list --service-id 123 --verbose --version 1"),
-			WantOutput: "Fastly API token not provided\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nID: abc\nPriority: 0\nDynamic: true\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nID: abc\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
+			Args:       args("vcl snippet list --service-id 123 --verbose --version 1 --token 123"),
+			WantOutput: "Fastly API token provided via --token\nFastly API endpoint: https://api.fastly.com\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nID: abc\nPriority: 0\nDynamic: true\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nID: abc\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
@@ -406,12 +409,12 @@ func TestVCLSnippetUpdate(t *testing.T) {
 	scenarios := []testutil.TestScenario{
 		{
 			Name:      "validate missing --version flag",
-			Args:      args("vcl snippet update"),
+			Args:      args("vcl snippet update --token 123"),
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Args:      args("vcl snippet update --version 3"),
+			Args:      args("vcl snippet update --version 3 --token 123"),
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -419,7 +422,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet update --service-id 123 --version 1"),
+			Args:      args("vcl snippet update --service-id 123 --version 1 --token 123"),
 			WantError: "service version 1 is not editable",
 		},
 		{
@@ -427,7 +430,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet update --content inline_vcl --new-name bar --service-id 123 --type recv --version 3"),
+			Args:      args("vcl snippet update --content inline_vcl --new-name bar --service-id 123 --type recv --version 3 --token 123"),
 			WantError: "error parsing arguments: must provide --name to update a versioned VCL snippet",
 		},
 		{
@@ -435,7 +438,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet update --content inline_vcl --dynamic --service-id 123 --version 3"),
+			Args:      args("vcl snippet update --content inline_vcl --dynamic --service-id 123 --version 3 --token 123"),
 			WantError: "error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet",
 		},
 		{
@@ -443,7 +446,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet update --content inline_vcl --new-name foobar --service-id 123 --snippet-id 456 --version 3"),
+			Args:      args("vcl snippet update --content inline_vcl --new-name foobar --service-id 123 --snippet-id 456 --version 3 --token 123"),
 			WantError: "error parsing arguments: --snippet-id is not supported when updating a versioned VCL snippet",
 		},
 		{
@@ -451,7 +454,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Args:      args("vcl snippet update --content inline_vcl --dynamic --new-name foobar --service-id 123 --snippet-id 456 --version 3"),
+			Args:      args("vcl snippet update --content inline_vcl --dynamic --new-name foobar --service-id 123 --snippet-id 456 --version 3 --token 123"),
 			WantError: "error parsing arguments: --new-name is not supported when updating a dynamic VCL snippet",
 		},
 		{
@@ -462,7 +465,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Args:      args("vcl snippet update --content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3"),
+			Args:      args("vcl snippet update --content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3 --token 123"),
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -483,7 +486,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet update --content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3"),
+			Args:       args("vcl snippet update --content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3 --token 123"),
 			WantOutput: "Updated VCL snippet 'bar' (previously: 'foo', service: 123, version: 3, type: recv, priority: 100)",
 		},
 		{
@@ -501,7 +504,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet update --content inline_vcl --dynamic --service-id 123 --snippet-id 456 --version 3"),
+			Args:       args("vcl snippet update --content inline_vcl --dynamic --service-id 123 --snippet-id 456 --version 3 --token 123"),
 			WantOutput: "Updated dynamic VCL snippet '456' (service: 123)",
 		},
 		{
@@ -523,7 +526,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("vcl snippet update --autoclone --content inline_vcl --name foo --new-name bar --priority 1 --service-id 123 --type recv --version 1"),
+			Args:       args("vcl snippet update --autoclone --content inline_vcl --name foo --new-name bar --priority 1 --service-id 123 --type recv --version 1 --token 123"),
 			WantOutput: "Updated VCL snippet 'bar' (previously: 'foo', service: 123, version: 4, type: recv, priority: 1)",
 		},
 	}

--- a/pkg/commands/whoami/whoami_test.go
+++ b/pkg/commands/whoami/whoami_test.go
@@ -1,3 +1,6 @@
+// NOTE: We always pass the --token flag as this allows us to side-step the
+// browser based authentication flow. This is because if a token is explicitly
+// provided, then we respect the user knows what they're doing.
 package whoami_test
 
 import (
@@ -28,12 +31,6 @@ func TestWhoami(t *testing.T) {
 		wantError  string
 		wantOutput string
 	}{
-		{
-			name:      "no token",
-			args:      args("whoami"),
-			client:    verifyClient(basicResponse),
-			wantError: "no token provided",
-		},
 		{
 			name:       "basic response",
 			args:       args("--token=x whoami"),

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -21,12 +21,6 @@ type Source uint8
 const (
 	// Filename is the name of the package manifest file.
 	// It is expected to be a project specific configuration file.
-	//
-	// TODO: The filename needs to be referenced outside of the compute package
-	// so consider moving this constant to a different location in the top-level
-	// pkg directory instead or even moving the whole manifest package up to the
-	// top-level pkg directory as finding a suitable package for just the
-	// manifest filename could be tricky.
 	Filename = "fastly.toml"
 
 	// ManifestLatestVersion represents the latest known manifest schema version

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"net/http"
+
 	"github.com/fastly/go-fastly/v6/fastly"
 )
 
@@ -8,6 +10,8 @@ import (
 // The zero value is useful, but will panic on all methods. Provide function
 // implementations for the method(s) your test will call.
 type API struct {
+	GetFn func(p string, ro *fastly.RequestOptions) (*http.Response, error)
+
 	AllDatacentersFn func() (datacenters []fastly.Datacenter, err error)
 	AllIPsFn         func() (v4, v6 fastly.IPAddrs, err error)
 
@@ -278,6 +282,11 @@ type API struct {
 	NewListACLEntriesPaginatorFn      func(i *fastly.ListACLEntriesInput) fastly.PaginatorACLEntries
 	NewListDictionaryItemsPaginatorFn func(i *fastly.ListDictionaryItemsInput) fastly.PaginatorDictionaryItems
 	NewListServicesPaginatorFn        func(i *fastly.ListServicesInput) fastly.PaginatorServices
+}
+
+// Get implements Interface.
+func (m API) Get(p string, ro *fastly.RequestOptions) (*http.Response, error) {
+	return m.GetFn(p, ro)
 }
 
 // AllDatacenters implements Interface.

--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -6,9 +6,9 @@ import (
 	"github.com/fastly/cli/pkg/api"
 )
 
-// APIClient takes a mock.API and returns an app.ClientFactory that uses that
+// ClientFactory takes a mock.API and returns an app.ClientFactory that uses that
 // mock, ignoring the token and endpoint. It should only be used for tests.
-func APIClient(a API) func(string, string) (api.Interface, error) {
+func ClientFactory(a API) api.ClientFactory {
 	return func(token, endpoint string) (api.Interface, error) {
 		return a, nil
 	}

--- a/pkg/testutil/args.go
+++ b/pkg/testutil/args.go
@@ -56,7 +56,7 @@ func Args(args string) []string {
 func NewRunOpts(args []string, stdout io.Writer) app.RunOpts {
 	return app.RunOpts{
 		Args:          args,
-		ClientFactory: mock.APIClient(mock.API{}),
+		ClientFactory: mock.ClientFactory(mock.API{}),
 		ConfigFile:    config.File{},
 		ConfigPath:    "/dev/null",
 		Env:           config.Environment{},

--- a/pkg/testutil/args.go
+++ b/pkg/testutil/args.go
@@ -55,12 +55,12 @@ func Args(args string) []string {
 // commonly changed for testing purposes will need to be provided.
 func NewRunOpts(args []string, stdout io.Writer) app.RunOpts {
 	return app.RunOpts{
-		ConfigPath:    "/dev/null",
 		Args:          args,
 		ClientFactory: mock.APIClient(mock.API{}),
+		ConfigFile:    config.File{},
+		ConfigPath:    "/dev/null",
 		Env:           config.Environment{},
 		ErrLog:        errors.Log,
-		ConfigFile:    config.File{},
 		HTTPClient:    http.DefaultClient,
 		Stdout:        stdout,
 	}

--- a/pkg/testutil/args.go
+++ b/pkg/testutil/args.go
@@ -55,13 +55,13 @@ func Args(args string) []string {
 // commonly changed for testing purposes will need to be provided.
 func NewRunOpts(args []string, stdout io.Writer) app.RunOpts {
 	return app.RunOpts{
-		ConfigPath: "/dev/null",
-		Args:       args,
-		APIClient:  mock.APIClient(mock.API{}),
-		Env:        config.Environment{},
-		ErrLog:     errors.Log,
-		ConfigFile: config.File{},
-		HTTPClient: http.DefaultClient,
-		Stdout:     stdout,
+		ConfigPath:    "/dev/null",
+		Args:          args,
+		ClientFactory: mock.APIClient(mock.API{}),
+		Env:           config.Environment{},
+		ErrLog:        errors.Log,
+		ConfigFile:    config.File{},
+		HTTPClient:    http.DefaultClient,
+		Stdout:        stdout,
 	}
 }


### PR DESCRIPTION
**Problem**: 
Users of the Fastly CLI currently have to manually log into the Fastly UI to create an access token, once created they need to run fastly configure where they’ll be prompted to enter the access token so it can be persisted to disk and reused for future commands. 

This process is tedious, time consuming, and is not ideal due to users typically creating tokens with no expiration date instead of using short-lived tokens that are regenerated periodically

**Solution**:
When running the Fastly CLI, the first operation should be to look for an existing short-lived access token within the CLI configuration file and, if one exists, check if it has expired. 

If the access token has expired or doesn't exist, then a new authentication flow will be initiated, otherwise the pre-existing access token will be utilised for the current command being executed.

The authentication flow will notify the user of what is about to happen and prompt the user to continue. Once the flow proceeds the CLI will open the user’s default web browser and direct it to a Fastly authentication service.

The full token flow will be opaque to the user, and they should only have to worry about their initial username/password login to the authentication service while the CLI takes care of the rest of the flow, persisting the access token to disk and managing its lifecycle.