### PR TITLE
feat(compute/build): support locating language manifests outside project directory

### DIFF
--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -77,8 +77,9 @@ func TestBuildRust(t *testing.T) {
 			language = "rust"`,
 			cargoManifest: `
 			[package]
-			name = "test"`,
-			wantError: "failed to find SDK 'fastly' in the 'Cargo.toml' manifest",
+      name = "test"
+			version = "1.0.0"`,
+			wantError: "required dependency missing",
 			applicationConfig: config.File{
 				Language: config.Language{
 					Rust: config.Rust{

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -66,6 +66,7 @@ func NewAssemblyScript(
 				FastlyManifestFile:            fastlyManifest,
 				Installer:                     JsInstaller,
 				Manifest:                      JsManifest,
+				ManifestCommand:               JsManifestCommand,
 				ManifestRemediation:           JsManifestRemediation,
 				Output:                        out,
 				PatchedManifestNotifier:       ch,

--- a/pkg/commands/compute/language_go.go
+++ b/pkg/commands/compute/language_go.go
@@ -1,6 +1,9 @@
 package compute
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"regexp"
 
@@ -42,12 +45,16 @@ const GoInstaller = "go mod download"
 // GoManifest is the manifest file for defining project configuration.
 const GoManifest = "go.mod"
 
+// GoManifestCommand is the toolchain command to validate the manifest exists,
+// and also enables parsing of the project's dependencies.
+const GoManifestCommand = "go mod edit -json"
+
 // GoManifestRemediation is a error remediation message for a missing manifest.
 const GoManifestRemediation = "go mod init"
 
 // GoSDK is the required Compute@Edge SDK.
 // https://pkg.go.dev/github.com/fastly/compute-sdk-go
-const GoSDK = "fastly/compute-sdk-go"
+const GoSDK = "github.com/fastly/compute-sdk-go"
 
 // GoSourceDirectory represents the source code directory.                                               │                                                           │
 const GoSourceDirectory = "."
@@ -89,10 +96,12 @@ func NewGo(
 			FastlyManifestFile:       fastlyManifest,
 			Installer:                GoInstaller,
 			Manifest:                 GoManifest,
+			ManifestCommand:          GoManifestCommand,
 			ManifestRemediation:      GoManifestRemediation,
 			Output:                   out,
 			PatchedManifestNotifier:  ch,
 			SDK:                      GoSDK,
+			SDKCustomValidator:       validateGoSDK,
 			Toolchain:                GoToolchain,
 			ToolchainLanguage:        "Go",
 			ToolchainVersionCommand:  GoToolchainVersionCommand,
@@ -146,4 +155,46 @@ func (g *Go) Build(out io.Writer, progress text.Progress, verbose bool, callback
 		postBuild:   g.postBuild,
 		timeout:     g.timeout,
 	}, out, progress, verbose, nil, callback)
+}
+
+// GoDependency represents the project's SDK and version.
+type GoDependency struct {
+	Path    string
+	Version string
+}
+
+// GoMod represents the project's go.mod manifest.
+type GoMod struct {
+	Require []GoDependency
+}
+
+// validateGoSDK uses the Go toolchain to identify if the required SDK
+// dependency is installed.
+func validateGoSDK(sdk string, manifestCommandOutput []byte, _ chan string) error {
+	var gm GoMod
+
+	err := json.Unmarshal(manifestCommandOutput, &gm)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal manifest metadata: %w", err)
+	}
+
+	remediation := fmt.Sprintf("Ensure your %s is valid and contains the '%s' dependency.", GoManifest, sdk)
+
+	if len(gm.Require) < 1 {
+		return fsterr.RemediationError{
+			Inner:       errors.New("no dependencies declared"),
+			Remediation: remediation,
+		}
+	}
+
+	for _, gd := range gm.Require {
+		if gd.Path == sdk {
+			return nil
+		}
+	}
+
+	return fsterr.RemediationError{
+		Inner:       errors.New("required dependency missing"),
+		Remediation: remediation,
+	}
 }

--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -47,6 +47,10 @@ const JsInstaller = "npm install"
 // JsManifest is the manifest file for defining project configuration.
 const JsManifest = "package.json"
 
+// JsManifestCommand is the toolchain command to validate the manifest exists,
+// and also enables parsing of the project's dependencies.
+const JsManifestCommand = "npm list --json --depth 0"
+
 // JsManifestRemediation is a error remediation message for a missing manifest.
 const JsManifestRemediation = "npm init"
 
@@ -77,24 +81,26 @@ func NewJavaScript(
 		postBuild: fastlyManifest.Scripts.PostBuild,
 		timeout:   timeout,
 		validator: ToolchainValidator{
-			Compilation:             JsCompilation,
-			CompilationIntegrated:   true,
-			CompilationSkipVersion:  true,
-			CompilationURL:          JsCompilationURL,
-			DefaultBuildCommand:     JsDefaultBuildCommand,
-			ErrLog:                  errlog,
-			FastlyManifestFile:      fastlyManifest,
-			Installer:               JsInstaller,
-			Manifest:                JsManifest,
-			ManifestRemediation:     JsManifestRemediation,
-			Output:                  out,
-			PatchedManifestNotifier: ch,
-			SDK:                     JsSDK,
-			SDKCustomValidator:      validateJsSDK,
-			Toolchain:               JsToolchain,
-			ToolchainLanguage:       "JavaScript",
-			ToolchainSkipVersion:    true,
-			ToolchainURL:            JsToolchainURL,
+			Compilation:              JsCompilation,
+			CompilationIntegrated:    true,
+			CompilationSkipVersion:   true,
+			CompilationURL:           JsCompilationURL,
+			DefaultBuildCommand:      JsDefaultBuildCommand,
+			ErrLog:                   errlog,
+			FastlyManifestFile:       fastlyManifest,
+			Installer:                JsInstaller,
+			Manifest:                 JsManifest,
+			ManifestCommand:          JsManifestCommand,
+			ManifestCommandSkipError: true,
+			ManifestRemediation:      JsManifestRemediation,
+			Output:                   out,
+			PatchedManifestNotifier:  ch,
+			SDK:                      JsSDK,
+			SDKCustomValidator:       validateJsSDK,
+			Toolchain:                JsToolchain,
+			ToolchainLanguage:        "JavaScript",
+			ToolchainSkipVersion:     true,
+			ToolchainURL:             JsToolchainURL,
 		},
 	}
 }
@@ -140,11 +146,21 @@ func (j JavaScript) Build(out io.Writer, progress text.Progress, verbose bool, c
 	}, out, progress, verbose, nil, callback)
 }
 
+// JsDependency represents the project's SDK and version.
+type JsDependency struct {
+	Version  string `json:"version"`
+	Resolved string `json:"resolved"`
+}
+
 // JsPackage represents a package.json manifest.
+//
+// NOTE: npm returns JSON that has an `invalid` field.
+// This means we know when searching for the manifest has failed.
 type JsPackage struct {
-	Dependencies    map[string]string `json:"dependencies"`
-	DevDependencies map[string]string `json:"devDependencies"`
-	Scripts         map[string]string `json:"scripts"`
+	Dependencies    map[string]JsDependency `json:"dependencies"`
+	DevDependencies map[string]JsDependency `json:"devDependencies"`
+	Scripts         map[string]string       `json:"scripts"`
+	Invalid         bool                    `json:"invalid"`
 }
 
 // validateJsSDK marshals the JS manifest into JSON to check if the dependency
@@ -152,16 +168,16 @@ type JsPackage struct {
 //
 // NOTE: This function also causes a side-effect of modifying the default build
 // script based on the user's project context (e.g does it require webpack).
-func validateJsSDK(name string, bs []byte, notifier chan string) error {
-	e := fmt.Errorf(SDKErrMessageFormat, name, JsManifest)
+func validateJsSDK(sdk string, manifestCommandOutput []byte, notifier chan string) error {
+	e := fmt.Errorf(SDKErrMessageFormat, sdk, JsManifest)
 
 	var p JsPackage
 
-	err := json.Unmarshal(bs, &p)
-	if err != nil {
+	err := json.Unmarshal(manifestCommandOutput, &p)
+	if err != nil || p.Invalid {
 		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("failed to unmarshal package.json: %w", err),
-			Remediation: fmt.Sprintf("Ensure your package.json is valid and contains the '%s' dependency.", name),
+			Remediation: fmt.Sprintf("Ensure your package.json is valid and contains the '%s' dependency.", sdk),
 		}
 	}
 
@@ -182,12 +198,12 @@ func validateJsSDK(name string, bs []byte, notifier chan string) error {
 	}()
 
 	for k := range p.Dependencies {
-		if k == name {
+		if k == sdk {
 			return nil
 		}
 	}
 	for k := range p.DevDependencies {
-		if k == name {
+		if k == sdk {
 			return nil
 		}
 	}


### PR DESCRIPTION
**Problem**: looking up the language manifest file (e.g. `Cargo.toml`, `go.mod`, `package.json`) would cause the CLI to fail if it wasn't in the same directory as the directory the CLI was being run in (which typically is the project directory where the `fastly.toml` exists).

**Solution**: We lean into specific language toolchain commands to help identify the language's manifest file, rather than just expecting to find it in the current directory.

**Notes**: I tested this PR by creating a project for Go, Rust and JavaScript where I run `compute init` and then manually moved the source code files/fastly.toml into a nested directory, then `cd` into the nested directory (because the CLI needs to execute where the fastly.toml file is) to validate I was able to build the projects successfully even though the language manifest files (e.g. `Cargo.toml`, `go.mod`, `package.json` where in a parent directory).

## Examples

### Go

```
.
├── README.md
├── go.mod
├── go.sum
└── nested
    ├── fastly.toml
    └── main.go
```

### JavaScript

```
.
├── README.md
├── nested
│   ├── fastly.toml
│   ├── src
│   │   ├── index.js
│   │   └── welcome-to-compute@edge.html
│   └── webpack.config.js
├── npm-shrinkwrap.json
└── package.json
```

### Rust

```
.
├── Cargo.lock
├── Cargo.toml
├── README.md
├── nested
│   ├── fastly.toml
│   └── src
│       ├── main.rs
│       └── welcome-to-compute@edge.html
└── rust-toolchain.toml
```

> **NOTE**: I needed the following change in the `Cargo.toml` so Cargo knew which binary crate it needs to reference:

```toml
[[bin]]
name = "fastly-compute-project"
path = "nested/src/main.rs"
```