### PR TITLE
Fix `compute serve --watch` to keep watching after build error.

### DIFF
--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -106,7 +106,7 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	srcDir := sourceDirectory(c.lang, c.manifest.File.Language, c.watch, out)
 
 	for {
-		err = local(bin, srcDir, c.file, c.addr, c.env.Value, c.debug, c.watch, c.Globals.Verbose(), progress, out, c.Globals.ErrLog)
+		err = local(bin, srcDir, c.file, c.addr, c.env.Value, c.debug, c.watch, c.Globals.Verbose(), out, c.Globals.ErrLog)
 		if err != nil {
 			if err != fsterr.ErrViceroyRestart {
 				if err == fsterr.ErrSignalInterrupt || err == fsterr.ErrSignalKilled {
@@ -414,7 +414,7 @@ func sourceDirectory(flag cmd.OptionalString, lang string, watch bool, out io.Wr
 }
 
 // local spawns a subprocess that runs the compiled binary.
-func local(bin, srcDir, file, addr, env string, debug, watch, verbose bool, progress text.Progress, out io.Writer, errLog fsterr.LogInterface) error {
+func local(bin, srcDir, file, addr, env string, debug, watch, verbose bool, out io.Writer, errLog fsterr.LogInterface) error {
 	if env != "" {
 		env = "." + env
 	}

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
+	"github.com/fatih/color"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -118,7 +119,10 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			// Before restarting Viceroy we should rebuild.
 			err = c.Build(in, out)
 			if err != nil {
-				return err
+				// NOTE: build errors at this point are going to be user related, so we
+				// should display the error but keep watching the files so we can
+				// rebuild successfully once the user has fixed the issues.
+				fsterr.Deduce(err).Print(color.Error)
 			}
 		}
 	}


### PR DESCRIPTION
Currently the CLI will stop completely when an error is encountered during a build, but the compilation error could well be because a user made a typo error in their code, and so we should keep watching the source code even when the compilation fails.

> **NOTE**: This only relates to the build compilation that occurs when file changes are detected. If the initial build fails then the CLI will still fail outright.

## Screenshots

Notice there was a compilation error during the development cycle:

<img width="2032" alt="Screenshot 2022-04-13 at 17 57 39" src="https://user-images.githubusercontent.com/180050/163232718-2f5ad6ca-8be6-4e75-bc65-8273998ee91a.png">

But the Fastly CLI will now continue to watch for file changes:

<img width="2032" alt="Screenshot 2022-04-13 at 17 57 46" src="https://user-images.githubusercontent.com/180050/163232836-6c789e07-667e-4892-aea2-6e8cc9006bfe.png">
