### PR TITLE
Support local directory with `compute init --from`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
+require github.com/otiai10/copy v1.7.0
+
 require (
 	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,13 @@ github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
+github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=
+github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -314,4 +321,3 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-// Cache Bust CI 1

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -676,7 +676,8 @@ COMMANDS
                                    defaulting to the current directory
     -a, --author=AUTHOR ...        Author(s) of the package
     -l, --language=LANGUAGE        Language of the package
-    -f, --from=FROM                Git repository URL, or URL referencing a
+    -f, --from=FROM                Local template project directory, or Git
+                                   repository URL, or URL referencing a
                                    .zip/.tar.gz file, containing a package
                                    template
         --force                    Skip non-empty directory verification step

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -676,10 +676,9 @@ COMMANDS
                                    defaulting to the current directory
     -a, --author=AUTHOR ...        Author(s) of the package
     -l, --language=LANGUAGE        Language of the package
-    -f, --from=FROM                Local template project directory, or Git
-                                   repository URL, or URL referencing a
-                                   .zip/.tar.gz file, containing a package
-                                   template
+    -f, --from=FROM                Local project directory, or Git repository
+                                   URL, or URL referencing a .zip/.tar.gz file,
+                                   containing a package template
         --force                    Skip non-empty directory verification step
                                    and force new project creation
 

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -58,7 +58,7 @@ func NewInitCommand(parent cmd.Registerer, globals *config.Data, data manifest.D
 	c.CmdClause.Flag("directory", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.dir)
 	c.CmdClause.Flag("author", "Author(s) of the package").Short('a').StringsVar(&c.manifest.File.Authors)
 	c.CmdClause.Flag("language", "Language of the package").Short('l').HintOptions(Languages...).EnumVar(&c.language, Languages...)
-	c.CmdClause.Flag("from", "Local template project directory, or Git repository URL, or URL referencing a .zip/.tar.gz file, containing a package template").Short('f').StringVar(&c.from)
+	c.CmdClause.Flag("from", "Local project directory, or Git repository URL, or URL referencing a .zip/.tar.gz file, containing a package template").Short('f').StringVar(&c.from)
 	c.CmdClause.Flag("branch", "Git branch name to clone from package template repository").Hidden().StringVar(&c.branch)
 	c.CmdClause.Flag("tag", "Git tag name to clone from package template repository").Hidden().StringVar(&c.tag)
 	c.CmdClause.Flag("force", "Skip non-empty directory verification step and force new project creation").BoolVar(&c.skipVerification)

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -535,9 +535,7 @@ func fetchPackageTemplate(
 	fi, err := os.Stat(from)
 	if err != nil {
 		errLog.Add(err)
-		return err
-	}
-	if fi.IsDir() {
+	} else if fi.IsDir() {
 		return cp.Copy(from, dst)
 	}
 


### PR DESCRIPTION
The CLI `compute init` command supports a `--from` flag that lets you specify either a remote URL or git server.  

To make it easier to validate SDK changes with the CLI we let a user specify a local directory to use as the project template. 

**Example**:

<img width="783" alt="Screenshot 2022-04-14 at 15 11 17" src="https://user-images.githubusercontent.com/180050/163415206-5ad30797-73f0-4d0c-9304-dfb5a5b9d08d.png">
