### PR TITLE
Update `--request-max-entries`/`--request-max-bytes` description default.

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1812,10 +1812,10 @@ COMMANDS
                                    execute
         --request-max-entries=REQUEST-MAX-ENTRIES
                                    Maximum number of logs to append to a batch,
-                                   if non-zero. Defaults to 0 for unbounded
+                                   if non-zero. Defaults to 10k
         --request-max-bytes=REQUEST-MAX-BYTES
                                    Maximum size of log batch, if non-zero.
-                                   Defaults to 0 for unbounded
+                                   Defaults to 100MB
 
   logging elasticsearch delete --version=VERSION --name=NAME [<flags>]
     Delete an Elasticsearch logging endpoint on a Fastly service version
@@ -1912,10 +1912,10 @@ COMMANDS
                                    execute
         --request-max-entries=REQUEST-MAX-ENTRIES
                                    Maximum number of logs to append to a batch,
-                                   if non-zero. Defaults to 0 for unbounded
+                                   if non-zero. Defaults to 10k
         --request-max-bytes=REQUEST-MAX-BYTES
                                    Maximum size of log batch, if non-zero.
-                                   Defaults to 0 for unbounded
+                                   Defaults to 100MB
 
   logging ftp create --name=NAME --version=VERSION --address=ADDRESS --user=USER --password=PASSWORD [<flags>]
     Create an FTP logging endpoint on a Fastly service version

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2580,10 +2580,10 @@ COMMANDS
                                    execute
         --request-max-entries=REQUEST-MAX-ENTRIES
                                    Maximum number of logs to append to a batch,
-                                   if non-zero. Defaults to 0 for unbounded
+                                   if non-zero. Defaults to 10k
         --request-max-bytes=REQUEST-MAX-BYTES
                                    Maximum size of log batch, if non-zero.
-                                   Defaults to 0 for unbounded
+                                   Defaults to 100MB
 
   logging https delete --version=VERSION --name=NAME [<flags>]
     Delete an HTTPS logging endpoint on a Fastly service version
@@ -2683,10 +2683,10 @@ COMMANDS
                                    execute
         --request-max-entries=REQUEST-MAX-ENTRIES
                                    Maximum number of logs to append to a batch,
-                                   if non-zero. Defaults to 0 for unbounded
+                                   if non-zero. Defaults to 10k
         --request-max-bytes=REQUEST-MAX-BYTES
                                    Maximum size of log batch, if non-zero.
-                                   Defaults to 0 for unbounded
+                                   Defaults to 100MB
 
   logging kafka create --name=NAME --version=VERSION --topic=TOPIC --brokers=BROKERS [<flags>]
     Create a Kafka logging endpoint on a Fastly service version

--- a/pkg/commands/logging/elasticsearch/create.go
+++ b/pkg/commands/logging/elasticsearch/create.go
@@ -80,8 +80,8 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
-	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
-	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 10k").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 100MB").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
 	return &c
 }
 

--- a/pkg/commands/logging/elasticsearch/update.go
+++ b/pkg/commands/logging/elasticsearch/update.go
@@ -82,8 +82,8 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
-	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
-	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 10k").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 100MB").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
 	return &c
 }
 

--- a/pkg/commands/logging/https/create.go
+++ b/pkg/commands/logging/https/create.go
@@ -86,8 +86,8 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
-	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
-	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 10k").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 100MB").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
 	return &c
 }
 

--- a/pkg/commands/logging/https/update.go
+++ b/pkg/commands/logging/https/update.go
@@ -88,8 +88,8 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("placement", "Where in the generated VCL the logging call should be placed, overriding any format_version default. Can be none or waf_debug").Action(c.Placement.Set).StringVar(&c.Placement.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)
-	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
-	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 0 for unbounded").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
+	c.CmdClause.Flag("request-max-entries", "Maximum number of logs to append to a batch, if non-zero. Defaults to 10k").Action(c.RequestMaxEntries.Set).UintVar(&c.RequestMaxEntries.Value)
+	c.CmdClause.Flag("request-max-bytes", "Maximum size of log batch, if non-zero. Defaults to 100MB").Action(c.RequestMaxBytes.Set).UintVar(&c.RequestMaxBytes.Value)
 	return &c
 }
 


### PR DESCRIPTION
This PR corrects the default values displayed for some args passed to the HTTPS create and update commands.