### PR TITLE
fix object store TOML definitions, add test data

### DIFF
--- a/pkg/commands/compute/testdata/init/fastly-viceroy-update.toml
+++ b/pkg/commands/compute/testdata/init/fastly-viceroy-update.toml
@@ -34,3 +34,14 @@ name = "Default Rust template"
       foo = "bar"
       baz = """
 qux"""
+
+  [local_server.object_store]
+    store_one = [{key = "first", data = "This is some data"}, {key = "second", path = "strings.json"}]
+
+    [[local_server.object_store.store_two]]
+      key = "first"
+      data = "This is some data"
+
+    [[local_server.object_store.store_two]]
+      key = "second"
+      path = "strings.json"

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -249,9 +249,9 @@ type SetupLogger struct {
 
 // LocalServer represents a list of mocked Viceroy resources.
 type LocalServer struct {
-	Backends     map[string]LocalBackend     `toml:"backends"`
-	Dictionaries map[string]LocalDictionary  `toml:"dictionaries,omitempty"`
-	ObjectStore  map[string]LocalObjectStore `toml:"object_stores,omitempty"`
+	Backends     map[string]LocalBackend       `toml:"backends"`
+	Dictionaries map[string]LocalDictionary    `toml:"dictionaries,omitempty"`
+	ObjectStore  map[string][]LocalObjectStore `toml:"object_store,omitempty"`
 }
 
 // LocalBackend represents a backend to be mocked by the local testing server.
@@ -272,8 +272,8 @@ type LocalDictionary struct {
 // LocalObjectStore represents an object_store to be mocked by the local testing server.
 type LocalObjectStore struct {
 	Key  string `toml:"key"`
-	Path string `toml:"path"`
-	Data string `toml:"data"`
+	Path string `toml:"path,omitempty"`
+	Data string `toml:"data,omitempty"`
 }
 
 // Exists yields whether the manifest exists.

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -12,6 +12,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
 	toml "github.com/pelletier/go-toml"
 )
 
@@ -295,7 +296,8 @@ func TestManifestPersistsLocalServerSection(t *testing.T) {
 		t.Fatal("expected [local_server] block to exist in fastly.toml but is missing")
 	}
 
-	if lt.(*toml.Tree).String() != ot.(*toml.Tree).String() {
-		t.Fatal("testing section between original and updated fastly.toml do not match")
+	got, want := lt.(*toml.Tree).String(), ot.(*toml.Tree).String()
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("testing section between original and updated fastly.toml do not match (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/manifest/testdata/fastly-viceroy-update.toml
+++ b/pkg/manifest/testdata/fastly-viceroy-update.toml
@@ -34,3 +34,14 @@ name = "Default Rust template"
       foo = "bar"
       baz = """
 qux"""
+
+  [local_server.object_store]
+    store_one = [{key = "first", data = "This is some data"}, {key = "second", path = "strings.json"}]
+
+    [[local_server.object_store.store_two]]
+      key = "first"
+      data = "This is some data"
+
+    [[local_server.object_store.store_two]]
+      key = "second"
+      path = "strings.json"


### PR DESCRIPTION
This fixes the object store configs to match the Viceroy implementation, and adds object store definitions to the test data.

I think it remains an open question as to whether we should change the Viceroy implementation to be more consistent with the existing local server definitions (backends, dictionaries).
