### PR TITLE
Change default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+.PHONY: default
+default: build ;
+
 SHELL := /bin/bash -o pipefail
 
 # the rationale for using both `git describe` and `git rev-parse` is because


### PR DESCRIPTION
**Problem**: Users expect `make` to compile a project successfully, but the current default target `fastly` would cause an error because it was setup to build with [goreleaser](https://goreleaser.com), which will report an error if the current commit of the `main` branch doesn't align with the latest git tag.

**Solution**: Set `build` to be the default target as it simply executes `go build` and will produce an executable binary for the user's OS/Arch.

Fixes #605