### PR TITLE
feat(build): code-sign Windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,10 @@ builds:
     id: windows
     goos: [windows]
     goarch: ["386", amd64, arm64]
+    hooks: # https://goreleaser.com/customization/builds/#build-hooks
+      post:
+        - osslsigncode sign -certs ./certkey/spc.pem -key ./certkey/private_key.pem -n "fastly-cli" -i "https://github.com/fastly/cli" -verbose -in "{{ .Path }}" -out "{{ .Path }}-signed"
+        - mv "{{ .Path }}-signed" "{{ .Path }}"
   - <<: *build_defaults
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
We're using `osslsigncode` to code-sign Windows binaries; to do that, we're told...

> Before you can sign a file you need a Software Publishing Certificate (SPC) and a corresponding private key.

There wasn't much (any) information on how to generate an SPC so I've used the following command:

```shell
openssl req -x509 -newkey rsa:2048 -keyout private_key.pem -out spc.pem -days 365 -nodes
```

This code generates a self-signed X.509 certificate using the RSA private key generated by the `openssl req` command. The private key is saved in a file named `private_key.pem`, and the certificate is saved in a file named `spc.pem`. The `-x509` option specifies that a self-signed certificate should be generated, while the `-newkey` option specifies that a new private key should be generated. The `-nodes` option specifies that the private key should not be encrypted. The `-days` option specifies the certificate's validity period, which is set to 365 days. This command is commonly used to generate a self-signed certificate for testing or development purposes.

I then tested the changes in this PR by running goreleaser locally...

```shell
make fastly GORELEASER_ARGS="--clean --skip-validate --id windows"

  • starting build...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=c7e5240957d8a8aa5fad748d96395ab55eec7a58 latest tag=v8.1.2
    • pipe skipped                                   reason=validation is disabled
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod tidy
    • running                                        hook=go mod download
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/windows_windows_arm64/fastly.exe
    • building                                       binary=dist/windows_windows_amd64_v1/fastly.exe
    • building                                       binary=dist/windows_windows_386/fastly.exe
    • running hook                                   hook=osslsigncode sign -certs ./certkey/spc.pem -key ./certkey/private_key.pem -n "fastly-cli" -i "https://github.com/fastly/cli" -verbose -in "/Users/integralist/Code/fastly/cli/dist/windows_windows_386/fastly.exe" -out "/Users/integralist/Code/fastly/cli/dist/windows_windows_386/fastly.exe-signed"
    • running hook                                   hook=osslsigncode sign -certs ./certkey/spc.pem -key ./certkey/private_key.pem -n "fastly-cli" -i "https://github.com/fastly/cli" -verbose -in "/Users/integralist/Code/fastly/cli/dist/windows_windows_arm64/fastly.exe" -out "/Users/integralist/Code/fastly/cli/dist/windows_windows_arm64/fastly.exe-signed"
    • running hook                                   hook=osslsigncode sign -certs ./certkey/spc.pem -key ./certkey/private_key.pem -n "fastly-cli" -i "https://github.com/fastly/cli" -verbose -in "/Users/integralist/Code/fastly/cli/dist/windows_windows_amd64_v1/fastly.exe" -out "/Users/integralist/Code/fastly/cli/dist/windows_windows_amd64_v1/fastly.exe-signed"
    • running hook                                   hook=mv "/Users/integralist/Code/fastly/cli/dist/windows_windows_arm64/fastly.exe-signed" "/Users/integralist/Code/fastly/cli/dist/windows_windows_arm64/fastly.exe"
    • running hook                                   hook=mv "/Users/integralist/Code/fastly/cli/dist/windows_windows_386/fastly.exe-signed" "/Users/integralist/Code/fastly/cli/dist/windows_windows_386/fastly.exe"
    • running hook                                   hook=mv "/Users/integralist/Code/fastly/cli/dist/windows_windows_amd64_v1/fastly.exe-signed" "/Users/integralist/Code/fastly/cli/dist/windows_windows_amd64_v1/fastly.exe"
    • took: 2s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • build succeeded after 2s
```