### PR TITLE
fix(compute/serve): stop spinner before starting another instance

### DIFF
--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -523,6 +523,12 @@ func updateViceroy(
 		}
 		defer os.RemoveAll(tmpBin)
 
+		spinner.StopMessage(msg)
+		err = spinner.Stop()
+		if err != nil {
+			return err
+		}
+
 		err = spinner.Start()
 		if err != nil {
 			return err

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -500,7 +500,6 @@ func updateViceroy(
 
 	if latest.GT(current) {
 		text.Break(out)
-		text.Break(out)
 		text.Output(out, "Current Viceroy version: %s", current)
 		text.Output(out, "Latest Viceroy version: %s", latest)
 		text.Break(out)


### PR DESCRIPTION
**Problem:**
<img width="402" alt="Screenshot 2023-03-15 at 11 18 33" src="https://user-images.githubusercontent.com/180050/225293947-4b90fc45-7175-4981-a13c-5aa8465c87b0.png">

**Solution:**
<img width="322" alt="Screenshot 2023-03-15 at 11 19 25" src="https://user-images.githubusercontent.com/180050/225294139-779cd5c8-fcd7-41e8-ba19-bec43f461a60.png">
