### PR TITLE
Support Viceroy "inline-toml" `format` and new `contents` field.

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -270,8 +270,9 @@ type LocalBackend struct {
 
 // LocalDictionary represents a dictionary to be mocked by the local testing server.
 type LocalDictionary struct {
-	File   string `toml:"file"`
-	Format string `toml:"format"`
+	File     string            `toml:"file,omitempty"`
+	Format   string            `toml:"format"`
+	Contents map[string]string `toml:"contents,omitempty"`
 }
 
 // Exists yields whether the manifest exists.


### PR DESCRIPTION
Make `file` optional as well.  This is an interim solution while a
more robust one is investigated that is `format` aware, that's it,
so either `file` or `contents` are added even if empty, depending
on whether the `format` is `json` or `inline-toml`, respectively.