### PR TITLE
breaking(profiles): replace `--name` with positional arg + allow global override

### DIFF
--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -630,7 +630,28 @@ func TestToken(t *testing.T) {
 		{
 			TestScenario: testutil.TestScenario{
 				Name:       "validate token is displayed for the specified profile",
-				Args:       args("profile token --name bar"), // we choose a non-default profile
+				Args:       args("profile token bar"), // we choose a non-default profile
+				WantOutput: "456",
+			},
+			ConfigFile: config.File{
+				Profiles: config.Profiles{
+					"foo": &config.Profile{
+						Default: true,
+						Email:   "foo@example.com",
+						Token:   "123",
+					},
+					"bar": &config.Profile{
+						Default: false,
+						Email:   "bar@example.com",
+						Token:   "456",
+					},
+				},
+			},
+		},
+		{
+			TestScenario: testutil.TestScenario{
+				Name:       "validate token is displayed for the specified profile using global --profile",
+				Args:       args("profile token --profile bar"), // we choose a non-default profile
 				WantOutput: "456",
 			},
 			ConfigFile: config.File{
@@ -651,7 +672,7 @@ func TestToken(t *testing.T) {
 		{
 			TestScenario: testutil.TestScenario{
 				Name:      "validate an unrecognised profile causes an error",
-				Args:      args("profile token --name unknown"),
+				Args:      args("profile token unknown"),
 				WantError: "profile 'unknown' does not exist",
 			},
 		},

--- a/pkg/commands/profile/token.go
+++ b/pkg/commands/profile/token.go
@@ -21,31 +21,42 @@ type TokenCommand struct {
 func NewTokenCommand(parent cmd.Registerer, g *global.Data) *TokenCommand {
 	var c TokenCommand
 	c.Globals = g
-	c.CmdClause = parent.Command("token", "Print access token")
-	c.CmdClause.Flag("name", "Print access token for the named profile").Short('n').StringVar(&c.profile)
+	c.CmdClause = parent.Command("token", "Print access token (defaults to the 'active' profile)")
+	c.CmdClause.Arg("profile", "Print access token for the named profile").Short('p').StringVar(&c.profile)
 	return &c
 }
 
 // Exec implements the command interface.
 func (c *TokenCommand) Exec(_ io.Reader, out io.Writer) (err error) {
-	if c.profile == "" {
-		if name, p := profile.Default(c.Globals.Config.Profiles); name != "" {
+	var p string
+	if c.profile != "" {
+		p = c.profile
+	}
+	if c.Globals.Flags.Profile != "" {
+		p = c.Globals.Flags.Profile
+		// NOTE: If global --profile is set, it take precedence over 'profile' arg.
+		// It's unlikely someone will provide both, but we'll code defensively.
+	}
+
+	if p != "" {
+		if name, p := profile.Get(p, c.Globals.Config.Profiles); name != "" {
 			text.Output(out, p.Token)
 			return nil
 		}
+		msg := fmt.Sprintf(profile.DoesNotExist, p)
 		return fsterr.RemediationError{
-			Inner:       fmt.Errorf("no profiles available"),
+			Inner:       fmt.Errorf(msg),
 			Remediation: fsterr.ProfileRemediation,
 		}
 	}
 
-	if name, p := profile.Get(c.profile, c.Globals.Config.Profiles); name != "" {
+	// If no 'profile' arg or global --profile, then we'll use 'active' profile.
+	if name, p := profile.Default(c.Globals.Config.Profiles); name != "" {
 		text.Output(out, p.Token)
 		return nil
 	}
-	msg := fmt.Sprintf(profile.DoesNotExist, c.profile)
 	return fsterr.RemediationError{
-		Inner:       fmt.Errorf(msg),
+		Inner:       fmt.Errorf("no profiles available"),
 		Remediation: fsterr.ProfileRemediation,
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/861

**NOTE:** Because we're removing a flag from the interface we must consider this a breaking change and consequently the next CLI release will be a new major version.