### PR TITLE
🗣️  Pass verbosity flag along to viceroy binary

### DIFF
--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -591,6 +591,7 @@ func local(bin, file, addr, env string, debug, watch bool, watchDir cmd.Optional
 		text.Break(out)
 		text.Output(out, "Wasm file: %s", file)
 		text.Output(out, "Manifest: %s", manifestPath)
+		args = append(args, "-v")
 	}
 
 	s := &fstexec.Streaming{


### PR DESCRIPTION
Putting this up as a possible solution to https://github.com/fastly/Viceroy/issues/235.

With the 0.4.0 release, the default Viceroy verbosity is "OFF" rather than "INFO" ([discussion here](https://github.com/fastly/Viceroy/pull/229#discussion_r1131582459)). This change would pass along the `--verbose` flag to viceroy when a user calls `fastly compute serve --verbose`.

Alternatively, we could just unconditionally pass the `-v` flag so the `fastly compute serve` output remains ~the same as before that Viceroy version.