### PR TITLE
Fix `compute deploy --package` 'no manifest' bug.

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -589,7 +589,7 @@ func manageNoServiceIDFlow(
 	progress.Done()
 
 	// NOTE: Only attempt to update the manifest if the user has not specified
-	// the --package flag, as this suggests that are not inside a project
+	// the --package flag, as this suggests they are not inside a project
 	// directory and subsequently we're reading the manifest content from within
 	// a given .tar.gz package archive file.
 	if packageFlag == "" {

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -28,7 +28,7 @@ type PublishCommand struct {
 	acceptDefaults cmd.OptionalBool
 	comment        cmd.OptionalString
 	domain         cmd.OptionalString
-	path           cmd.OptionalString
+	pkg            cmd.OptionalString
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -49,7 +49,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("name", "Package name").Action(c.name.Set).StringVar(&c.name.Value)
-	c.CmdClause.Flag("package", "Path to a package tar.gz").Short('p').Action(c.path.Set).StringVar(&c.path.Value)
+	c.CmdClause.Flag("package", "Path to a package tar.gz").Short('p').Action(c.pkg.Set).StringVar(&c.pkg.Value)
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -118,8 +118,8 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if c.acceptDefaults.WasSet {
 		c.deploy.AcceptDefaults = c.acceptDefaults.Value
 	}
-	if c.path.WasSet {
-		c.deploy.Path = c.path.Value
+	if c.pkg.WasSet {
+		c.deploy.Package = c.pkg.Value
 	}
 	if c.serviceName.WasSet {
 		c.deploy.ServiceName = c.serviceName // deploy's field is a cmd.OptionalServiceNameID

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -105,7 +105,7 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	srcDir := sourceDirectory(c.lang, c.manifest.File.Language, c.watch, out)
 
 	for {
-		err = local(bin, srcDir, c.file, c.addr, c.env.Value, c.debug, c.watch, c.Globals.Verbose(), progress, out, c.Globals.ErrLog)
+		err = local(bin, srcDir, c.file, c.addr, c.env.Value, c.debug, c.watch, c.Globals.Verbose(), out, c.Globals.ErrLog)
 		if err != nil {
 			if err != fsterr.ErrViceroyRestart {
 				if err == fsterr.ErrSignalInterrupt || err == fsterr.ErrSignalKilled {
@@ -410,7 +410,7 @@ func sourceDirectory(flag cmd.OptionalString, lang string, watch bool, out io.Wr
 }
 
 // local spawns a subprocess that runs the compiled binary.
-func local(bin, srcDir, file, addr, env string, debug, watch, verbose bool, progress text.Progress, out io.Writer, errLog fsterr.LogInterface) error {
+func local(bin, srcDir, file, addr, env string, debug, watch, verbose bool, out io.Writer, errLog fsterr.LogInterface) error {
 	if env != "" {
 		env = "." + env
 	}


### PR DESCRIPTION
**Before**
Trying to deploy a project via the `--package` flag would cause an error because the code logic would try to update a manifest file in the user's current directory to have a `service_id` field. But as the user has provided the `--package` flag, this indicates the user isn't in a project directory and is trying to deploy a prior build from some other location.

<img width="802" alt="Screenshot 2022-04-13 at 14 10 16" src="https://user-images.githubusercontent.com/180050/163190169-455197f4-be4e-4b93-bd2b-db9adaf25dd1.png">

**After**
The deploy will now succeed because we skip the manifest update when dealing with a manifest from within a package archive.

<img width="802" alt="Screenshot 2022-04-13 at 14 10 32" src="https://user-images.githubusercontent.com/180050/163190179-4e93280a-fdd4-4703-973f-86ef3a214195.png">
