### PR TITLE
Fix Rust 'existing project' bug

### DIFF
--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -125,7 +125,7 @@ func TestBuildRust(t *testing.T) {
 			language = "rust"
 
       [scripts]
-      build = "%s"`, compute.RustDefaultBuildCommand),
+      build = "%s"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustPackageName)),
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{
@@ -160,7 +160,7 @@ func TestBuildRust(t *testing.T) {
 			language = "rust"
 
       [scripts]
-      build = "%s"`, compute.RustDefaultBuildCommand),
+      build = "%s"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustPackageName)),
 			cargoManifest: `
 			[package]
 			name = "fastly-compute-project"
@@ -796,7 +796,7 @@ func TestCustomPostBuild(t *testing.T) {
 			language = "rust"
 			[scripts]
       build = "%s"
-			post_build = "echo custom post_build"`, compute.RustDefaultBuildCommand),
+			post_build = "echo custom post_build"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustPackageName)),
 			cargoManifest: `
 			[package]
 			name = "fastly-compute-project"
@@ -829,7 +829,7 @@ func TestCustomPostBuild(t *testing.T) {
 			language = "rust"
 			[scripts]
       build = "%s"
-			post_build = "echo custom post_build"`, compute.RustDefaultBuildCommand),
+			post_build = "echo custom post_build"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustPackageName)),
 			cargoManifest: `
 			[package]
 			name = "fastly-compute-project"
@@ -863,7 +863,7 @@ func TestCustomPostBuild(t *testing.T) {
 			language = "rust"
 			[scripts]
       build = "%s"
-			post_build = "echo custom post_build"`, compute.RustDefaultBuildCommand),
+			post_build = "echo custom post_build"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustPackageName)),
 			cargoManifest: `
 			[package]
 			name = "fastly-compute-project"


### PR DESCRIPTION
The v4 release didn't take into account a user who upgrades to the latest CLI version but has a pre-existing project.

The pre-existing project will have in their Cargo.toml a `[package.name]` set to something like `compute-starter-kit-rust-default`, which doesn't match the expected package name that the build script is looking for: `--bin fastly-compute-project`.