### PR TITLE
Handle build info more accurately

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -16,9 +16,8 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.18.x'
-    - name: "Set GOVERSION"
-      id: set_goversion
-      run: echo "GOVERSION=$(go version)" >> $GITHUB_ENV
+    - name: "Set GOHOSTOS and GOHOSTARCH"
+      run: echo "GOHOSTOS=$(go env GOHOSTOS)" >> $GITHUB_ENV && echo "GOHOSTARCH=$(go env GOHOSTARCH)" >> $GITHUB_ENV
     - name: "Download latest app config"
       run: |
         make config
@@ -41,11 +40,14 @@ jobs:
     - name: "Run GoReleaser"
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: v1.5.0 # goreleaser version (NOT goreleaser-action version)
+        # goreleaser version (NOT goreleaser-action version)
+        # update inline with the Makefile
+        version: v1.9.2
         args: release --rm-dist
       env:
         AUR_KEY: '${{ github.workspace }}/aur_key'
-        GOVERSION: ${{ env.GOVERSION }}
+        GOHOSTOS: ${{ env.GOHOSTOS }}
+        GOHOSTARCH: ${{ env.GOHOSTARCH }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     - name: "Generate release commits"
       id: generate-commits

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,8 @@ builds:
       ldflags:
         - -s -w -X "github.com/fastly/cli/pkg/revision.AppVersion=v{{ .Version }}"
         - -X "github.com/fastly/cli/pkg/revision.GitCommit={{ .ShortCommit }}"
-        - -X "github.com/fastly/cli/pkg/revision.GoVersion={{ .Env.GOVERSION }}"
+        - -X "github.com/fastly/cli/pkg/revision.GoHostOS={{ .Env.GOHOSTOS }}"
+        - -X "github.com/fastly/cli/pkg/revision.GoHostArch={{ .Env.GOHOSTARCH }}"
         - -X "github.com/fastly/cli/pkg/revision.Environment=release"
     id: macos
     goos: [darwin]

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,13 +15,13 @@ Note that by default the tests are run using `go test` with the following config
 To run a specific test use the `-run` flag (exposed by `go test`) and also provide the path to the directory where the test files reside (replace `...` and `<path>` with appropriate values):
 
 ```sh
-make test TESTARGS="-run <...> <path>"
+make test TEST_ARGS="-run <...> <path>"
 ```
 
 **Example**:
 
 ```sh
-make test TESTARGS="-run TestBackendCreate ./pkg/backend/..."
+make test TEST_ARGS="-run TestBackendCreate ./pkg/backend/..."
 ```
 
 Some integration tests aren't run outside of the CI environment, to enable these tests locally you'll need to set a specific environment variable relevant to the test.
@@ -38,7 +38,7 @@ The available environment variables are:
 **Example**:
 
 ```sh
-TEST_COMPUTE_BUILD_RUST=1 make test TESTARGS="-run TestBuildRust/fastly_crate_prerelease ./pkg/compute/..." 
+TEST_COMPUTE_BUILD_RUST=1 make test TEST_ARGS="-run TestBuildRust/fastly_crate_prerelease ./pkg/compute/..." 
 ```
 
 When running the tests locally, if you don't have the relevant language ecosystems set-up properly then the tests will fail to run and you'll need to review the code to see what the remediation steps are, as that output doesn't get shown when running the test suite.

--- a/pkg/revision/revision.go
+++ b/pkg/revision/revision.go
@@ -1,24 +1,40 @@
-// Package revision defines variables that will be populated with values from
-// the Makefile at build time via LDFLAGS.
+// Package revision defines variables that will be populated with values
+// specified at build time via LDFLAGS. goreleaser will prompt for missing env
+// variables.
+// For more details on LDFLAGS:
+// https://github.com/golang/go/wiki/GcToolchainTricks#including-build-information-in-the-executable
 package revision
 
-import "strings"
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
 
 var (
 	// AppVersion is the semver for this version of the client, or
-	// "v0.0.0-unknown". Set by `make release`.
+	// "v0.0.0-unknown". Handled by goreleaser.
 	AppVersion string
 
 	// GitCommit is the short git SHA associated with this build, or
-	// "unknown". Set by `make release`.
+	// "unknown". Handled by goreleaser.
 	GitCommit string
 
-	// GoVersion is the output of `go version` associated with this build, or
-	// "go version unknown". Set by `make release`.
+	// GoVersion - Prefer letting the code handle this and set GoHostOS and
+	// GoHostArc instead. It can be set to the build host's `go version` output.
 	GoVersion string
+
+	// GoHostOS is the output of `go env GOHOSTOS` Passed to goreleaser by
+	// `make fastly` or the GHA workflow.
+	GoHostOS string
+
+	// GoHostArch is the output of `go env GOHOSTARCH` Passed to goreleaser by
+	// `make fastly` or the GHA workflow.
+	GoHostArch string
 
 	// Environment is set to either "development" (when working locally) or
 	// "release" when the code being executed is from a published release.
+	// Handled by goreleaser.
 	Environment string
 )
 
@@ -32,8 +48,17 @@ func init() {
 	if GitCommit == "" {
 		GitCommit = "unknown"
 	}
+	if GoHostOS == "" {
+		GoHostOS = "unknown"
+	}
+	if GoHostArch == "" {
+		GoHostArch = "unknown"
+	}
 	if GoVersion == "" {
-		GoVersion = "go version unknown"
+		// runtime.Version() provides the Go tree's version string at build time
+		// the other values like OS and Arch aren't accessible and are passed in
+		// separately
+		GoVersion = fmt.Sprintf("go version %s %s/%s", runtime.Version(), GoHostOS, GoHostArch)
 	}
 	if Environment == "" {
 		Environment = "development"


### PR DESCRIPTION
`runtime.Version()` will always give an accurate build host version

https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/runtime/extern.go;l=251-266

For the host's GOOS and host's GOARCH they're not available so they must still be passed in via ldflags

matches the `go version` cli output

https://github.com/golang/go/blob/master/src/cmd/go/internal/version/version.go#L76

`make fastly` now uses goreleaser. I removed the cleanup comment and left the ldflags for the "dev" builds
Maybe the whole LDFLAGS entry can be removed and the dev builds just dont have version info?
