### PR TITLE
update config

### DIFF
--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -10,7 +10,7 @@ ttl = "5m"
 [language]
   [language.go]
     tinygo_constraint = ">= 0.24.0"
-    toolchain_constraint = ">= 1.17"
+    toolchain_constraint = ">= 1.17 < 1.19" # upper limit should be temporary (just while we figure out any rough edges)
 
   [language.rust]
   toolchain_version = "1.56.1"

--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -8,6 +8,10 @@ remote_config = "https://developer.fastly.com/api/internal/cli-config"
 ttl = "5m"
 
 [language]
+  [language.go]
+    tinygo_constraint = ">= 0.24.0"
+    toolchain_constraint = ">= 1.17"
+
   [language.rust]
   toolchain_version = "1.56.1"
   toolchain_constraint = ">= 1.56.1"


### PR DESCRIPTION
In preparation for a new Compute@Edge language, I'm updating the CLI configuration.

Once this PR is merged we can initiate an internal build process to ensure the CLI config endpoint starts to return the updated config.

This means the PR for integrating the new C@E language will not have a conflict with the 'static' config baked in (which gets automatically updated via a `make config` target that overrides the static config with whatever happens to be exposed via the remote config endpoint). As we need that PR to have the static config contain the new language fields.