### PR TITLE
Fix language validation

### DIFF
--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -118,33 +118,6 @@ func TestBuildRust(t *testing.T) {
 			wantRemediationError: "Run `rustup update stable`, or ensure your `rust-toolchain` file specifies a version matching the constraint (e.g. `channel = \"stable\"`).",
 		},
 		{
-			name: "fastly crate prerelease",
-			args: args("compute build"),
-			fastlyManifest: fmt.Sprintf(`
-			manifest_version = 2
-			name = "test"
-			language = "rust"
-
-      [scripts]
-      build = "%s"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustPackageName)),
-			applicationConfig: config.File{
-				Language: config.Language{
-					Rust: config.Rust{
-						ToolchainConstraint: ">= 1.54.0",
-						WasmWasiTarget:      "wasm32-wasi",
-					},
-				},
-			},
-			cargoManifest: `
-			[package]
-			name = "fastly-compute-project"
-			version = "0.1.0"
-
-			[dependencies]
-			fastly = "0.6.0"`,
-			wantOutputContains: "Built package",
-		},
-		{
 			name: "successful build",
 			args: args("compute build"),
 			applicationConfig: config.File{

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -77,8 +77,9 @@ func TestBuildRust(t *testing.T) {
 			language = "rust"`,
 			cargoManifest: `
 			[package]
-			name = "test"`,
-			wantError: "failed to find SDK 'fastly' in the 'Cargo.toml' manifest",
+			name = "test"
+      version = "1.0.0"`,
+			wantError: "required dependency missing",
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -66,6 +66,7 @@ func NewAssemblyScript(
 				FastlyManifestFile:            fastlyManifest,
 				Installer:                     JsInstaller,
 				Manifest:                      JsManifest,
+				ManifestCommand:               JsManifestCommand,
 				ManifestRemediation:           JsManifestRemediation,
 				Output:                        out,
 				PatchedManifestNotifier:       ch,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -55,7 +55,7 @@ const RustManifest = "Cargo.toml"
 
 // RustManifestCommand is the toolchain command to validate the manifest exists,
 // and also enables parsing of the project's dependencies.
-const RustManifestCommand = "cargo metadata --format-version 1"
+const RustManifestCommand = "cargo metadata --format-version 1 --quiet"
 
 // RustManifestRemediation is a error remediation message for a missing manifest.
 const RustManifestRemediation = "cargo new $NAME --bin"
@@ -82,7 +82,7 @@ const RustToolchainURL = "https://doc.rust-lang.org/stable/cargo/"
 
 // RustToolchainVersionCommand is the shell command for returning the Rust
 // version.
-const RustToolchainVersionCommand = "cargo version"
+const RustToolchainVersionCommand = "cargo version --quiet"
 
 // NewRust constructs a new Rust toolchain.
 func NewRust(
@@ -156,6 +156,7 @@ func (r Rust) Initialize(_ io.Writer) error {
 
 // Verify ensures the user's environment has all the required resources/tools.
 func (r *Rust) Verify(_ io.Writer) error {
+	// FIXME: The following checks should happen AFTER the RustToolchain check.
 	// NOTE: Validate whether the --bin flag matches the Cargo.toml package name.
 	// If it doesn't match, update the default build script to match.
 

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -159,7 +159,7 @@ func (r *Rust) Verify(_ io.Writer) error {
 	// NOTE: Validate whether the --bin flag matches the Cargo.toml package name.
 	// If it doesn't match, update the default build script to match.
 
-	s := "cargo locate-project"
+	s := "cargo locate-project --quiet"
 	args := strings.Split(s, " ")
 	// gosec flagged this:
 	// G204 (CWE-78): Subprocess launched with variable

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -178,7 +178,7 @@ func (r *Rust) Verify(_ io.Writer) error {
 	var cp *CargoLocateProject
 	err = json.Unmarshal(stdoutStderr, &cp)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal manifest metadata: %w", err)
+		return fmt.Errorf("failed to unmarshal manifest project root metadata: %w", err)
 	}
 
 	r.projectRoot = cp.Root


### PR DESCRIPTION
This PR is currently blocked by an internal system change.

---

**Problem**: looking up the language manifest file (e.g. `Cargo.toml`, `go.mod`, `package.json`) would cause the CLI to fail if it wasn't in the same directory as the directory the CLI was being run in (which typically is the project directory where the `fastly.toml` exists).

**Solution**: We lean into specific language toolchain commands to help identify the language's manifest file, rather than just expecting to find it in the current directory.

**Notes**: I tested this PR by creating a project for Go, Rust and JavaScript where I run `compute init` and then manually moved the source code files/fastly.toml into a nested directory to validate I was able to build the projects successfully.

## Examples

### Rust

```
.
├── Cargo.lock
├── Cargo.toml
├── README.md
├── nested
│   ├── fastly.toml
│   └── src
│       ├── main.rs
│       └── welcome-to-compute@edge.html
└── rust-toolchain.toml
```

> **NOTE**: I needed the following change in the `Cargo.toml` so Cargo knew which binary crate it needs to reference:

```toml
[[bin]]
name = "fastly-compute-project"
path = "nested/src/main.rs"
```

<img width="1076" alt="Screenshot 2022-10-13 at 11 50 48" src="https://user-images.githubusercontent.com/180050/195577837-d2209a23-950a-4f72-a32f-cb118cf0d193.png">

### Go

```
.
├── README.md
├── go.mod
├── go.sum
└── nested
    ├── fastly.toml
    └── main.go
```

<img width="1074" alt="Screenshot 2022-10-13 at 11 53 25" src="https://user-images.githubusercontent.com/180050/195578323-756a8539-c54f-4bf0-9e5e-ab1abd3a6f5e.png">

### JavaScript

```
.
├── README.md
├── nested
│   ├── fastly.toml
│   ├── src
│   │   ├── index.js
│   │   └── welcome-to-compute@edge.html
│   └── webpack.config.js
├── npm-shrinkwrap.json
└── package.json
```

<img width="1076" alt="Screenshot 2022-10-13 at 12 08 41" src="https://user-images.githubusercontent.com/180050/195581205-1cfe3d8a-809f-4a23-8eac-6a15b9b95f17.png">


Fixes: https://github.com/fastly/cli/issues/598 https://github.com/fastly/cli/issues/666