### PR TITLE
feat(compute/deploy): add Secret Store to manifest `[setup]`

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -126,7 +126,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return nil
 	}
 
-	so, err := constructSetupKVs(
+	so, err := constructSetupObjects(
 		newService, serviceID, serviceVersion.Number, c, in, out,
 	)
 	if err != nil {
@@ -848,7 +848,7 @@ type setupObjects struct {
 	secretStores *setup.SecretStores
 }
 
-func constructSetupKVs(
+func constructSetupObjects(
 	newService bool,
 	serviceID string,
 	serviceVersion int,

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -109,7 +109,7 @@ func (s *SecretStores) Configure() error {
 func (s *SecretStores) Create() error {
 	if s.Spinner == nil {
 		return fsterrors.RemediationError{
-			Inner:       fmt.Errorf("internal logic error: no text.Progress configured for setup.SecretStores"),
+			Inner:       fmt.Errorf("internal logic error: no spinner configured for setup.SecretStores"),
 			Remediation: fsterrors.BugRemediation,
 		}
 	}

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -1,0 +1,194 @@
+package setup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/api"
+	fsterrors "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v8/fastly"
+)
+
+// SecretStores represents the service state related to secret stores defined
+// within the fastly.toml [setup] configuration.
+//
+// NOTE: It implements the setup.Interface interface.
+type SecretStores struct {
+	// Public
+	APIClient      api.Interface
+	AcceptDefaults bool
+	NonInteractive bool
+	Spinner        text.Spinner
+	ServiceID      string
+	ServiceVersion int
+	Setup          map[string]*manifest.SetupSecretStore
+	Stdin          io.Reader
+	Stdout         io.Writer
+
+	// Private
+	required []SecretStore
+}
+
+// SecretStore represents the configuration parameters for creating a
+// secret store via the API client.
+type SecretStore struct {
+	Name    string
+	Entries []SecretStoreEntry
+}
+
+// SecretStoreEntry represents the configuration parameters for creating
+// secret store items via the API client.
+type SecretStoreEntry struct {
+	Name   string
+	Secret string
+}
+
+// Predefined indicates if the service resource has been specified within the
+// fastly.toml file using a [setup] configuration block.
+func (s *SecretStores) Predefined() bool {
+	return len(s.Setup) > 0
+}
+
+// Configure prompts the user for specific values related to the service resource.
+func (s *SecretStores) Configure() error {
+	for name, settings := range s.Setup {
+		if !s.AcceptDefaults && !s.NonInteractive {
+			text.Break(s.Stdout)
+			text.Output(s.Stdout, "Configuring secret store '%s'", name)
+			if settings.Description != "" {
+				text.Output(s.Stdout, settings.Description)
+			}
+		}
+
+		store := SecretStore{
+			Name:    name,
+			Entries: make([]SecretStoreEntry, 0, len(settings.Entries)),
+		}
+
+		for key, entry := range settings.Entries {
+			var (
+				value string
+				err   error
+			)
+
+			if !s.AcceptDefaults && !s.NonInteractive {
+				text.Break(s.Stdout)
+				text.Output(s.Stdout, "Create a secret store entry called '%s'", key)
+				if entry.Description != "" {
+					text.Output(s.Stdout, entry.Description)
+				}
+				text.Break(s.Stdout)
+
+				prompt := text.BoldYellow("Value: ")
+				value, err = text.InputSecure(s.Stdout, prompt, s.Stdin)
+				if err != nil {
+					return fmt.Errorf("error reading prompt input: %w", err)
+				}
+			}
+
+			if value == "" {
+				return errors.New("value cannot be blank")
+			}
+
+			store.Entries = append(store.Entries, SecretStoreEntry{
+				Name:   key,
+				Secret: value,
+			})
+		}
+
+		s.required = append(s.required, store)
+	}
+
+	return nil
+}
+
+// Create calls the relevant API to create the service resource(s).
+func (s *SecretStores) Create() error {
+	if s.Spinner == nil {
+		return fsterrors.RemediationError{
+			Inner:       fmt.Errorf("internal logic error: no text.Progress configured for setup.SecretStores"),
+			Remediation: fsterrors.BugRemediation,
+		}
+	}
+
+	for _, secretStore := range s.required {
+		if err := s.Spinner.Start(); err != nil {
+			return err
+		}
+		msg := fmt.Sprintf("Creating secret store '%s'", secretStore.Name)
+		s.Spinner.Message(msg + "...")
+
+		store, err := s.APIClient.CreateSecretStore(&fastly.CreateSecretStoreInput{
+			Name: secretStore.Name,
+		})
+		if err != nil {
+			s.Spinner.StopFailMessage(msg)
+			if serr := s.Spinner.StopFail(); serr != nil {
+				return serr
+			}
+			return fmt.Errorf("error creating secret store %q: %w", secretStore.Name, err)
+		}
+		s.Spinner.StopMessage(msg)
+		if err = s.Spinner.Stop(); err != nil {
+			return err
+		}
+
+		for _, entry := range secretStore.Entries {
+			if err = s.Spinner.Start(); err != nil {
+				return err
+			}
+			msg = fmt.Sprintf("Creating secret store entry '%s'...", entry.Name)
+			s.Spinner.Message(msg)
+
+			_, err = s.APIClient.CreateSecret(&fastly.CreateSecretInput{
+				ID:     store.ID,
+				Name:   entry.Name,
+				Secret: []byte(entry.Secret),
+			})
+			if err != nil {
+				s.Spinner.StopFailMessage(msg)
+				if serr := s.Spinner.StopFail(); serr != nil {
+					return serr
+				}
+				return fmt.Errorf("error creating secret store entry %q: %w", entry.Name, err)
+			}
+
+			s.Spinner.StopMessage(msg)
+			if err = s.Spinner.Stop(); err != nil {
+				return err
+			}
+		}
+
+		if err = s.Spinner.Start(); err != nil {
+			return err
+		}
+		msg = fmt.Sprintf("Creating resource link between service and secret store '%s'...", store.Name)
+		s.Spinner.Message(msg)
+
+		// We need to link the secret store to the C@E Service, otherwise the service
+		// will not have access to the store.
+		_, err = s.APIClient.CreateResource(&fastly.CreateResourceInput{
+			ServiceID:      s.ServiceID,
+			ServiceVersion: s.ServiceVersion,
+			Name:           fastly.String(store.Name),
+			ResourceID:     fastly.String(store.ID),
+		})
+		if err != nil {
+			s.Spinner.StopFailMessage(msg)
+			if serr := s.Spinner.StopFail(); serr != nil {
+				return serr
+			}
+			return fmt.Errorf("error creating resource link between the service %q and the secret store %q: %w", s.ServiceID, store.Name, err)
+		}
+
+		s.Spinner.StopMessage(msg)
+		if err = s.Spinner.Stop(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -218,10 +218,11 @@ type Scripts struct {
 // Setup represents a set of service configuration that works with the code in
 // the package. See https://developer.fastly.com/reference/fastly-toml/.
 type Setup struct {
-	Backends     map[string]*SetupBackend    `toml:"backends,omitempty"`
-	Dictionaries map[string]*SetupDictionary `toml:"dictionaries,omitempty"`
-	Loggers      map[string]*SetupLogger     `toml:"log_endpoints,omitempty"`
-	KVStores     map[string]*SetupKVStore    `toml:"kv_stores,omitempty"`
+	Backends     map[string]*SetupBackend     `toml:"backends,omitempty"`
+	Dictionaries map[string]*SetupDictionary  `toml:"dictionaries,omitempty"`
+	Loggers      map[string]*SetupLogger      `toml:"log_endpoints,omitempty"`
+	KVStores     map[string]*SetupKVStore     `toml:"kv_stores,omitempty"`
+	SecretStores map[string]*SetupSecretStore `toml:"secret_stores,omitempty"`
 }
 
 // Defined indicates if there is any [setup] configuration in the manifest.
@@ -277,6 +278,20 @@ type SetupKVStore struct {
 // SetupKVStoreItems represents a '[setup.kv_stores.<T>.items]' instance.
 type SetupKVStoreItems struct {
 	Value       string `toml:"value,omitempty"`
+	Description string `toml:"description,omitempty"`
+}
+
+// SetupSecretStore represents a '[setup.secret_stores.<T>]' instance.
+type SetupSecretStore struct {
+	Entries     map[string]SetupSecretStoreEntry `toml:"entries,omitempty"`
+	Description string                           `toml:"description,omitempty"`
+}
+
+// SetupSecretStoreEntry represents a '[setup.secret_stores.<T>.entries]' instance.
+type SetupSecretStoreEntry struct {
+	// The secret value is intentionally omitted to avoid secrets
+	// from being included in the manifest. Instead, secret
+	// values are input during setup.
 	Description string `toml:"description,omitempty"`
 }
 


### PR DESCRIPTION
Adds ability to define Secret Stores in the `[setup]` section of a `fastly.toml` config file. The user will be prompted to create the defined stores and secrets on creation of a service when using `fastly compute deploy`.

Related: #717, #764