### PR TITLE
feat(compute/deploy): add Object Store to manifest `[setup]`

### DIFF
--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -49,6 +49,17 @@ func createDictionaryItemOK(i *fastly.CreateDictionaryItemInput) (*fastly.Dictio
 	}, nil
 }
 
+func createObjectStoreOK(i *fastly.CreateObjectStoreInput) (*fastly.ObjectStore, error) {
+	return &fastly.ObjectStore{
+		ID:   "example-store",
+		Name: i.Name,
+	}, nil
+}
+
+func createObjectStoreItemOK(i *fastly.InsertObjectStoreKeyInput) error {
+	return nil
+}
+
 func getPackageOk(i *fastly.GetPackageInput) (*fastly.Package, error) {
 	return &fastly.Package{ServiceID: i.ServiceID, ServiceVersion: i.ServiceVersion}, nil
 }

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -480,7 +480,7 @@ func validatePackage(
 
 	hashSum, err = getHashSum(contents)
 	if err != nil {
-		return pkgPath, hashSum, err
+		return pkgPath, "", err
 	}
 
 	return pkgPath, hashSum, nil

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -1266,6 +1266,188 @@ func TestDeploy(t *testing.T) {
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
+		// NOTE: The following test validates [setup] only works for a new service.
+		{
+			name: "success with setup.object_stores configuration and existing service",
+			args: args("compute deploy --service-id 123 --token 123"),
+			api: mock.API{
+				ActivateVersionFn:   activateVersionOk,
+				CloneVersionFn:      testutil.CloneVersionResult(4),
+				CreateBackendFn:     createBackendOK,
+				GetPackageFn:        getPackageOk,
+				GetServiceFn:        getServiceOK,
+				GetServiceDetailsFn: getServiceDetailsWasm,
+				ListDomainsFn:       listDomainsOk,
+				ListVersionsFn:      testutil.ListVersions,
+				UpdatePackageFn:     updatePackageOk,
+			},
+			manifest: `
+			name = "package"
+			manifest_version = 2
+			language = "rust"
+
+			[setup.object_stores.store_one]
+			description = "My first object store"
+			[setup.object_stores.store_one.items.foo]
+			value = "my default value for foo"
+			description = "a good description about foo"
+			[setup.object_stores.store_one.items.bar]
+			value = "my default value for bar"
+			description = "a good description about bar"
+			`,
+			wantOutput: []string{
+				"Uploading package...",
+				"Activating version...",
+				"SUCCESS: Deployed package (service 123, version 4)",
+			},
+			dontWantOutput: []string{
+				"Configuring object store 'store_one'",
+				"Create an object store key called 'foo'",
+				"Create an object store key called 'bar'",
+				"Creating object store 'store_one'...",
+				"Creating object store key 'foo'...",
+				"Creating object store key 'bar'...",
+			},
+		},
+		{
+			name: "success with setup.object_stores configuration and no existing service",
+			args: args("compute deploy --token 123"),
+			api: mock.API{
+				ActivateVersionFn:      activateVersionOk,
+				CreateBackendFn:        createBackendOK,
+				CreateObjectStoreFn:    createObjectStoreOK,
+				InsertObjectStoreKeyFn: createObjectStoreItemOK,
+				CreateDomainFn:         createDomainOK,
+				CreateServiceFn:        createServiceOK,
+				GetPackageFn:           getPackageOk,
+				GetServiceFn:           getServiceOK,
+				GetServiceDetailsFn:    getServiceDetailsWasm,
+				ListDomainsFn:          listDomainsOk,
+				ListVersionsFn:         testutil.ListVersions,
+				UpdatePackageFn:        updatePackageOk,
+			},
+			manifest: `
+			name = "package"
+			manifest_version = 2
+			language = "rust"
+
+			[setup.object_stores.store_one]
+			description = "My first object store"
+			[setup.object_stores.store_one.items.foo]
+			value = "my default value for foo"
+			description = "a good description about foo"
+			[setup.object_stores.store_one.items.bar]
+			value = "my default value for bar"
+			description = "a good description about bar"
+			`,
+			stdin: []string{
+				"Y", // when prompted to create a new service
+			},
+			wantOutput: []string{
+				"Configuring object store 'store_one'",
+				"Create an object store key called 'foo'",
+				"Create an object store key called 'bar'",
+				"Creating object store 'store_one'...",
+				"Creating object store key 'foo'...",
+				"Creating object store key 'bar'...",
+				"Uploading package...",
+				"Activating version...",
+				"SUCCESS: Deployed package (service 12345, version 1)",
+			},
+		},
+		{
+			name: "success with setup.object_stores configuration and no existing service and --non-interactive",
+			args: args("compute deploy --non-interactive --token 123"),
+			api: mock.API{
+				ActivateVersionFn:      activateVersionOk,
+				CreateBackendFn:        createBackendOK,
+				CreateObjectStoreFn:    createObjectStoreOK,
+				InsertObjectStoreKeyFn: createObjectStoreItemOK,
+				CreateDomainFn:         createDomainOK,
+				CreateServiceFn:        createServiceOK,
+				GetPackageFn:           getPackageOk,
+				GetServiceFn:           getServiceOK,
+				GetServiceDetailsFn:    getServiceDetailsWasm,
+				ListDomainsFn:          listDomainsOk,
+				ListVersionsFn:         testutil.ListVersions,
+				UpdatePackageFn:        updatePackageOk,
+			},
+			manifest: `
+			name = "package"
+			manifest_version = 2
+			language = "rust"
+
+			[setup.object_stores.store_one]
+			description = "My first object store"
+			[setup.object_stores.store_one.items.foo]
+			value = "my default value for foo"
+			description = "a good description about foo"
+			[setup.object_stores.store_one.items.bar]
+			value = "my default value for bar"
+			description = "a good description about bar"
+			`,
+			stdin: []string{
+				"Y", // when prompted to create a new service
+			},
+			wantOutput: []string{
+				"Creating object store 'store_one'...",
+				"Creating object store key 'foo'...",
+				"Creating object store key 'bar'...",
+				"Uploading package...",
+				"Activating version...",
+				"SUCCESS: Deployed package (service 12345, version 1)",
+			},
+		},
+		{
+			name: "success with setup.object_stores configuration and no existing service and no predefined values",
+			args: args("compute deploy --token 123"),
+			api: mock.API{
+				ActivateVersionFn:      activateVersionOk,
+				CreateBackendFn:        createBackendOK,
+				CreateObjectStoreFn:    createObjectStoreOK,
+				InsertObjectStoreKeyFn: createObjectStoreItemOK,
+				CreateDomainFn:         createDomainOK,
+				CreateServiceFn:        createServiceOK,
+				GetPackageFn:           getPackageOk,
+				GetServiceFn:           getServiceOK,
+				GetServiceDetailsFn:    getServiceDetailsWasm,
+				ListDomainsFn:          listDomainsOk,
+				ListVersionsFn:         testutil.ListVersions,
+				UpdatePackageFn:        updatePackageOk,
+			},
+			manifest: `
+			name = "package"
+			manifest_version = 2
+			language = "rust"
+
+			[setup.object_stores.store_one]
+			[setup.object_stores.store_one.items.foo]
+			[setup.object_stores.store_one.items.bar]
+			`,
+			stdin: []string{
+				"Y", // when prompted to create a new service
+			},
+			wantOutput: []string{
+				"Configuring object store 'store_one'",
+				"Create an object store key called 'foo'",
+				"Create an object store key called 'bar'",
+				"Creating object store 'store_one'...",
+				"Creating object store key 'foo'...",
+				"Creating object store key 'bar'...",
+				"Uploading package...",
+				"Activating version...",
+				"SUCCESS: Deployed package (service 12345, version 1)",
+			},
+			// The following are predefined values for the `description` and `value`
+			// fields from the prior setup.dictionaries tests that we expect to not
+			// be present in the stdout/stderr as the [setup/dictionaries]
+			// configuration does not define them.
+			dontWantOutput: []string{
+				"My first object store",
+				"my default value for foo",
+				"my default value for bar",
+			},
+		},
 	}
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]

--- a/pkg/commands/compute/setup/object_store.go
+++ b/pkg/commands/compute/setup/object_store.go
@@ -125,7 +125,7 @@ func (d *ObjectStores) Create() error {
 
 		if len(objectStore.Items) > 0 {
 			for _, item := range objectStore.Items {
-				d.Progress.Step(fmt.Sprintf("Creating object store key/value '%s'...", item.Key))
+				d.Progress.Step(fmt.Sprintf("Creating object store key '%s'...", item.Key))
 
 				err := d.APIClient.InsertObjectStoreKey(&fastly.InsertObjectStoreKeyInput{
 					ID:    dict.ID,
@@ -134,7 +134,7 @@ func (d *ObjectStores) Create() error {
 				})
 				if err != nil {
 					d.Progress.Fail()
-					return fmt.Errorf("error creating object store key/value: %w", err)
+					return fmt.Errorf("error creating object store key: %w", err)
 				}
 			}
 		}

--- a/pkg/commands/compute/setup/object_store.go
+++ b/pkg/commands/compute/setup/object_store.go
@@ -1,0 +1,150 @@
+package setup
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/api"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v7/fastly"
+)
+
+// ObjectStores represents the service state related to dictionaries defined
+// within the fastly.toml [setup] configuration.
+//
+// NOTE: It implements the setup.Interface interface.
+type ObjectStores struct {
+	// Public
+	APIClient      api.Interface
+	AcceptDefaults bool
+	NonInteractive bool
+	Progress       text.Progress
+	Setup          map[string]*manifest.SetupObjectStore
+	Stdin          io.Reader
+	Stdout         io.Writer
+
+	// Private
+	required []ObjectStore
+}
+
+// ObjectStore represents the configuration parameters for creating an
+// object store via the API client.
+//
+// NOTE: WriteOnly (i.e. private) dictionaries not supported.
+type ObjectStore struct {
+	Name  string
+	Items []ObjectStoreItem
+}
+
+// ObjectStoreItem represents the configuration parameters for creating
+// object store items via the API client.
+type ObjectStoreItem struct {
+	Key   string
+	Value string
+}
+
+// Configure prompts the user for specific values related to the service resource.
+func (d *ObjectStores) Configure() error {
+	for name, settings := range d.Setup {
+		if !d.AcceptDefaults && !d.NonInteractive {
+			text.Break(d.Stdout)
+			text.Output(d.Stdout, "Configuring object store '%s'", name)
+			if settings.Description != "" {
+				text.Output(d.Stdout, settings.Description)
+			}
+		}
+
+		var items []ObjectStoreItem
+
+		for key, item := range settings.Items {
+			dv := "example"
+			if item.Value != "" {
+				dv = item.Value
+			}
+			prompt := text.BoldYellow(fmt.Sprintf("Value: [%s] ", dv))
+
+			var (
+				value string
+				err   error
+			)
+
+			if !d.AcceptDefaults && !d.NonInteractive {
+				text.Break(d.Stdout)
+				text.Output(d.Stdout, "Create an object store key called '%s'", key)
+				if item.Description != "" {
+					text.Output(d.Stdout, item.Description)
+				}
+				text.Break(d.Stdout)
+
+				value, err = text.Input(d.Stdout, prompt, d.Stdin)
+				if err != nil {
+					return fmt.Errorf("error reading prompt input: %w", err)
+				}
+			}
+
+			if value == "" {
+				value = dv
+			}
+
+			items = append(items, ObjectStoreItem{
+				Key:   key,
+				Value: value,
+			})
+		}
+
+		d.required = append(d.required, ObjectStore{
+			Name:  name,
+			Items: items,
+		})
+	}
+
+	return nil
+}
+
+// Create calls the relevant API to create the service resource(s).
+func (d *ObjectStores) Create() error {
+	if d.Progress == nil {
+		return errors.RemediationError{
+			Inner:       fmt.Errorf("internal logic error: no text.Progress configured for setup.ObjectStores"),
+			Remediation: errors.BugRemediation,
+		}
+	}
+
+	for _, objectStore := range d.required {
+		d.Progress.Step(fmt.Sprintf("Creating object store '%s'...", objectStore.Name))
+
+		dict, err := d.APIClient.CreateObjectStore(&fastly.CreateObjectStoreInput{
+			Name: objectStore.Name,
+		})
+		if err != nil {
+			d.Progress.Fail()
+			return fmt.Errorf("error creating object store: %w", err)
+		}
+
+		if len(objectStore.Items) > 0 {
+			for _, item := range objectStore.Items {
+				d.Progress.Step(fmt.Sprintf("Creating object store key/value '%s'...", item.Key))
+
+				err := d.APIClient.InsertObjectStoreKey(&fastly.InsertObjectStoreKeyInput{
+					ID:    dict.ID,
+					Key:   item.Key,
+					Value: item.Value,
+				})
+				if err != nil {
+					d.Progress.Fail()
+					return fmt.Errorf("error creating object store key/value: %w", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Predefined indicates if the service resource has been specified within the
+// fastly.toml file using a [setup] configuration block.
+func (d *ObjectStores) Predefined() bool {
+	return len(d.Setup) > 0
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -218,9 +218,10 @@ type Scripts struct {
 // Setup represents a set of service configuration that works with the code in
 // the package. See https://developer.fastly.com/reference/fastly-toml/.
 type Setup struct {
-	Backends     map[string]*SetupBackend    `toml:"backends,omitempty"`
-	Dictionaries map[string]*SetupDictionary `toml:"dictionaries,omitempty"`
-	Loggers      map[string]*SetupLogger     `toml:"log_endpoints,omitempty"`
+	Backends     map[string]*SetupBackend     `toml:"backends,omitempty"`
+	Dictionaries map[string]*SetupDictionary  `toml:"dictionaries,omitempty"`
+	Loggers      map[string]*SetupLogger      `toml:"log_endpoints,omitempty"`
+	ObjectStores map[string]*SetupObjectStore `toml:"object_stores,omitempty"`
 }
 
 // SetupBackend represents a '[setup.backends.<T>]' instance.
@@ -245,6 +246,18 @@ type SetupDictionaryItems struct {
 // SetupLogger represents a '[setup.log_endpoints.<T>]' instance.
 type SetupLogger struct {
 	Provider string `toml:"provider,omitempty"`
+}
+
+// SetupObjectStore represents a '[setup.object_stores.<T>]' instance.
+type SetupObjectStore struct {
+	Items       map[string]SetupObjectStoreItems `toml:"items,omitempty"`
+	Description string                           `toml:"description,omitempty"`
+}
+
+// SetupObjectStoreItems represents a '[setup.object_stores.<T>.items]' instance.
+type SetupObjectStoreItems struct {
+	Value       string `toml:"value,omitempty"`
+	Description string `toml:"description,omitempty"`
 }
 
 // LocalServer represents a list of mocked Viceroy resources.

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -392,7 +392,7 @@ func (f *File) AutoMigrateVersion(data []byte, path string) ([]byte, error) {
 
 		data, err = tree.Marshal()
 		if err != nil {
-			return data, fmt.Errorf("error marshalling modified manifest_version fastly.toml: %w", err)
+			return nil, fmt.Errorf("error marshalling modified manifest_version fastly.toml: %w", err)
 		}
 
 		// NOTE: The scenario will end up triggering two calls to toml.Unmarshal().


### PR DESCRIPTION
```toml
[setup]

  [setup.object_stores]

    [setup.object_stores.store_one]
      description = "My first object store"

      [setup.object_stores.store_one.items]

        [setup.object_stores.store_one.items.bar]
          description = "a good description about bar"
          value = "my default value for bar"

        [setup.object_stores.store_one.items.foo]
          description = "a good description about foo"
          value = "my default value for foo"
```

<img width="579" alt="Screenshot 2023-01-17 at 15 02 29" src="https://user-images.githubusercontent.com/180050/212933393-378ab618-b1fe-45fc-96ca-c7ed13f4464f.png">

<img width="742" alt="Screenshot 2023-01-17 at 15 05 41" src="https://user-images.githubusercontent.com/180050/212934182-b0969047-593d-45db-aab9-4f08240cb420.png">
