### PR TITLE
fix(service/create): input.Type assigned wrong value

### DIFF
--- a/pkg/commands/service/create.go
+++ b/pkg/commands/service/create.go
@@ -45,8 +45,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if c.comment.WasSet {
 		input.Comment = &c.comment.Value
 	}
-	if c.comment.WasSet {
-		input.Type = &c.comment.Value
+	if c.stype.WasSet {
+		input.Type = &c.stype.Value
 	}
 	s, err := c.Globals.APIClient.CreateService(&input)
 	if err != nil {


### PR DESCRIPTION
Cannot create a service with a comment, or change type of service creation due to bug.