### PR TITLE
fix(dns): migrate to go1.20

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
     # NOTE: Manage GitHub Actions cache https://github.com/fastly/cli/actions/caches
     # This is useful if you need to clear the cache when a dependency doesn't update correctly.
     - name: "Restore golang bin cache"
@@ -82,8 +82,8 @@ jobs:
     needs: config
     strategy:
       matrix:
-        tinygo-version: [0.26.0]
-        go-version: [1.19.x]
+        tinygo-version: [0.27.0]
+        go-version: [1.20.x]
         node-version: [18]
         rust-toolchain: [stable]
         platform: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: "Install Go"
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
     - name: "Set GOHOSTOS and GOHOSTARCH"
       run: echo "GOHOSTOS=$(go env GOHOSTOS)" >> $GITHUB_ENV && echo "GOHOSTARCH=$(go env GOHOSTARCH)" >> $GITHUB_ENV
     - name: "Install Rust"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fastly/cli
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -163,15 +163,15 @@ func (d *Domains) createDomain(name string, attempt int) error {
 		Name:           &name,
 	})
 	if err != nil {
-		if attempt > d.RetryLimit {
-			return fmt.Errorf("too many attempts")
-		}
-
 		// We have to stop the ticker so we can now prompt the user.
 		d.Spinner.StopFailMessage(msg)
 		spinErr := d.Spinner.StopFail()
 		if spinErr != nil {
 			return spinErr
+		}
+
+		if attempt > d.RetryLimit {
+			return fmt.Errorf("too many attempts")
 		}
 
 		if e, ok := err.(*fastly.HTTPError); ok {

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -3,11 +3,9 @@ package setup
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"regexp"
 	"strings"
-	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/fastly/cli/pkg/api"
@@ -216,6 +214,7 @@ func generateDomainName() string {
 	// IMPORTANT: go1.20 deprecates rand.Seed
 	// The global random number generator (RNG) is now automatically seeded.
 	// If not seeded, the same domain name is repeated on each run.
-	rand.Seed(time.Now().UnixNano())
+	// If reverting CLI compilation to using <go1.20 then add the following line:
+	// rand.Seed(time.Now().UnixNano())
 	return fmt.Sprintf("%s.%s", petname.Generate(3, "-"), defaultTopLevelDomain)
 }


### PR DESCRIPTION
The latest version of Go (1.20)...

> DNS resolution will detect changes to /etc/nsswitch.conf and reload the file when it changes. Checks are made at most once every five seconds, matching the previous handling of /etc/hosts and /etc/resolv.conf.

Additionally, under https://tip.golang.org/doc/go1.20#cgo 

> On macOS, the net and os/user packages have been rewritten not to use cgo: the same code is now used for cgo and non-cgo builds as well as cross-compiled builds.

We're hoping the DNS related changes to Go for programs compiled without CGO should help resolve https://github.com/fastly/cli/issues/289.