### PR TITLE
fix(compute/serve): allow overriding of viceroy binary

### DIFF
--- a/pkg/commands/compute/compute_test.go
+++ b/pkg/commands/compute/compute_test.go
@@ -98,6 +98,7 @@ func TestServeFlagDivergence(t *testing.T) {
 		"env",
 		"file",
 		"skip-build",
+		"viceroy-path",
 		"watch",
 		"watch-dir",
 	}

--- a/pkg/commands/compute/serve_test.go
+++ b/pkg/commands/compute/serve_test.go
@@ -95,7 +95,8 @@ func TestGetViceroy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = compute.GetViceroy(spinner, &out, av, &g)
+	viceroyBinPath := "" // --viceroy-path flag for overriding CLI handling the Viceroy checks/downloads.
+	_, err = compute.GetViceroy(spinner, &out, av, &g, viceroyBinPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/828 https://github.com/fastly/cli/issues/858 

## Problem

The `compute serve` subcommand requires [Viceroy](https://github.com/fastly/viceroy) to be installed but some users have had problems with the Fastly CLI handling the downloading of the required Viceroy binary 'out-of-band'.

Examples of this are: 

- When the CLI needs to be packaged alongside an external version of Viceroy (e.g. NixOS packaging).
- When the CLI is run inside Docker/CI and the network can be flaky (causing timeouts to be reached).

## Solution

To solve this issue the user needs to be able to have the Fastly CLI use a version of the Viceroy binary that they have installed separately from the CLI (e.g. as part of a CI pipeline the user would manually install Viceroy, then install/run the Fastly CLI and inform it of where the Viceroy binary exists). 

This PR introduces two new behaviours...

1. A new `--viceroy-path` flag.
2. A new `FASTLY_VICEROY_USE_PATH` environment variable.

### --viceroy-path

A new `--viceroy-path=<PATH_TO_VICEROY_BINARY>` flag on the `compute serve` subcommand.

If set the Fastly CLI will use the version of the `viceroy` binary that the given path references.

If the `--verbose` flag is set, then the CLI will display the following INFO log output:

```
INFO: Using user provided install of Viceroy via --viceroy-path flag: /your/given/path/to/viceroy
```

### FASTLY_VICEROY_USE_PATH

If the environment variable `FASTLY_VICEROY_USE_PATH` is set to either `1`, `true` or `TRUE` then the CLI will attempt to lookup the `viceroy` binary from the user's `$PATH`.

```
FASTLY_VICEROY_USE_PATH=1 fastly compute serve
```

<img width="1207" alt="Screenshot 2023-03-07 at 11 17 19" src="https://user-images.githubusercontent.com/180050/223407232-83ce9aae-fb34-4c0b-8998-b7a40bbe306e.png">

If passing the `--verbose` flag (and the binary exists in the user's PATH), then you'll see an INFO log indicating where the `viceroy` binary is being sourced from.