### PR TITLE
Ensure the `./bin` directory is present even with `--skip-verification`

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.m
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
-github.com/fastly/go-fastly/v6 v6.5.2 h1:oeHoRoddStqHn1Ukyz+oVxPjvYDBARNr+hP6+HAt4TY=
-github.com/fastly/go-fastly/v6 v6.5.2/go.mod h1:NrIbx45etTFv35rgfRe+eQY+8kA47arWABIkOaQ+roY=
 github.com/fastly/go-fastly/v6 v6.6.0 h1:H+KpD/K2FlhB6JHFxXIUst7aJRyF3r0Ro0uMdSX85AI=
 github.com/fastly/go-fastly/v6 v6.6.0/go.mod h1:NrIbx45etTFv35rgfRe+eQY+8kA47arWABIkOaQ+roY=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -204,6 +204,18 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return nil
 	}
 
+	// NOTE: A ./bin directory is required for the main.wasm to be placed inside.
+	dir, err := os.Getwd()
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return fmt.Errorf("failed to identify the current working directory: %w", err)
+	}
+	binDir := filepath.Join(dir, "bin")
+	if err := filesystem.MakeDirectoryIfNotExists(binDir); err != nil {
+		c.Globals.ErrLog.Add(err)
+		return fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
 	if err := language.Build(out, progress, c.Globals.Flag.Verbose, postBuildCallback); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Language": language.Name,

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -171,6 +171,18 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return fmt.Errorf("unsupported language %s", toolchain)
 	}
 
+	// NOTE: A ./bin directory is required for the main.wasm to be placed inside.
+	dir, err := os.Getwd()
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return fmt.Errorf("failed to identify the current working directory: %w", err)
+	}
+	binDir := filepath.Join(dir, "bin")
+	if err := filesystem.MakeDirectoryIfNotExists(binDir); err != nil {
+		c.Globals.ErrLog.Add(err)
+		return fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
 	if !c.Flags.SkipVerification {
 		progress.Step(fmt.Sprintf("Verifying local %s toolchain...", toolchain))
 
@@ -202,18 +214,6 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			}
 		}
 		return nil
-	}
-
-	// NOTE: A ./bin directory is required for the main.wasm to be placed inside.
-	dir, err := os.Getwd()
-	if err != nil {
-		c.Globals.ErrLog.Add(err)
-		return fmt.Errorf("failed to identify the current working directory: %w", err)
-	}
-	binDir := filepath.Join(dir, "bin")
-	if err := filesystem.MakeDirectoryIfNotExists(binDir); err != nil {
-		c.Globals.ErrLog.Add(err)
-		return fmt.Errorf("failed to create bin directory: %w", err)
 	}
 
 	if err := language.Build(out, progress, c.Globals.Flag.Verbose, postBuildCallback); err != nil {

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -1008,7 +1008,7 @@ func TestBuildBinDirectory(t *testing.T) {
 			opts.ConfigFile.Language.Go.TinyGoConstraint = ">= 0.24.0-0" // NOTE: -0 is to allow prereleases.
 			opts.ConfigFile.Language.Go.ToolchainConstraint = ">= 1.17 < 1.19"
 
-			err = app.Run(opts)
+			_ = app.Run(opts)
 
 			t.Log(stdout.String())
 

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -531,25 +531,6 @@ func (tv ToolchainValidator) buildScript() error {
 	return nil
 }
 
-// binDir validates a bin directory is available.
-func (tv ToolchainValidator) binDir() error {
-	dir, err := os.Getwd()
-	if err != nil {
-		err = fmt.Errorf("failed to identify the current working directory: %w", err)
-		tv.ErrLog.Add(err)
-		return err
-	}
-
-	binDir := filepath.Join(dir, "bin")
-	if err := filesystem.MakeDirectoryIfNotExists(binDir); err != nil {
-		err = fmt.Errorf("failed to create 'bin' directory: %w", err)
-		tv.ErrLog.Add(err)
-		return err
-	}
-
-	return nil
-}
-
 // visitURLRemediation returns a remediation error that suggests visiting the
 // official resource URL.
 func (tv ToolchainValidator) visitURLRemediation(resource, resourceURL string) string {

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -171,10 +171,7 @@ func (tv ToolchainValidator) Validate() error {
 	if err := tv.compilation(); err != nil {
 		return err
 	}
-	if err := tv.buildScript(); err != nil {
-		return err
-	}
-	return tv.binDir()
+	return tv.buildScript()
 }
 
 // toolchain validates the toolchain is installed.


### PR DESCRIPTION
**Problem**: Currently, using `--skip-verification` will remove a critical side-effect step (i.e. it will also skip creating a `./bin` directory necessary for compilers to place the `main.wasm` file into).

**Solution**: We move the code for creating the bin directory out of the validation code section, to _before_ we attempt validating the user's toolchain.