### PR TITLE
feat(objectstore): add `--json` support to keys/list subcommands

### DIFF
--- a/pkg/commands/objectstore/insert.go
+++ b/pkg/commands/objectstore/insert.go
@@ -23,11 +23,11 @@ func NewInsertKeyCommand(parent cmd.Registerer, globals *config.Data, data manif
 	c.Globals = globals
 	c.manifest = data
 	c.CmdClause = parent.Command("insert", "Insert key/value pair into a Fastly object store")
-	c.CmdClause.Flag("id", "Name of Object Store").Short('n').Required().StringVar(&c.Input.ID)
 	// FIXME: This should be `--key` with a short `-k` flag.
 	c.CmdClause.Flag("k", "Key to insert").Required().StringVar(&c.Input.Key)
 	// FIXME: This should be `--value`.
 	c.CmdClause.Flag("v", "Value to insert").Required().StringVar(&c.Input.Value)
+	c.CmdClause.Flag("id", "ID of Object Store").Short('n').Required().StringVar(&c.Input.ID)
 
 	return &c
 }

--- a/pkg/commands/objectstore/insert.go
+++ b/pkg/commands/objectstore/insert.go
@@ -23,11 +23,9 @@ func NewInsertKeyCommand(parent cmd.Registerer, globals *config.Data, data manif
 	c.Globals = globals
 	c.manifest = data
 	c.CmdClause = parent.Command("insert", "Insert key/value pair into a Fastly object store")
-	// FIXME: This should be `--key` with a short `-k` flag.
-	c.CmdClause.Flag("k", "Key to insert").Required().StringVar(&c.Input.Key)
-	// FIXME: This should be `--value`.
-	c.CmdClause.Flag("v", "Value to insert").Required().StringVar(&c.Input.Value)
 	c.CmdClause.Flag("id", "ID of Object Store").Short('n').Required().StringVar(&c.Input.ID)
+	c.CmdClause.Flag("key", "Key to insert").Short('k').Required().StringVar(&c.Input.Key)
+	c.CmdClause.Flag("value", "Value to insert").Required().StringVar(&c.Input.Value)
 
 	return &c
 }

--- a/pkg/commands/objectstore/keys.go
+++ b/pkg/commands/objectstore/keys.go
@@ -1,10 +1,13 @@
 package objectstore
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v7/fastly"
@@ -13,6 +16,7 @@ import (
 // KeysCommand calls the Fastly API to list the keys for a given object store.
 type KeysCommand struct {
 	cmd.Base
+	json     bool
 	manifest manifest.Data
 	Input    fastly.ListObjectStoreKeysInput
 }
@@ -23,16 +27,43 @@ func NewKeysCommand(parent cmd.Registerer, globals *config.Data, data manifest.D
 	c.Globals = globals
 	c.manifest = data
 	c.CmdClause = parent.Command("keys", "List Fastly object store keys")
+
+	// required
 	c.CmdClause.Flag("id", "ID of object store").Required().StringVar(&c.Input.ID)
+
+	// optional
+	c.RegisterFlagBool(cmd.BoolFlagOpts{
+		Name:        cmd.FlagJSONName,
+		Description: cmd.FlagJSONDesc,
+		Dst:         &c.json,
+		Short:       'j',
+	})
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *KeysCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.json {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
 	o, err := c.Globals.APIClient.ListObjectStoreKeys(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
+	}
+
+	if c.json {
+		data, err := json.Marshal(o)
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(data)
+		if err != nil {
+			c.Globals.ErrLog.Add(err)
+			return fmt.Errorf("error: unable to write data to stdout: %w", err)
+		}
+		return nil
 	}
 
 	text.PrintObjectStoreKeys(out, "", o.Data)

--- a/pkg/commands/objectstore/list.go
+++ b/pkg/commands/objectstore/list.go
@@ -1,10 +1,13 @@
 package objectstore
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/config"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v7/fastly"
@@ -13,6 +16,7 @@ import (
 // ListCommand calls the Fastly API to list the available object stores.
 type ListCommand struct {
 	cmd.Base
+	json     bool
 	manifest manifest.Data
 	Input    fastly.ListObjectStoresInput
 }
@@ -26,15 +30,41 @@ func NewListCommand(parent cmd.Registerer, globals *config.Data, data manifest.D
 		manifest: data,
 	}
 	c.CmdClause = parent.Command("list", "List Fastly object stores")
+
+	// optional
+	c.RegisterFlagBool(cmd.BoolFlagOpts{
+		Name:        cmd.FlagJSONName,
+		Description: cmd.FlagJSONDesc,
+		Dst:         &c.json,
+		Short:       'j',
+	})
+
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.json {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
 	o, err := c.Globals.APIClient.ListObjectStores(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
+	}
+
+	if c.json {
+		data, err := json.Marshal(o)
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(data)
+		if err != nil {
+			c.Globals.ErrLog.Add(err)
+			return fmt.Errorf("error: unable to write data to stdout: %w", err)
+		}
+		return nil
 	}
 
 	for _, o := range o.Data {

--- a/pkg/text/objectstore.go
+++ b/pkg/text/objectstore.go
@@ -15,7 +15,7 @@ import (
 func PrintObjectStore(out io.Writer, prefix string, d *fastly.ObjectStore) {
 	out = textio.NewPrefixWriter(out, prefix)
 
-	fmt.Fprintf(out, "ID: %s\n", d.ID)
+	fmt.Fprintf(out, "\nID: %s\n", d.ID)
 	fmt.Fprintf(out, "Name: %s\n", d.Name)
 	fmt.Fprintf(out, "Created (UTC): %s\n", d.CreatedAt.UTC().Format(time.Format))
 	fmt.Fprintf(out, "Last edited (UTC): %s\n", d.UpdatedAt.UTC().Format(time.Format))


### PR DESCRIPTION
> **NOTE:** This PR also contains a breaking change related to the `--k` and `--v` flags which should not have been released (they instead should have been `--key` and `--value` with possible short key variants, e.g. `-k`).