### PR TITLE
Support `fastly --help <command>` format

### DIFF
--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -361,6 +361,12 @@ func processCommandInput(
 		return command, cmdName, fsterr.RemediationError{Prefix: buf.String()}
 	}
 
+	// Catch scenario where user wants to view help with the following format:
+	// fastly --help <command>
+	if cmd.IsHelpFlagOnly(opts.Args) {
+		return command, cmdName, help(vars, nil)
+	}
+
 	return command, cmdName, nil
 }
 


### PR DESCRIPTION
We currently support:

- `fastly help <command>`
- `fastly <command> --help`

A customer tried to use `fastly --help <command>` and this triggered a runtime panic.