### PR TITLE
Fix typo ouput -> output

### DIFF
--- a/pkg/text/progress.go
+++ b/pkg/text/progress.go
@@ -74,7 +74,7 @@ func WithReset() Option {
 // isTerminal indicates if the consumer is a modern terminal.
 //
 // EXAMPLE: If the user is on a standard Windows 'command prompt' the spinner
-// output doesn't work, nor does any colour ouput, so we avoid both features.
+// output doesn't work, nor does any colour output, so we avoid both features.
 func isTerminal() bool {
 	if isatty.IsTerminal(os.Stdout.Fd()) && !fstruntime.Windows || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		return true


### PR DESCRIPTION
This PR fixes a typo. `ouput` -> `output`