### PR TITLE
ignore TTL & update config if app version doesn't match config version

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -145,7 +145,8 @@ func main() {
 	// NOTE: We don't want to trigger a config check when the user is making an
 	// autocomplete request because this can add additional latency to the user's
 	// shell loading completely.
-	if check.Stale(file.CLI.LastChecked, file.CLI.TTL) && !cmd.IsCompletion(args) && !cmd.IsCompletionScript(args) {
+	stale := (file.CLI.Version != revision.AppVersion) || check.Stale(file.CLI.LastChecked, file.CLI.TTL)
+	if stale && !cmd.IsCompletion(args) && !cmd.IsCompletionScript(args) {
 		if verboseOutput {
 			text.Info(out, `
 Compatibility and versioning information for the Fastly CLI is being updated in the background.  The updated data will be used next time you execute a fastly command.

--- a/pkg/commands/update/root.go
+++ b/pkg/commands/update/root.go
@@ -122,15 +122,6 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 		}
 	}
 
-	file := c.Globals.File
-	err = file.Load(file.CLI.RemoteConfig, config.FilePath, c.Globals.HTTPClient)
-	if err != nil {
-		return errors.RemediationError{
-			Inner:       fmt.Errorf("error updating the versioning information for the Fastly CLI: %w", err),
-			Remediation: errors.UpdateRemediation,
-		}
-	}
-
 	progress.Done()
 
 	text.Success(out, "Updated %s to %s.", currentPath, latest)

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -154,6 +154,3 @@ var ComputeTrialRemediation = "For more help with this error see fastly.help/cli
 
 // ProfileRemediation suggests no profiles exist.
 var ProfileRemediation = "Run `fastly profile create <NAME>` to create a profile, or `fastly profile list` to view available profiles (at least one profile should be set as 'default')."
-
-// UpdateRemediation suggests no profiles exist.
-var UpdateRemediation = "We'll attempt to update the Fastly CLI versioning information on the next invocation. If there are any errors, ensure `fastly config` matches https://developer.fastly.com/api/internal/cli-config"


### PR DESCRIPTION
Fixes an issue where the local config did not have the Go starter kit
after updating until at least 5 minutes afterward.

The issue went something like this:
1. You run `fastly update` to get the latest software
2. The config gets updated to the latest version, but unsupported features (like the new Go support) are dropped when the config gets reserialized to disk
3. The software gets updated
4. The config file gets updated again (from #610), but it's still the old software version so there's no change
5. The config file has its last checked time updated to now
6. You run the new software and its check as to whether to update the config file sees that it's been updated within the TTL (5m) and doesn't update it
7. The Go starter kit is sill missing

This PR fixes the issue by having the runtime check for whether the config needs to be updated ignore the TTL when the version in the config file does not match the currently-running CLI version.  That way, the first time you run the CLI after updating, it will always update the config file first.

The change from #610 should probably be reverted?  It doesn't seem to have any effect since the same update happens immediately before downloading the software.  I wasn't 100% sure on that and didn't include it in this PR but I can add it if it's the right thing to do.
