### PR TITLE
Correct installation instructions for Go

### DIFF
--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -246,9 +246,15 @@ func (tv ToolchainValidator) toolchainVersion() error {
 	}
 
 	if !c.Check(v) {
+		remediation := tv.visitURLRemediation(tv.Toolchain, tv.ToolchainURL)
+
+		if tv.ToolchainCommandRemediation != "" {
+			remediation = tv.commandRemediation(tv.Toolchain, tv.ToolchainURL, tv.ToolchainCommandRemediation)
+		}
+
 		err := fsterr.RemediationError{
 			Inner:       fmt.Errorf("toolchain version %s didn't meet the constraint %s", version, constraint),
-			Remediation: tv.commandRemediation(tv.Toolchain, tv.ToolchainURL, tv.ToolchainCommandRemediation),
+			Remediation: remediation,
 		}
 		tv.ErrLog.Add(err)
 		return err


### PR DESCRIPTION
Fixes #664, #681.

Output after this PR:

```
fastly compute build
✓ Initializing...
✓ Verifying package manifest...
✗ Verifying local go toolchain...

ERROR: toolchain version 1.19.2 didn't meet the constraint >= 1.17 < 1.19.

To fix this error, install 'go' by visiting:

    https://go.dev/

  Then execute:

    $ fastly compute build
```