### PR TITLE
fix(build): show build output with --verbose flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ gosec:
 # NOTE: We can only exclude the import-text-template rule via a semgrep CLI flag
 .PHONY: semgrep
 semgrep:
-	if command -v semgrep &> /dev/null; then semgrep ci --config auto --exclude-rule go.lang.security.audit.xss.import-text-template.import-text-template; fi
+	if command -v semgrep &> /dev/null; then semgrep ci --config auto --exclude-rule go.lang.security.audit.xss.import-text-template.import-text-template $(SEMGREP_ARGS); fi
 
 # Run third-party static analysis.
 .PHONY: staticcheck

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -118,11 +118,16 @@ func (s *Streaming) Exec() error {
 	if err := cmd.Wait(); err != nil {
 		text.Output(output, divider)
 
-		if s.Spinner != nil {
-			s.Spinner.StopFailMessage(s.SpinnerMessage)
-			spinErr := s.Spinner.StopFail()
-			if spinErr != nil {
-				return spinErr
+		// If we're in verbose mode, the build output is shown.
+		// So in that case we don't want to have a spinner as it'll interweave output.
+		// In non-verbose mode we have a spinner running while the build is happening.
+		if !s.Verbose {
+			if s.Spinner != nil {
+				s.Spinner.StopFailMessage(s.SpinnerMessage)
+				spinErr := s.Spinner.StopFail()
+				if spinErr != nil {
+					return spinErr
+				}
 			}
 		}
 


### PR DESCRIPTION
The `--verbose` flag now shows "Command output".

<img width="1070" alt="Screenshot 2023-03-06 at 17 25 36" src="https://user-images.githubusercontent.com/180050/223185092-f8eef56e-1352-48b6-a8ae-9da17fc425ce.png">
