### PR TITLE
fix(compute/serve): check for missing override_host

### DIFF
--- a/pkg/commands/secretstoreentry/create.go
+++ b/pkg/commands/secretstoreentry/create.go
@@ -113,6 +113,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 
 	case c.secretFile != "":
 		var err error
+		// nosemgrep: trailofbits.go.questionable-assignment.questionable-assignment
 		if c.Input.Secret, err = os.ReadFile(c.secretFile); err != nil {
 			return err
 		}


### PR DESCRIPTION
Add an `INFO` log message to the `--verbose` output indicating whether any defined `local_server.backends` are missing the `override_host` property, as this can cause confusing errors.

```
$ fastly compute serve --verbose

Fastly API token provided via FASTLY_API_TOKEN
Fastly API endpoint: https://api.fastly.com

INFO: One of the project's `local_server.backends` has a backend configured
without an `override_host` and in some cases can result in unexpected errors. See
https://developer.fastly.com/reference/compute/fastly-toml/#local-server for more details.

Running local server...
Wasm file: bin/main.wasm
Manifest: /Users/integralist/Code/test-projects/testing-fastly-cli/fastly.toml

2023-02-21T10:41:19.545494Z  INFO checking if backend 'backend_a' is up
2023-02-21T10:41:19.546455Z  WARN backend 'backend_a' on 'http://127.0.0.1/' is not up right now
2023-02-21T10:41:19.546550Z  INFO Listening on http://127.0.0.1:7676
```