### PR TITLE
fix help text for object store commands

### DIFF
--- a/pkg/commands/objectstore/create.go
+++ b/pkg/commands/objectstore/create.go
@@ -22,7 +22,7 @@ func NewCreateCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	var c CreateCommand
 	c.Globals = globals
 	c.manifest = data
-	c.CmdClause = parent.Command("create", "Create a Fastly edge config store")
+	c.CmdClause = parent.Command("create", "Create a Fastly object store")
 	c.CmdClause.Flag("name", "Name of Object Store").Short('n').Required().StringVar(&c.Input.Name)
 	return &c
 }

--- a/pkg/commands/objectstore/getkey.go
+++ b/pkg/commands/objectstore/getkey.go
@@ -22,7 +22,7 @@ func NewGetKeyCommand(parent cmd.Registerer, globals *config.Data, data manifest
 	var c GetKeyCommand
 	c.Globals = globals
 	c.manifest = data
-	c.CmdClause = parent.Command("get", "Get Fastly edge config store key")
+	c.CmdClause = parent.Command("get", "Get Fastly object store key")
 	c.CmdClause.Flag("id", "ID of object store").Required().StringVar(&c.Input.ID)
 	// FIXME: This should be `--key` with a short `-k` flag.
 	c.CmdClause.Flag("k", "Key to fetch").Required().StringVar(&c.Input.Key)

--- a/pkg/commands/objectstore/insert.go
+++ b/pkg/commands/objectstore/insert.go
@@ -22,7 +22,7 @@ func NewInsertKeyCommand(parent cmd.Registerer, globals *config.Data, data manif
 	var c InsertKeyCommand
 	c.Globals = globals
 	c.manifest = data
-	c.CmdClause = parent.Command("insert", "Insert key/value pair into a Fastly edge config store")
+	c.CmdClause = parent.Command("insert", "Insert key/value pair into a Fastly object store")
 	c.CmdClause.Flag("id", "Name of Object Store").Short('n').Required().StringVar(&c.Input.ID)
 	// FIXME: This should be `--key` with a short `-k` flag.
 	c.CmdClause.Flag("k", "Key to insert").Required().StringVar(&c.Input.Key)

--- a/pkg/commands/objectstore/keys.go
+++ b/pkg/commands/objectstore/keys.go
@@ -22,7 +22,7 @@ func NewKeysCommand(parent cmd.Registerer, globals *config.Data, data manifest.D
 	var c KeysCommand
 	c.Globals = globals
 	c.manifest = data
-	c.CmdClause = parent.Command("keys", "List Fastly edge config store keys")
+	c.CmdClause = parent.Command("keys", "List Fastly object store keys")
 	c.CmdClause.Flag("id", "ID of object store").Required().StringVar(&c.Input.ID)
 	return &c
 }

--- a/pkg/commands/objectstore/list.go
+++ b/pkg/commands/objectstore/list.go
@@ -22,7 +22,7 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data, data manifest.D
 	var c ListCommand
 	c.Globals = globals
 	c.manifest = data
-	c.CmdClause = parent.Command("list", "List Fastly edge config stores")
+	c.CmdClause = parent.Command("list", "List Fastly object stores")
 	return &c
 }
 


### PR DESCRIPTION
They said "edge config stores" instead of "object stores"
