### PR TITLE
Remove user identifiable values

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -610,11 +610,11 @@ func manageNoServiceIDFlow(
 //
 // NOTE: If the creation of the service fails because the user has not
 // activated a free trial, then we'll trigger the trial for their account.
-func createService(name string, apiClient api.Interface, activateTrial activator, progress text.Progress, errLog fsterr.LogInterface) (serviceID string, serviceVersion *fastly.Version, err error) {
+func createService(pkgName string, apiClient api.Interface, activateTrial activator, progress text.Progress, errLog fsterr.LogInterface) (serviceID string, serviceVersion *fastly.Version, err error) {
 	progress.Step("Creating service...")
 
 	service, err := apiClient.CreateService(&fastly.CreateServiceInput{
-		Name: name,
+		Name: pkgName,
 		Type: "wasm",
 	})
 	if err != nil {
@@ -636,15 +636,14 @@ func createService(name string, apiClient api.Interface, activateTrial activator
 			}
 
 			errLog.AddWithContext(err, map[string]interface{}{
-				"Name":        name,
-				"User":        user.Name,
-				"Customer ID": user.CustomerID,
+				"Package Name": pkgName,
+				"Customer ID":  user.CustomerID,
 			})
-			return createService(name, apiClient, activateTrial, progress, errLog)
+			return createService(pkgName, apiClient, activateTrial, progress, errLog)
 		}
 
 		errLog.AddWithContext(err, map[string]interface{}{
-			"Name": name,
+			"Package Name": pkgName,
 		})
 		return serviceID, serviceVersion, fmt.Errorf("error creating service: %w", err)
 	}

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -134,11 +134,8 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	name, desc, authors, err := promptOrReturn(c.manifest, c.dir, email, in, out)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
-			"Authors":     authors,
 			"Description": desc,
 			"Directory":   c.dir,
-			"Email":       email,
-			"Name":        name,
 		})
 		return err
 	}
@@ -189,9 +186,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
 			"Directory":   c.dir,
-			"Name":        name,
 			"Description": desc,
-			"Authors":     authors,
 			"Language":    language,
 		})
 		return err

--- a/pkg/commands/service/create.go
+++ b/pkg/commands/service/create.go
@@ -31,9 +31,9 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 	s, err := c.Globals.APIClient.CreateService(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
-			"Name":    c.Input.Name,
-			"Type":    c.Input.Type,
-			"Comment": c.Input.Comment,
+			"Service Name": c.Input.Name,
+			"Type":         c.Input.Type,
+			"Comment":      c.Input.Comment,
 		})
 		return err
 	}

--- a/pkg/commands/service/search.go
+++ b/pkg/commands/service/search.go
@@ -32,7 +32,7 @@ func (c *SearchCommand) Exec(in io.Reader, out io.Writer) error {
 	service, err := c.Globals.APIClient.SearchService(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
-			"Name": c.Input.Name,
+			"Service Name": c.Input.Name,
 		})
 		return err
 	}

--- a/pkg/commands/service/update.go
+++ b/pkg/commands/service/update.go
@@ -80,9 +80,9 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	s, err := c.Globals.APIClient.UpdateService(&c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
-			"Service ID": serviceID,
-			"Name":       c.name.Value,
-			"Comment":    c.comment.Value,
+			"Service ID":   serviceID,
+			"Service Name": c.name.Value,
+			"Comment":      c.comment.Value,
 		})
 		return err
 	}

--- a/pkg/commands/user/update.go
+++ b/pkg/commands/user/update.go
@@ -54,9 +54,6 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 
 		err = c.Globals.APIClient.ResetUserPassword(input)
 		if err != nil {
-			c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
-				"User Login": c.login,
-			})
 			return err
 		}
 
@@ -73,7 +70,6 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
 			"User ID": c.id,
-			"Input":   input,
 		})
 		return err
 	}

--- a/pkg/commands/whoami/root.go
+++ b/pkg/commands/whoami/root.go
@@ -34,9 +34,6 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	fullurl := fmt.Sprintf("%s/verify", strings.TrimSuffix(endpoint, "/"))
 	req, err := http.NewRequest("GET", fullurl, nil)
 	if err != nil {
-		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{
-			"GET": fullurl,
-		})
 		return fmt.Errorf("error constructing API request: %w", err)
 	}
 


### PR DESCRIPTION
The data removed via this PR was originally only exposed locally on the user's machine (this was so that users could reach out to customer support and have a record of an error they could choose to share or discuss).