### PR TITLE
Implement new global flags related to interactivity prompts and default values

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -96,10 +96,13 @@ func Run(opts RunOpts) error {
 	//
 	// NOTE: Short flags CAN be safely reused across commands.
 	tokenHelp := fmt.Sprintf("Fastly API token (or via %s)", env.Token)
-	app.Flag("token", tokenHelp).Short('t').StringVar(&globals.Flag.Token)
-	app.Flag("profile", "Switch account profile for single command execution (see also: 'fastly profile switch')").Short('o').StringVar(&globals.Flag.Profile)
-	app.Flag("verbose", "Verbose logging").Short('v').BoolVar(&globals.Flag.Verbose)
+	app.Flag("accept-defaults", "...").Short('d').BoolVar(&globals.Flag.AcceptDefaults)
+	app.Flag("auto-yes", "...").Short('y').BoolVar(&globals.Flag.AutoYes)
 	app.Flag("endpoint", "Fastly API endpoint").Hidden().StringVar(&globals.Flag.Endpoint)
+	app.Flag("non-interactive", "...").Short('i').BoolVar(&globals.Flag.NonInteractive)
+	app.Flag("profile", "Switch account profile for single command execution (see also: 'fastly profile switch')").Short('o').StringVar(&globals.Flag.Profile)
+	app.Flag("token", tokenHelp).Short('t').StringVar(&globals.Flag.Token)
+	app.Flag("verbose", "Verbose logging").Short('v').BoolVar(&globals.Flag.Verbose)
 
 	commands := defineCommands(app, &globals, md, opts)
 	command, name, err := processCommandInput(opts, app, &globals, commands)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -90,16 +90,17 @@ func Run(opts RunOpts) error {
 	// therefore if you add/remove a global flag you will also need to update
 	// the globalFlags map in pkg/app/usage.go which is used for usage rendering.
 	//
-	// NOTE: Global flags, unlike command flags, must be unique. For example, if
-	// you try to use a letter that is already taken by any other command flag,
-	// then kingpin will trigger a runtime panic 🎉
+	// NOTE: Global flags, unlike command flags, must be unique. This means BOTH
+	// the long flag and the short flag identifiers must be unique. If you try to
+	// reuse an identifier (long or short), then kingpin will trigger a runtime
+	// panic 🎉
 	//
 	// NOTE: Short flags CAN be safely reused across commands.
 	tokenHelp := fmt.Sprintf("Fastly API token (or via %s)", env.Token)
-	app.Flag("accept-defaults", "...").Short('d').BoolVar(&globals.Flag.AcceptDefaults)
-	app.Flag("auto-yes", "...").Short('y').BoolVar(&globals.Flag.AutoYes)
+	app.Flag("accept-defaults", "Accept default options for all interactive prompts apart from Yes/No confirmations").Short('d').BoolVar(&globals.Flag.AcceptDefaults)
+	app.Flag("auto-yes", "Answer yes automatically to all Yes/No confirmations. This may suppress security warnings").Short('y').BoolVar(&globals.Flag.AutoYes)
 	app.Flag("endpoint", "Fastly API endpoint").Hidden().StringVar(&globals.Flag.Endpoint)
-	app.Flag("non-interactive", "...").Short('i').BoolVar(&globals.Flag.NonInteractive)
+	app.Flag("non-interactive", "Do not prompt for user input - suitable for CI processes. Equivalent to --accept-defaults and --auto-yes").Short('i').BoolVar(&globals.Flag.NonInteractive)
 	app.Flag("profile", "Switch account profile for single command execution (see also: 'fastly profile switch')").Short('o').StringVar(&globals.Flag.Profile)
 	app.Flag("token", tokenHelp).Short('t').StringVar(&globals.Flag.Token)
 	app.Flag("verbose", "Verbose logging").Short('v').BoolVar(&globals.Flag.Verbose)

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -187,9 +187,16 @@ A tool to interact with the Fastly API
 
 GLOBAL FLAGS
       --help             Show context-sensitive help.
-  -t, --token=TOKEN      Fastly API token (or via FASTLY_API_TOKEN)
+  -d, --accept-defaults  Accept default options for all interactive prompts
+                         apart from Yes/No confirmations
+  -y, --auto-yes         Answer yes automatically to all Yes/No confirmations.
+                         This may suppress security warnings
+  -i, --non-interactive  Do not prompt for user input - suitable for CI
+                         processes. Equivalent to --accept-defaults and
+                         --auto-yes
   -o, --profile=PROFILE  Switch account profile for single command execution
                          (see also: 'fastly profile switch')
+  -t, --token=TOKEN      Fastly API token (or via FASTLY_API_TOKEN)
   -v, --verbose          Verbose logging
 
 COMMANDS
@@ -229,9 +236,16 @@ USAGE
 
 GLOBAL FLAGS
       --help             Show context-sensitive help.
-  -t, --token=TOKEN      Fastly API token (or via FASTLY_API_TOKEN)
+  -d, --accept-defaults  Accept default options for all interactive prompts
+                         apart from Yes/No confirmations
+  -y, --auto-yes         Answer yes automatically to all Yes/No confirmations.
+                         This may suppress security warnings
+  -i, --non-interactive  Do not prompt for user input - suitable for CI
+                         processes. Equivalent to --accept-defaults and
+                         --auto-yes
   -o, --profile=PROFILE  Switch account profile for single command execution
                          (see also: 'fastly profile switch')
+  -t, --token=TOKEN      Fastly API token (or via FASTLY_API_TOKEN)
   -v, --verbose          Verbose logging
 
 SUBCOMMANDS
@@ -299,9 +313,16 @@ A tool to interact with the Fastly API
 
 GLOBAL FLAGS
       --help             Show context-sensitive help.
-  -t, --token=TOKEN      Fastly API token (or via FASTLY_API_TOKEN)
+  -d, --accept-defaults  Accept default options for all interactive prompts
+                         apart from Yes/No confirmations
+  -y, --auto-yes         Answer yes automatically to all Yes/No confirmations.
+                         This may suppress security warnings
+  -i, --non-interactive  Do not prompt for user input - suitable for CI
+                         processes. Equivalent to --accept-defaults and
+                         --auto-yes
   -o, --profile=PROFILE  Switch account profile for single command execution
                          (see also: 'fastly profile switch')
+  -t, --token=TOKEN      Fastly API token (or via FASTLY_API_TOKEN)
   -v, --verbose          Verbose logging
 
 COMMANDS
@@ -642,13 +663,11 @@ COMMANDS
   compute build [<flags>]
     Build a Compute@Edge package locally
 
-    --accept-custom-build  Skip confirmation prompts when running custom build
-                           commands
-    --include-source       Include source code in built package
-    --language=LANGUAGE    Language type
-    --name=NAME            Package name
-    --skip-verification    Skip verification steps and force build
-    --timeout=TIMEOUT      Timeout, in seconds, for the build compilation step
+    --include-source     Include source code in built package
+    --language=LANGUAGE  Language type
+    --name=NAME          Package name
+    --skip-verification  Skip verification steps and force build
+    --timeout=TIMEOUT    Timeout, in seconds, for the build compilation step
 
   compute deploy [<flags>]
     Deploy a package to a Fastly Compute@Edge service
@@ -659,8 +678,6 @@ COMMANDS
                                  The name of the service
         --version=VERSION        'latest', 'active', or the number of a specific
                                  version
-        --accept-defaults        Accept default values for all prompts and
-                                 perform deploy non-interactively
         --comment=COMMENT        Human-readable comment
         --domain=DOMAIN          The name of the domain associated to the
                                  package
@@ -671,7 +688,7 @@ COMMANDS
     Initialize a new Compute@Edge package locally
 
     -n, --name=NAME                Name of package, falls back to --directory
-    -d, --description=DESCRIPTION  Description of the package
+        --description=DESCRIPTION  Description of the package
     -p, --directory=DIRECTORY      Destination to write the new package,
                                    defaulting to the current directory
     -a, --author=AUTHOR ...        Author(s) of the package
@@ -690,10 +707,6 @@ COMMANDS
   compute publish [<flags>]
     Build and deploy a Compute@Edge package to a Fastly service
 
-        --accept-custom-build    Skip confirmation prompts when running custom
-                                 build commands
-        --accept-defaults        Accept default values for all prompts and
-                                 perform deploy non-interactively
         --comment=COMMENT        Human-readable comment
         --domain=DOMAIN          The name of the domain associated to the
                                  package
@@ -714,8 +727,6 @@ COMMANDS
   compute serve [<flags>]
     Build and run a Compute@Edge package locally
 
-    --accept-custom-build    Skip confirmation prompts when running custom build
-                             commands
     --addr="127.0.0.1:7676"  The IPv4 address and port to listen on
     --env=ENV                The environment configuration to use (e.g. stage)
     --file="bin/main.wasm"   The Wasm file to run
@@ -4737,7 +4748,7 @@ COMMANDS
                                  then fastly.toml)
         --service-name=SERVICE-NAME
                                  The name of the service
-    -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
+        --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
 
   vcl snippet list --version=VERSION [<flags>]
     List the uploaded VCL snippets for a particular service and version
@@ -4768,7 +4779,7 @@ COMMANDS
                                  then fastly.toml)
         --service-name=SERVICE-NAME
                                  The name of the service
-    -i, --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
+        --snippet-id=SNIPPET-ID  Alphanumeric string identifying a VCL Snippet
         --type=TYPE              The location in generated VCL where the snippet
                                  should be placed
 

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -139,13 +139,18 @@ var UsageTemplateFuncs = template.FuncMap{
 }
 
 // WARNING: kingpin has no way of decorating flags as being "global" therefore
-// if you add/remove a global flag you will also need to update flag binding in
-// pkg/app/app.go.
+// if you add/remove a global flag you will also need to update the app.Flag()
+// bindings in pkg/app/run.go.
+//
+// NOTE: These map is used to help populate the CLI 'usage' template renderer.
 var globalFlags = map[string]bool{
-	"help":    true,
-	"profile": true,
-	"token":   true,
-	"verbose": true,
+	"accept-defaults": true,
+	"auto-yes":        true,
+	"help":            true,
+	"non-interactive": true,
+	"profile":         true,
+	"token":           true,
+	"verbose":         true,
 }
 
 // VerboseUsageTemplate is the full-fat usage template, rendered when users type

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -142,7 +142,7 @@ var UsageTemplateFuncs = template.FuncMap{
 // if you add/remove a global flag you will also need to update the app.Flag()
 // bindings in pkg/app/run.go.
 //
-// NOTE: These map is used to help populate the CLI 'usage' template renderer.
+// NOTE: This map is used to help populate the CLI 'usage' template renderer.
 var globalFlags = map[string]bool{
 	"accept-defaults": true,
 	"auto-yes":        true,

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -193,7 +193,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 	}
 
-	if c.Globals.Verbose() && (!c.Globals.Flag.AutoYes && !c.Globals.Flag.NonInteractive) {
+	if c.Globals.Verbose() {
 		text.Break(out)
 	}
 

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -181,7 +181,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	progress.Done()
 
 	if toolchain == "custom" {
-		if !c.Globals.Flag.AutoYes || !c.Globals.Flag.NonInteractive {
+		if !c.Globals.Flag.AutoYes && !c.Globals.Flag.NonInteractive {
 			// NOTE: A third-party could share a project with a build command for a
 			// language that wouldn't normally require one (e.g. Rust), and do evil
 			// things. So we should notify the user and confirm they would like to
@@ -193,7 +193,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 	}
 
-	if c.Globals.Verbose() && (!c.Globals.Flag.AutoYes || !c.Globals.Flag.NonInteractive) {
+	if c.Globals.Verbose() && (!c.Globals.Flag.AutoYes && !c.Globals.Flag.NonInteractive) {
 		text.Break(out)
 	}
 
@@ -201,7 +201,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	progress.Step(fmt.Sprintf("Building package using %s toolchain...", toolchain))
 
 	postBuildCallback := func() error {
-		if !c.Globals.Flag.AutoYes || !c.Globals.Flag.NonInteractive {
+		if !c.Globals.Flag.AutoYes && !c.Globals.Flag.NonInteractive {
 			err := promptForBuildContinue(CustomPostBuildScriptMessage, c.Manifest.File.Scripts.PostBuild, out, in, c.Globals.Verbose())
 			if err != nil {
 				return err

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -40,12 +40,11 @@ type Toolchain interface {
 
 // Flags represents the flags defined for the command.
 type Flags struct {
-	AcceptCustomBuild bool
-	IncludeSrc        bool
-	Lang              string
-	PackageName       string
-	SkipVerification  bool
-	Timeout           int
+	IncludeSrc       bool
+	Lang             string
+	PackageName      string
+	SkipVerification bool
+	Timeout          int
 }
 
 // BuildCommand produces a deployable artifact from files on the local disk.
@@ -67,7 +66,6 @@ func NewBuildCommand(parent cmd.Registerer, globals *config.Data, data manifest.
 
 	// NOTE: when updating these flags, be sure to update the composite commands:
 	// `compute publish` and `compute serve`.
-	c.CmdClause.Flag("accept-custom-build", "Skip confirmation prompts when running custom build commands").BoolVar(&c.Flags.AcceptCustomBuild)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.Flags.IncludeSrc)
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Flags.Lang)
 	c.CmdClause.Flag("name", "Package name").StringVar(&c.Flags.PackageName)
@@ -183,7 +181,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	progress.Done()
 
 	if toolchain == "custom" {
-		if !c.Flags.AcceptCustomBuild {
+		if !c.Globals.Flag.AutoYes || !c.Globals.Flag.NonInteractive {
 			// NOTE: A third-party could share a project with a build command for a
 			// language that wouldn't normally require one (e.g. Rust), and do evil
 			// things. So we should notify the user and confirm they would like to
@@ -195,7 +193,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 	}
 
-	if c.Globals.Verbose() && c.Flags.AcceptCustomBuild {
+	if c.Globals.Verbose() && (!c.Globals.Flag.AutoYes || !c.Globals.Flag.NonInteractive) {
 		text.Break(out)
 	}
 
@@ -203,7 +201,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	progress.Step(fmt.Sprintf("Building package using %s toolchain...", toolchain))
 
 	postBuildCallback := func() error {
-		if !c.Flags.AcceptCustomBuild {
+		if !c.Globals.Flag.AutoYes || !c.Globals.Flag.NonInteractive {
 			err := promptForBuildContinue(CustomPostBuildScriptMessage, c.Manifest.File.Scripts.PostBuild, out, in, c.Globals.Verbose())
 			if err != nil {
 				return err

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -689,7 +689,7 @@ func TestCustomBuild(t *testing.T) {
 		},
 		{
 			name: "avoid prompt confirmation",
-			args: args("compute build --accept-custom-build --language other"),
+			args: args("compute build --auto-yes --language other"),
 			fastlyManifest: `
 			manifest_version = 2
 			name = "test"
@@ -856,7 +856,7 @@ func TestCustomPostBuild(t *testing.T) {
 		},
 		{
 			name: "avoid prompt confirmation",
-			args: args("compute build --accept-custom-build"),
+			args: args("compute build --auto-yes"),
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -194,9 +194,8 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 
 		loggers = &setup.Loggers{
-			AcceptDefaults: c.Globals.Flag.AcceptDefaults,
-			Setup:          c.Manifest.File.Setup.Loggers,
-			Stdout:         out,
+			Setup:  c.Manifest.File.Setup.Loggers,
+			Stdout: out,
 		}
 	}
 
@@ -558,7 +557,7 @@ func manageNoServiceIDFlow(
 	manifestFile *manifest.File,
 	activateTrial activator,
 ) (serviceID string, serviceVersion *fastly.Version, err error) {
-	if !globalFlags.AutoYes || !globalFlags.NonInteractive {
+	if !globalFlags.AutoYes && !globalFlags.NonInteractive {
 		text.Break(out)
 		text.Output(out, "There is no Fastly service associated with this package. To connect to an existing service add the Service ID to the fastly.toml file, otherwise follow the prompts to create a service now.")
 		text.Break(out)

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -40,7 +40,6 @@ type DeployCommand struct {
 
 	// NOTE: these are public so that the "publish" composite command can set the
 	// values appropriately before calling the Exec() function.
-	AcceptDefaults bool
 	Comment        cmd.OptionalString
 	Domain         string
 	Manifest       manifest.Data
@@ -76,7 +75,6 @@ func NewDeployCommand(parent cmd.Registerer, globals *config.Data, data manifest
 		Dst:         &c.ServiceVersion.Value,
 		Name:        cmd.FlagVersionName,
 	})
-	c.CmdClause.Flag("accept-defaults", "Accept default values for all prompts and perform deploy non-interactively").BoolVar(&c.AcceptDefaults)
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.Comment.Set).StringVar(&c.Comment.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.Domain)
 	c.CmdClause.Flag("name", "Package name").StringVar(&c.Manifest.Flag.Name)
@@ -122,7 +120,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	if source == manifest.SourceUndefined {
 		newService = true
-		serviceID, serviceVersion, err = manageNoServiceIDFlow(c.AcceptDefaults, in, out, verbose, apiClient, pkgName, c.Package, errLog, &c.Manifest.File, activateTrial)
+		serviceID, serviceVersion, err = manageNoServiceIDFlow(c.Globals.Flag, in, out, verbose, apiClient, pkgName, c.Package, errLog, &c.Manifest.File, activateTrial)
 		if err != nil {
 			return err
 		}
@@ -154,7 +152,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	domains := &setup.Domains{
 		APIClient:      apiClient,
-		AcceptDefaults: c.AcceptDefaults,
+		AcceptDefaults: c.Globals.Flag.AcceptDefaults,
 		PackageDomain:  c.Domain,
 		ServiceID:      serviceID,
 		ServiceVersion: serviceVersion.Number,
@@ -177,7 +175,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if newService {
 		backends = &setup.Backends{
 			APIClient:      apiClient,
-			AcceptDefaults: c.AcceptDefaults,
+			AcceptDefaults: c.Globals.Flag.AcceptDefaults,
 			ServiceID:      serviceID,
 			ServiceVersion: serviceVersion.Number,
 			Setup:          c.Manifest.File.Setup.Backends,
@@ -187,7 +185,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 		dictionaries = &setup.Dictionaries{
 			APIClient:      apiClient,
-			AcceptDefaults: c.AcceptDefaults,
+			AcceptDefaults: c.Globals.Flag.AcceptDefaults,
 			ServiceID:      serviceID,
 			ServiceVersion: serviceVersion.Number,
 			Setup:          c.Manifest.File.Setup.Dictionaries,
@@ -196,7 +194,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 
 		loggers = &setup.Loggers{
-			AcceptDefaults: c.AcceptDefaults,
+			AcceptDefaults: c.Globals.Flag.AcceptDefaults,
 			Setup:          c.Manifest.File.Setup.Loggers,
 			Stdout:         out,
 		}
@@ -266,7 +264,9 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 		if err := domains.Create(); err != nil {
 			errLog.AddWithContext(err, map[string]interface{}{
-				"Accept defaults": c.AcceptDefaults,
+				"Accept defaults": c.Globals.Flag.AcceptDefaults,
+				"Auto-yes":        c.Globals.Flag.AutoYes,
+				"Non-interactive": c.Globals.Flag.NonInteractive,
 				"Service ID":      serviceID,
 				"Service Version": serviceVersion.Number,
 			})
@@ -283,7 +283,9 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 		if err := backends.Create(); err != nil {
 			errLog.AddWithContext(err, map[string]interface{}{
-				"Accept defaults": c.AcceptDefaults,
+				"Accept defaults": c.Globals.Flag.AcceptDefaults,
+				"Auto-yes":        c.Globals.Flag.AutoYes,
+				"Non-interactive": c.Globals.Flag.NonInteractive,
 				"Service ID":      serviceID,
 				"Service Version": serviceVersion.Number,
 			})
@@ -292,7 +294,9 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 		if err := dictionaries.Create(); err != nil {
 			errLog.AddWithContext(err, map[string]interface{}{
-				"Accept defaults": c.AcceptDefaults,
+				"Accept defaults": c.Globals.Flag.AcceptDefaults,
+				"Auto-yes":        c.Globals.Flag.AutoYes,
+				"Non-interactive": c.Globals.Flag.NonInteractive,
 				"Service ID":      serviceID,
 				"Service Version": serviceVersion.Number,
 			})
@@ -544,7 +548,7 @@ func preconfigureActivateTrial(endpoint, token string, httpClient api.HTTPClient
 
 // manageNoServiceIDFlow handles creating a new service when no Service ID is found.
 func manageNoServiceIDFlow(
-	acceptDefaults bool,
+	globalFlags config.Flag,
 	in io.Reader,
 	out io.Writer,
 	verbose bool,
@@ -554,7 +558,7 @@ func manageNoServiceIDFlow(
 	manifestFile *manifest.File,
 	activateTrial activator,
 ) (serviceID string, serviceVersion *fastly.Version, err error) {
-	if !acceptDefaults {
+	if !globalFlags.AutoYes || !globalFlags.NonInteractive {
 		text.Break(out)
 		text.Output(out, "There is no Fastly service associated with this package. To connect to an existing service add the Service ID to the fastly.toml file, otherwise follow the prompts to create a service now.")
 		text.Break(out)

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -694,10 +694,10 @@ func TestDeploy(t *testing.T) {
 			},
 		},
 		// The following test validates no prompts are displayed to the user due to
-		// the use of the --accept-defaults flag.
+		// the use of the --non-interactive flag.
 		{
 			name: "success with setup.backends configuration and accept-defaults",
-			args: args("compute deploy --accept-defaults --token 123"),
+			args: args("compute deploy --non-interactive --token 123"),
 			api: mock.API{
 				ActivateVersionFn: activateVersionOk,
 				CreateBackendFn:   createBackendOK,
@@ -740,13 +740,13 @@ func TestDeploy(t *testing.T) {
 		},
 		// The following test validates that a new 'originless' backend is created
 		// when the user has no [setup] configuration and they also pass the
-		// --accept-defaults flag. This is done by ensuring we DON'T see the
+		// --non-interactive flag. This is done by ensuring we DON'T see the
 		// standard 'Creating backend' output because we want to conceal the fact
 		// that we require a backend for compute services because it's a temporary
 		// implementation detail.
 		{
-			name: "success with no setup.backends configuration and --accept-defaults for new service creation",
-			args: args("compute deploy --accept-defaults --token 123"),
+			name: "success with no setup.backends configuration and non-interactive for new service creation",
+			args: args("compute deploy --non-interactive --token 123"),
 			api: mock.API{
 				ActivateVersionFn: activateVersionOk,
 				CreateBackendFn:   createBackendOK,
@@ -852,10 +852,10 @@ func TestDeploy(t *testing.T) {
 			},
 		},
 		// The following test is the same setup as above, but if the user provides
-		// the --accept-defaults flag we won't prompt for any backends.
+		// the --non-interactive flag we won't prompt for any backends.
 		{
-			name: "success with no setup.backends configuration and use of --accept-defaults",
-			args: args("compute deploy --accept-defaults --token 123"),
+			name: "success with no setup.backends configuration and use of --non-interactive",
+			args: args("compute deploy --non-interactive --token 123"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
 				CreateBackendFn:     createBackendOK,
@@ -1012,8 +1012,8 @@ func TestDeploy(t *testing.T) {
 			},
 		},
 		{
-			name: "success with setup.dictionaries configuration and no existing service and --accept-defaults",
-			args: args("compute deploy --accept-defaults --token 123"),
+			name: "success with setup.dictionaries configuration and no existing service and --non-interactive",
+			args: args("compute deploy --non-interactive --token 123"),
 			api: mock.API{
 				ActivateVersionFn:      activateVersionOk,
 				CreateBackendFn:        createBackendOK,
@@ -1218,8 +1218,8 @@ func TestDeploy(t *testing.T) {
 			},
 		},
 		{
-			name: "success with setup.log_entries configuration and no existing service and --accept-defaults",
-			args: args("compute deploy --accept-defaults --token 123"),
+			name: "success with setup.log_entries configuration and no existing service, but a provider defined",
+			args: args("compute deploy --token 123"),
 			api: mock.API{
 				ActivateVersionFn:      activateVersionOk,
 				CreateBackendFn:        createBackendOK,
@@ -1246,16 +1246,14 @@ func TestDeploy(t *testing.T) {
 				"Y", // when prompted to create a new service
 			},
 			wantOutput: []string{
-				"Uploading package...",
-				"Activating version...",
-				"SUCCESS: Deployed package (service 12345, version 1)",
-			},
-			dontWantOutput: []string{
 				"The package code requires the following log endpoints to be created.",
 				"Name: foo",
 				"Provider: BigQuery",
 				"Refer to the help documentation for each provider (if no provider shown, then select your own):",
 				"fastly logging <provider> create --help",
+				"Uploading package...",
+				"Activating version...",
+				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
 	} {
@@ -1268,7 +1266,7 @@ func TestDeploy(t *testing.T) {
 			if testcase.manifest != "" {
 				manifestContent = testcase.manifest
 			}
-			if err := os.WriteFile(filepath.Join(rootdir, manifest.Filename), []byte(manifestContent), 0777); err != nil {
+			if err := os.WriteFile(filepath.Join(rootdir, manifest.Filename), []byte(manifestContent), 0o777); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -54,7 +54,7 @@ func NewInitCommand(parent cmd.Registerer, globals *config.Data, data manifest.D
 	c.manifest = data
 	c.CmdClause = parent.Command("init", "Initialize a new Compute@Edge package locally")
 	c.CmdClause.Flag("name", "Name of package, falls back to --directory").Short('n').StringVar(&c.manifest.File.Name)
-	c.CmdClause.Flag("description", "Description of the package").Short('d').StringVar(&c.manifest.File.Description)
+	c.CmdClause.Flag("description", "Description of the package").StringVar(&c.manifest.File.Description)
 	c.CmdClause.Flag("directory", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.dir)
 	c.CmdClause.Flag("author", "Author(s) of the package").Short('a').StringsVar(&c.manifest.File.Authors)
 	c.CmdClause.Flag("language", "Language of the package").Short('l').HintOptions(Languages...).EnumVar(&c.language, Languages...)

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -17,15 +17,13 @@ type PublishCommand struct {
 	deploy   *DeployCommand
 
 	// Build fields
-	acceptCustomBuild cmd.OptionalBool
-	includeSrc        cmd.OptionalBool
-	lang              cmd.OptionalString
-	name              cmd.OptionalString
-	skipVerification  cmd.OptionalBool
-	timeout           cmd.OptionalInt
+	includeSrc       cmd.OptionalBool
+	lang             cmd.OptionalString
+	name             cmd.OptionalString
+	skipVerification cmd.OptionalBool
+	timeout          cmd.OptionalInt
 
 	// Deploy fields
-	acceptDefaults cmd.OptionalBool
 	comment        cmd.OptionalString
 	domain         cmd.OptionalString
 	pkg            cmd.OptionalString
@@ -42,8 +40,6 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 	c.deploy = deploy
 	c.CmdClause = parent.Command("publish", "Build and deploy a Compute@Edge package to a Fastly service")
 
-	c.CmdClause.Flag("accept-custom-build", "Skip confirmation prompts when running custom build commands").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
-	c.CmdClause.Flag("accept-defaults", "Accept default values for all prompts and perform deploy non-interactively").Action(c.acceptDefaults.Set).BoolVar(&c.acceptDefaults.Value)
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.comment.Set).StringVar(&c.comment.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
@@ -83,9 +79,6 @@ func NewPublishCommand(parent cmd.Registerer, globals *config.Data, build *Build
 // the progress indicator.
 func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// Reset the fields on the BuildCommand based on PublishCommand values.
-	if c.acceptCustomBuild.WasSet {
-		c.build.Flags.AcceptCustomBuild = c.acceptCustomBuild.Value
-	}
 	if c.includeSrc.WasSet {
 		c.build.Flags.IncludeSrc = c.includeSrc.Value
 	}
@@ -114,9 +107,6 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// Reset the fields on the DeployCommand based on PublishCommand values.
 	if c.name.WasSet {
 		c.manifest.Flag.Name = c.name.Value
-	}
-	if c.acceptDefaults.WasSet {
-		c.deploy.AcceptDefaults = c.acceptDefaults.Value
 	}
 	if c.pkg.WasSet {
 		c.deploy.Package = c.pkg.Value

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -39,12 +39,11 @@ type ServeCommand struct {
 	viceroyVersioner update.Versioner
 
 	// Build fields
-	acceptCustomBuild cmd.OptionalBool
-	includeSrc        cmd.OptionalBool
-	lang              cmd.OptionalString
-	name              cmd.OptionalString
-	skipVerification  cmd.OptionalBool
-	timeout           cmd.OptionalInt
+	includeSrc       cmd.OptionalBool
+	lang             cmd.OptionalString
+	name             cmd.OptionalString
+	skipVerification cmd.OptionalBool
+	timeout          cmd.OptionalInt
 
 	// Serve fields
 	addr      string
@@ -66,7 +65,6 @@ func NewServeCommand(parent cmd.Registerer, globals *config.Data, build *BuildCo
 	c.CmdClause = parent.Command("serve", "Build and run a Compute@Edge package locally")
 	c.manifest = data
 
-	c.CmdClause.Flag("accept-custom-build", "Skip confirmation prompts when running custom build commands").Action(c.acceptCustomBuild.Set).BoolVar(&c.acceptCustomBuild.Value)
 	c.CmdClause.Flag("addr", "The IPv4 address and port to listen on").Default("127.0.0.1:7676").StringVar(&c.addr)
 	c.CmdClause.Flag("debug", "Run the server in Debug Adapter mode").Hidden().BoolVar(&c.debug)
 	c.CmdClause.Flag("env", "The environment configuration to use (e.g. stage)").Action(c.env.Set).StringVar(&c.env.Value)
@@ -133,9 +131,6 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 // Build constructs and executes the build logic.
 func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 	// Reset the fields on the BuildCommand based on ServeCommand values.
-	if c.acceptCustomBuild.WasSet {
-		c.build.Flags.AcceptCustomBuild = c.acceptCustomBuild.Value
-	}
 	if c.includeSrc.WasSet {
 		c.build.Flags.IncludeSrc = c.includeSrc.Value
 	}

--- a/pkg/commands/compute/setup/loggers.go
+++ b/pkg/commands/compute/setup/loggers.go
@@ -12,9 +12,8 @@ import (
 //
 // NOTE: It implements the setup.Interface interface.
 type Loggers struct {
-	AcceptDefaults bool
-	Setup          map[string]*manifest.SetupLogger
-	Stdout         io.Writer
+	Setup  map[string]*manifest.SetupLogger
+	Stdout io.Writer
 }
 
 // Logger represents the configuration parameters for creating a dictionary
@@ -25,25 +24,23 @@ type Logger struct {
 
 // Configure prompts the user for specific values related to the service resource.
 func (l *Loggers) Configure() error {
-	if !l.AcceptDefaults {
-		text.Break(l.Stdout)
-		text.Info(l.Stdout, "The package code requires the following log endpoints to be created.")
-		text.Break(l.Stdout)
+	text.Break(l.Stdout)
+	text.Info(l.Stdout, "The package code requires the following log endpoints to be created.")
+	text.Break(l.Stdout)
 
-		for name, settings := range l.Setup {
-			text.Output(l.Stdout, "%s %s", text.Bold("Name:"), name)
-			if settings.Provider != "" {
-				text.Output(l.Stdout, "%s %s", text.Bold("Provider:"), settings.Provider)
-			}
-			text.Break(l.Stdout)
+	for name, settings := range l.Setup {
+		text.Output(l.Stdout, "%s %s", text.Bold("Name:"), name)
+		if settings.Provider != "" {
+			text.Output(l.Stdout, "%s %s", text.Bold("Provider:"), settings.Provider)
 		}
-
-		text.Description(
-			l.Stdout,
-			"Refer to the help documentation for each provider (if no provider shown, then select your own)",
-			"fastly logging <provider> create --help",
-		)
+		text.Break(l.Stdout)
 	}
+
+	text.Description(
+		l.Stdout,
+		"Refer to the help documentation for each provider (if no provider shown, then select your own)",
+		"fastly logging <provider> create --help",
+	)
 
 	return nil
 }

--- a/pkg/commands/vcl/snippet/describe.go
+++ b/pkg/commands/vcl/snippet/describe.go
@@ -48,7 +48,7 @@ func NewDescribeCommand(parent cmd.Registerer, globals *config.Data, data manife
 		Description: cmd.FlagServiceDesc,
 		Dst:         &c.serviceName.Value,
 	})
-	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").Short('i').StringVar(&c.snippetID)
+	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").StringVar(&c.snippetID)
 
 	return &c
 }

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -49,7 +49,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 		Description: cmd.FlagServiceDesc,
 		Dst:         &c.serviceName.Value,
 	})
-	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").Short('i').StringVar(&c.snippetID)
+	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").StringVar(&c.snippetID)
 
 	// NOTE: Locations is defined in the same snippet package inside create.go
 	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed").HintOptions(Locations...).Action(c.location.Set).EnumVar(&c.location.Value, Locations...)

--- a/pkg/config/data.go
+++ b/pkg/config/data.go
@@ -608,10 +608,13 @@ func (e *Environment) Read(state map[string]string) {
 // explicit flags. Consumers should bind their flag values to these fields
 // directly.
 type Flag struct {
-	Profile  string
-	Token    string
-	Verbose  bool
-	Endpoint string
+	AcceptDefaults bool
+	AutoYes        bool
+	Endpoint       string
+	NonInteractive bool
+	Profile        string
+	Token          string
+	Verbose        bool
 }
 
 // This suggests our embedded config is unexpectedly faulty and so we should


### PR DESCRIPTION
**Problem**: Previously we introduced overlapping flags related to how interactive prompts and default values were handled. This made things more confusing when used within the context of 'composite' commands like `compute serve` and `compute publish`.

**Solution**: Implement a collection of global flags that handle this behaviour more broadly.

**Notes**: This is a breaking change and will require a major version release (`v3.0.0`).