### PR TITLE
fix(compute/deploy): service availability

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -175,7 +175,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	serviceURL := fmt.Sprintf("https://%s", domain)
 
-	if !c.StatusCheckOff {
+	if !c.StatusCheckOff && newService {
 		var status int
 		if status, err = checkingServiceAvailability(serviceURL+c.StatusCheckPath, spinner, c); err != nil {
 			if re, ok := err.(fsterr.RemediationError); ok {

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/text"
 )
 
 // PublishCommand produces and deploys an artifact from files on the local disk.
@@ -103,6 +104,8 @@ func (c *PublishCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
+
+	text.Break(out)
 
 	// Reset the fields on the DeployCommand based on PublishCommand values.
 	if c.pkg.WasSet {


### PR DESCRIPTION
This PR includes the following modifications to the service availability check...

1. We only run the service availability check when deploying the service for the first time.
2. We add a countdown to the output message (so users know how long is left before we timeout).
3. We allow `--status-check-code` to be used as the 'expected status code' within the service availability check.

## Screenshots

In the first screenshot, we can see the service availability check (eventually) received a non-500 status code, which signified the service was deployed to/available from the user's nearest Fastly POP...

<img width="908" alt="Screenshot 2023-03-17 at 11 24 06" src="https://user-images.githubusercontent.com/180050/225893191-97b388a0-07c9-45dc-9d34-4636ab7fcce2.png">

When running the `fastly compute deploy` command a second time after we already deployed the first time, we see there is no service availability check executed...

<img width="918" alt="Screenshot 2023-03-17 at 11 24 14" src="https://user-images.githubusercontent.com/180050/225893197-8eaa050a-8e5c-46d8-b799-140eebc34b16.png">

In the following screenshot, we can see the service availability check 'in-flight' (i.e. running) and that it contains a timeout which helps users to see that the CLI has not stalled...

<img width="909" alt="Screenshot 2023-03-17 at 11 23 28" src="https://user-images.githubusercontent.com/180050/225893712-55b1483b-33f3-40e8-92f1-7e6d1b1307a6.png">

In the following screenshot, we can see what happens when a timeout is reached. In the default case we're looking for a non-500 and so the WARNING message indicates this...

<img width="861" alt="Screenshot 2023-03-17 at 11 22 33" src="https://user-images.githubusercontent.com/180050/225894105-56cd12f1-31f5-40ea-a9bd-5a56401388db.png">

Whereas the next screenshot demonstrates how the WARNING message changes when the user sets the `--status-check-code` flag, which tells the CLI the user expects a specific status code from the endpoint being checked...

<img width="885" alt="Screenshot 2023-03-17 at 11 22 40" src="https://user-images.githubusercontent.com/180050/225894108-b4af88ce-16b3-4af4-baa5-ce2400b4a1d7.png">

Finally, the following screenshot demonstrates a contrived example where a user _expects_ their application to return a 500 by setting `--status-check-code` and thus the service availability check finishes almost immediately (but this doesn't mean the service is available and has returned an explicit 500, it's more likely in this scenario that the app hasn't reached the user's nearest POP and so the lookup has failed with a "No service available")...

<img width="869" alt="Screenshot 2023-03-17 at 11 28 44" src="https://user-images.githubusercontent.com/180050/225894110-19b8b4fd-6fe5-4394-847b-28e2218f1fda.png">
