### PR TITLE
fix(compute/build): ensure build output doesn't show unless --verbose flag is set

### DIFF
--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -113,11 +113,6 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// NOTE: We set the progress indicator to Done() so that any output we now
 	// print doesn't get hidden by the progress status.
 	progress.Done()
-
-	if c.Globals.Verbose() {
-		text.Break(out)
-	}
-
 	progress = text.ResetProgress(out, c.Globals.Verbose())
 
 	postBuildCallback := func() error {

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -15,6 +15,9 @@ import (
 	"github.com/fastly/cli/pkg/threadsafe"
 )
 
+// divider is used as separator lines around shell output.
+const divider = "--------------------------------------------------------------------------------"
+
 // Streaming models a generic command execution that consumers can use to
 // execute commands and stream their output to an io.Writer. For example
 // compute commands can use this to standardize the flow control for each
@@ -63,7 +66,7 @@ func (s *Streaming) MonitorSignalsAsync() {
 func (s *Streaming) Exec() error {
 	if s.Verbose {
 		text.Break(s.Output)
-		text.Description(s.Output, "Process command", fmt.Sprintf("%s %s", s.Command, strings.Join(s.Args, " ")))
+		text.Description(s.Output, "Executing command", fmt.Sprintf("%s %s", s.Command, strings.Join(s.Args, " ")))
 	}
 
 	// Construct the command with given arguments and environment.
@@ -109,12 +112,18 @@ func (s *Streaming) Exec() error {
 	}
 	if s.Verbose {
 		output = s.Output
+		text.Info(output, "Command output:")
+		text.Output(output, divider)
 	}
 
 	cmd.Stdout = io.MultiWriter(output, &stdoutBuf)
 	cmd.Stderr = io.MultiWriter(output, &stderrBuf)
 
 	if err := cmd.Start(); err != nil {
+		if s.Verbose {
+			text.Break(output)
+			text.Output(output, divider)
+		}
 		return err
 	}
 
@@ -145,9 +154,17 @@ func (s *Streaming) Exec() error {
 			}
 			ctx = fmt.Sprintf(":%s\n\n%s", cmdOutput, err)
 		}
+		if s.Verbose {
+			text.Break(output)
+			text.Output(output, divider)
+		}
 		return fmt.Errorf("error during execution process%s", ctx)
 	}
 
+	if s.Verbose {
+		text.Break(output)
+		text.Output(output, divider)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem
When there is an error building a user's project, the build output is displayed to the user and is so visually noisy you can’t see the list of instructions for how to _debug_ things when there is an error.

The following screenshot isn't even that bad of an example as the error output from my example is actually quite short, whereas in practice the output is usually a lot denser and harder to scan, but it's still a useful example of how hard it is 'at a glance' to distinguish the various output categories (expected/unexpected/error/guidance)...

<img width="973" alt="Screenshot 2023-02-13 at 13 32 47" src="https://user-images.githubusercontent.com/180050/218471607-f71f4011-0a57-4ad4-82e7-0cca022d7a74.png">

## Solution
Only show the build output/error when the `--verbose` flag is set.

## Context
Prior versions of the CLI would default to displaying the build output because users didn't know they could pass `--verbose` to see the build output and get more information. But since 6.x the CLI no longer validates a user's environment, and instead if there is an error building, we just display a bullet list of suggestions. So the current behaviour results in lots of output by default and makes knowing where to look for guidance much harder! 

## Screenshots
The first screenshot shows what happens when the user runs `compute build` and there is a build error (notice the output is much more succinct and clear)...

<img width="973" alt="Screenshot 2023-02-13 at 13 09 06" src="https://user-images.githubusercontent.com/180050/218470228-2742e4e8-9515-48e5-9f97-3379df9cb196.png">

The second screenshot shows what happens if the user follows our guidance and re-runs the command with the `--verbose` set (notice the extra contextual information and a clearly marked/delimited section for the command's output so users can more easily identify build information and build output)...

<img width="973" alt="Screenshot 2023-02-13 at 13 40 00" src="https://user-images.githubusercontent.com/180050/218473282-4030ff9b-dc50-4c31-b452-9d1db733d89a.png">

The last screenshot shows us fixing the issue and then what the output of `compute build` now looks like when it's successful, both with and without the `--verbose` flag...

<img width="896" alt="Screenshot 2023-02-13 at 13 42 13" src="https://user-images.githubusercontent.com/180050/218473723-f1509427-a0c8-4ce1-b5c4-8451a5a5b4c2.png">
