### PR TITLE
Change default service version selection behaviour

### DIFF
--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -102,8 +102,11 @@ func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fast
 		return vs[0], nil
 	case "active":
 		v, err = GetActiveVersion(vs)
-	case "":
-		return vs[0], nil
+	case "": // no --version flag provided
+		v, err = GetActiveVersion(vs)
+		if err != nil {
+			return vs[0], nil // if no active version, return latest version
+		}
 	default:
 		v, err = GetSpecifiedVersion(vs, sv.Value)
 	}

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -29,13 +29,15 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 			flagValue:   "active",
 			wantVersion: 1,
 		},
+		// NOTE: Default behaviour for an empty flag value (or no flag at all) is to
+		// get the active version, and if no active version return the latest.
 		"empty": {
 			flagValue:   "",
-			wantVersion: 3,
+			wantVersion: 1,
 		},
 		"omitted": {
 			flagOmitted: true,
-			wantVersion: 3,
+			wantVersion: 1,
 		},
 		"specific version OK": {
 			flagValue:   "2",

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -175,6 +175,7 @@ func TestDeploy(t *testing.T) {
 			name: "list domains error",
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
 				ListDomainsFn:       listDomainsError,
@@ -383,6 +384,7 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionError,
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateDomainFn:      createDomainOK,
 				DeleteDomainFn:      deleteDomainOK,
 				GetPackageFn:        getPackageOk,
@@ -405,6 +407,7 @@ func TestDeploy(t *testing.T) {
 			name: "identical package",
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				GetPackageFn:        getPackageIdentical,
 				GetServiceFn:        getServiceOK,
 				GetServiceDetailsFn: getServiceDetailsWasm,
@@ -420,6 +423,7 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				GetPackageFn:        getPackageOk,
 				GetServiceFn:        getServiceOK,
 				GetServiceDetailsFn: getServiceDetailsWasm,
@@ -434,7 +438,7 @@ func TestDeploy(t *testing.T) {
 				"https://manage.fastly.com/configure/services/123",
 				"View this service at:",
 				"https://directly-careful-coyote.edgecompute.app",
-				"Deployed package (service 123, version 3)",
+				"Deployed package (service 123, version 4)",
 			},
 		},
 		{
@@ -489,7 +493,7 @@ func TestDeploy(t *testing.T) {
 		},
 		{
 			name: "success with inactive version",
-			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz"),
+			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version latest"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
 				GetPackageFn:        getPackageOk,
@@ -885,6 +889,7 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBackendFn:     createBackendOK,
 				GetPackageFn:        getPackageOk,
 				GetServiceFn:        getServiceOK,
@@ -914,7 +919,7 @@ func TestDeploy(t *testing.T) {
 			wantOutput: []string{
 				"Uploading package...",
 				"Activating version...",
-				"SUCCESS: Deployed package (service 123, version 3)",
+				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
 				"Creating backend 'google' (host: beep.com, port: 123)",
@@ -926,6 +931,7 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBackendFn:     createBackendOK,
 				GetPackageFn:        getPackageOk,
 				GetServiceFn:        getServiceOK,
@@ -951,7 +957,7 @@ func TestDeploy(t *testing.T) {
 			wantOutput: []string{
 				"Uploading package...",
 				"Activating version...",
-				"SUCCESS: Deployed package (service 123, version 3)",
+				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
 				"Configuring dictionary 'dict_a'",
@@ -1109,6 +1115,7 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
+				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBackendFn:     createBackendOK,
 				GetPackageFn:        getPackageOk,
 				GetServiceFn:        getServiceOK,
@@ -1128,7 +1135,7 @@ func TestDeploy(t *testing.T) {
 			wantOutput: []string{
 				"Uploading package...",
 				"Activating version...",
-				"SUCCESS: Deployed package (service 123, version 3)",
+				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
 				"The package code requires the following log endpoints to be created.",
@@ -1263,7 +1270,7 @@ func TestDeploy(t *testing.T) {
 			// Because the manifest can be mutated on each test scenario, we recreate
 			// the file each time.
 			manifestContent := `manifest_version = 2
-			name = "package"			
+			name = "package"
 			`
 			if testcase.manifest != "" {
 				manifestContent = testcase.manifest


### PR DESCRIPTION
Fixes #631

**Current behaviour**:
If there is no `--version` flag, then use the 'latest' version to clone from (which itself may be 'active' or 'locked').

**New behaviour**:
If there is no `--version` flag, then use the 'active' version to clone from, and if there is no active version, use the 'latest' version available.