### PR TITLE
Fix `compute pack` to produce expected `package.tar.gz` file name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,7 @@ require (
 	github.com/getsentry/sentry-go v0.12.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v38 v38.1.0
-	github.com/kennygrant/sanitize v1.2.4
 	github.com/mattn/go-isatty v0.0.14
-	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/mapstructure v1.4.3
@@ -33,6 +31,7 @@ require (
 )
 
 require (
+	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/otiai10/copy v1.7.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/tcnksm/go-gitconfig v0.1.2
@@ -55,6 +54,5 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.m
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
-github.com/fastly/go-fastly/v6 v6.5.2 h1:oeHoRoddStqHn1Ukyz+oVxPjvYDBARNr+hP6+HAt4TY=
-github.com/fastly/go-fastly/v6 v6.5.2/go.mod h1:NrIbx45etTFv35rgfRe+eQY+8kA47arWABIkOaQ+roY=
 github.com/fastly/go-fastly/v6 v6.6.0 h1:H+KpD/K2FlhB6JHFxXIUst7aJRyF3r0Ro0uMdSX85AI=
 github.com/fastly/go-fastly/v6 v6.6.0/go.mod h1:NrIbx45etTFv35rgfRe+eQY+8kA47arWABIkOaQ+roY=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
@@ -109,8 +107,6 @@ github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYb
 github.com/kataras/neffos v0.0.14/go.mod h1:8lqADm8PnbeFfL7CLXh1WHw53dG27MC3pgi2R1rmoTE=
 github.com/kataras/pio v0.0.2/go.mod h1:hAoW0t9UmXi4R5Oyq5Z4irTbaTsOemSrDGUtaTl7Dro=
 github.com/kataras/sitemap v0.0.5/go.mod h1:KY2eugMKiPwsJgx7+U103YZehfvNGOXURubcGyk0Bz8=
-github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
-github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -310,8 +310,8 @@ func promptForBuildContinue(msg, script string, out io.Writer, in io.Reader, ver
 	return nil
 }
 
-// CreatePackageArchive packages build artifacts as a Fastly package, which
-// must be a GZipped Tar archive such as: package-name.tar.gz.
+// CreatePackageArchive packages build artifacts as a Fastly package.
+// The package must be a GZipped Tar archive.
 //
 // Due to a behavior of archiver.Archive() which recursively writes all files in
 // a provided directory to the archive we first copy our input files to a

--- a/pkg/commands/compute/pack.go
+++ b/pkg/commands/compute/pack.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/kennygrant/sanitize"
 	"github.com/mholt/archiver/v3"
 )
 
@@ -48,8 +47,7 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	if err = c.manifest.File.ReadError(); err != nil {
 		return err
 	}
-	name := sanitize.BaseName(c.manifest.File.Name)
-	pkg := fmt.Sprintf("pkg/%s/bin/main.wasm", name)
+	pkg := "pkg/package/bin/main.wasm"
 	dir := filepath.Dir(pkg)
 	err = filesystem.MakeDirectoryIfNotExists(dir)
 	if err != nil {
@@ -91,7 +89,7 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 
 	progress.Step("Copying manifest...")
 	src = manifest.Filename
-	dst = fmt.Sprintf("pkg/%s/%s", name, manifest.Filename)
+	dst = fmt.Sprintf("pkg/package/%s", manifest.Filename)
 	if err := filesystem.CopyFile(src, dst); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Manifest (destination)": dst,
@@ -104,7 +102,7 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	tar := archiver.NewTarGz()
 	tar.OverwriteExisting = true
 	{
-		dir := fmt.Sprintf("pkg/%s", name)
+		dir := "pkg/package"
 		src := []string{dir}
 		dst := fmt.Sprintf("%s.tar.gz", dir)
 		if err = tar.Archive(src, dst); err != nil {

--- a/pkg/commands/compute/pack_test.go
+++ b/pkg/commands/compute/pack_test.go
@@ -21,10 +21,8 @@ func TestPack(t *testing.T) {
 		wantOutput    []string
 		expectedFiles [][]string
 	}{
-		// The following test validates that the expected directory structure was
-		// created successfully.
 		{
-			name: "success for directory structure",
+			name: "success",
 			args: args("compute pack --wasm-binary ./main.wasm"),
 			manifest: `
 			manifest_version = 2
@@ -36,41 +34,17 @@ func TestPack(t *testing.T) {
 				"Creating .tar.gz file...",
 			},
 			expectedFiles: [][]string{
-				{"pkg", "package", "bin", "main.wasm"},
-				{"pkg", "package", "fastly.toml"},
 				{"pkg", "package.tar.gz"},
 			},
 		},
-		// The following test validates that the expected directory structure was
-		// created successfully when `name` contains whitespace.
 		{
-			name: "success with name containing whitespace",
-			args: args("compute pack --wasm-binary ./main.wasm"),
-			manifest: `
-			manifest_version = 2
-			name = "another name"`,
-			wantOutput: []string{
-				"Initializing...",
-				"Copying wasm binary...",
-				"Copying manifest...",
-				"Creating .tar.gz file...",
-			},
-			expectedFiles: [][]string{
-				{"pkg", "package", "bin", "main.wasm"},
-				{"pkg", "package", "fastly.toml"},
-				{"pkg", "package.tar.gz"},
-			},
-		},
-		// The following tests validate that a valid path flag value should be
-		// provided.
-		{
-			name:      "error no path flag",
+			name:      "no wasm binary path flag",
 			args:      args("compute pack"),
 			manifest:  `name = "precompiled"`,
 			wantError: "error parsing arguments: required flag --wasm-binary not provided",
 		},
 		{
-			name: "error no path flag value provided",
+			name: "no wasm binary path flag value",
 			args: args("compute pack --wasm-binary "),
 			manifest: `
 			manifest_version = 2

--- a/pkg/commands/compute/pack_test.go
+++ b/pkg/commands/compute/pack_test.go
@@ -36,9 +36,9 @@ func TestPack(t *testing.T) {
 				"Creating .tar.gz file...",
 			},
 			expectedFiles: [][]string{
-				{"pkg", "mypackagename", "bin", "main.wasm"},
-				{"pkg", "mypackagename", "fastly.toml"},
-				{"pkg", "mypackagename.tar.gz"},
+				{"pkg", "package", "bin", "main.wasm"},
+				{"pkg", "package", "fastly.toml"},
+				{"pkg", "package.tar.gz"},
 			},
 		},
 		// The following test validates that the expected directory structure was
@@ -56,9 +56,9 @@ func TestPack(t *testing.T) {
 				"Creating .tar.gz file...",
 			},
 			expectedFiles: [][]string{
-				{"pkg", "another-name", "bin", "main.wasm"},
-				{"pkg", "another-name", "fastly.toml"},
-				{"pkg", "another-name.tar.gz"},
+				{"pkg", "package", "bin", "main.wasm"},
+				{"pkg", "package", "fastly.toml"},
+				{"pkg", "package.tar.gz"},
 			},
 		},
 		// The following tests validate that a valid path flag value should be


### PR DESCRIPTION
We updated the `compute build` and `compute deploy` commands to generate, and lookup, a package inside `/pkg/package.tar.gz` but we then neglected to update the `compute pack` command (which still had the old behaviour of _dynamically_ generating the package filename, e.g. `/pkg/<dynamic_name>.tar.gz`).