### PR TITLE
CI/Dockerfiles: minor dockerfiles improvements

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -144,3 +144,12 @@ jobs:
           TEST_COMPUTE_INIT: true
           TEST_COMPUTE_BUILD: true
           TEST_COMPUTE_DEPLOY: true
+  docker-builds:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout code"
+      uses: actions/checkout@v3
+    - name: Build docker images
+        run: |
+          for dockerFile in Dockerfile*; do docker build -f $dockerFile . ; done
+          

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -150,6 +150,6 @@ jobs:
     - name: "Checkout code"
       uses: actions/checkout@v3
     - name: Build docker images
-        run: |
-          for dockerFile in Dockerfile*; do docker build -f $dockerFile . ; done
+      run: |
+        for dockerFile in Dockerfile*; do docker build -f $dockerFile . ; done
           

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: pull_request
 name: Test
 
 # Stop any in-flight CI jobs when a new commit is pushed.

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,4 +1,4 @@
-on: pull_request
+on: [push, pull_request]
 name: Test
 
 # Stop any in-flight CI jobs when a new commit is pushed.

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,17 +1,16 @@
 FROM node:latest
 LABEL maintainer="Fastly OSS <oss@fastly.com>"
 
-RUN apt-get update && apt-get install -y curl jq
-RUN export FASTLY_CLI_VERSION=$(curl --silent https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \
-  GOARCH=$(dpkg --print-architecture) \
-  && curl -vL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_linux-$GOARCH.tar.gz" -o fastly.tar.gz \
-  && curl -vL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_SHA256SUMS" -o sha256sums \
+RUN apt-get update && apt-get install -y curl jq && apt-get -y clean && rm -rf /var/lib/apt/lists/* \
+  && export FASTLY_CLI_VERSION=$(curl -s https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \
+            GOARCH=$(dpkg --print-architecture) \
+  && curl -sL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_linux-$GOARCH.tar.gz" -o fastly.tar.gz \
+  && curl -sL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_SHA256SUMS" -o sha256sums \
   && dlsha=$(shasum -a 256 fastly.tar.gz | cut -d " " -f 1) && expected=$(cat sha256sums | awk -v pat="$dlsha" '$0~pat' | cut -d " " -f 1) \
-  && if [[ "$dlsha" != "$expected" ]]; then echo "shasums don't match" && exit 1; fi
+  && if [ "$dlsha" != "$expected" ]; then echo "shasums don't match" && exit 1; fi \
+  && tar -xzf fastly.tar.gz --directory /usr/bin && rm -f sha256sums fastly.tar.gz \
+  && useradd -ms /bin/bash fastly
 
-RUN tar -xzf fastly.tar.gz --directory /usr/bin && rm fastly.tar.gz
-
-RUN adduser fastly
 USER fastly
 
 WORKDIR /app

--- a/Dockerfile-rust
+++ b/Dockerfile-rust
@@ -2,21 +2,21 @@ FROM rust:latest
 LABEL maintainer="Fastly OSS <oss@fastly.com>"
 
 ENV RUST_TOOLCHAIN=stable
-RUN rustup toolchain install ${RUST_TOOLCHAIN}
-RUN rustup target add wasm32-wasi --toolchain ${RUST_TOOLCHAIN}
-
-RUN apt-get update && apt-get install -y curl jq
-RUN export FASTLY_CLI_VERSION=$(curl --silent https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \
-  GOARCH=$(dpkg --print-architecture) \
-  && curl -vL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_linux-$GOARCH.tar.gz" -o fastly.tar.gz \
-  && curl -vL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_SHA256SUMS" -o sha256sums \
+RUN rustup toolchain install ${RUST_TOOLCHAIN} \
+  && rustup target add wasm32-wasi --toolchain ${RUST_TOOLCHAIN} \
+  && apt-get update && apt-get install -y curl jq && apt-get -y clean && rm -rf /var/lib/apt/lists/* \
+  && export FASTLY_CLI_VERSION=$(curl -s https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \
+            GOARCH=$(dpkg --print-architecture) \
+  && curl -sL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_linux-$GOARCH.tar.gz" -o fastly.tar.gz \
+  && curl -sL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_SHA256SUMS" -o sha256sums \
   && dlsha=$(shasum -a 256 fastly.tar.gz | cut -d " " -f 1) && expected=$(cat sha256sums | awk -v pat="$dlsha" '$0~pat' | cut -d " " -f 1) \
-  && if [[ "$dlsha" != "$expected" ]]; then echo "shasums don't match" && exit 1; fi
+  && if [ "$dlsha" != "$expected" ]; then echo "shasums don't match" && exit 1; fi \
+  && tar -xzf fastly.tar.gz --directory /usr/bin && rm -f sha256sums fastly.tar.gz \
+  && useradd -ms /bin/bash fastly
 
-RUN tar -xzf fastly.tar.gz --directory /usr/bin && rm fastly.tar.gz
-
-RUN adduser fastly
 USER fastly
+# this forces the download of the crates index; it will save build time if the image was recently built
+RUN cargo search --limit 0
 
 WORKDIR /app
 ENTRYPOINT ["/usr/bin/fastly"]


### PR DESCRIPTION
* CI: suggesting to execute the PR test flow also on push events (*useful while developing? At least it was for me*)
* CI: executing a dumb docker-build for each Dockerfile to ensure we can generate images / there are no syntax issues or other base-image changes (we are pointing to `latest`!) that make break `RUN` statements.
* Dockerfiles: consolidating `RUN` stages to reduce the number of images
* Dockerfiles: cleaning apt cache after installing software, to save some space / make resulting image a bit slimmer, but..
* for the rust Dockerfile: caching the crates index to save time when building C@E apps (*so bye bye disk savings*)
* Dockerfiles: Consistent usage of `curl --silent` to avoid verbose docker-build output
* Dockerfiles: Removing bash-specific syntax that was generating errors in the output and probably breaking checksum validations
* Dockerfiles: Replacing `adduser` by `useradd` to avoid errors in the output (as `adduser` is expected to be interactive)