### PR TITLE
Makefile: when building binary, depend on .go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ LDFLAGS = -ldflags "\
  -X 'github.com/fastly/cli/pkg/revision.Environment=${CLI_ENV}' \
  "
 
-fastly:
+ GO_FILES = $(shell find cmd pkg -type f -name '*.go')
+
+fastly: $(GO_FILES)
 	@go build -trimpath $(LDFLAGS) -o "$@" ./cmd/fastly
 
 # useful for attaching a debugger such as https://github.com/go-delve/delve


### PR DESCRIPTION
If you made a change to a source file and ran `make fastly`, it'd say
that fastly was up-to-date because the makefile target did not depend on
its input files.  Fix that by creating a list of all the Go source files
and having the makefile target depend on it.
