### PR TITLE
feat(compute/deploy): check service availability

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -79,12 +79,10 @@ func Run(opts RunOpts) error {
 	// the globalFlags map in pkg/app/usage.go which is used for usage rendering.
 	// You should also update `IsGlobalFlagsOnly` in ../cmd/cmd.go
 	//
-	// NOTE: Global flags, unlike command flags, must be unique. This means BOTH
-	// the long flag and the short flag identifiers must be unique. If you try to
-	// reuse an identifier (long or short), then kingpin will trigger a runtime
-	// panic 🎉
-	//
-	// NOTE: Short flags CAN be safely reused across commands.
+	// NOTE: Global flags (long and short) MUST be unique.
+	// A subcommand can't define a flag that is already global.
+	// Kingpin will otherwise trigger a runtime panic 🎉
+	// Interestingly, short flags can be reused but only across subcommands.
 	tokenHelp := fmt.Sprintf("Fastly API token (or via %s)", env.Token)
 	app.Flag("accept-defaults", "Accept default options for all interactive prompts apart from Yes/No confirmations").Short('d').BoolVar(&g.Flags.AcceptDefaults)
 	app.Flag("auto-yes", "Answer yes automatically to all Yes/No confirmations. This may suppress security warnings").Short('y').BoolVar(&g.Flags.AutoYes)

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -1112,7 +1112,7 @@ func processService(c *DeployCommand, serviceID string, serviceVersion int, spin
 	if err != nil {
 		return err
 	}
-	msg := "Activating version"
+	msg := fmt.Sprintf("Activating service (version %d)", serviceVersion)
 	spinner.Message(msg + "...")
 
 	_, err = c.Globals.APIClient.ActivateVersion(&fastly.ActivateVersionInput{
@@ -1164,13 +1164,13 @@ func checkingServiceAvailability(
 		return 0, err
 	}
 	msg := "Checking service availability"
-	spinner.Message(msg + "...")
+	spinner.Message(msg + " (app is being deployed across Fastly's global network)...")
 
 	timeout := time.After(time.Duration(c.StatusCheckTimeout) * time.Second)
 	ticker := time.NewTicker(1 * time.Second)
 	defer func() { ticker.Stop() }()
 
-	remediation := "The service has been successfully deployed and activated, but our service 'availability' check %s (last status code response was: %d). If using a custom domain, please be sure to check your DNS settings. Otherwise, your application might be taking longer than usual to deploy across our global network. Please continue to check the service URL and if still unavailable please contact Fastly support."
+	remediation := "The service has been successfully deployed and activated, but the service 'availability' check %s (last status code response was: %d). If using a custom domain, please be sure to check your DNS settings. Otherwise, your application might be taking longer than usual to deploy across our global network. Please continue to check the service URL and if still unavailable please contact Fastly support."
 
 	// Keep trying until we're timed out, got a result or got an error
 	for {

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -1169,6 +1169,8 @@ func checkingServiceAvailability(serviceURL string, spinner text.Spinner, httpCl
 	}
 }
 
+// pingServiceURL indicates if the service returned a non-5xx response, which
+// should help signify if the service is generally available.
 func pingServiceURL(serviceURL string, httpClient api.HTTPClient) (ok bool, err error) {
 	req, err := http.NewRequest("GET", serviceURL, nil)
 	if err != nil {
@@ -1183,7 +1185,7 @@ func pingServiceURL(serviceURL string, httpClient api.HTTPClient) (ok bool, err 
 	if err != nil {
 		return false, err
 	}
-	if resp.StatusCode == http.StatusOK {
+	if resp.StatusCode < http.StatusInternalServerError {
 		return true, nil
 	}
 	return false, nil

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -1170,6 +1170,10 @@ func checkingServiceAvailability(serviceURL string, spinner text.Spinner) error 
 }
 
 func pingServiceURL(serviceURL string) (ok bool, err error) {
+	// gosec flagged this:
+	// G107 (CWE-88): Potential HTTP request made with variable url
+	// Disabling as we trust the source of the variable.
+	// #nosec
 	resp, err := http.Get(serviceURL)
 	if err != nil {
 		return false, err

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -974,7 +974,7 @@ func processSetupCreation(
 	out io.Writer,
 ) error {
 	// NOTE: We need to output this message immediately to avoid breaking prompt.
-	if newService {
+	if newService && c.Manifest.File.Setup.Defined() {
 		text.Info(out, "Processing of the fastly.toml [setup] configuration happens only when there is no existing service. Once a service is created, any further changes to the service or its resources must be made manually.")
 		text.Break(out)
 	}

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -80,11 +80,16 @@ func TestDeploy(t *testing.T) {
 	originalPackageSizeLimit := compute.PackageSizeLimit
 	args := testutil.Args
 	scenarios := []struct {
-		api                  mock.API
-		args                 []string
-		dontWantOutput       []string
-		httpClientRes        *http.Response
-		httpClientErr        error
+		api            mock.API
+		args           []string
+		dontWantOutput []string
+		// There are two times the HTTPClient is used.
+		// The first is if we need to activate a free trial.
+		// The second is when we ping for service availability.
+		// In this test case the free trial activation isn't used.
+		// So we only define a single HTTP client call for service availability.
+		httpClientRes        []*http.Response
+		httpClientErr        []error
 		manifest             string
 		name                 string
 		noManifest           bool
@@ -124,6 +129,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			stdin: []string{
 				"Y", // when prompted to create a new service
 			},
@@ -144,6 +159,16 @@ func TestDeploy(t *testing.T) {
 				GetPackageFn:      getPackageOk,
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			stdin: []string{
 				"Y", // when prompted to create a new service
@@ -261,12 +286,16 @@ func TestDeploy(t *testing.T) {
 				CreateServiceFn:  createServiceErrorNoTrial,
 				GetCurrentUserFn: getCurrentUser,
 			},
-			httpClientRes: &http.Response{
-				Body:       io.NopCloser(strings.NewReader(testutil.Err.Error())),
-				Status:     http.StatusText(http.StatusBadRequest),
-				StatusCode: http.StatusBadRequest,
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader(testutil.Err.Error())),
+					Status:     http.StatusText(http.StatusBadRequest),
+					StatusCode: http.StatusBadRequest,
+				},
 			},
-			httpClientErr: nil,
+			httpClientErr: []error{
+				nil,
+			},
 			stdin: []string{
 				"Y", // when prompted to create a new service
 			},
@@ -285,8 +314,12 @@ func TestDeploy(t *testing.T) {
 				CreateServiceFn:  createServiceErrorNoTrial,
 				GetCurrentUserFn: getCurrentUser,
 			},
-			httpClientRes: nil,
-			httpClientErr: &url.Error{Err: context.DeadlineExceeded},
+			httpClientRes: []*http.Response{
+				nil,
+			},
+			httpClientErr: []error{
+				&url.Error{Err: context.DeadlineExceeded},
+			},
 			stdin: []string{
 				"Y", // when prompted to create a new service
 			},
@@ -309,12 +342,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
 			},
-			httpClientRes: &http.Response{
-				Body:       io.NopCloser(strings.NewReader("success")),
-				Status:     http.StatusText(http.StatusOK),
-				StatusCode: http.StatusOK,
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
 			},
-			httpClientErr: nil,
+			httpClientErr: []error{
+				nil,
+			},
 			stdin: []string{
 				"Y", // when prompted to create a new service
 			},
@@ -452,6 +489,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			wantOutput: []string{
 				"Uploading package",
 				"Activating version",
@@ -473,6 +520,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:       listDomainsOk,
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			wantOutput: []string{
 				"Uploading package",
@@ -500,6 +557,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			noManifest: true,
 			wantOutput: []string{
 				"Using fastly.toml within --package archive:",
@@ -524,6 +591,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			wantOutput: []string{
 				"Uploading package",
 				"Activating version",
@@ -543,6 +620,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			wantOutput: []string{
 				"Uploading package",
 				"Activating version",
@@ -561,6 +648,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:       listDomainsOk,
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			wantOutput: []string{
 				"Uploading package",
@@ -582,6 +679,16 @@ func TestDeploy(t *testing.T) {
 				UpdatePackageFn:     updatePackageOk,
 				UpdateVersionFn:     updateVersionOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			wantOutput: []string{
 				"Uploading package",
 				"Activating version",
@@ -600,9 +707,20 @@ func TestDeploy(t *testing.T) {
 				CreateBackendFn:   createBackendOK,
 				CreateDomainFn:    createDomainOK,
 				CreateServiceFn:   createServiceOK,
+				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -644,9 +762,20 @@ func TestDeploy(t *testing.T) {
 				CreateBackendFn:   createBackendOK,
 				CreateDomainFn:    createDomainOK,
 				CreateServiceFn:   createServiceOK,
+				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -685,9 +814,20 @@ func TestDeploy(t *testing.T) {
 				CreateBackendFn:   createBackendOK,
 				CreateDomainFn:    createDomainOK,
 				CreateServiceFn:   createServiceOK,
+				DeleteServiceFn:   deleteServiceOK,
 				GetPackageFn:      getPackageOk,
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -731,6 +871,16 @@ func TestDeploy(t *testing.T) {
 				GetPackageFn:      getPackageOk,
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -780,6 +930,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			wantOutput: []string{
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
@@ -798,6 +958,16 @@ func TestDeploy(t *testing.T) {
 				GetPackageFn:      getPackageOk,
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			stdin: []string{
 				"Y",      // when prompted to create a new service
@@ -830,10 +1000,20 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			stdin: []string{
-				"Y",      // when prompted to create a new service
-				"foobar", // when prompted for service name
-				"fastly.com",
+				"Y",          // when prompted to create a new service
+				"foobar",     // when prompted for service name
+				"fastly.com", // when prompted for a backend
 				"443",
 				"", // this is so we generate a backend name using a built-in formula
 				"google.com",
@@ -865,6 +1045,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:     listDomainsOk,
 				UpdatePackageFn:   updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			stdin: []string{
 				"Y",      // when prompted to create a new service
 				"foobar", // when prompted for service name
@@ -894,6 +1084,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			wantOutput: []string{
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
@@ -920,6 +1120,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:       listDomainsOk,
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -962,6 +1172,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:       listDomainsOk,
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1007,6 +1227,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:          listDomainsOk,
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1057,6 +1287,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			manifest: `
 			name = "package"
 			manifest_version = 2
@@ -1099,6 +1339,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:          listDomainsOk,
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1147,6 +1397,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			manifest: `
 			name = "package"
 			manifest_version = 2
@@ -1184,6 +1444,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:          listDomainsOk,
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1223,6 +1493,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:          listDomainsOk,
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1264,6 +1544,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			manifest: `
 			name = "package"
 			manifest_version = 2
@@ -1300,6 +1590,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:       listDomainsOk,
 				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1346,6 +1646,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:          listDomainsOk,
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1394,6 +1704,16 @@ func TestDeploy(t *testing.T) {
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
 			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
+			},
 			manifest: `
 			name = "package"
 			manifest_version = 2
@@ -1437,6 +1757,16 @@ func TestDeploy(t *testing.T) {
 				ListDomainsFn:          listDomainsOk,
 				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
+			},
+			httpClientRes: []*http.Response{
+				{
+					Body:       io.NopCloser(strings.NewReader("success")),
+					Status:     http.StatusText(http.StatusOK),
+					StatusCode: http.StatusOK,
+				},
+			},
+			httpClientErr: []error{
+				nil,
 			},
 			manifest: `
 			name = "package"
@@ -1555,7 +1885,7 @@ func TestDeploy(t *testing.T) {
 				select {
 				case <-done:
 					// Wait for app.Run() to finish
-				case <-time.After(time.Second):
+				case <-time.After(5 * time.Second):
 					t.Fatalf("unexpected timeout waiting for mocked prompt inputs to be processed")
 				}
 			} else {

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -456,7 +456,7 @@ func TestDeploy(t *testing.T) {
 			wantError: "error activating version: test error",
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 			},
 		},
 		// The following test validates that if a package contains code that has
@@ -501,7 +501,7 @@ func TestDeploy(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"Manage this service at:",
 				"https://manage.fastly.com/configure/services/123",
 				"View this service at:",
@@ -533,7 +533,7 @@ func TestDeploy(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"Manage this service at:",
 				"https://manage.fastly.com/configure/services/123",
 				"View this service at:",
@@ -571,7 +571,7 @@ func TestDeploy(t *testing.T) {
 			wantOutput: []string{
 				"Using fastly.toml within --package archive:",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"Manage this service at:",
 				"https://manage.fastly.com/configure/services/123",
 				"View this service at:",
@@ -603,7 +603,7 @@ func TestDeploy(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"Deployed package (service 123, version 3)",
 			},
 		},
@@ -632,7 +632,7 @@ func TestDeploy(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"Deployed package (service 123, version 4)",
 			},
 		},
@@ -661,7 +661,7 @@ func TestDeploy(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"Deployed package (service 123, version 4)",
 			},
 		},
@@ -691,7 +691,7 @@ func TestDeploy(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"Deployed package (service 123, version 4)",
 			},
 		},
@@ -748,7 +748,7 @@ func TestDeploy(t *testing.T) {
 				"Creating backend 'backend_name' (host: developer.fastly.com, port: 443)",
 				"Creating backend 'other_backend_name' (host: httpbin.org, port: 443)",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -799,7 +799,7 @@ func TestDeploy(t *testing.T) {
 				"Creating backend 'foo_backend' (host: developer.fastly.com, port: 80)",
 				"Creating backend 'bar_backend' (host: httpbin.org, port: 80)",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 			dontWantOutput: []string{
@@ -851,7 +851,7 @@ func TestDeploy(t *testing.T) {
 				"Creating backend 'foo_backend' (host: 127.0.0.1, port: 80)",
 				"Creating backend 'bar_backend' (host: 127.0.0.1, port: 80)",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 			dontWantOutput: []string{
@@ -901,7 +901,7 @@ func TestDeploy(t *testing.T) {
 				"Creating backend 'backend_name' (host: developer.fastly.com, port: 443)",
 				"Creating backend 'other_backend_name' (host: httpbin.org, port: 443)",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 			dontWantOutput: []string{
@@ -1151,7 +1151,7 @@ func TestDeploy(t *testing.T) {
 			`,
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
@@ -1199,7 +1199,7 @@ func TestDeploy(t *testing.T) {
 			`,
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
@@ -1266,7 +1266,7 @@ func TestDeploy(t *testing.T) {
 				"Creating dictionary item 'foo'",
 				"Creating dictionary item 'bar'",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -1319,7 +1319,7 @@ func TestDeploy(t *testing.T) {
 				"Creating dictionary item 'foo'",
 				"Creating dictionary item 'bar'",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -1370,7 +1370,7 @@ func TestDeploy(t *testing.T) {
 				"Creating dictionary item 'foo'",
 				"Creating dictionary item 'bar'",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 			// The following are predefined values for the `description` and `value`
@@ -1417,7 +1417,7 @@ func TestDeploy(t *testing.T) {
 			`,
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
@@ -1473,7 +1473,7 @@ func TestDeploy(t *testing.T) {
 				"Refer to the help documentation for each provider (if no provider shown, then select your own):",
 				"fastly logging <provider> create --help",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -1520,7 +1520,7 @@ func TestDeploy(t *testing.T) {
 				"Refer to the help documentation for each provider (if no provider shown, then select your own):",
 				"fastly logging <provider> create --help",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 			dontWantOutput: []string{
@@ -1572,7 +1572,7 @@ func TestDeploy(t *testing.T) {
 				"Refer to the help documentation for each provider (if no provider shown, then select your own):",
 				"fastly logging <provider> create --help",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -1617,7 +1617,7 @@ func TestDeploy(t *testing.T) {
 			`,
 			wantOutput: []string{
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
@@ -1682,7 +1682,7 @@ func TestDeploy(t *testing.T) {
 				"Creating object store key 'foo'",
 				"Creating object store key 'bar'",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -1736,7 +1736,7 @@ func TestDeploy(t *testing.T) {
 				"Creating object store key 'foo'",
 				"Creating object store key 'bar'",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
@@ -1788,7 +1788,7 @@ func TestDeploy(t *testing.T) {
 				"Creating object store key 'foo'",
 				"Creating object store key 'bar'",
 				"Uploading package",
-				"Activating version",
+				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 			// The following are predefined values for the `description` and `value`

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -6,7 +6,6 @@ import (
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/cli/pkg/text"
 )
 
 // PublishCommand produces and deploys an artifact from files on the local disk.
@@ -96,8 +95,6 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
-
-	text.Break(out)
 
 	// Reset the fields on the DeployCommand based on PublishCommand values.
 	if c.pkg.WasSet {

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -66,14 +66,14 @@ func (b *Backends) Create() error {
 		// Avoids range-loop variable issue (i.e. var is reused across iterations).
 		bk := bk
 
-		msg := fmt.Sprintf("Creating backend '%s' (host: %s, port: %d)...", bk.Name, bk.Address, bk.Port)
+		msg := fmt.Sprintf("Creating backend '%s' (host: %s, port: %d)", bk.Name, bk.Address, bk.Port)
 
 		if !b.isOriginless() {
 			err := b.Spinner.Start()
 			if err != nil {
 				return err
 			}
-			b.Spinner.Message(msg)
+			b.Spinner.Message(msg + "...")
 		}
 
 		opts := &fastly.CreateBackendInput{

--- a/pkg/commands/compute/setup/dictionary.go
+++ b/pkg/commands/compute/setup/dictionary.go
@@ -119,8 +119,8 @@ func (d *Dictionaries) Create() error {
 		if err != nil {
 			return err
 		}
-		msg := fmt.Sprintf("Creating dictionary '%s'...", dictionary.Name)
-		d.Spinner.Message(msg)
+		msg := fmt.Sprintf("Creating dictionary '%s'", dictionary.Name)
+		d.Spinner.Message(msg + "...")
 
 		dict, err := d.APIClient.CreateDictionary(&fastly.CreateDictionaryInput{
 			ServiceID:      d.ServiceID,
@@ -148,8 +148,8 @@ func (d *Dictionaries) Create() error {
 				if err != nil {
 					return err
 				}
-				msg := fmt.Sprintf("Creating dictionary item '%s'...", item.Key)
-				d.Spinner.Message(msg)
+				msg := fmt.Sprintf("Creating dictionary item '%s'", item.Key)
+				d.Spinner.Message(msg + "...")
 
 				_, err = d.APIClient.CreateDictionaryItem(&fastly.CreateDictionaryItemInput{
 					ServiceID:    d.ServiceID,

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -66,6 +66,7 @@ func (d *Domains) Configure() error {
 		err    error
 	)
 	if !d.AcceptDefaults && !d.NonInteractive {
+		text.Break(d.Stdout)
 		domain, err = text.Input(d.Stdout, text.BoldYellow(fmt.Sprintf("Domain: [%s] ", defaultDomain)), d.Stdin, d.validateDomain)
 		if err != nil {
 			return fmt.Errorf("error reading input %w", err)
@@ -149,6 +150,10 @@ func (d *Domains) validateDomain(input string) error {
 }
 
 func (d *Domains) createDomain(name string, attempt int) error {
+	if !d.AcceptDefaults && !d.NonInteractive {
+		text.Break(d.Stdout)
+	}
+
 	err := d.Spinner.Start()
 	if err != nil {
 		return err

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -153,8 +153,8 @@ func (d *Domains) createDomain(name string, attempt int) error {
 	if err != nil {
 		return err
 	}
-	msg := fmt.Sprintf("Creating domain '%s'...", name)
-	d.Spinner.Message(msg)
+	msg := fmt.Sprintf("Creating domain '%s'", name)
+	d.Spinner.Message(msg + "...")
 
 	_, err = d.APIClient.CreateDomain(&fastly.CreateDomainInput{
 		ServiceID:      d.ServiceID,

--- a/pkg/commands/compute/setup/object_store.go
+++ b/pkg/commands/compute/setup/object_store.go
@@ -117,8 +117,8 @@ func (o *ObjectStores) Create() error {
 		if err != nil {
 			return err
 		}
-		msg := fmt.Sprintf("Creating object store '%s'...", objectStore.Name)
-		o.Spinner.Message(msg)
+		msg := fmt.Sprintf("Creating object store '%s'", objectStore.Name)
+		o.Spinner.Message(msg + "...")
 
 		store, err := o.APIClient.CreateObjectStore(&fastly.CreateObjectStoreInput{
 			Name: objectStore.Name,

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -224,6 +224,26 @@ type Setup struct {
 	ObjectStores map[string]*SetupObjectStore `toml:"object_stores,omitempty"`
 }
 
+// Defined indicates if there is any [setup] configuration in the manifest.
+func (s Setup) Defined() bool {
+	var defined bool
+
+	if len(s.Backends) > 0 {
+		defined = true
+	}
+	if len(s.Dictionaries) > 0 {
+		defined = true
+	}
+	if len(s.Loggers) > 0 {
+		defined = true
+	}
+	if len(s.ObjectStores) > 0 {
+		defined = true
+	}
+
+	return defined
+}
+
 // SetupBackend represents a '[setup.backends.<T>]' instance.
 type SetupBackend struct {
 	Address     string `toml:"address,omitempty"`

--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -15,19 +15,23 @@ func APIClient(a API) func(string, string) (api.Interface, error) {
 }
 
 type mockHTTPClient struct {
-	res *http.Response
-	err error
+	// index keeps track of which response/error to return
+	index int
+	res   []*http.Response
+	err   []error
 }
 
 func (c mockHTTPClient) Do(_ *http.Request) (*http.Response, error) {
-	return c.res, c.err
+	c.index++
+	return c.res[c.index], c.err[c.index]
 }
 
 // HTMLClient returns a mock HTTP Client that returns a stubbed response or
 // error.
-func HTMLClient(res *http.Response, err error) api.HTTPClient {
+func HTMLClient(res []*http.Response, err []error) api.HTTPClient {
 	return mockHTTPClient{
-		res: res,
-		err: err,
+		index: -1,
+		res:   res,
+		err:   err,
 	}
 }


### PR DESCRIPTION
## Problem
Users running `compute deploy` or `compute publish` are immediately presented with a 'Service URL' which when clicked on by a user will typically return a `500 Internal Server` error (as the user's application is still being deployed across Fastly's global network).

## Solution 
Ping the Service URL until an appropriate response is received.

## Notes
The implementation checks for a non-500 response and if it gets one within the specified timeout it will show a 'green tick' to indicate the service URL will work when visited. 

The reason we've chosen this approach, rather than checking for a `200 OK` from the service URL, is that we don't control a user's service and so a 4xx status code for the root path `/` of a service might be a completely valid response! 

Whereas we feel fairly confident that a `500 Internal Server` error is unlikely to be expected behaviour for anyone's service. 

We also ensure our messaging asks users to check their DNS if they have defined a custom domain, as some users will specify a custom domain and activate a service via the CLI and only _then_ will setup the DNS to point to Fastly.

**This is an interim solution until we have either an API or HTTP response header that helps us identify service availability.**

Refer to the following 'example output' gif and see also the updated screenshots in the below thread.

![output](https://user-images.githubusercontent.com/180050/223498828-cdb74e9f-0a37-42b7-a74b-2aeecc96c2f5.gif)
