### PR TITLE
update local_server object and secret store formats

### DIFF
--- a/pkg/commands/compute/testdata/init/fastly-viceroy-update.toml
+++ b/pkg/commands/compute/testdata/init/fastly-viceroy-update.toml
@@ -35,24 +35,24 @@ name = "Default Rust template"
       baz = """
 qux"""
 
-  [local_server.object_store]
+  [local_server.object_stores]
     store_one = [{key = "first", data = "This is some data"}, {key = "second", path = "strings.json"}]
 
-    [[local_server.object_store.store_two]]
+    [[local_server.object_stores.store_two]]
       key = "first"
       data = "This is some data"
 
-    [[local_server.object_store.store_two]]
+    [[local_server.object_stores.store_two]]
       key = "second"
-      path = "strings.json"
+      file = "strings.json"
 
-  [local_server.secret_store]
-    store_one = [{key = "first", data = "This is some secret data"}, {key = "second", path = "/path/to/secret.json"}]
+  [local_server.secret_stores]
+    store_one = [{key = "first", data = "This is some secret data"}, {key = "second", file = "/path/to/secret.json"}]
 
-    [[local_server.secret_store.store_two]]
+    [[local_server.secret_stores.store_two]]
       key = "first"
       data = "This is also some secret data"
 
-    [[local_server.secret_store.store_two]]
+    [[local_server.secret_stores.store_two]]
       key = "second"
-      path = "/path/to/other/secret.json"
+      file = "/path/to/other/secret.json"

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -264,8 +264,8 @@ type SetupObjectStoreItems struct {
 type LocalServer struct {
 	Backends     map[string]LocalBackend       `toml:"backends"`
 	Dictionaries map[string]LocalDictionary    `toml:"dictionaries,omitempty"`
-	ObjectStore  map[string][]LocalObjectStore `toml:"object_store,omitempty"`
-	SecretStore  map[string][]LocalSecretStore `toml:"secret_store,omitempty"`
+	ObjectStores map[string][]LocalObjectStore `toml:"object_stores,omitempty"`
+	SecretStores map[string][]LocalSecretStore `toml:"secret_stores,omitempty"`
 }
 
 // LocalBackend represents a backend to be mocked by the local testing server.
@@ -286,14 +286,14 @@ type LocalDictionary struct {
 // LocalObjectStore represents an object_store to be mocked by the local testing server.
 type LocalObjectStore struct {
 	Key  string `toml:"key"`
-	Path string `toml:"path,omitempty"`
+	File string `toml:"file,omitempty"`
 	Data string `toml:"data,omitempty"`
 }
 
 // LocalSecretStore represents a secret_store to be mocked by the local testing server.
 type LocalSecretStore struct {
 	Key  string `toml:"key"`
-	Path string `toml:"path,omitempty"`
+	File string `toml:"file,omitempty"`
 	Data string `toml:"data,omitempty"`
 }
 

--- a/pkg/manifest/testdata/fastly-viceroy-update.toml
+++ b/pkg/manifest/testdata/fastly-viceroy-update.toml
@@ -35,24 +35,24 @@ name = "Default Rust template"
       baz = """
 qux"""
 
-  [local_server.object_store]
-    store_one = [{key = "first", data = "This is some data"}, {key = "second", path = "strings.json"}]
+  [local_server.object_stores]
+    store_one = [{key = "first", data = "This is some data"}, {key = "second", file = "strings.json"}]
 
-    [[local_server.object_store.store_two]]
+    [[local_server.object_stores.store_two]]
       key = "first"
       data = "This is some data"
 
-    [[local_server.object_store.store_two]]
+    [[local_server.object_stores.store_two]]
       key = "second"
-      path = "strings.json"
+      file = "strings.json"
 
-  [local_server.secret_store]
-    store_one = [{key = "first", data = "This is some secret data"}, {key = "second", path = "/path/to/secret.json"}]
+  [local_server.secret_stores]
+    store_one = [{key = "first", data = "This is some secret data"}, {key = "second", file = "/path/to/secret.json"}]
 
-    [[local_server.secret_store.store_two]]
+    [[local_server.secret_stores.store_two]]
       key = "first"
       data = "This is also some secret data"
 
-    [[local_server.secret_store.store_two]]
+    [[local_server.secret_stores.store_two]]
       key = "second"
-      path = "/path/to/other/secret.json"
+      file = "/path/to/other/secret.json"


### PR DESCRIPTION
`object_store` becomes `object_stores`
`secret_store` becomes `secret_stores`
`path` becomes `file`

This makes these more consistent with other parts of the manifest like
dictionaries, backends, geolocation, etc.

Companion to https://github.com/fastly/Viceroy/pull/206
