### PR TITLE
Support `[scripts.post_build]`

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -642,8 +642,8 @@ COMMANDS
   compute build [<flags>]
     Build a Compute@Edge package locally
 
-    --accept-custom-build  Do not prompt when project manifest defines
-                           [scripts.build]
+    --accept-custom-build  Do not prompt when project manifest defines either a
+                           [scripts.build] or [scripts.post_build]
     --include-source       Include source code in built package
     --language=LANGUAGE    Language type
     --name=NAME            Package name
@@ -691,7 +691,8 @@ COMMANDS
     Build and deploy a Compute@Edge package to a Fastly service
 
         --accept-custom-build    Do not prompt when project manifest defines
-                                 [scripts.build]
+                                 either a [scripts.build] or
+                                 [scripts.post_build]
         --accept-defaults        Accept default values for all prompts and
                                  perform deploy non-interactively
         --comment=COMMENT        Human-readable comment
@@ -714,8 +715,8 @@ COMMANDS
   compute serve [<flags>]
     Build and run a Compute@Edge package locally
 
-    --accept-custom-build    Do not prompt when project manifest defines
-                             [scripts.build]
+    --accept-custom-build    Do not prompt when project manifest defines either
+                             a [scripts.build] or [scripts.post_build]
     --addr="127.0.0.1:7676"  The IPv4 address and port to listen on
     --env=ENV                The environment configuration to use (e.g. stage)
     --file="bin/main.wasm"   The Wasm file to run

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -642,8 +642,8 @@ COMMANDS
   compute build [<flags>]
     Build a Compute@Edge package locally
 
-    --accept-custom-build  Do not prompt when project manifest defines either a
-                           [scripts.build] or [scripts.post_build]
+    --accept-custom-build  Skip confirmation prompts when running custom build
+                           commands
     --include-source       Include source code in built package
     --language=LANGUAGE    Language type
     --name=NAME            Package name
@@ -690,9 +690,8 @@ COMMANDS
   compute publish [<flags>]
     Build and deploy a Compute@Edge package to a Fastly service
 
-        --accept-custom-build    Do not prompt when project manifest defines
-                                 either a [scripts.build] or
-                                 [scripts.post_build]
+        --accept-custom-build    Skip confirmation prompts when running custom
+                                 build commands
         --accept-defaults        Accept default values for all prompts and
                                  perform deploy non-interactively
         --comment=COMMENT        Human-readable comment
@@ -715,8 +714,8 @@ COMMANDS
   compute serve [<flags>]
     Build and run a Compute@Edge package locally
 
-    --accept-custom-build    Do not prompt when project manifest defines either
-                             a [scripts.build] or [scripts.post_build]
+    --accept-custom-build    Skip confirmation prompts when running custom build
+                             commands
     --addr="127.0.0.1:7676"  The IPv4 address and port to listen on
     --env=ENV                The environment configuration to use (e.g. stage)
     --file="bin/main.wasm"   The Wasm file to run

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -123,26 +123,26 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			Name:            "assemblyscript",
 			SourceDirectory: ASSourceDirectory,
 			IncludeFiles:    []string{"package.json"},
-			Toolchain:       NewAssemblyScript(c.Flags.Timeout, name, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
+			Toolchain:       NewAssemblyScript(c.Flags.Timeout, name, c.Manifest.File.Scripts, c.Globals.ErrLog),
 		})
 	case "javascript":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "javascript",
 			SourceDirectory: JSSourceDirectory,
 			IncludeFiles:    []string{"package.json"},
-			Toolchain:       NewJavaScript(c.Flags.Timeout, name, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
+			Toolchain:       NewJavaScript(c.Flags.Timeout, name, c.Manifest.File.Scripts, c.Globals.ErrLog),
 		})
 	case "rust":
 		language = NewLanguage(&LanguageOptions{
 			Name:            "rust",
 			SourceDirectory: RustSourceDirectory,
 			IncludeFiles:    []string{"Cargo.toml"},
-			Toolchain:       NewRust(c.Globals.HTTPClient, c.Globals.File.Language.Rust, c.Globals.ErrLog, c.Flags.Timeout, name, c.Manifest.File.Scripts.Build),
+			Toolchain:       NewRust(c.Globals.HTTPClient, c.Globals.File.Language.Rust, c.Globals.ErrLog, c.Flags.Timeout, name, c.Manifest.File.Scripts),
 		})
 	case "other":
 		language = NewLanguage(&LanguageOptions{
 			Name:      "other",
-			Toolchain: NewOther(c.Flags.Timeout, c.Manifest.File.Scripts.Build, c.Globals.ErrLog),
+			Toolchain: NewOther(c.Flags.Timeout, c.Manifest.File.Scripts, c.Globals.ErrLog),
 		})
 	default:
 		return fmt.Errorf("unsupported language %s", identLang)
@@ -280,7 +280,7 @@ func CreatePackageArchive(files []string, destination string) error {
 		fmt.Sprintf("fastly-build-%x", p[:n]),
 	)
 
-	if err := os.MkdirAll(tmpDir, 0700); err != nil {
+	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		return fmt.Errorf("error creating temporary directory: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
@@ -289,7 +289,7 @@ func CreatePackageArchive(files []string, destination string) error {
 	// root of the archive. This replaces the `tar.ImplicitTopLevelFolder`
 	// behavior.
 	dir := filepath.Join(tmpDir, FileNameWithoutExtension(destination))
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(dir, 0o700); err != nil {
 		return fmt.Errorf("error creating temporary directory: %w", err)
 	}
 

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -67,7 +67,7 @@ func NewBuildCommand(parent cmd.Registerer, globals *config.Data, data manifest.
 
 	// NOTE: when updating these flags, be sure to update the composite commands:
 	// `compute publish` and `compute serve`.
-	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines either a [scripts.build] or [scripts.post_build]").BoolVar(&c.Flags.AcceptCustomBuild)
+	c.CmdClause.Flag("accept-custom-build", "Skip confirmation prompts when running custom build commands").BoolVar(&c.Flags.AcceptCustomBuild)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.Flags.IncludeSrc)
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Flags.Lang)
 	c.CmdClause.Flag("name", "Package name").StringVar(&c.Flags.PackageName)

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/commands/compute"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/testutil"
@@ -531,13 +532,13 @@ func TestBuildJavaScript(t *testing.T) {
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			if testcase.fastlyManifest != "" {
-				if err := os.WriteFile(filepath.Join(rootdir, manifest.Filename), []byte(testcase.fastlyManifest), 0777); err != nil {
+				if err := os.WriteFile(filepath.Join(rootdir, manifest.Filename), []byte(testcase.fastlyManifest), 0o777); err != nil {
 					t.Fatal(err)
 				}
 			}
 
 			if testcase.sourceOverride != "" {
-				if err := os.WriteFile(filepath.Join(rootdir, "src", "index.js"), []byte(testcase.sourceOverride), 0777); err != nil {
+				if err := os.WriteFile(filepath.Join(rootdir, "src", "index.js"), []byte(testcase.sourceOverride), 0o777); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -609,9 +610,7 @@ func TestCustomBuild(t *testing.T) {
 			manifest_version = 2
 			name = "test"
 			language = "other"`,
-			dontWantOutput: []string{
-				"This project has a custom build script defined in the fastly.toml manifest",
-			},
+			dontWantOutput:       []string{compute.CustomBuildScriptMessage},
 			wantError:            "error reading custom build instructions from fastly.toml manifest",
 			wantRemediationError: "Add a [scripts.build] setting for your custom build process",
 		},
@@ -626,7 +625,7 @@ func TestCustomBuild(t *testing.T) {
 			build = "echo custom build"`,
 			stdin: "N",
 			wantOutput: []string{
-				"This project has a custom build script defined in the fastly.toml manifest",
+				compute.CustomBuildScriptMessage,
 				"Are you sure you want to continue with the build step?",
 				"Stopping the build process",
 			},
@@ -644,7 +643,7 @@ func TestCustomBuild(t *testing.T) {
 			build = "echo custom build"`,
 			stdin: "Y",
 			wantOutput: []string{
-				"This project has a custom build script defined in the fastly.toml manifest",
+				compute.CustomBuildScriptMessage,
 				"Are you sure you want to continue with the build step?",
 				"Building package using custom toolchain",
 				"Built package 'test'",
@@ -661,7 +660,7 @@ func TestCustomBuild(t *testing.T) {
 			build = "echo custom build"`,
 			stdin: "Y",
 			wantOutput: []string{
-				"This project has a custom build script defined in the fastly.toml manifest",
+				compute.CustomBuildScriptMessage,
 				"Are you sure you want to continue with the build step?",
 				"Building package using custom toolchain",
 				"Built package 'test'",
@@ -678,7 +677,7 @@ func TestCustomBuild(t *testing.T) {
 			build = "echo custom build"`,
 			stdin: "Y",
 			wantOutput: []string{
-				"This project has a custom build script defined in the fastly.toml manifest",
+				compute.CustomBuildScriptMessage,
 				"echo custom build",
 				"Are you sure you want to continue with the build step?",
 				"Building package using custom toolchain",
@@ -696,7 +695,7 @@ func TestCustomBuild(t *testing.T) {
 			build = "echo custom build"`,
 			stdin: "Y",
 			wantOutput: []string{
-				"This project has a custom build script defined in the fastly.toml manifest",
+				compute.CustomBuildScriptMessage,
 				"echo custom build",
 				"Are you sure you want to continue with the build step?",
 				"Building package using custom toolchain",
@@ -717,14 +716,14 @@ func TestCustomBuild(t *testing.T) {
 				"Built package 'test'",
 			},
 			dontWantOutput: []string{
-				"This project has a custom build script defined in the fastly.toml manifest",
+				compute.CustomBuildScriptMessage,
 				"Are you sure you want to continue with the build step?",
 			},
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			if testcase.fastlyManifest != "" {
-				if err := os.WriteFile(filepath.Join(rootdir, manifest.Filename), []byte(testcase.fastlyManifest), 0777); err != nil {
+				if err := os.WriteFile(filepath.Join(rootdir, manifest.Filename), []byte(testcase.fastlyManifest), 0o777); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -140,7 +140,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return err
 	}
 
-	languages := NewLanguages(c.Globals.File.StarterKits, c.Globals, name, mf.Scripts.Build)
+	languages := NewLanguages(c.Globals.File.StarterKits, c.Globals, name, mf.Scripts)
 	language, err := selectLanguage(c.from, c.language, languages, mf, in, out)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]interface{}{

--- a/pkg/commands/compute/language.go
+++ b/pkg/commands/compute/language.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/manifest"
 )
 
 // NewLanguages returns a list of supported programming languages.
@@ -14,25 +15,25 @@ import (
 // NOTE: The 'timeout' value zero is passed into each New<Language> call as it's
 // only useful during the `compute build` phase and is expected to be
 // provided by the user via a flag on the build command.
-func NewLanguages(kits config.StarterKitLanguages, d *config.Data, pkgName, customBuild string) []*Language {
+func NewLanguages(kits config.StarterKitLanguages, d *config.Data, pkgName string, scripts manifest.Scripts) []*Language {
 	return []*Language{
 		NewLanguage(&LanguageOptions{
 			Name:        "rust",
 			DisplayName: "Rust",
 			StarterKits: kits.Rust,
-			Toolchain:   NewRust(d.HTTPClient, d.File.Language.Rust, d.ErrLog, 0, pkgName, customBuild),
+			Toolchain:   NewRust(d.HTTPClient, d.File.Language.Rust, d.ErrLog, 0, pkgName, scripts),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "javascript",
 			DisplayName: "JavaScript",
 			StarterKits: kits.JavaScript,
-			Toolchain:   NewJavaScript(0, pkgName, customBuild, d.ErrLog),
+			Toolchain:   NewJavaScript(0, pkgName, scripts, d.ErrLog),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "assemblyscript",
 			DisplayName: "AssemblyScript (beta)",
 			StarterKits: kits.AssemblyScript,
-			Toolchain:   NewAssemblyScript(0, pkgName, customBuild, d.ErrLog),
+			Toolchain:   NewAssemblyScript(0, pkgName, scripts, d.ErrLog),
 		}),
 		NewLanguage(&LanguageOptions{
 			Name:        "other",

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -533,14 +533,6 @@ func (r *Rust) Build(out, progress io.Writer, verbose bool) error {
 		return err
 	}
 
-	if r.postBuild != "" {
-		cmd, args := r.Shell.Build(r.postBuild)
-		err := r.execCommand(cmd, args, out, progress, verbose)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Get working directory.
 	dir, err := os.Getwd()
 	if err != nil {
@@ -566,6 +558,14 @@ func (r *Rust) Build(out, progress io.Writer, verbose bool) error {
 	if err != nil {
 		r.errlog.Add(err)
 		return fmt.Errorf("copying wasm binary: %w", err)
+	}
+
+	if r.postBuild != "" {
+		cmd, args := r.Shell.Build(r.postBuild)
+		err := r.execCommand(cmd, args, out, progress, verbose)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -42,7 +42,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.deploy = deploy
 	c.CmdClause = parent.Command("publish", "Build and deploy a Compute@Edge package to a Fastly service")
 
-	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines either a [scripts.build] or [scripts.post_build]").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
+	c.CmdClause.Flag("accept-custom-build", "Skip confirmation prompts when running custom build commands").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
 	c.CmdClause.Flag("accept-defaults", "Accept default values for all prompts and perform deploy non-interactively").Action(c.acceptDefaults.Set).BoolVar(&c.acceptDefaults.Value)
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.comment.Set).StringVar(&c.comment.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -42,7 +42,7 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.deploy = deploy
 	c.CmdClause = parent.Command("publish", "Build and deploy a Compute@Edge package to a Fastly service")
 
-	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines [scripts.build]").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
+	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines either a [scripts.build] or [scripts.post_build]").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
 	c.CmdClause.Flag("accept-defaults", "Accept default values for all prompts and perform deploy non-interactively").Action(c.acceptDefaults.Set).BoolVar(&c.acceptDefaults.Value)
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.comment.Set).StringVar(&c.comment.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -66,7 +66,7 @@ func NewServeCommand(parent cmd.Registerer, globals *config.Data, build *BuildCo
 	c.CmdClause = parent.Command("serve", "Build and run a Compute@Edge package locally")
 	c.manifest = data
 
-	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines [scripts.build]").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
+	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines either a [scripts.build] or [scripts.post_build]").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
 	c.CmdClause.Flag("addr", "The IPv4 address and port to listen on").Default("127.0.0.1:7676").StringVar(&c.addr)
 	c.CmdClause.Flag("debug", "Run the server in Debug Adapter mode").Hidden().BoolVar(&c.debug)
 	c.CmdClause.Flag("env", "The environment configuration to use (e.g. stage)").Action(c.env.Set).StringVar(&c.env.Value)

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -66,7 +66,7 @@ func NewServeCommand(parent cmd.Registerer, globals *config.Data, build *BuildCo
 	c.CmdClause = parent.Command("serve", "Build and run a Compute@Edge package locally")
 	c.manifest = data
 
-	c.CmdClause.Flag("accept-custom-build", "Do not prompt when project manifest defines either a [scripts.build] or [scripts.post_build]").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
+	c.CmdClause.Flag("accept-custom-build", "Skip confirmation prompts when running custom build commands").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
 	c.CmdClause.Flag("addr", "The IPv4 address and port to listen on").Default("127.0.0.1:7676").StringVar(&c.addr)
 	c.CmdClause.Flag("debug", "Run the server in Debug Adapter mode").Hidden().BoolVar(&c.debug)
 	c.CmdClause.Flag("env", "The environment configuration to use (e.g. stage)").Action(c.env.Set).StringVar(&c.env.Value)

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -37,7 +37,7 @@ const (
 	ManifestLatestVersion = 2
 
 	// FilePermissions represents a read/write file mode.
-	FilePermissions = 0666
+	FilePermissions = 0o666
 
 	// SourceUndefined indicates the parameter isn't provided in any of the
 	// available sources, similar to "not found".
@@ -219,7 +219,8 @@ type File struct {
 
 // Scripts represents custom operations.
 type Scripts struct {
-	Build string `toml:"build,omitempty"`
+	Build     string `toml:"build,omitempty"`
+	PostBuild string `toml:"post_build,omitempty"`
 }
 
 // Setup represents a set of service configuration that works with the code in


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/534

## EXAMPLE

Use `wasp-strip` to reduce the size of the WASM binary.

In the `fastly.toml` file:

```toml
[scripts]
post_build = "ls -lh bin/main.wasm | cut -d ' ' -f 9 && wasm-strip bin/main.wasm && ls -lh bin/main.wasm | cut -d ' ' -f 9"
```

Some of the output has been omitted (`...`) for brevity:

```bash
$ fastly compute build --verbose

...
Verifying package manifest...
Verifying local rust toolchain...
Checking if `rustc` is installed...
Checking the `rustc` version...
Checking the `wasm32-wasi` target is installed...
Checking if `cargo` is installed...

...

Building package using rust toolchain...
       ...
       Fresh testing-fastly-cli v0.1.0 (/Users/integralist/Code/test-projects/testing-fastly-cli)
    Finished release [optimized + debuginfo] target(s) in 0.02s

5.5M
468K

Creating package archive...

SUCCESS: Built package 'testing-fastly-cli' (pkg/testing-fastly-cli.tar.gz)
```

We can see the 'before' size `5.5M` vs the 'after' size `468K` of the `bin/main.wasm` file.  

If we run `tar -ztvf pkg/testing-fastly-cli.tar.gz` we can also see that the wasm file inside the `.tar.gz` is the reduced file size:

```
drwx------  0 integralist staff       0 24 May 16:49 testing-fastly-cli/
-rw-r--r--  0 integralist staff     195 24 May 16:49 testing-fastly-cli/Cargo.toml
drwx------  0 integralist staff       0 24 May 16:49 testing-fastly-cli/bin/
-rw-r--r--  0 integralist staff  479157 24 May 16:49 testing-fastly-cli/bin/main.wasm
-rw-r--r--  0 integralist staff     684 24 May 16:49 testing-fastly-cli/fastly.toml
```

This demonstrates the post_build is executed after the wasm file is created but _before_ it's packaged inside a tar.gz archive.

## Additional

I have a separate (internal) PR ready to update https://developer.fastly.com/reference/compute/fastly-toml/ to document the new `post_build` field.