### PR TITLE
Implement `profile token` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD
 # Enables support for tools such as https://github.com/rakyll/gotest
 TEST_COMMAND ?= go test
 
-TESTARGS ?= ./{cmd,pkg}/...
+# The compute tests can sometimes exceed the default 10m limit.
+TESTARGS ?= -timeout 15m ./{cmd,pkg}/...
 
 CLI_ENV ?= "development"
 

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -290,6 +290,7 @@ func defineCommands(
 	profileDelete := profile.NewDeleteCommand(profileCmdRoot.CmdClause, globals)
 	profileList := profile.NewListCommand(profileCmdRoot.CmdClause, globals)
 	profileSwitch := profile.NewSwitchCommand(profileCmdRoot.CmdClause, globals)
+	profileToken := profile.NewTokenCommand(profileCmdRoot.CmdClause, globals)
 	profileUpdate := profile.NewUpdateCommand(profileCmdRoot.CmdClause, profile.APIClientFactory(opts.APIClient), globals)
 	purgeCmdRoot := purge.NewRootCommand(app, globals, data)
 	serviceCmdRoot := service.NewRootCommand(app, globals)
@@ -558,6 +559,7 @@ func defineCommands(
 		profileDelete,
 		profileList,
 		profileSwitch,
+		profileToken,
 		profileUpdate,
 		purgeCmdRoot,
 		serviceCmdRoot,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -4431,6 +4431,11 @@ COMMANDS
     Switch user profile
 
 
+  profile token [<flags>]
+    Print user token
+
+    -u, --user=USER  Profile user to print token for
+
   profile update [<profile>]
     Update user profile
 

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -4432,9 +4432,9 @@ COMMANDS
 
 
   profile token [<flags>]
-    Print user token
+    Print access token
 
-    -u, --user=USER  Profile user to print token for
+    -n, --name=NAME  Print access token for the named profile
 
   profile update [<profile>]
     Update user profile

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -16,8 +16,7 @@ import (
 	"github.com/fastly/go-fastly/v6/fastly"
 )
 
-// CreateCommand is the parent command for all subcommands in this package.
-// It should be installed under the primary root command.
+// CreateCommand represents a Kingpin command.
 type CreateCommand struct {
 	cmd.Base
 

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -562,12 +562,8 @@ func TestToken(t *testing.T) {
 	scenarios := []Scenario{
 		{
 			TestScenario: testutil.TestScenario{
-				Name: "validate default user token is displayed",
-				Args: args("profile token"),
-				API: mock.API{
-					GetTokenSelfFn: getToken,
-					GetUserFn:      getUser,
-				},
+				Name:       "validate default user token is displayed",
+				Args:       args("profile token"),
 				WantOutput: "123",
 			},
 			ConfigFile: config.File{
@@ -587,12 +583,8 @@ func TestToken(t *testing.T) {
 		},
 		{
 			TestScenario: testutil.TestScenario{
-				Name: "validate specified user token is displayed",
-				Args: args("profile token --user bar"), // we choose a non-default profile
-				API: mock.API{
-					GetTokenSelfFn: getToken,
-					GetUserFn:      getUser,
-				},
+				Name:       "validate specified user token is displayed",
+				Args:       args("profile token --user bar"), // we choose a non-default profile
 				WantOutput: "456",
 			},
 			ConfigFile: config.File{

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -562,7 +562,7 @@ func TestToken(t *testing.T) {
 	scenarios := []Scenario{
 		{
 			TestScenario: testutil.TestScenario{
-				Name:       "validate default user token is displayed",
+				Name:       "validate the active profile token is displayed by default",
 				Args:       args("profile token"),
 				WantOutput: "123",
 			},
@@ -583,7 +583,7 @@ func TestToken(t *testing.T) {
 		},
 		{
 			TestScenario: testutil.TestScenario{
-				Name:       "validate specified user token is displayed",
+				Name:       "validate token is displayed for the specified profile",
 				Args:       args("profile token --name bar"), // we choose a non-default profile
 				WantOutput: "456",
 			},
@@ -604,7 +604,7 @@ func TestToken(t *testing.T) {
 		},
 		{
 			TestScenario: testutil.TestScenario{
-				Name:      "validate unknown user causes an error",
+				Name:      "validate an unrecognised profile causes an error",
 				Args:      args("profile token --name unknown"),
 				WantError: "profile 'unknown' does not exist",
 			},

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -584,7 +584,7 @@ func TestToken(t *testing.T) {
 		{
 			TestScenario: testutil.TestScenario{
 				Name:       "validate specified user token is displayed",
-				Args:       args("profile token --user bar"), // we choose a non-default profile
+				Args:       args("profile token --name bar"), // we choose a non-default profile
 				WantOutput: "456",
 			},
 			ConfigFile: config.File{
@@ -605,7 +605,7 @@ func TestToken(t *testing.T) {
 		{
 			TestScenario: testutil.TestScenario{
 				Name:      "validate unknown user causes an error",
-				Args:      args("profile token --user unknown"),
+				Args:      args("profile token --name unknown"),
 				WantError: "profile 'unknown' does not exist",
 			},
 		},

--- a/pkg/commands/profile/token.go
+++ b/pkg/commands/profile/token.go
@@ -1,0 +1,46 @@
+package profile
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/profile"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// TokenCommand represents a Kingpin command.
+type TokenCommand struct {
+	cmd.Base
+
+	clientFactory APIClientFactory
+	profile       string
+}
+
+// NewTokenCommand returns a new command registered in the parent.
+func NewTokenCommand(parent cmd.Registerer, globals *config.Data) *TokenCommand {
+	var c TokenCommand
+	c.Globals = globals
+	c.CmdClause = parent.Command("token", "Print user token")
+	c.CmdClause.Flag("user", "Profile user to print token for").Short('u').StringVar(&c.profile)
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *TokenCommand) Exec(in io.Reader, out io.Writer) (err error) {
+	if c.profile == "" {
+		if name, p := profile.Default(c.Globals.File.Profiles); name != "" {
+			fmt.Println(p.Token)
+		} else {
+			text.Error(out, "no profiles available")
+		}
+	} else {
+		if name, p := profile.Get(c.profile, c.Globals.File.Profiles); name != "" {
+			fmt.Println(p.Token)
+		} else {
+			text.Error(out, "profile '%s' does not exist", c.profile)
+		}
+	}
+	return nil
+}

--- a/pkg/commands/profile/token.go
+++ b/pkg/commands/profile/token.go
@@ -32,15 +32,16 @@ func (c *TokenCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if c.profile == "" {
 		if name, p := profile.Default(c.Globals.File.Profiles); name != "" {
 			fmt.Println(p.Token)
-		} else {
-			text.Error(out, "no profiles available")
+			return nil
 		}
-	} else {
-		if name, p := profile.Get(c.profile, c.Globals.File.Profiles); name != "" {
-			fmt.Println(p.Token)
-		} else {
-			text.Error(out, "profile '%s' does not exist", c.profile)
-		}
+		text.Error(out, "no profiles available")
+		return nil
 	}
+
+	if name, p := profile.Get(c.profile, c.Globals.File.Profiles); name != "" {
+		fmt.Println(p.Token)
+		return nil
+	}
+	text.Error(out, "profile '%s' does not exist", c.profile)
 	return nil
 }

--- a/pkg/commands/profile/token.go
+++ b/pkg/commands/profile/token.go
@@ -21,8 +21,8 @@ type TokenCommand struct {
 func NewTokenCommand(parent cmd.Registerer, globals *config.Data) *TokenCommand {
 	var c TokenCommand
 	c.Globals = globals
-	c.CmdClause = parent.Command("token", "Print user token")
-	c.CmdClause.Flag("user", "Profile user to print token for").Short('u').StringVar(&c.profile)
+	c.CmdClause = parent.Command("token", "Print access token")
+	c.CmdClause.Flag("name", "Print access token for the named profile").Short('n').StringVar(&c.profile)
 	return &c
 }
 


### PR DESCRIPTION
Users would like an easy way to extract their profile token from the CLI configuration file, and thus avoid doing things like:

```bash
curl ... "Fastly-Key: $(fastly config | tomlq -r .profile.user.token)"
```