### PR TITLE
fix(http/client): address confusion with timeout error

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -63,7 +63,7 @@ func main() {
 	var (
 		args                    = os.Args[1:]
 		clientFactory           = app.FastlyAPIClient
-		httpClient              = &http.Client{Timeout: time.Second * 5}
+		httpClient              = &http.Client{Timeout: time.Second * 15}
 		in            io.Reader = os.Stdin
 		out           io.Writer = sync.NewWriter(color.Output)
 	)

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -215,7 +215,7 @@ func createArchive(assetBase, tmpDir string, data io.ReadCloser) (path string, e
 
 	_, err = io.Copy(archive, data)
 	if err != nil {
-		return "", fmt.Errorf("failed to download release asset: %w", err)
+		return "", fmt.Errorf("failed to copy the release asset response body: %w", err)
 	}
 
 	if err := archive.Close(); err != nil {


### PR DESCRIPTION
A customer reported the following error...

```
✗ Fetching latest Viceroy release

ERROR: error downloading latest Viceroy release: failed to download release asset: context deadline exceeded (Client.Timeout or context cancellation while reading body).
```

This is a confusing error because the message "failed to download" suggests the error is related to the request to the API endpoint timed out, when in fact this error happens when the response body is being read.

So this PR addresses two things...

1. It updates the error message to be clearer.
2. It updates the http.Client.Timeout setting to be longer (†).

> † Refer to the below image which shows the timeout includes all stages up to reading the body.

![](https://blog.cloudflare.com/content/images/2016/06/Timeouts-002.png)