### PR TITLE
Prevent profile data from being unexpectedly deleted

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	_ "embed"
-	"log"
-	"time"
-
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/check"
@@ -88,7 +87,7 @@ func main() {
 	// Extract a subset of configuration options from the local application directory.
 	var file config.File
 	file.SetStatic(cfg)
-	err = file.Read(config.FilePath, in, out)
+	err = file.Read(config.FilePath, in, out, fsterr.Log)
 
 	if err != nil {
 		if err == config.ErrLegacyConfig {

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -177,7 +177,16 @@ func Run(opts RunOpts) error {
 	if opts.Versioners.CLI != nil && name != "update" && !version.IsPreRelease(revision.AppVersion) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel() // push cancel on the defer stack first...
-		f := update.CheckAsync(ctx, opts.ConfigFile, opts.ConfigPath, revision.AppVersion, opts.Versioners.CLI, opts.Stdin, opts.Stdout)
+		f := update.CheckAsync(
+			ctx,
+			opts.ConfigFile,
+			opts.ConfigPath,
+			revision.AppVersion,
+			opts.Versioners.CLI,
+			opts.Stdin,
+			opts.Stdout,
+			opts.ErrLog,
+		)
 		defer f(opts.Stdout) // ...and the printing function second, so we hit the timeout
 	}
 

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -9,16 +9,13 @@ import (
 // EXAMPLE:
 // dur is a string like "24h", "10m" or "5s".
 func Stale(lastVersionCheck string, dur string) bool {
-	d, err := time.ParseDuration("-" + dur)
+	ttl, err := time.ParseDuration(dur)
 	if err != nil {
 		// If there is no duration provided, then we should presume the loading of
 		// remote configuration failed and that we should retry that operation.
 		return true
 	}
 
-	if t, _ := time.Parse(time.RFC3339, lastVersionCheck); !t.Before(time.Now().Add(d)) {
-		return false
-	}
-
-	return true
+	lastChecked, _ := time.Parse(time.RFC3339, lastVersionCheck)
+	return lastChecked.Add(ttl).Before(time.Now())
 }

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -97,7 +97,7 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	progress := text.ResetProgress(out, c.Globals.Verbose())
 
-	bin, err := getViceroy(progress, out, c.viceroyVersioner, c.Globals)
+	bin, err := GetViceroy(progress, out, c.viceroyVersioner, c.Globals)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 	return nil
 }
 
-// getViceroy returns the path to the installed binary.
+// GetViceroy returns the path to the installed binary.
 //
 // NOTE: if Viceroy is installed then it is updated, otherwise download the
 // latest version and install it in the same directory as the application
@@ -170,7 +170,7 @@ func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 //
 // In the case of a network failure we fallback to the latest installed version of the
 // Viceroy binary as long as one is installed and has the correct permissions.
-func getViceroy(progress text.Progress, out io.Writer, versioner update.Versioner, cfg *config.Data) (bin string, err error) {
+func GetViceroy(progress text.Progress, out io.Writer, versioner update.Versioner, cfg *config.Data) (bin string, err error) {
 	defer func() {
 		if err != nil {
 			progress.Fail()

--- a/pkg/commands/compute/serve_test.go
+++ b/pkg/commands/compute/serve_test.go
@@ -1,4 +1,4 @@
-package compute
+package compute_test
 
 import (
 	"bytes"
@@ -7,9 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fastly/cli/pkg/commands/compute"
 	"github.com/fastly/cli/pkg/config"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
 )
 
@@ -24,22 +26,50 @@ import (
 // release as we have instructed the mock to provide that behaviour.
 //
 // Subsequently the `os.Rename()` will move the downloaded Viceroy binary,
-// which is just a dummy file created by `makeEnvironment()`, into the intended
+// which is just a dummy file created by `testutil.NewEnv`, into the intended
 // destination directory.
 func TestGetViceroy(t *testing.T) {
-	binary := "foo"
-	downloadDir, installDir, binPath, configPath := makeEnvironment(binary, t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	defer os.RemoveAll(downloadDir) // clean up
+	viceroyBinName := "foo"
+	installDirName := "install"
 
-	InstallDir = installDir
+	rootdir := testutil.NewEnv(testutil.EnvOpts{
+		T: t,
+		Dirs: []string{
+			installDirName,
+		},
+		Write: []testutil.FileIO{
+			{Src: "...", Dst: viceroyBinName},
+
+			// NOTE: The reason for creating this file is that in serve.go when it tries
+			// to write in-memory data back to disk, although we don't need to validate
+			// the contents being written, we don't want the write to fail because no
+			// such file existed.
+			{Src: "", Dst: config.FileName},
+		},
+	})
+	installDir := filepath.Join(rootdir, installDirName)
+	binPath := filepath.Join(rootdir, viceroyBinName)
+	configPath := filepath.Join(rootdir, config.FileName)
+	defer os.RemoveAll(rootdir)
+
+	if err := os.Chdir(rootdir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(wd)
+
+	compute.InstallDir = installDir
 
 	var out bytes.Buffer
 
 	progress := text.NewQuietProgress(&out)
 	versioner := mock.Versioner{
 		Version:        "v1.2.3",
-		BinaryFilename: binary,
+		BinaryFilename: viceroyBinName,
 		DownloadOK:     true,
 		DownloadedFile: binPath,
 	}
@@ -53,7 +83,7 @@ func TestGetViceroy(t *testing.T) {
 	// but the function call should fallback to using the stubbed static config
 	// defined above. We also don't pass stdin, stdout arguments as that
 	// particular user flow isn't executed in this test case.
-	err := file.Read("/example", nil, nil, nil)
+	err = file.Read("example", nil, nil, fsterr.MockLog{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +94,7 @@ func TestGetViceroy(t *testing.T) {
 		ErrLog: fsterr.MockLog{},
 	}
 
-	_, err = getViceroy(progress, &out, versioner, &data)
+	_, err = compute.GetViceroy(progress, &out, versioner, &data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,51 +111,9 @@ func TestGetViceroy(t *testing.T) {
 		t.Fatalf("expected file to be downloaded successfully")
 	}
 
-	movedPath := filepath.Join(installDir, binary)
+	movedPath := filepath.Join(installDir, viceroyBinName)
 
 	if _, err := os.Stat(movedPath); err != nil {
 		t.Fatalf("binary was not moved to the install directory: %s", err)
 	}
 }
-
-// makeEnvironment creates a temporary directory for the test suite to utilise
-// when validating Viceroy installation behaviours.
-//
-// It will create a file within the temporary directory to represent the call
-// to `versioner.Download()` being successful.
-//
-// It also creates a nested directory within the temp directory to represent
-// where the downloaded binary should be moved into.
-//
-// TODO: refactor testutil.NewEnv() to support directory creation.
-func makeEnvironment(downloadedFilename string, t *testing.T) (string, string, string, string) {
-	t.Helper()
-
-	downloadDir, err := os.MkdirTemp("", "fastly-serve-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	binPath := filepath.Join(downloadDir, downloadedFilename)
-	if err := os.WriteFile(binPath, []byte("..."), 0o777); err != nil {
-		t.Fatal(err)
-	}
-
-	// NOTE: The reason for creating this file is that in serve.go when it tries
-	// to write in-memory data back to disk, although we don't need to validate
-	// the contents being written, we don't want the write to fail because no
-	// such file existed.
-	configPath := filepath.Join(downloadDir, "config.toml")
-	if err := os.WriteFile(configPath, []byte("..."), 0o777); err != nil {
-		t.Fatal(err)
-	}
-
-	installDir, err := os.MkdirTemp(downloadDir, "install")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return downloadDir, installDir, binPath, configPath
-}
-
-// TODO: Write tests for the other functions in serve.go

--- a/pkg/commands/compute/serve_test.go
+++ b/pkg/commands/compute/serve_test.go
@@ -53,7 +53,7 @@ func TestGetViceroy(t *testing.T) {
 	// but the function call should fallback to using the stubbed static config
 	// defined above. We also don't pass stdin, stdout arguments as that
 	// particular user flow isn't executed in this test case.
-	err := file.Read("/example", nil, nil)
+	err := file.Read("/example", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func makeEnvironment(downloadedFilename string, t *testing.T) (string, string, s
 	}
 
 	binPath := filepath.Join(downloadDir, downloadedFilename)
-	if err := os.WriteFile(binPath, []byte("..."), 0777); err != nil {
+	if err := os.WriteFile(binPath, []byte("..."), 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -116,7 +116,7 @@ func makeEnvironment(downloadedFilename string, t *testing.T) (string, string, s
 	// the contents being written, we don't want the write to fail because no
 	// such file existed.
 	configPath := filepath.Join(downloadDir, "config.toml")
-	if err := os.WriteFile(configPath, []byte("..."), 0777); err != nil {
+	if err := os.WriteFile(configPath, []byte("..."), 0o777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/commands/config/root.go
+++ b/pkg/commands/config/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/text"
 )
 
 // RootCommand is the parent command for all subcommands in this package.
@@ -31,6 +32,9 @@ func NewRootCommand(parent cmd.Registerer, globals *config.Data) *RootCommand {
 // Exec implements the command interface.
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if c.location {
+		if c.Globals.Flag.Verbose {
+			text.Break(out)
+		}
 		fmt.Fprintln(out, c.filePath)
 		return nil
 	}

--- a/pkg/commands/update/check_test.go
+++ b/pkg/commands/update/check_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/config"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/google/go-cmp/cmp"
 )
@@ -136,7 +137,16 @@ func TestCheckAsync(t *testing.T) {
 				out bytes.Buffer
 				buf bytes.Buffer
 			)
-			f := update.CheckAsync(ctx, testcase.file, configFilePath, testcase.currentVersion, testcase.cliVersioner, in, &out)
+			f := update.CheckAsync(
+				ctx,
+				testcase.file,
+				configFilePath,
+				testcase.currentVersion,
+				testcase.cliVersioner,
+				in,
+				&out,
+				fsterr.MockLog{},
+			)
 			f(&buf)
 
 			if want, have := testcase.wantOutput, buf.String(); want != have {

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -167,13 +167,16 @@ func (d *Data) Endpoint() (string, Source) {
 	return DefaultEndpoint, SourceDefault // this method should not fail
 }
 
+// FileName is the name of the application configuration file.
+const FileName = "config.toml"
+
 // FilePath is the location of the fastly CLI application config file.
 var FilePath = func() string {
 	if dir, err := os.UserConfigDir(); err == nil {
-		return filepath.Join(dir, "fastly", "config.toml")
+		return filepath.Join(dir, "fastly", FileName)
 	}
 	if dir, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(dir, ".fastly", "config.toml")
+		return filepath.Join(dir, ".fastly", FileName)
 	}
 	panic("unable to deduce user config dir or user home dir")
 }()

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -483,7 +483,11 @@ func (f *File) Read(path string, in io.Reader, out io.Writer, errLog fsterr.LogI
 	// The reason we're writing data back to disk, although we've only just read
 	// data from the same file, is because we've already potentially mutated some
 	// fields like [cli.last_checked] and [cli.version].
-	f.Write(path)
+	err = f.Write(path)
+	if err != nil {
+		errLog.Add(err)
+		return err
+	}
 
 	// The top-level 'user' section is what we're using to identify whether the
 	// local config.toml file is using a legacy format. If we find that key, then

--- a/pkg/config/data_test.go
+++ b/pkg/config/data_test.go
@@ -150,7 +150,7 @@ func TestConfigRead(t *testing.T) {
 			var out bytes.Buffer
 			in := strings.NewReader(testcase.userResponseToPrompt)
 
-			err = f.Read(configPath, in, &out)
+			err = f.Read(configPath, in, &out, nil)
 
 			if testcase.remediation {
 				e, ok := err.(fsterr.RemediationError)
@@ -232,7 +232,7 @@ func TestUseStatic(t *testing.T) {
 	// embedded in the CLI binary.
 	f = config.File{}
 	var out bytes.Buffer
-	f.Read(configPath, strings.NewReader(""), &out)
+	f.Read(configPath, strings.NewReader(""), &out, nil)
 	f.UseStatic(staticConfig, configPath)
 
 	if f.CLI.LastChecked == "" || f.CLI.Version == "" {
@@ -395,7 +395,7 @@ func TestValidConfig(t *testing.T) {
 			var stdout bytes.Buffer
 			in := strings.NewReader("") // these tests won't trigger a user prompt
 
-			err = f.Read(configPath, in, &stdout)
+			err = f.Read(configPath, in, &stdout, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/config/data_test.go
+++ b/pkg/config/data_test.go
@@ -150,7 +150,8 @@ func TestConfigRead(t *testing.T) {
 			var out bytes.Buffer
 			in := strings.NewReader(testcase.userResponseToPrompt)
 
-			err = f.Read(configPath, in, &out, nil)
+			mockLog := fsterr.MockLog{}
+			err = f.Read(configPath, in, &out, mockLog)
 
 			if testcase.remediation {
 				e, ok := err.(fsterr.RemediationError)
@@ -232,7 +233,7 @@ func TestUseStatic(t *testing.T) {
 	// embedded in the CLI binary.
 	f = config.File{}
 	var out bytes.Buffer
-	f.Read(configPath, strings.NewReader(""), &out, nil)
+	f.Read(configPath, strings.NewReader(""), &out, fsterr.MockLog{})
 	f.UseStatic(staticConfig, configPath)
 
 	if f.CLI.LastChecked == "" || f.CLI.Version == "" {


### PR DESCRIPTION
**PROBLEM**: 
Users have reported that their profile data is getting removed from the CLI config file.

**SOLUTION**:
As the root cause of the bug is unclear, I've opted to add extra error handling to hopefully surface the cause, as well as utilise a mutex to prevent overlapping calls to functions that would change the in-memory data representation.

**NOTES**: 
This appears to only affect a select number of users, and isn't isolated to any one command.

We already have a mutex around writing to the config file so there should be no data race with regards to that segment of the logic flow. 

My initial thoughts were that it's likely either the `update.CheckAsync` function, which calls `config.File.Read`, OR the asynchronous updating of the config (when the data is considered stale) when calling `config.File.Load`.