### PR TITLE
fix(compute): don't validate js-compute-runtime binary location

### DIFF
--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -78,37 +77,24 @@ func NewJavaScript(
 		postBuild: fastlyManifest.Scripts.PostBuild,
 		timeout:   timeout,
 		validator: ToolchainValidator{
-			Compilation: JsCompilation,
-			CompilationDirectPath: func() (string, error) {
-				p, err := getJsToolchainBinPath(JsToolchain)
-				if err != nil {
-					errlog.Add(err)
-					remediation := "npm install --global npm@latest"
-					return "", fsterr.RemediationError{
-						Inner:       fmt.Errorf("could not determine %s bin path", JsToolchain),
-						Remediation: fmt.Sprintf(fsterr.FormatTemplate, text.Bold(remediation)),
-					}
-				}
-
-				return filepath.Join(p, JsCompilation), nil
-			},
-			CompilationCommandRemediation: fmt.Sprintf(JsCompilationCommandRemediation, JsSDK),
-			CompilationSkipVersion:        true,
-			CompilationURL:                JsCompilationURL,
-			DefaultBuildCommand:           JsDefaultBuildCommand,
-			ErrLog:                        errlog,
-			FastlyManifestFile:            fastlyManifest,
-			Installer:                     JsInstaller,
-			Manifest:                      JsManifest,
-			ManifestRemediation:           JsManifestRemediation,
-			Output:                        out,
-			PatchedManifestNotifier:       ch,
-			SDK:                           JsSDK,
-			SDKCustomValidator:            validateJsSDK,
-			Toolchain:                     JsToolchain,
-			ToolchainLanguage:             "JavaScript",
-			ToolchainSkipVersion:          true,
-			ToolchainURL:                  JsToolchainURL,
+			Compilation:             JsCompilation,
+			CompilationIntegrated:   true,
+			CompilationSkipVersion:  true,
+			CompilationURL:          JsCompilationURL,
+			DefaultBuildCommand:     JsDefaultBuildCommand,
+			ErrLog:                  errlog,
+			FastlyManifestFile:      fastlyManifest,
+			Installer:               JsInstaller,
+			Manifest:                JsManifest,
+			ManifestRemediation:     JsManifestRemediation,
+			Output:                  out,
+			PatchedManifestNotifier: ch,
+			SDK:                     JsSDK,
+			SDKCustomValidator:      validateJsSDK,
+			Toolchain:               JsToolchain,
+			ToolchainLanguage:       "JavaScript",
+			ToolchainSkipVersion:    true,
+			ToolchainURL:            JsToolchainURL,
 		},
 	}
 }

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -365,7 +365,13 @@ func (tv ToolchainValidator) installDependencies() error {
 // toolchain. If an external command, we lookup the command on the $PATH and
 // check its version meets any defined constraints.
 func (tv ToolchainValidator) compilation() error {
-	fmt.Fprintf(tv.Output, "\nChecking if '%s' is installed...\n", tv.Compilation)
+	if !tv.CompilationIntegrated && !tv.CompilationSkipVersion {
+		// For example JavaScript's SDK js-compute has an integrated runtime
+		// js-compute-runtime binary that is installed via the prior
+		// `installDependencies` step and so we don't want to display a message to
+		// say we're checking for it, nor will we check its version.
+		fmt.Fprintf(tv.Output, "\nChecking if '%s' is installed...\n", tv.Compilation)
+	}
 
 	// Lookup the compilation target as an executable binary.
 	if !tv.CompilationIntegrated {


### PR DESCRIPTION
NPM 9 has removed the `npm bin` command that determines the location of where NPM installs binaries.

The CLI is using this command to validate whether the compilation binary `js-compute-runtime` has been successfully installed, while the Compute@Edge 'Starter Kits' have a build script which prefixes calls to certain dependent commands with the result of a subprocess execution of `npm bin`.

For the latter, the workaround is to replace the subprocess call with `npm exec` but for the Fastly CLI we've decided there is no need to validate the `js-compute-runtime` binary exists inside of the user's `node_modules` directory. This is because the step prior to this is `npm install`, and as we already validate the required JS SDK is installed (and that is what provides `js-compute-runtime`), then we should trust `npm install` is run successfully (and if not the appropriate error from that invocation will be bubbled up to the user).