### PR TITLE
fix(compute/setup): fix duplicated domains

### DIFF
--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -3,7 +3,9 @@ package setup
 import (
 	"fmt"
 	"io"
+	"math/rand"
 	"regexp"
+	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/fastly/cli/pkg/api"
@@ -55,6 +57,10 @@ func (d *Domains) Configure() error {
 		return nil
 	}
 
+	// IMPORTANT: go1.20 deprecates rand.Seed
+	// The global random number generator (RNG) is now automatically seeded.
+	// If not seeded, the same domain name is repeated on each run.
+	rand.Seed(time.Now().UnixNano())
 	defaultDomain := fmt.Sprintf("%s.%s", petname.Generate(3, "-"), defaultTopLevelDomain)
 
 	var (


### PR DESCRIPTION
In a prior PR I had bumped the CLI go version to 1.20 but then had some tooling issues which meant we needed to drop down to go 1.19 but I neglected to put back some code that was seeding the global RNG (which I had removed when bumping to go 1.20 as that version auto-seeds).