### PR TITLE
Link to Starter Kits during `compute init`

### DIFF
--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	gitRepositoryRegEx        = regexp.MustCompile(`((git|ssh|http(s)?)|(git@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?`)
+	gitRepositoryRegEx        = regexp.MustCompile(`((git|ssh|http(s)?)|(git@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?`)
 	fastlyOrgRegEx            = regexp.MustCompile(`^https:\/\/github\.com\/fastly`)
 	fastlyFileIgnoreListRegEx = regexp.MustCompile(`\.github|LICENSE|SECURITY\.md|CHANGELOG\.md|screenshot\.png`)
 )

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -513,6 +513,10 @@ func promptForStarterKit(flags config.Flag, kits []config.StarterKit, in io.Read
 			fmt.Fprintf(out, "[%d] %s\n", i+1, text.Bold(kit.Name))
 			text.Indent(out, 4, "%s\n%s", kit.Description, kit.Path)
 		}
+
+		text.Info(out, "For a complete list of Starter Kits:\n\thttps://developer.fastly.com/solutions/starters/")
+		text.Break(out)
+
 		option, err = text.Input(out, "Choose option or paste git URL: [1] ", in, validateTemplateOptionOrURL(kits))
 		if err != nil {
 			return "", "", "", fmt.Errorf("error reading input: %w", err)


### PR DESCRIPTION
There are two related changes made in this PR:

1. Relax the git regex to allow a GitHub URL without a `.git` suffix. This means when a user looks up a Starter-Kit on the Fastly Developer Hub, they'll be able to just copy/paste the standard HTTP URL.

2. Add a link to the Fastly Developer Hub 'Starter-Kits' page during the `compute init` flow so that users know there are more kits than are listed in the terminal output (screenshot below).

<img width="718" alt="Screenshot 2022-12-08 at 17 10 37" src="https://user-images.githubusercontent.com/180050/206522119-8b9fc40c-c659-4e26-804e-76da1b29db2e.png">
