### PR TITLE
fix(objectstore/get): output value unless verbose/json flag passed

### DIFF
--- a/pkg/commands/objectstore/getkey.go
+++ b/pkg/commands/objectstore/getkey.go
@@ -58,7 +58,11 @@ func (c *GetKeyCommand) Exec(_ io.Reader, out io.Writer) error {
 		return nil
 	}
 
-	text.PrintObjectStoreKeyValue(out, "", c.Input.Key, value)
+	if c.Globals.Flag.Verbose {
+		text.PrintObjectStoreKeyValue(out, "", c.Input.Key, value)
+		return nil
+	}
 
+	text.Output(out, value)
 	return nil
 }


### PR DESCRIPTION
The following screenshot demonstrates the new behaviour...

<img width="1050" alt="Screenshot 2023-01-25 at 10 56 18" src="https://user-images.githubusercontent.com/180050/214552243-9cd4bea1-8555-4ea4-94f4-aba447497c5d.png">
