### PR TITLE
`pkg/commands/compute/serve.go`: `--watch` to support ignore files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,10 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
-require github.com/otiai10/copy v1.7.0
+require (
+	github.com/otiai10/copy v1.7.0
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
+)
 
 require (
 	github.com/andybalholm/brotli v1.0.3 // indirect
@@ -48,7 +51,6 @@ require (
 	github.com/peterhellberg/link v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
-	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 require (
 	github.com/otiai10/copy v1.7.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
+	github.com/tcnksm/go-gitconfig v0.1.2
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/peterhellberg/link v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/segmentio/textio v1.2.0 h1:Ug4IkV3kh72juJbG8azoSBlgebIbUUxVNrfFcKHfTSQ=
 github.com/segmentio/textio v1.2.0/go.mod h1:+Rb7v0YVODP+tK5F7FD9TCkV7gOYx9IgLHWiqtvY8ag=
@@ -219,6 +221,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -320,4 +324,4 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -219,7 +219,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,7 @@ github.com/nwaples/rardecode v1.1.2 h1:Cj0yZY6T1Zx1R7AhTbyGSALm44/Mmq+BAPc4B/p/d
 github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
 github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
@@ -222,6 +223,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tcnksm/go-gitconfig v0.1.2 h1:iiDhRitByXAEyjgBqsKi9QU4o2TNtv9kPP3RgPgXBPw=
+github.com/tcnksm/go-gitconfig v0.1.2/go.mod h1:/8EhP4H7oJZdIPyT+/UIsG87kTzrzM4UsLGSItWYCpE=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -297,6 +300,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -327,4 +327,6 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -589,12 +589,12 @@ func watchFiles(verbose bool, dir string, cmd *fstexec.Streaming, out io.Writer,
 		// NOTE: Watching a directory implies watching all files within the root of
 		// the directory. This means we don't need to call Add(path) for each file.
 		if gi == nil && entry.IsDir() {
-			watchFile(path, watcher, verbose)
+			watchFile(path, watcher, verbose, out)
 		}
 		if gi != nil && !entry.IsDir() && !gi.MatchesPath(path) {
 			// If there is an ignore file, we avoid watching directories and instead
 			// will only add files that don't match the exclusion patterns defined.
-			watchFile(path, watcher, verbose)
+			watchFile(path, watcher, verbose, out)
 		}
 		return nil
 	})
@@ -640,12 +640,11 @@ func readIgnoreFile(path string) (lines []string) {
 	return strings.Split(string(bs), "\n")
 }
 
-func watchFile(path string, watcher *fsnotify.Watcher, verbose bool) {
-	if verbose {
-		fmt.Printf("watching: %+v\n", path)
-	}
+func watchFile(path string, watcher *fsnotify.Watcher, verbose bool, out io.Writer) {
 	err := watcher.Add(path)
 	if err != nil {
-		log.Fatal(err)
+		text.Output(out, "%s: %s", text.BoldRed("failed to watch"), path)
+	} else if verbose {
+		text.Output(out, "%s: %s", text.BoldYellow("watching"), path)
 	}
 }

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -633,6 +633,13 @@ func gitIgnore() *ignore.GitIgnore {
 // NOTE: If there's an error reading the given path, then we'll return an empty
 // string slice so that the caller can continue to function as expected.
 func readIgnoreFile(path string) (lines []string) {
+	// gosec flagged this:
+	// G304 (CWE-22): Potential file inclusion via variable
+	//
+	// Disabling as the input is either provided by our own package or in the
+	// case of identifying the user's global git ignore we need to read it from
+	// their global git configuration.
+	/* #nosec */
 	bs, err := os.ReadFile(path)
 	if err != nil {
 		return lines

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -509,7 +509,7 @@ func watchFiles(verbose bool, dir string, cmd *fstexec.Streaming, out io.Writer,
 
 	done := make(chan bool)
 	debounced := debounce.New(1 * time.Second)
-	eventHandler := func(modifiedFile string, op fsnotify.Op) {
+	eventHandler := func(modifiedFile string, _ fsnotify.Op) {
 		// NOTE: We avoid describing the file operation (e.g. created, modified,
 		// deleted, renamed etc) rather than checking the fsnotify.Op iota/enum type
 		// because the output can be confusing depending on the application used to

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -499,7 +499,7 @@ func local(bin, srcDir, file, addr, env string, debug, watch, verbose bool, out 
 // watchFiles watches the language source directory and restarts the viceroy
 // executable when changes are detected.
 func watchFiles(verbose bool, dir string, cmd *fstexec.Streaming, out io.Writer, restart chan<- bool) {
-	gi := gitIgnore(out)
+	gi := gitIgnore()
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -611,7 +611,7 @@ func watchFiles(verbose bool, dir string, cmd *fstexec.Streaming, out io.Writer,
 // - .ignore (local)
 // - .gitignore (local)
 // - core.excludesfile (global)
-func gitIgnore(out io.Writer) *ignore.GitIgnore {
+func gitIgnore() *ignore.GitIgnore {
 	var (
 		globalIgnore string
 		patterns     []string

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -602,16 +602,13 @@ func watchFiles(verbose bool, dir, ignoreFile string, gi *ignore.GitIgnore, cmd 
 		//
 		// NOTE: Watching a directory implies watching all files within the root of
 		// the directory. This means we don't need to call Add(path) for each file.
-		if gi == nil {
-			if entry.IsDir() {
-				watchFile(path, watcher, verbose)
-			}
-		} else {
+		if gi == nil && entry.IsDir() {
+			watchFile(path, watcher, verbose)
+		}
+		if gi != nil && !entry.IsDir() && !gi.MatchesPath(path) {
 			// If there is an ignore file, we avoid watching directories and instead
 			// will only add files that don't match the exclusion patterns defined.
-			if !gi.MatchesPath(path) && !entry.IsDir() {
-				watchFile(path, watcher, verbose)
-			}
+			watchFile(path, watcher, verbose)
 		}
 		return nil
 	})
@@ -621,7 +618,7 @@ func watchFiles(verbose bool, dir, ignoreFile string, gi *ignore.GitIgnore, cmd 
 		respect = fmt.Sprintf(" (respecting %s)", ignoreFile)
 	}
 
-	text.Info(out, "Watching ./%s/* for changes%s", dir, respect)
+	text.Info(out, "Watching ./%s/**/* for changes%s", dir, respect)
 	text.Break(out)
 	<-done
 }

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -609,6 +609,7 @@ func watchFiles(verbose bool, dir string, cmd *fstexec.Streaming, out io.Writer,
 	<-done
 }
 
+// gitIgnore returns the specific ignore file/rules being respected.
 func gitIgnore(out io.Writer) (string, *ignore.GitIgnore) {
 	var (
 		err error

--- a/pkg/filesystem/home.go
+++ b/pkg/filesystem/home.go
@@ -1,0 +1,49 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// UnixHome is the home directory for a unix system.
+	UnixHome = "$HOME"
+	// UnixHomeShort is the 'short' home directory for a unix system.
+	UnixHomeShort = "~"
+	// WindowsHome is the home directory for a Windows system.
+	WindowsHome = "%USERPROFILE%"
+)
+
+// ResolveAbs returns an absolute path with the user home directory resolved.
+//
+// EXAMPLE (unix):
+// $HOME/.gitignore -> /Users/<USER>/.gitignore
+// ~/.gitignore     -> /Users/<USER>/.gitignore
+func ResolveAbs(path string) string {
+	var uhd string
+	if strings.HasPrefix(path, UnixHome) {
+		uhd = UnixHome
+	}
+	if strings.HasPrefix(path, UnixHomeShort) {
+		uhd = UnixHomeShort
+	}
+	if strings.HasPrefix(path, WindowsHome) {
+		uhd = WindowsHome
+	}
+
+	if uhd != "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		path = strings.Replace(path, uhd, "", 1)
+		return filepath.Join(home, path)
+	}
+
+	s, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return s
+}


### PR DESCRIPTION
This PR adds the ability for the CLI to respect the following ignore files (in order of precedence)...

- `.ignore` (local)
- `.gitignore` (local)
- `~/.gitconfig`'s `core.excludesfile` (global)

> **NOTE**: Although `git` also consults `$GIT_DIR/info/exclude` I've not included this as (in my experience) it's a rarely used location for configuring ignore patterns.

If there are no ignore files present, the CLI will default to watching all files inside the project's `./src` directory.