### PR TITLE
Add support for TOML secret_store section

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -252,6 +252,7 @@ type LocalServer struct {
 	Backends     map[string]LocalBackend       `toml:"backends"`
 	Dictionaries map[string]LocalDictionary    `toml:"dictionaries,omitempty"`
 	ObjectStore  map[string][]LocalObjectStore `toml:"object_store,omitempty"`
+	SecretStore  map[string][]LocalSecretStore `toml:"secret_store,omitempty"`
 }
 
 // LocalBackend represents a backend to be mocked by the local testing server.
@@ -271,6 +272,13 @@ type LocalDictionary struct {
 
 // LocalObjectStore represents an object_store to be mocked by the local testing server.
 type LocalObjectStore struct {
+	Key  string `toml:"key"`
+	Path string `toml:"path,omitempty"`
+	Data string `toml:"data,omitempty"`
+}
+
+// LocalSecretStore represents a secret_store to be mocked by the local testing server.
+type LocalSecretStore struct {
 	Key  string `toml:"key"`
 	Path string `toml:"path,omitempty"`
 	Data string `toml:"data,omitempty"`

--- a/pkg/manifest/testdata/fastly-viceroy-update.toml
+++ b/pkg/manifest/testdata/fastly-viceroy-update.toml
@@ -45,3 +45,14 @@ qux"""
     [[local_server.object_store.store_two]]
       key = "second"
       path = "strings.json"
+
+  [local_server.secret_store]
+    store_one = [{key = "first", data = "This is some secret data"}, {key = "second", path = "/path/to/secret.json"}]
+
+    [[local_server.secret_store.store_two]]
+      key = "first"
+      data = "This is also some secret data"
+
+    [[local_server.secret_store.store_two]]
+      key = "second"
+      path = "/path/to/other/secret.json"


### PR DESCRIPTION
Viceroy is being updated with a new `local_server.secret_store` configuration section. Viceroy change:
https://github.com/fastly/Viceroy/pull/210

This change adds support for the new Secret Store configuration section.

Related change: https://github.com/fastly/cli/pull/717