### PR TITLE
Document the newly supported Datadog sites for logging

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -1545,7 +1545,8 @@ COMMANDS
         --service-name=SERVICE-NAME
                                  The name of the service
         --region=REGION          The region that log data will be sent to.
-                                 One of US or EU. Defaults to US if undefined
+                                 One of US, US3, US5, or EU. Defaults to US if
+                                 undefined
         --format=FORMAT          Apache style log formatting. For details on
                                  the default value refer to the documentation
                                  (https://developer.fastly.com/reference/api/logging/datadog/)
@@ -1613,7 +1614,8 @@ COMMANDS
         --new-name=NEW-NAME      New name of the Datadog logging object
         --auth-token=AUTH-TOKEN  The API key from your Datadog account
         --region=REGION          The region that log data will be sent to.
-                                 One of US or EU. Defaults to US if undefined
+                                 One of US, US3, US5, or EU. Defaults to US if
+                                 undefined
         --format=FORMAT          Apache style log formatting. For details on
                                  the default value refer to the documentation
                                  (https://developer.fastly.com/reference/api/logging/datadog/)

--- a/pkg/commands/logging/datadog/create.go
+++ b/pkg/commands/logging/datadog/create.go
@@ -61,7 +61,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 		Description: cmd.FlagServiceDesc,
 		Dst:         &c.ServiceName.Value,
 	})
-	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
+	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US, US3, US5, or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. For details on the default value refer to the documentation (https://developer.fastly.com/reference/api/logging/datadog/)").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)

--- a/pkg/commands/logging/datadog/update.go
+++ b/pkg/commands/logging/datadog/update.go
@@ -63,7 +63,7 @@ func NewUpdateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	})
 	c.CmdClause.Flag("new-name", "New name of the Datadog logging object").Action(c.NewName.Set).StringVar(&c.NewName.Value)
 	c.CmdClause.Flag("auth-token", "The API key from your Datadog account").Action(c.Token.Set).StringVar(&c.Token.Value)
-	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
+	c.CmdClause.Flag("region", "The region that log data will be sent to. One of US, US3, US5, or EU. Defaults to US if undefined").Action(c.Region.Set).StringVar(&c.Region.Value)
 	c.CmdClause.Flag("format", "Apache style log formatting. For details on the default value refer to the documentation (https://developer.fastly.com/reference/api/logging/datadog/)").Action(c.Format.Set).StringVar(&c.Format.Value)
 	c.CmdClause.Flag("format-version", "The version of the custom logging format used for the configured endpoint. Can be either 2 (default) or 1").Action(c.FormatVersion.Set).UintVar(&c.FormatVersion.Value)
 	c.CmdClause.Flag("response-condition", "The name of an existing condition in the configured endpoint, or leave blank to always execute").Action(c.ResponseCondition.Set).StringVar(&c.ResponseCondition.Value)


### PR DESCRIPTION
Update the help documentation for the `--region` option for the datadog logging to
reflect the newly support US3 and US5 sites.