### PR TITLE
Skip checking for updates for completion commands

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/check"
+	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/config"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -141,7 +142,10 @@ func main() {
 	var errLoadConfig error
 
 	// Validate if configuration is older than its TTL
-	if check.Stale(file.CLI.LastChecked, file.CLI.TTL) {
+	// NOTE: We don't want to trigger a config check when the user is making an
+	// autocomplete request because this can add additional latency to the user's
+	// shell loading completely.
+	if check.Stale(file.CLI.LastChecked, file.CLI.TTL) && !cmd.IsCompletion(args) && !cmd.IsCompletionScript(args) {
 		if verboseOutput {
 			text.Info(out, `
 Compatibility and versioning information for the Fastly CLI is being updated in the background.  The updated data will be used next time you execute a fastly command.


### PR DESCRIPTION
I have my shell (ZSH) configured to support completion of `fastly` CLI commands. To do this, I have placed the following into my ~/.zshrc:

```shell
eval "$(fastly --completion-script-zsh)"
```

When on high-latency internet connections, the asynchronous update check adds 3 seconds to the loading of my shell. Furthermore, because the check fails with such spotty internet, I see the following message before my shell prompt following the 3 second timeout:

```
ERROR: there was a problem updating the versioning information for the Fastly CLI (we won't check again until 5m have passed):

Get "https://developer.fastly.com/api/internal/cli-config": context deadline exceeded (Client.Timeout exceeded while awaiting headers).

If you believe this error is the result of a bug, please file an issue: https://github.com/fastly/cli/issues/new?labels=bug&template=bug_report.md

There is a fallback version of the configuration provided with the CLI install (run `fastly config` to view the config) which enables the CLI to continue to be usable even though the config couldn't be updated.
```

Instead of filing a bug, I thought I'd try to fix it myself. ~I'm not sure if this actually works because I can't build the source code given my spotty airplane wi-fi.~