### PR TITLE
build with Go 1.19

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - name: "Restore golang bin cache"
       id: go-bin-cache
       uses: actions/cache@v3
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         tinygo-version: [0.26.0]
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         node-version: [18]
         rust-toolchain: [stable]
         platform: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: "Install Go"
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: '1.19.x'
     - name: "Set GOHOSTOS and GOHOSTARCH"
       run: echo "GOHOSTOS=$(go env GOHOSTOS)" >> $GITHUB_ENV && echo "GOHOSTARCH=$(go env GOHOSTARCH)" >> $GITHUB_ENV
     - name: "Install Rust"


### PR DESCRIPTION
Did this because CI started failing with tools saying, "module requires Go 1.19": https://github.com/fastly/cli/actions/runs/4087575206/jobs/7048248681

Also, as of Go 1.20's release, 1.18 is now unsupported.  Happy to bump this to 1.20 if that's desired, BTW.
