### PR TITLE
Fix Rust output regression

### DIFF
--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -203,11 +203,20 @@ func rustupToolchain() string {
 		return stable
 	}
 
-	reader := bufio.NewReader(bytes.NewReader(stdoutStderr))
-	line, err := reader.ReadString('\n')
-	if err != nil {
+	// WARNING: Reading the first line might result in an unexpected error.
+	// This is because rustup might display 'sync' output.
+	// e.g. info: syncing channel updates for 'stable-aarch64-apple-darwin'
+	// The solution is to get the last line of output instead.
+	scanner := bufio.NewScanner(bytes.NewReader(stdoutStderr))
+	line := ""
+	for scanner.Scan() {
+		line = scanner.Text()
+	}
+	err = scanner.Err()
+	if line == "" || err != nil {
 		return stable
 	}
+	line = strings.TrimSpace(line)
 
 	// Example outputs:
 	// stable-x86_64-apple-darwin (default)


### PR DESCRIPTION
**NOTE**: This was first seen in CI but can be reproduced by uninstalling all toolchains (e.g. `rustup toolchain uninstall <toolchain>`) and then running `rustup show active-toolchain` (see output below). The CLI was expecting one line of output but in fact there is now multiple lines, and the line we're interested in is actually the _last_ line of output.

```
info: syncing channel updates for 'stable-aarch64-apple-darwin'
info: latest update on 2022-09-22, rust version 1.64.0 (a55dd71d5 2022-09-19)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
 18.8 MiB /  18.8 MiB (100 %)  11.3 MiB/s in  1s ETA:  0s
info: downloading component 'rust-std'
 25.6 MiB /  25.6 MiB (100 %)  10.5 MiB/s in  2s ETA:  0s
info: downloading component 'rustc'
 49.1 MiB /  49.1 MiB (100 %)   9.6 MiB/s in  5s ETA:  0s
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
 18.8 MiB /  18.8 MiB (100 %)   6.4 MiB/s in  2s ETA:  0s
info: installing component 'rust-std'
 25.6 MiB /  25.6 MiB (100 %)  18.3 MiB/s in  1s ETA:  0s
info: installing component 'rustc'
 49.1 MiB /  49.1 MiB (100 %)  20.8 MiB/s in  2s ETA:  0s
info: installing component 'rustfmt'
stable-aarch64-apple-darwin (default)
```