### PR TITLE
Workaround Window's `cmd.exe`'s lack of support for command substitution

### DIFF
--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -592,7 +592,7 @@ func execCommand(cmd string, args []string, out, progress io.Writer, verbose boo
 // The generics support in Go1.18 doesn't include accessing struct fields.
 type buildOpts struct {
 	buildScript string
-	buildFn     func(string) (string, []string)
+	buildFn     func(string, io.Writer) (string, []string)
 	errlog      fsterr.LogInterface
 	postBuild   string
 	timeout     int
@@ -607,7 +607,7 @@ func build(
 	optionalLocationProcess func() error,
 	postBuildCallback func() error,
 ) error {
-	cmd, args := l.buildFn(l.buildScript)
+	cmd, args := l.buildFn(l.buildScript, out)
 
 	err := execCommand(cmd, args, out, progress, verbose, l.timeout, l.errlog)
 	if err != nil {
@@ -628,7 +628,7 @@ func build(
 
 	if l.postBuild != "" {
 		if err = postBuildCallback(); err == nil {
-			cmd, args := l.buildFn(l.postBuild)
+			cmd, args := l.buildFn(l.postBuild, out)
 			err := execCommand(cmd, args, out, progress, verbose, l.timeout, l.errlog)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes #675 

Refer to the linked issue for context.

## Notes

This PR could introduce behaviour that is unexpected in two ways:

1. We're replacing shell command substitution at runtime.
2. We're only doing that for instances of `$(npm bin)`.

If the fastly.toml `[scripts.build]` uses command substitution (e.g. `$(npm bin)`) and the CLI internally evaluates that on behalf of the user (i.e. it doesn't actually allow the command substitution to happen, but makes a separate subshell call instead to work around the fact that command substitution isn't supported well in Windows), then that could confuse a seasoned Windows developer who might look at the `[scripts.build]` and wonder how it is working (if they happen to know that command substitution isn't supported by the default Command Prompt, `cmd.exe`, on Windows).

That said, the user doesn't actually know we're using `cmd.exe` (on Windows) unless they look at the CLI source code, as we don't display the shell used during a `compute build`. 

To avoid confusion I've added a note that will be printed for Windows users if a command substitution for `npm bin` has been evaluated by the CLI.

We might want to expand this behaviour to command substitution in general. But I'll await an initial review to gauge feedback.