### PR TITLE
Add cert_host and use_sni to TOML

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -252,6 +252,8 @@ type LocalServer struct {
 type LocalBackend struct {
 	URL          string `toml:"url"`
 	OverrideHost string `toml:"override_host,omitempty"`
+	CertHost     string `toml:"cert_host,omitempty"`
+	UseSNI       string `toml:"use_sni,omitempty"`
 }
 
 // LocalDictionary represents a dictionary to be mocked by the local testing server.

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -253,7 +253,7 @@ type LocalBackend struct {
 	URL          string `toml:"url"`
 	OverrideHost string `toml:"override_host,omitempty"`
 	CertHost     string `toml:"cert_host,omitempty"`
-	UseSNI       string `toml:"use_sni,omitempty"`
+	UseSNI       bool   `toml:"use_sni,omitempty"`
 }
 
 // LocalDictionary represents a dictionary to be mocked by the local testing server.


### PR DESCRIPTION
Implement TOML property parsing, given [functionality is in Viceroy](https://github.com/fastly/Viceroy/pull/168).