### PR TITLE
Add missing --help flag to globals

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -266,6 +266,7 @@ func IsGlobalFlagsOnly(args []string) bool {
 		"--auto-yes":        0,
 		"-y":                0,
 		"--endpoint":        1,
+		"--help":            0,
 		"--non-interactive": 0,
 		"-i":                0,
 		"--profile":         1,


### PR DESCRIPTION
`--help` is a Kingpin global flag but it was missing from the list of global flags to check for.