### PR TITLE
fix(compute/build): move log calls before subprocess call

### DIFF
--- a/pkg/commands/compute/language_go.go
+++ b/pkg/commands/compute/language_go.go
@@ -131,6 +131,10 @@ func (g *Go) Build() error {
 // The warning is to help a user know something isn't quite right and gives them
 // the opportunity to do something about it if they choose.
 func (g *Go) toolchainConstraint(toolchain, pattern, constraint string) {
+	if g.verbose {
+		text.Info(g.output, "The Fastly CLI requires a %s version '%s'. ", toolchain, constraint)
+	}
+
 	versionCommand := fmt.Sprintf("%s version", toolchain)
 	args := strings.Split(versionCommand, " ")
 
@@ -161,10 +165,6 @@ func (g *Go) toolchainConstraint(toolchain, pattern, constraint string) {
 	c, err := semver.NewConstraint(constraint)
 	if err != nil {
 		return
-	}
-
-	if g.verbose {
-		text.Info(g.output, "The Fastly CLI requires a %s version '%s'. ", toolchain, constraint)
 	}
 
 	if !c.Check(v) {

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -192,6 +192,10 @@ func (r *Rust) modifyCargoPackageName() error {
 // The warning is to help a user know something isn't quite right and gives them
 // the opportunity to do something about it if they choose.
 func (r *Rust) toolchainConstraint() {
+	if r.verbose {
+		text.Info(r.output, "The Fastly CLI requires a Rust version '%s'. ", r.config.ToolchainConstraint)
+	}
+
 	versionCommand := "cargo version --quiet"
 	args := strings.Split(versionCommand, " ")
 
@@ -222,10 +226,6 @@ func (r *Rust) toolchainConstraint() {
 	c, err := semver.NewConstraint(r.config.ToolchainConstraint)
 	if err != nil {
 		return
-	}
-
-	if r.verbose {
-		text.Info(r.output, "The Fastly CLI requires a Rust version '%s'. ", r.config.ToolchainConstraint)
 	}
 
 	if !c.Check(v) {


### PR DESCRIPTION
**Problem:** If a toolchain isn't installed at all, then the log info for what was expected was not shown (as the subprocess error prevented the program from reaching the log call).

**Solution:** Move the log calls to the top of the function call stack.