### PR TITLE
Add support for TOML object_store section

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,6 +1,6 @@
 ## Development
 
-The Fastly CLI requires [Go 1.19 or above](https://golang.org). Clone this repo
+The Fastly CLI requires [Go 1.18](https://golang.org). Clone this repo
 to any path and type `make` to run all of the tests and generate a development
 build locally.
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -257,8 +257,9 @@ type SetupLogger struct {
 
 // LocalServer represents a list of mocked Viceroy resources.
 type LocalServer struct {
-	Backends     map[string]LocalBackend    `toml:"backends"`
-	Dictionaries map[string]LocalDictionary `toml:"dictionaries,omitempty"`
+	Backends     map[string]LocalBackend     `toml:"backends"`
+	Dictionaries map[string]LocalDictionary  `toml:"dictionaries,omitempty"`
+	ObjectStore  map[string]LocalObjectStore `toml:"object_stores,omitempty"`
 }
 
 // LocalBackend represents a backend to be mocked by the local testing server.
@@ -272,6 +273,13 @@ type LocalDictionary struct {
 	File     string            `toml:"file,omitempty"`
 	Format   string            `toml:"format"`
 	Contents map[string]string `toml:"contents,omitempty"`
+}
+
+// LocalObjectStore represents an object_store to be mocked by the local testing server.
+type LocalObjectStore struct {
+	Key  string `toml:"key"`
+	Path string `toml:"path"`
+	Data string `toml:"data"`
 }
 
 // Exists yields whether the manifest exists.


### PR DESCRIPTION
- Adds CLI (TOML file) support for the [Viceroy addition](https://github.com/fastly/Viceroy/pull/167)
- Adjustment to note that currently Go 1.18 is required.