### PR TITLE
Improve compute init remediation

### DIFF
--- a/pkg/commands/compute/language_go.go
+++ b/pkg/commands/compute/language_go.go
@@ -75,7 +75,7 @@ type Go struct {
 func (g Go) Initialize(out io.Writer) error {
 	// Remediation used in variation sections.
 	goURL := "https://go.dev/"
-	remediation := fmt.Sprintf("To fix this error, install %s by visiting:\n\n\t$ %s", g.toolchain, text.Bold(goURL))
+	remediation := fmt.Sprintf("To fix this error, install %s by visiting:\n\n\t$ %s\n\nThen execute:\n\n\t$ fastly compute init", g.toolchain, text.Bold(goURL))
 
 	var (
 		bin string
@@ -147,10 +147,11 @@ func (g Go) Initialize(out io.Writer) error {
 		}
 
 		if !filesystem.FileExists(m) {
-			remediation := "go mod init"
+			msg := fmt.Sprintf(fsterr.FormatTemplate, text.Bold("go mod init"))
+			remediation := fmt.Sprintf("%s\n\nThen execute:\n\n\t$ fastly compute init", msg)
 			err := fsterr.RemediationError{
 				Inner:       fmt.Errorf("%s not found", JSManifestName),
-				Remediation: fmt.Sprintf(fsterr.FormatTemplate, text.Bold(remediation)),
+				Remediation: remediation,
 			}
 			g.errlog.Add(err)
 			return err

--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -112,7 +112,7 @@ func (j JavaScript) Initialize(out io.Writer) error {
 	if err != nil {
 		j.errlog.Add(err)
 		nodejsURL := "https://nodejs.org/"
-		remediation := fmt.Sprintf("To fix this error, install Node.js and %s by visiting:\n\n\t$ %s", j.toolchain, text.Bold(nodejsURL))
+		remediation := fmt.Sprintf("To fix this error, install Node.js and %s by visiting:\n\n\t$ %s\n\nThen execute:\n\n\t$ fastly compute init", j.toolchain, text.Bold(nodejsURL))
 
 		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("`%s` not found in $PATH", j.toolchain),
@@ -133,7 +133,8 @@ func (j JavaScript) Initialize(out io.Writer) error {
 	}
 
 	if !filesystem.FileExists(m) {
-		remediation := "npm init"
+		msg := fmt.Sprintf(fsterr.FormatTemplate, text.Bold("npm init"))
+		remediation := fmt.Sprintf("%s\n\nThen execute\n\n\t$ fastly compute init", msg)
 		err := fsterr.RemediationError{
 			Inner:       fmt.Errorf("%s not found", JSManifestName),
 			Remediation: fmt.Sprintf(fsterr.FormatTemplate, text.Bold(remediation)),


### PR DESCRIPTION
While investigating a different issue I noticed that if there was an error when running `compute init`, although a remediation is provided it's unclear that you should actually re-run the `compute init` command to complete any outstanding validation steps. So I wanted to make that clearer.