### PR TITLE
build(goreleaser): build with explicit CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,18 +17,26 @@ builds:
         - -X "github.com/fastly/cli/pkg/revision.GoHostOS={{ .Env.GOHOSTOS }}"
         - -X "github.com/fastly/cli/pkg/revision.GoHostArch={{ .Env.GOHOSTARCH }}"
         - -X "github.com/fastly/cli/pkg/revision.Environment=release"
+    env:
+      - CGO_ENABLED=0
     id: macos
     goos: [darwin]
     goarch: [amd64, arm64]
   - <<: *build_defaults
+    env:
+      - CGO_ENABLED=0
     id: linux
     goos: [linux]
     goarch: ["386", amd64, arm64]
   - <<: *build_defaults
+    env:
+      - CGO_ENABLED=0
     id: windows
     goos: [windows]
     goarch: ["386", amd64, arm64]
   - <<: *build_defaults
+    env:
+      - CGO_ENABLED=0
     id: generate-usage
     goos: [linux]
     goarch: [amd64]
@@ -45,6 +53,7 @@ archives:
       name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
       files:
         - none*
+      rlcp: true
     wrap_in_directory: false
     format: tar.gz
   - id: windows-tar


### PR DESCRIPTION
A gotcha of using Go 1.20 is that if you build a binary on Ubuntu 22.04, it won't run on Ubuntu 20.04 (or earlier).

You'll see the following error:

```
/opt/hostedtoolcache/fastly/6.0.5/x64/fastly: 
    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found 
    (required by /opt/hostedtoolcache/fastly/6.0.5/x64/fastly)
```

The Fastly CLI does not knowingly use any external CGO, only stdlib.

The issue is caused by changes in GLIBC, between the OS versions, and this can be solved by building it on an older version (e.g. building on Ubuntu 20.04).

Alternatively, we can set `CGO_ENABLED=0` (this is the approach taken in this PR), which forces Go to use internal libraries. It's unclear if this will introduce any other issues so we may need to revert to the first approach of building with an older OS.
