### PR TITLE
fix(http/client): bump timeout to account for poor network conditions

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -63,7 +63,7 @@ func main() {
 	var (
 		args                    = os.Args[1:]
 		clientFactory           = app.FastlyAPIClient
-		httpClient              = &http.Client{Timeout: time.Second * 15}
+		httpClient              = &http.Client{Timeout: time.Minute * 2}
 		in            io.Reader = os.Stdin
 		out           io.Writer = sync.NewWriter(color.Output)
 	)


### PR DESCRIPTION
After an internal discussion, it was determined that the time needed to stream the response body (via `io.Copy`) to a `*os.File` should require a larger `http.Client` timeout (measured in minutes rather than seconds).