### PR TITLE
Switch JavaScript build script based on webpack in package.json prebuild

### DIFF
--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -385,7 +385,7 @@ func TestBuildJavaScript(t *testing.T) {
 			language = "javascript"
 
       [scripts]
-      build = "%s"`, compute.JsDefaultBuildCommand),
+      build = "%s"`, compute.JsDefaultBuildCommandForWebpack),
 			sourceOverride: `D"F;
 			'GREGERgregeg '
 			ERG`,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -308,7 +308,7 @@ func (m *CargoMetadata) Read(errlog fsterr.LogInterface) error {
 
 // validateRustSDK marshals the Rust manifest into toml to check if the
 // dependency has been defined in the Cargo.toml manifest.
-func validateRustSDK(name string, bs []byte) error {
+func validateRustSDK(name string, bs []byte, _ chan string) error {
 	e := fmt.Errorf(SDKErrMessageFormat, name, RustManifest)
 
 	tree, err := toml.LoadBytes(bs)


### PR DESCRIPTION
**Problem**: Not all JS starter-kits require web pack, but the default build script in the CLI will try to execute webpack regardless.
**Context**: The default build script in the CLI is there to support CLI versions <4.0.0 that see the `[scripts.build]` field as optional (i.e. we want starter kits to continue to work with older CLI versions).
**Solution**: Check for `prebuild: webpack` in the package.json and if there, then we know our default build script should call webpack.