### PR TITLE
prevent runtime panic in error logging package

### DIFF
--- a/cmd/fastly/static/config.toml
+++ b/cmd/fastly/static/config.toml
@@ -7,6 +7,10 @@ api_endpoint = "https://api.fastly.com"
 remote_config = "https://developer.fastly.com/api/internal/cli-config"
 ttl = "5m"
 
+[language.go]
+tinygo_constraint = ">= 0.24.0-0"
+toolchain_constraint = ">= 1.17 < 1.19"
+
 [language.rust]
 toolchain_version = "1.56.1"
 toolchain_constraint = ">= 1.56.1"

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -724,7 +724,7 @@ func manageExistingServiceFlow(
 		return serviceVersion, err
 	}
 	if serviceDetails.Type != "wasm" {
-		errLog.AddWithContext(err, map[string]interface{}{
+		errLog.AddWithContext(fmt.Errorf("error: invalid service type: '%s'", serviceDetails.Type), map[string]interface{}{
 			"Service ID":      serviceID,
 			"Service Version": serviceVersion,
 			"Service Type":    serviceDetails.Type,

--- a/pkg/errors/log.go
+++ b/pkg/errors/log.go
@@ -202,8 +202,12 @@ func createLogEntry(err error) LogEntry {
 
 	_, file, line, ok := runtime.Caller(2)
 	if ok {
+		idx := strings.Index(file, "/pkg/")
+		if idx == -1 {
+			idx = 0
+		}
 		le.Caller = map[string]interface{}{
-			"FILE": file[strings.Index(file, "/pkg/"):],
+			"FILE": file[idx:],
 			"LINE": line,
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/593

The CLI checks and validates the given service is the expected 'wasm' type, but a user wouldn't see the error because a logic bug triggered a runtime panic before the actual error (and remediation) could be displayed. 

See the below screenshot that shows what the user _should_ see once this PR is merged:

<img width="1349" alt="Screenshot 2022-07-15 at 11 29 05" src="https://user-images.githubusercontent.com/180050/179206807-277ac67b-d8d9-4751-8b08-ae88e11d82af.png">

The panic was being caused by an `err` variable that we expected to have an error value assigned but was actually being assigned `nil` (the reason it was being assigned `nil` was because of a variable shadowing mistake).