### PR TITLE
Fix runtime panic in arg parser

### DIFF
--- a/cmd/fastly/static/config.toml
+++ b/cmd/fastly/static/config.toml
@@ -17,15 +17,10 @@ rustup_constraint = ">= 1.23.0"
 [viceroy]
 ttl = "24h"
 
-[[starter-kits.assemblyscript]]
-name = "Default starter for AssemblyScript"
-description = "A basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
-path = "https://github.com/fastly/compute-starter-kit-assemblyscript-default"
-
-[[starter-kits.javascript]]
-name = "Default starter for JavaScript"
-description = "A basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
-path = "https://github.com/fastly/compute-starter-kit-javascript-default"
+[[starter-kits.rust]]
+name = "Authenticate at edge with OAuth"
+description = "Connect to an identity provider such as Auth0 using OAuth 2.0 and validate authentication status at the Edge, to authorize access to your edge or origin hosted applications."
+path = "https://github.com/fastly/compute-rust-auth"
 
 [[starter-kits.rust]]
 name = "Beacon termination"
@@ -46,3 +41,18 @@ path = "https://github.com/fastly/compute-starter-kit-rust-empty"
 name = "Static content"
 description = "Apply performance, security and usability upgrades to static bucket services such as Google Cloud Storage or AWS S3."
 path = "https://github.com/fastly/compute-starter-kit-rust-static-content"
+
+[[starter-kits.assemblyscript]]
+name = "Default starter for AssemblyScript"
+description = "A basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
+path = "https://github.com/fastly/compute-starter-kit-assemblyscript-default"
+
+[[starter-kits.javascript]]
+name = "Default starter for JavaScript"
+description = "A basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
+path = "https://github.com/fastly/compute-starter-kit-javascript-default"
+
+[[starter-kits.javascript]]
+name = "Empty starter for JavaScript"
+description = "An empty application template for the Fastly Compute@Edge environment which simply returns a 200 OK response."
+path = "https://github.com/fastly/compute-starter-kit-javascript-empty"

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -55,8 +55,11 @@ func TestBackendCreate(t *testing.T) {
 		},
 		// The following test is the same as above but mocks a successful backend
 		// creation so we can validate the correct service version was utilised.
+		//
+		// NOTE: Added --port flag to validate that a nil pointer dereference is
+		// not triggered at runtime when parsing the arguments.
 		{
-			Args: args("backend create --service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone"),
+			Args: args("backend create --service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --port 8080"),
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),

--- a/pkg/commands/backend/create.go
+++ b/pkg/commands/backend/create.go
@@ -17,13 +17,19 @@ type CreateCommand struct {
 	cmd.Base
 	manifest manifest.Data
 
-	Input fastly.CreateBackendInput
+	input               fastly.CreateBackendInput
+	port                cmd.OptionalUint
+	connectTimeout      cmd.OptionalUint
+	maxConn             cmd.OptionalUint
+	firstByteTimeout    cmd.OptionalUint
+	betweenBytesTimeout cmd.OptionalUint
+	weight              cmd.OptionalUint
 
 	// We must store all of the boolean flags separately to the input structure
 	// so they can be casted to go-fastly's custom `Compatibool` type later.
-	AutoLoadbalance bool
-	SSLCheckCert    bool
-	UseSSL          bool
+	autoLoadBalance bool
+	sslCheckCert    bool
+	useSSL          bool
 
 	autoClone       cmd.OptionalAutoClone
 	overrideHost    cmd.OptionalString
@@ -61,30 +67,30 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})
-	c.CmdClause.Flag("name", "Backend name").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("address", "A hostname, IPv4, or IPv6 address for the backend").Required().StringVar(&c.Input.Address)
-	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.Input.Comment)
-	c.CmdClause.Flag("port", "Port number of the address").UintVar(c.Input.Port)
+	c.CmdClause.Flag("name", "Backend name").Short('n').Required().StringVar(&c.input.Name)
+	c.CmdClause.Flag("address", "A hostname, IPv4, or IPv6 address for the backend").Required().StringVar(&c.input.Address)
+	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.input.Comment)
+	c.CmdClause.Flag("port", "Port number of the address").Action(c.port.Set).UintVar(&c.port.Value)
 	c.CmdClause.Flag("override-host", "The hostname to override the Host header").Action(c.overrideHost.Set).StringVar(&c.overrideHost.Value)
-	c.CmdClause.Flag("connect-timeout", "How long to wait for a timeout in milliseconds").UintVar(c.Input.ConnectTimeout)
-	c.CmdClause.Flag("max-conn", "Maximum number of connections").UintVar(c.Input.MaxConn)
-	c.CmdClause.Flag("first-byte-timeout", "How long to wait for the first bytes in milliseconds").UintVar(c.Input.FirstByteTimeout)
-	c.CmdClause.Flag("between-bytes-timeout", "How long to wait between bytes in milliseconds").UintVar(c.Input.BetweenBytesTimeout)
-	c.CmdClause.Flag("auto-loadbalance", "Whether or not this backend should be automatically load balanced").BoolVar(&c.AutoLoadbalance)
-	c.CmdClause.Flag("weight", "Weight used to load balance this backend against others").UintVar(c.Input.Weight)
-	c.CmdClause.Flag("request-condition", "Condition, which if met, will select this backend during a request").StringVar(&c.Input.RequestCondition)
-	c.CmdClause.Flag("healthcheck", "The name of the healthcheck to use with this backend").StringVar(&c.Input.HealthCheck)
-	c.CmdClause.Flag("shield", "The shield POP designated to reduce inbound load on this origin by serving the cached data to the rest of the network").StringVar(&c.Input.Shield)
-	c.CmdClause.Flag("use-ssl", "Whether or not to use SSL to reach the backend").BoolVar(&c.UseSSL)
-	c.CmdClause.Flag("ssl-check-cert", "Be strict on checking SSL certs").BoolVar(&c.SSLCheckCert)
-	c.CmdClause.Flag("ssl-ca-cert", "CA certificate attached to origin").StringVar(&c.Input.SSLCACert)
-	c.CmdClause.Flag("ssl-client-cert", "Client certificate attached to origin").StringVar(&c.Input.SSLClientCert)
-	c.CmdClause.Flag("ssl-client-key", "Client key attached to origin").StringVar(&c.Input.SSLClientKey)
+	c.CmdClause.Flag("connect-timeout", "How long to wait for a timeout in milliseconds").Action(c.connectTimeout.Set).UintVar(&c.connectTimeout.Value)
+	c.CmdClause.Flag("max-conn", "Maximum number of connections").Action(c.maxConn.Set).UintVar(&c.maxConn.Value)
+	c.CmdClause.Flag("first-byte-timeout", "How long to wait for the first bytes in milliseconds").Action(c.firstByteTimeout.Set).UintVar(&c.firstByteTimeout.Value)
+	c.CmdClause.Flag("between-bytes-timeout", "How long to wait between bytes in milliseconds").Action(c.betweenBytesTimeout.Set).UintVar(&c.betweenBytesTimeout.Value)
+	c.CmdClause.Flag("auto-loadbalance", "Whether or not this backend should be automatically load balanced").BoolVar(&c.autoLoadBalance)
+	c.CmdClause.Flag("weight", "Weight used to load balance this backend against others").Action(c.weight.Set).UintVar(&c.weight.Value)
+	c.CmdClause.Flag("request-condition", "Condition, which if met, will select this backend during a request").StringVar(&c.input.RequestCondition)
+	c.CmdClause.Flag("healthcheck", "The name of the healthcheck to use with this backend").StringVar(&c.input.HealthCheck)
+	c.CmdClause.Flag("shield", "The shield POP designated to reduce inbound load on this origin by serving the cached data to the rest of the network").StringVar(&c.input.Shield)
+	c.CmdClause.Flag("use-ssl", "Whether or not to use SSL to reach the backend").BoolVar(&c.useSSL)
+	c.CmdClause.Flag("ssl-check-cert", "Be strict on checking SSL certs").BoolVar(&c.sslCheckCert)
+	c.CmdClause.Flag("ssl-ca-cert", "CA certificate attached to origin").StringVar(&c.input.SSLCACert)
+	c.CmdClause.Flag("ssl-client-cert", "Client certificate attached to origin").StringVar(&c.input.SSLClientCert)
+	c.CmdClause.Flag("ssl-client-key", "Client key attached to origin").StringVar(&c.input.SSLClientKey)
 	c.CmdClause.Flag("ssl-cert-hostname", "Overrides ssl_hostname, but only for cert verification. Does not affect SNI at all.").Action(c.sslCertHostname.Set).StringVar(&c.sslCertHostname.Value)
 	c.CmdClause.Flag("ssl-sni-hostname", "Overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all.").Action(c.sslSNIHostname.Set).StringVar(&c.sslSNIHostname.Value)
-	c.CmdClause.Flag("min-tls-version", "Minimum allowed TLS version on SSL connections to this backend").StringVar(&c.Input.MinTLSVersion)
-	c.CmdClause.Flag("max-tls-version", "Maximum allowed TLS version on SSL connections to this backend").StringVar(&c.Input.MaxTLSVersion)
-	c.CmdClause.Flag("ssl-ciphers", "Colon delimited list of OpenSSL ciphers (see https://www.openssl.org/docs/man1.0.2/man1/ciphers for details)").StringVar(&c.Input.SSLCiphers)
+	c.CmdClause.Flag("min-tls-version", "Minimum allowed TLS version on SSL connections to this backend").StringVar(&c.input.MinTLSVersion)
+	c.CmdClause.Flag("max-tls-version", "Maximum allowed TLS version on SSL connections to this backend").StringVar(&c.input.MaxTLSVersion)
+	c.CmdClause.Flag("ssl-ciphers", "Colon delimited list of OpenSSL ciphers (see https://www.openssl.org/docs/man1.0.2/man1/ciphers for details)").StringVar(&c.input.SSLCiphers)
 
 	return &c
 }
@@ -108,41 +114,57 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	c.Input.ServiceID = serviceID
-	c.Input.ServiceVersion = serviceVersion.Number
+	c.input.ServiceID = serviceID
+	c.input.ServiceVersion = serviceVersion.Number
 
 	// Sadly, go-fastly uses custom a `Compatibool` type as a boolean value that
 	// marshalls to 0/1 instead of true/false for compatability with the API.
 	// Therefore, we need to cast our real flag bool to a fastly.Compatibool.
-	c.Input.AutoLoadbalance = fastly.Compatibool(c.AutoLoadbalance)
-	c.Input.UseSSL = fastly.Compatibool(c.UseSSL)
-	c.Input.SSLCheckCert = fastly.Compatibool(c.SSLCheckCert)
+	c.input.AutoLoadbalance = fastly.Compatibool(c.autoLoadBalance)
+	c.input.UseSSL = fastly.Compatibool(c.useSSL)
+	c.input.SSLCheckCert = fastly.Compatibool(c.sslCheckCert)
 
-	if c.UseSSL && c.Input.Port == nil {
+	if c.useSSL && !c.port.WasSet {
 		if c.Globals.Flag.Verbose {
 			text.Warning(out, "Use-ssl was set but no port was specified, using default port 443")
 		}
-		c.Input.Port = fastly.Uint(443)
+		c.input.Port = fastly.Uint(443)
+	}
+
+	if c.connectTimeout.WasSet {
+		c.input.ConnectTimeout = fastly.Uint(c.connectTimeout.Value)
+	}
+	if c.maxConn.WasSet {
+		c.input.MaxConn = fastly.Uint(c.maxConn.Value)
+	}
+	if c.firstByteTimeout.WasSet {
+		c.input.FirstByteTimeout = fastly.Uint(c.firstByteTimeout.Value)
+	}
+	if c.betweenBytesTimeout.WasSet {
+		c.input.BetweenBytesTimeout = fastly.Uint(c.betweenBytesTimeout.Value)
+	}
+	if c.weight.WasSet {
+		c.input.Weight = fastly.Uint(c.weight.Value)
 	}
 
 	if !c.overrideHost.WasSet && !c.sslCertHostname.WasSet && !c.sslSNIHostname.WasSet {
-		overrideHost, sslSNIHostname, sslCertHostname := SetBackendHostDefaults(c.Input.Address)
-		c.Input.OverrideHost = overrideHost
-		c.Input.SSLSNIHostname = sslSNIHostname
-		c.Input.SSLCertHostname = sslCertHostname
+		overrideHost, sslSNIHostname, sslCertHostname := SetBackendHostDefaults(c.input.Address)
+		c.input.OverrideHost = overrideHost
+		c.input.SSLSNIHostname = sslSNIHostname
+		c.input.SSLCertHostname = sslCertHostname
 	} else {
 		if c.overrideHost.WasSet {
-			c.Input.OverrideHost = c.overrideHost.Value
+			c.input.OverrideHost = c.overrideHost.Value
 		}
 		if c.sslCertHostname.WasSet {
-			c.Input.SSLCertHostname = c.sslCertHostname.Value
+			c.input.SSLCertHostname = c.sslCertHostname.Value
 		}
 		if c.sslSNIHostname.WasSet {
-			c.Input.SSLSNIHostname = c.sslSNIHostname.Value
+			c.input.SSLSNIHostname = c.sslSNIHostname.Value
 		}
 	}
 
-	b, err := c.Globals.APIClient.CreateBackend(&c.Input)
+	b, err := c.Globals.APIClient.CreateBackend(&c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
 			"Service ID":      serviceID,

--- a/pkg/commands/healthcheck/create.go
+++ b/pkg/commands/healthcheck/create.go
@@ -14,11 +14,17 @@ import (
 // CreateCommand calls the Fastly API to create healthchecks.
 type CreateCommand struct {
 	cmd.Base
-	manifest       manifest.Data
-	Input          fastly.CreateHealthCheckInput
-	serviceName    cmd.OptionalServiceNameID
-	serviceVersion cmd.OptionalServiceVersion
-	autoClone      cmd.OptionalAutoClone
+	input            fastly.CreateHealthCheckInput
+	autoClone        cmd.OptionalAutoClone
+	checkInterval    cmd.OptionalUint
+	expectedResponse cmd.OptionalUint
+	initial          cmd.OptionalUint
+	manifest         manifest.Data
+	serviceName      cmd.OptionalServiceNameID
+	serviceVersion   cmd.OptionalServiceVersion
+	threshold        cmd.OptionalUint
+	timeout          cmd.OptionalUint
+	window           cmd.OptionalUint
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -49,18 +55,18 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 		Action: c.autoClone.Set,
 		Dst:    &c.autoClone.Value,
 	})
-	c.CmdClause.Flag("name", "Healthcheck name").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.Input.Comment)
-	c.CmdClause.Flag("method", "Which HTTP method to use").StringVar(&c.Input.Method)
-	c.CmdClause.Flag("host", "Which host to check").StringVar(&c.Input.Host)
-	c.CmdClause.Flag("path", "The path to check").StringVar(&c.Input.Path)
-	c.CmdClause.Flag("http-version", "Whether to use version 1.0 or 1.1 HTTP").StringVar(&c.Input.HTTPVersion)
-	c.CmdClause.Flag("timeout", "Timeout in milliseconds").UintVar(c.Input.Timeout)
-	c.CmdClause.Flag("check-interval", "How often to run the healthcheck in milliseconds").UintVar(c.Input.CheckInterval)
-	c.CmdClause.Flag("expected-response", "The status code expected from the host").UintVar(c.Input.ExpectedResponse)
-	c.CmdClause.Flag("window", "The number of most recent healthcheck queries to keep for this healthcheck").UintVar(c.Input.Window)
-	c.CmdClause.Flag("threshold", "How many healthchecks must succeed to be considered healthy").UintVar(c.Input.Threshold)
-	c.CmdClause.Flag("initial", "When loading a config, the initial number of probes to be seen as OK").UintVar(c.Input.Initial)
+	c.CmdClause.Flag("name", "Healthcheck name").Short('n').Required().StringVar(&c.input.Name)
+	c.CmdClause.Flag("comment", "A descriptive note").StringVar(&c.input.Comment)
+	c.CmdClause.Flag("method", "Which HTTP method to use").StringVar(&c.input.Method)
+	c.CmdClause.Flag("host", "Which host to check").StringVar(&c.input.Host)
+	c.CmdClause.Flag("path", "The path to check").StringVar(&c.input.Path)
+	c.CmdClause.Flag("http-version", "Whether to use version 1.0 or 1.1 HTTP").StringVar(&c.input.HTTPVersion)
+	c.CmdClause.Flag("timeout", "Timeout in milliseconds").Action(c.timeout.Set).UintVar(&c.timeout.Value)
+	c.CmdClause.Flag("check-interval", "How often to run the healthcheck in milliseconds").Action(c.checkInterval.Set).UintVar(&c.checkInterval.Value)
+	c.CmdClause.Flag("expected-response", "The status code expected from the host").Action(c.expectedResponse.Set).UintVar(&c.expectedResponse.Value)
+	c.CmdClause.Flag("window", "The number of most recent healthcheck queries to keep for this healthcheck").Action(c.window.Set).UintVar(&c.window.Value)
+	c.CmdClause.Flag("threshold", "How many healthchecks must succeed to be considered healthy").Action(c.threshold.Set).UintVar(&c.threshold.Value)
+	c.CmdClause.Flag("initial", "When loading a config, the initial number of probes to be seen as OK").Action(c.initial.Set).UintVar(&c.initial.Value)
 	return &c
 }
 
@@ -83,10 +89,29 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	c.Input.ServiceID = serviceID
-	c.Input.ServiceVersion = serviceVersion.Number
+	c.input.ServiceID = serviceID
+	c.input.ServiceVersion = serviceVersion.Number
 
-	h, err := c.Globals.APIClient.CreateHealthCheck(&c.Input)
+	if c.timeout.WasSet {
+		c.input.Timeout = fastly.Uint(c.timeout.Value)
+	}
+	if c.checkInterval.WasSet {
+		c.input.CheckInterval = fastly.Uint(c.checkInterval.Value)
+	}
+	if c.expectedResponse.WasSet {
+		c.input.ExpectedResponse = fastly.Uint(c.expectedResponse.Value)
+	}
+	if c.window.WasSet {
+		c.input.Window = fastly.Uint(c.window.Value)
+	}
+	if c.threshold.WasSet {
+		c.input.Threshold = fastly.Uint(c.threshold.Value)
+	}
+	if c.initial.WasSet {
+		c.input.Initial = fastly.Uint(c.initial.Value)
+	}
+
+	h, err := c.Globals.APIClient.CreateHealthCheck(&c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
 			"Service ID":      serviceID,

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -33,8 +33,10 @@ func TestHealthCheckCreate(t *testing.T) {
 			},
 			wantError: errTest.Error(),
 		},
+		// NOTE: Added --timeout flag to validate that a nil pointer dereference is
+		// not triggered at runtime when parsing the arguments.
 		{
-			args: args("healthcheck create --service-id 123 --version 1 --name www.test.com --autoclone"),
+			args: args("healthcheck create --service-id 123 --version 1 --name www.test.com --autoclone --timeout 10"),
 			api: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				CloneVersionFn:      testutil.CloneVersionResult(4),


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/540

This was caused by a nil pointer dereference. 

The solution is to pass a non-pointer type to the arg parser. We are then able to (after the CLI arg parser has run) inspect whether the value was provided, and if so, set the corresponding Go-Fastly struct field.

> **NOTE**: I've checked all other Go-Fastly CREATE input types and there doesn't appear to be any other instances that need to be corrected within the CLI.