### PR TITLE
feat(ratelimit): implement rate-limiter API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v7 v7.5.0
+	github.com/fastly/go-fastly/v7 v7.5.1
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/otiai10/copy v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:90Ly+6UfUypEF6vvvW5rQIv9opIL8CbmW9FT20LDQoY=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
-github.com/fastly/go-fastly/v7 v7.5.0 h1:5keaPPC8YA3seDKx5n0JVLhvgs4WmNtHl043Pey+Ho8=
-github.com/fastly/go-fastly/v7 v7.5.0/go.mod h1:/Z2GD7NuxV3vVMAyrtckg1WvZVnCuM2Z8ok/z70XTEQ=
+github.com/fastly/go-fastly/v7 v7.5.1 h1:BkuUTHGgpuxb8/EDYDmgxyMUwP4JZOSO7cYZQFFpc9A=
+github.com/fastly/go-fastly/v7 v7.5.1/go.mod h1:/Z2GD7NuxV3vVMAyrtckg1WvZVnCuM2Z8ok/z70XTEQ=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -368,6 +368,12 @@ type Interface interface {
 	GetResource(i *fastly.GetResourceInput) (*fastly.Resource, error)
 	ListResources(i *fastly.ListResourcesInput) ([]*fastly.Resource, error)
 	UpdateResource(i *fastly.UpdateResourceInput) (*fastly.Resource, error)
+
+	CreateERL(i *fastly.CreateERLInput) (*fastly.ERL, error)
+	DeleteERL(i *fastly.DeleteERLInput) error
+	GetERL(i *fastly.GetERLInput) (*fastly.ERL, error)
+	ListERLs(i *fastly.ListERLsInput) ([]*fastly.ERL, error)
+	UpdateERL(i *fastly.UpdateERLInput) (*fastly.ERL, error)
 }
 
 // RealtimeStatsInterface is the subset of go-fastly's realtime stats API used here.

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -47,6 +47,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/pop"
 	"github.com/fastly/cli/pkg/commands/profile"
 	"github.com/fastly/cli/pkg/commands/purge"
+	"github.com/fastly/cli/pkg/commands/ratelimit"
 	"github.com/fastly/cli/pkg/commands/resourcelink"
 	"github.com/fastly/cli/pkg/commands/secretstore"
 	"github.com/fastly/cli/pkg/commands/secretstoreentry"
@@ -327,6 +328,12 @@ func defineCommands(
 	profileToken := profile.NewTokenCommand(profileCmdRoot.CmdClause, g)
 	profileUpdate := profile.NewUpdateCommand(profileCmdRoot.CmdClause, profile.APIClientFactory(opts.APIClient), g)
 	purgeCmdRoot := purge.NewRootCommand(app, g, m)
+	rateLimitCmdRoot := ratelimit.NewRootCommand(app, g)
+	rateLimitCreate := ratelimit.NewCreateCommand(rateLimitCmdRoot.CmdClause, g, m)
+	rateLimitDelete := ratelimit.NewDeleteCommand(rateLimitCmdRoot.CmdClause, g, m)
+	rateLimitDescribe := ratelimit.NewDescribeCommand(rateLimitCmdRoot.CmdClause, g, m)
+	rateLimitList := ratelimit.NewListCommand(rateLimitCmdRoot.CmdClause, g, m)
+	rateLimitUpdate := ratelimit.NewUpdateCommand(rateLimitCmdRoot.CmdClause, g, m)
 	resourcelinkCmdRoot := resourcelink.NewRootCommand(app, g)
 	resourcelinkCreate := resourcelink.NewCreateCommand(resourcelinkCmdRoot.CmdClause, g, m)
 	resourcelinkDelete := resourcelink.NewDeleteCommand(resourcelinkCmdRoot.CmdClause, g, m)
@@ -670,6 +677,12 @@ func defineCommands(
 		profileToken,
 		profileUpdate,
 		purgeCmdRoot,
+		rateLimitCmdRoot,
+		rateLimitCreate,
+		rateLimitDelete,
+		rateLimitDescribe,
+		rateLimitList,
+		rateLimitUpdate,
 		resourcelinkCmdRoot,
 		resourcelinkCreate,
 		resourcelinkDelete,

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -77,6 +77,7 @@ object-store-entry
 pops
 profile
 purge
+rate-limit
 resource-link
 secret-store
 secret-store-entry

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -20,7 +20,7 @@ var (
 	// FlagVersionName is the flag name.
 	FlagVersionName = "version"
 	// FlagVersionDesc is the flag description.
-	FlagVersionDesc = "'latest', 'active', or the number of a specific version"
+	FlagVersionDesc = "'latest', 'active', or the number of a specific Fastly service version"
 )
 
 // PaginationDirection is a list of directions the page results can be displayed.

--- a/pkg/commands/ratelimit/create.go
+++ b/pkg/commands/ratelimit/create.go
@@ -1,0 +1,315 @@
+package ratelimit
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fastly/cli/pkg/cmd"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/lookup"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v7/fastly"
+)
+
+// rateLimitActions is a list of supported actions.
+// It is used to construct the API input.
+// It is also used to construct input for the --action enum flag.
+// We build the flag input dynamically so we can avoid hardcoding the values.
+// This is in case the underlying values in go-fastly change between releases.
+var rateLimitActions = []fastly.ERLAction{
+	fastly.ERLActionLogOnly,
+	fastly.ERLActionResponse,
+	fastly.ERLActionResponseObject,
+}
+
+// rateLimitActionFlagOpts is a string representation of rateLimitActions
+// suitable for use within the enum flag definition below.
+var rateLimitActionFlagOpts = func() (actions []string) {
+	for _, a := range rateLimitActions {
+		actions = append(actions, string(a))
+	}
+	return actions
+}()
+
+// rateLimitLoggers is a list of supported logger types.
+// It is used to construct the API input.
+// It is also used to construct input for the --logger-type enum flag.
+// We build the flag input dynamically so we can avoid hardcoding the values.
+// This is in case the underlying values in go-fastly change between releases.
+var rateLimitLoggers = []fastly.ERLLogger{
+	fastly.ERLLogAzureBlob,
+	fastly.ERLLogBigQuery,
+	fastly.ERLLogCloudFiles,
+	fastly.ERLLogDataDog,
+	fastly.ERLLogDigitalOcean,
+	fastly.ERLLogElasticSearch,
+	fastly.ERLLogFtp,
+	fastly.ERLLogGcs,
+	fastly.ERLLogGoogleAnalytics,
+	fastly.ERLLogHeroku,
+	fastly.ERLLogHoneycomb,
+	fastly.ERLLogHTTP,
+	fastly.ERLLogHTTPS,
+	fastly.ERLLogKafta,
+	fastly.ERLLogKinesis,
+	fastly.ERLLogLogEntries,
+	fastly.ERLLogLoggly,
+	fastly.ERLLogLogShuttle,
+	fastly.ERLLogNewRelic,
+	fastly.ERLLogOpenStack,
+	fastly.ERLLogPaperTrail,
+	fastly.ERLLogPubSub,
+	fastly.ERLLogS3,
+	fastly.ERLLogScalyr,
+	fastly.ERLLogSftp,
+	fastly.ERLLogSplunk,
+	fastly.ERLLogStackDriver,
+	fastly.ERLLogSumoLogic,
+	fastly.ERLLogSysLog,
+}
+
+// rateLimitLoggerFlagOpts is a string representation of rateLimitLoggers
+// suitable for use within the enum flag definition below.
+var rateLimitLoggerFlagOpts = func() (loggers []string) {
+	for _, l := range rateLimitLoggers {
+		loggers = append(loggers, string(l))
+	}
+	return loggers
+}()
+
+// rateLimitWindowSizes is a list of supported time window sizes.
+// It is used to construct the API input.
+// It is also used to construct input for the --window-size enum flag.
+// We build the flag input dynamically so we can avoid hardcoding the values.
+// This is in case the underlying values in go-fastly change between releases.
+var rateLimitWindowSizes = []fastly.ERLWindowSize{
+	fastly.ERLSize1,
+	fastly.ERLSize10,
+	fastly.ERLSize60,
+}
+
+// rateLimitWindowSizeFlagOpts is a string representation of rateLimitWindowSizes
+// suitable for use within the enum flag definition below.
+var rateLimitWindowSizeFlagOpts = func() (windowSizes []string) {
+	for _, w := range rateLimitWindowSizes {
+		windowSizes = append(windowSizes, fmt.Sprint(w))
+	}
+	return windowSizes
+}()
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *CreateCommand {
+	c := CreateCommand{
+		Base: cmd.Base{
+			Globals: g,
+		},
+		manifest: m,
+	}
+
+	c.CmdClause = parent.Command("create", "Create a rate limiter for a particular service and version").Alias("add")
+
+	// Required.
+	c.RegisterFlag(cmd.StringFlagOpts{
+		Name:        cmd.FlagVersionName,
+		Description: cmd.FlagVersionDesc,
+		Dst:         &c.serviceVersion.Value,
+		Required:    true,
+	})
+
+	// Optional.
+	c.CmdClause.Flag("action", "The action to take when a rate limiter violation is detected").HintOptions(rateLimitActionFlagOpts...).EnumVar(&c.action, rateLimitActionFlagOpts...)
+	c.RegisterAutoCloneFlag(cmd.AutoCloneFlagOpts{
+		Action: c.autoClone.Set,
+		Dst:    &c.autoClone.Value,
+	})
+	c.CmdClause.Flag("client-key", "Comma-separated list of VCL variable used to generate a counter key to identify a client").StringVar(&c.clientKeys)
+	c.CmdClause.Flag("http-methods", "Comma-separated list of HTTP methods to apply rate limiting to").StringVar(&c.httpMethods)
+	c.RegisterFlagBool(c.JSONFlag()) // --json
+	c.CmdClause.Flag("logger-type", "Name of the type of logging endpoint to be used when action is `log_only`").HintOptions(rateLimitLoggerFlagOpts...).EnumVar(&c.loggerType, rateLimitLoggerFlagOpts...)
+	c.CmdClause.Flag("name", "A human readable name for the rate limiting rule").StringVar(&c.name)
+	c.CmdClause.Flag("penalty-box-dur", "Length of time in minutes that the rate limiter is in effect after the initial violation is detected").IntVar(&c.penaltyDuration)
+	c.CmdClause.Flag("response-content", "HTTP response body data").StringVar(&c.responseContent)
+	c.CmdClause.Flag("response-content-type", "HTTP Content-Type (e.g. application/json)").StringVar(&c.responseContentType)
+	c.CmdClause.Flag("response-status", "HTTP response status code (e.g. 429)").IntVar(&c.responseStatus)
+	c.CmdClause.Flag("rps-limit", "Upper limit of requests per second allowed by the rate limiter").IntVar(&c.rpsLimit)
+	c.RegisterFlag(cmd.StringFlagOpts{
+		Name:        cmd.FlagServiceIDName,
+		Description: cmd.FlagServiceIDDesc,
+		Dst:         &c.manifest.Flag.ServiceID,
+		Short:       's',
+	})
+	c.RegisterFlag(cmd.StringFlagOpts{
+		Action:      c.serviceName.Set,
+		Name:        cmd.FlagServiceName,
+		Description: cmd.FlagServiceDesc,
+		Dst:         &c.serviceName.Value,
+	})
+	c.CmdClause.Flag("window-size", "Number of seconds during which the RPS limit must be exceeded in order to trigger a violation").HintOptions(rateLimitWindowSizeFlagOpts...).EnumVar(&c.windowSize, rateLimitWindowSizeFlagOpts...)
+
+	return &c
+}
+
+// CreateCommand calls the Fastly API to create an appropriate resource.
+type CreateCommand struct {
+	cmd.Base
+	cmd.JSONOutput
+
+	action              string
+	autoClone           cmd.OptionalAutoClone
+	clientKeys          string
+	httpMethods         string
+	loggerType          string
+	manifest            manifest.Data
+	name                string
+	penaltyDuration     int
+	responseContent     string
+	responseContentType string
+	responseStatus      int
+	rpsLimit            int
+	serviceName         cmd.OptionalServiceNameID
+	serviceVersion      cmd.OptionalServiceVersion
+	windowSize          string
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
+	_, s := c.Globals.Token()
+	if s == lookup.SourceUndefined {
+		return fsterr.ErrNoToken
+	}
+
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	if err := c.responseFlagValidator(); err != nil {
+		return fsterr.RemediationError{
+			Inner:       err,
+			Remediation: "When defining a response, all response flags (--response-content, --response-content-type, --response-status) should be set",
+		}
+	}
+
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AutoCloneFlag:      c.autoClone,
+		APIClient:          c.Globals.APIClient,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceNameFlag:    c.serviceName,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flags.Verbose,
+	})
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
+		})
+		return err
+	}
+
+	input := c.constructInput()
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion.Number
+
+	o, err := c.Globals.APIClient.CreateERL(input)
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
+		})
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	text.Success(out, "Created rate limiter '%s' (%s)", o.Name, o.ID)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *CreateCommand) constructInput() *fastly.CreateERLInput {
+	var input fastly.CreateERLInput
+
+	if c.action != "" {
+		for _, a := range rateLimitActions {
+			if c.action == string(a) {
+				input.Action = fastly.ERLActionPtr(a)
+				break
+			}
+		}
+	}
+
+	if c.clientKeys != "" {
+		clientKeys := strings.Split(strings.ReplaceAll(c.clientKeys, " ", ""), ",")
+		input.ClientKey = &clientKeys
+	}
+
+	if c.httpMethods != "" {
+		httpMethods := strings.Split(strings.ReplaceAll(c.httpMethods, " ", ""), ",")
+		input.HTTPMethods = &httpMethods
+	}
+
+	if c.loggerType != "" {
+		for _, l := range rateLimitLoggers {
+			if c.loggerType == string(l) {
+				input.LoggerType = fastly.ERLLoggerPtr(l)
+				break
+			}
+		}
+	}
+
+	if c.name != "" {
+		input.Name = fastly.String(c.name)
+	}
+
+	if c.penaltyDuration > 0 {
+		input.PenaltyBoxDuration = fastly.Int(c.penaltyDuration)
+	}
+
+	if c.responseContent != "" && c.responseContentType != "" && c.responseStatus > 0 {
+		input.Response = &fastly.ERLResponseType{
+			ERLContent:     c.responseContent,
+			ERLContentType: c.responseContentType,
+			ERLStatus:      c.responseStatus,
+		}
+	}
+
+	if c.rpsLimit > 0 {
+		input.RpsLimit = fastly.Int(c.rpsLimit)
+	}
+
+	if c.windowSize != "" {
+		for _, w := range rateLimitWindowSizes {
+			if c.windowSize == fmt.Sprint(w) {
+				input.WindowSize = fastly.ERLWindowSizePtr(w)
+				break
+			}
+		}
+	}
+
+	return &input
+}
+
+// responseFlagValidator ensures if a user specifies one of the response flags,
+// that they must specify ALL of the response flags.
+func (c *CreateCommand) responseFlagValidator() error {
+	var state int
+	if c.responseContent != "" {
+		state++
+	}
+	if c.responseContentType != "" {
+		state++
+	}
+	if c.responseStatus > 0 {
+		state++
+	}
+	if state > 0 && state < 3 {
+		return errors.New("invalid flag use")
+	}
+	return nil
+}

--- a/pkg/commands/ratelimit/delete.go
+++ b/pkg/commands/ratelimit/delete.go
@@ -1,0 +1,64 @@
+package ratelimit
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/lookup"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v7/fastly"
+)
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent cmd.Registerer, globals *global.Data, m manifest.Data) *DeleteCommand {
+	var c DeleteCommand
+	c.CmdClause = parent.Command("delete", "Delete a rate limiter by its ID").Alias("remove")
+	c.Globals = globals
+	c.manifest = m
+
+	// Required.
+	c.CmdClause.Flag("id", "Alphanumeric string identifying the rate limiter").Required().StringVar(&c.id)
+
+	return &c
+}
+
+// DeleteCommand calls the Fastly API to delete an appropriate resource.
+type DeleteCommand struct {
+	cmd.Base
+
+	id       string
+	manifest manifest.Data
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
+	_, s := c.Globals.Token()
+	if s == lookup.SourceUndefined {
+		return errors.ErrNoToken
+	}
+
+	input := c.constructInput()
+
+	err := c.Globals.APIClient.DeleteERL(input)
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"User ID": c.id,
+		})
+		return err
+	}
+
+	text.Success(out, "Deleted rate limter '%s'", c.id)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DeleteCommand) constructInput() *fastly.DeleteERLInput {
+	var input fastly.DeleteERLInput
+
+	input.ERLID = c.id
+
+	return &input
+}

--- a/pkg/commands/ratelimit/describe.go
+++ b/pkg/commands/ratelimit/describe.go
@@ -1,0 +1,106 @@
+package ratelimit
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/lookup"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/go-fastly/v7/fastly"
+)
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *DescribeCommand {
+	var c DescribeCommand
+	c.CmdClause = parent.Command("describe", "Get a rate limiter by its ID").Alias("get")
+	c.Globals = g
+	c.manifest = m
+
+	// Required.
+	c.CmdClause.Flag("id", "Alphanumeric string identifying the rate limiter").Required().StringVar(&c.id)
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag()) // --json
+
+	return &c
+}
+
+// DescribeCommand calls the Fastly API to describe an appropriate resource.
+type DescribeCommand struct {
+	cmd.Base
+	cmd.JSONOutput
+
+	id       string
+	manifest manifest.Data
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
+	_, s := c.Globals.Token()
+	if s == lookup.SourceUndefined {
+		return fsterr.ErrNoToken
+	}
+
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	input, err := c.constructInput()
+	if err != nil {
+		return err
+	}
+
+	o, err := c.Globals.APIClient.GetERL(input)
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	c.print(out, o)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DescribeCommand) constructInput() (*fastly.GetERLInput, error) {
+	var input fastly.GetERLInput
+
+	input.ERLID = c.id
+
+	return &input, nil
+}
+
+// print displays the information returned from the API.
+func (c *DescribeCommand) print(out io.Writer, o *fastly.ERL) {
+	fmt.Fprintf(out, "\nAction: %+v\n", o.Action)
+	fmt.Fprintf(out, "Client Key: %+v\n", o.ClientKey)
+	fmt.Fprintf(out, "Feature Revision: %+v\n", o.FeatureRevision)
+	fmt.Fprintf(out, "HTTP Methods: %+v\n", o.HTTPMethods)
+	fmt.Fprintf(out, "ID: %+v\n", o.ID)
+	fmt.Fprintf(out, "Logger Type: %+v\n", o.LoggerType)
+	fmt.Fprintf(out, "Name: %+v\n", o.Name)
+	fmt.Fprintf(out, "Penalty Box Duration: %+v\n", o.PenaltyBoxDuration)
+	fmt.Fprintf(out, "Response: %+v\n", o.Response)
+	fmt.Fprintf(out, "Response Object Name: %+v\n", o.ResponseObjectName)
+	fmt.Fprintf(out, "RPS Limit: %+v\n", o.RpsLimit)
+	fmt.Fprintf(out, "Service ID: %+v\n", o.ServiceID)
+	fmt.Fprintf(out, "URI Dictionary Name: %+v\n", o.URIDictionaryName)
+	fmt.Fprintf(out, "Version: %+v\n", o.Version)
+	fmt.Fprintf(out, "WindowSize: %+v\n", o.WindowSize)
+
+	if o.CreatedAt != nil {
+		fmt.Fprintf(out, "Created at: %s\n", o.CreatedAt)
+	}
+	if o.UpdatedAt != nil {
+		fmt.Fprintf(out, "Updated at: %s\n", o.UpdatedAt)
+	}
+	if o.DeletedAt != nil {
+		fmt.Fprintf(out, "Deleted at: %s\n", o.DeletedAt)
+	}
+}

--- a/pkg/commands/ratelimit/doc.go
+++ b/pkg/commands/ratelimit/doc.go
@@ -1,0 +1,3 @@
+// Package ratelimit contains commands to inspect and manipulate Fastly edge
+// rate limiters.
+package ratelimit

--- a/pkg/commands/ratelimit/list.go
+++ b/pkg/commands/ratelimit/list.go
@@ -1,0 +1,153 @@
+package ratelimit
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/lookup"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v7/fastly"
+)
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *ListCommand {
+	var c ListCommand
+	c.CmdClause = parent.Command("list", "List all rate limiters for a particular service and version")
+	c.Globals = g
+	c.manifest = m
+
+	// Required.
+	c.RegisterFlag(cmd.StringFlagOpts{
+		Name:        cmd.FlagVersionName,
+		Description: cmd.FlagVersionDesc,
+		Dst:         &c.serviceVersion.Value,
+		Required:    true,
+	})
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag()) // --json
+	c.RegisterFlag(cmd.StringFlagOpts{
+		Name:        cmd.FlagServiceIDName,
+		Description: cmd.FlagServiceIDDesc,
+		Dst:         &c.manifest.Flag.ServiceID,
+		Short:       's',
+	})
+	c.RegisterFlag(cmd.StringFlagOpts{
+		Action:      c.serviceName.Set,
+		Name:        cmd.FlagServiceName,
+		Description: cmd.FlagServiceDesc,
+		Dst:         &c.serviceName.Value,
+	})
+	return &c
+}
+
+// ListCommand calls the Fastly API to list appropriate resources.
+type ListCommand struct {
+	cmd.Base
+	cmd.JSONOutput
+
+	manifest       manifest.Data
+	serviceName    cmd.OptionalServiceNameID
+	serviceVersion cmd.OptionalServiceVersion
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
+	_, s := c.Globals.Token()
+	if s == lookup.SourceUndefined {
+		return fsterr.ErrNoToken
+	}
+
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	serviceID, serviceVersion, err := cmd.ServiceDetails(cmd.ServiceDetailsOpts{
+		AllowActiveLocked:  true,
+		APIClient:          c.Globals.APIClient,
+		Manifest:           c.manifest,
+		Out:                out,
+		ServiceNameFlag:    c.serviceName,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flags.Verbose,
+	})
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
+		})
+		return err
+	}
+
+	input := &fastly.ListERLsInput{
+		ServiceID:      serviceID,
+		ServiceVersion: serviceVersion.Number,
+	}
+
+	o, err := c.Globals.APIClient.ListERLs(input)
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": serviceVersion,
+		})
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	if c.Globals.Verbose() {
+		c.printVerbose(out, o)
+	} else {
+		c.printSummary(out, o)
+	}
+	return nil
+}
+
+// printVerbose displays the information returned from the API in a verbose
+// format.
+func (c *ListCommand) printVerbose(out io.Writer, o []*fastly.ERL) {
+	for _, u := range o {
+		fmt.Fprintf(out, "\nAction: %+v\n", u.Action)
+		fmt.Fprintf(out, "Client Key: %+v\n", u.ClientKey)
+		fmt.Fprintf(out, "Feature Revision: %+v\n", u.FeatureRevision)
+		fmt.Fprintf(out, "HTTP Methods: %+v\n", u.HTTPMethods)
+		fmt.Fprintf(out, "ID: %+v\n", u.ID)
+		fmt.Fprintf(out, "Logger Type: %+v\n", u.LoggerType)
+		fmt.Fprintf(out, "Name: %+v\n", u.Name)
+		fmt.Fprintf(out, "Penalty Box Duration: %+v\n", u.PenaltyBoxDuration)
+		fmt.Fprintf(out, "Response: %+v\n", u.Response)
+		fmt.Fprintf(out, "Response Object Name: %+v\n", u.ResponseObjectName)
+		fmt.Fprintf(out, "RPS Limit: %+v\n", u.RpsLimit)
+		fmt.Fprintf(out, "Service ID: %+v\n", u.ServiceID)
+		fmt.Fprintf(out, "URI Dictionary Name: %+v\n", u.URIDictionaryName)
+		fmt.Fprintf(out, "Version: %+v\n", u.Version)
+		fmt.Fprintf(out, "WindowSize: %+v\n", u.WindowSize)
+
+		if u.CreatedAt != nil {
+			fmt.Fprintf(out, "Created at: %s\n", u.CreatedAt)
+		}
+		if u.UpdatedAt != nil {
+			fmt.Fprintf(out, "Updated at: %s\n", u.UpdatedAt)
+		}
+		if u.DeletedAt != nil {
+			fmt.Fprintf(out, "Deleted at: %s\n", u.DeletedAt)
+		}
+	}
+}
+
+// printSummary displays the information returned from the API in a summarised
+// format.
+func (c *ListCommand) printSummary(out io.Writer, o []*fastly.ERL) {
+	t := text.NewTable(out)
+	t.AddHeader("ID", "NAME", "ACTION", "RPS LIMIT", "WINDOW SIZE", "PENALTY BOX DURATION")
+	for _, u := range o {
+		t.AddLine(u.ID, u.Name, u.Action, u.RpsLimit, u.WindowSize, u.PenaltyBoxDuration)
+	}
+	t.Print()
+}

--- a/pkg/commands/ratelimit/ratelimit_test.go
+++ b/pkg/commands/ratelimit/ratelimit_test.go
@@ -1,0 +1,227 @@
+package ratelimit_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v7/fastly"
+)
+
+func TestCreate(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name: "validate CreateERL API error",
+			API: mock.API{
+				CreateERLFn: func(i *fastly.CreateERLInput) (*fastly.ERL, error) {
+					return nil, testutil.Err
+				},
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("rate-limit create --name example --service-id 123 --token abc --version 3"),
+			WantError: testutil.Err.Error(),
+		},
+		{
+			Name: "validate CreateERL API success",
+			API: mock.API{
+				CreateERLFn: func(i *fastly.CreateERLInput) (*fastly.ERL, error) {
+					return &fastly.ERL{
+						Name: *i.Name,
+						ID:   "123",
+					}, nil
+				},
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:       args("rate-limit create --name example --service-id 123 --token abc --version 3"),
+			WantOutput: "Created rate limiter 'example' (123)",
+		},
+	}
+
+	for testcaseIdx := range scenarios {
+		testcase := &scenarios[testcaseIdx]
+		t.Run(testcase.Name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			opts := testutil.NewRunOpts(testcase.Args, &stdout)
+			opts.APIClient = mock.APIClient(testcase.API)
+			err := app.Run(opts)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name: "validate DeleteERL API error",
+			API: mock.API{
+				DeleteERLFn: func(i *fastly.DeleteERLInput) error {
+					return testutil.Err
+				},
+			},
+			Args:      args("rate-limit delete --id 123 --token abc"),
+			WantError: testutil.Err.Error(),
+		},
+		{
+			Name: "validate DeleteERL API success",
+			API: mock.API{
+				DeleteERLFn: func(i *fastly.DeleteERLInput) error {
+					return nil
+				},
+			},
+			Args:       args("rate-limit delete --id 123 --token abc"),
+			WantOutput: "\nSUCCESS: Deleted rate limter '123'\n",
+		},
+	}
+
+	for testcaseIdx := range scenarios {
+		testcase := &scenarios[testcaseIdx]
+		t.Run(testcase.Name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			opts := testutil.NewRunOpts(testcase.Args, &stdout)
+			opts.APIClient = mock.APIClient(testcase.API)
+			err := app.Run(opts)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name: "validate GetERL API error",
+			API: mock.API{
+				GetERLFn: func(i *fastly.GetERLInput) (*fastly.ERL, error) {
+					return nil, testutil.Err
+				},
+			},
+			Args:      args("rate-limit describe --id 123 --token abc"),
+			WantError: testutil.Err.Error(),
+		},
+		{
+			Name: "validate ListERL API success",
+			API: mock.API{
+				GetERLFn: func(i *fastly.GetERLInput) (*fastly.ERL, error) {
+					return &fastly.ERL{
+						ID:                 "123",
+						Name:               "example",
+						Action:             fastly.ERLActionResponse,
+						RpsLimit:           10,
+						WindowSize:         fastly.ERLSize60,
+						PenaltyBoxDuration: 20,
+					}, nil
+				},
+			},
+			Args:       args("rate-limit describe --id 123 --token abc"),
+			WantOutput: "\nAction: response\nClient Key: []\nFeature Revision: 0\nHTTP Methods: []\nID: 123\nLogger Type: \nName: example\nPenalty Box Duration: 20\nResponse: <nil>\nResponse Object Name: \nRPS Limit: 10\nService ID: \nURI Dictionary Name: \nVersion: 0\nWindowSize: 60\n",
+		},
+	}
+
+	for testcaseIdx := range scenarios {
+		testcase := &scenarios[testcaseIdx]
+		t.Run(testcase.Name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			opts := testutil.NewRunOpts(testcase.Args, &stdout)
+			opts.APIClient = mock.APIClient(testcase.API)
+			err := app.Run(opts)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name: "validate ListERL API error",
+			API: mock.API{
+				ListERLsFn: func(i *fastly.ListERLsInput) ([]*fastly.ERL, error) {
+					return nil, testutil.Err
+				},
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:      args("rate-limit list --service-id 123 --token abc --version 3"),
+			WantError: testutil.Err.Error(),
+		},
+		{
+			Name: "validate ListERL API success",
+			API: mock.API{
+				ListERLsFn: func(i *fastly.ListERLsInput) ([]*fastly.ERL, error) {
+					return []*fastly.ERL{
+						{
+							ID:                 "123",
+							Name:               "example",
+							Action:             fastly.ERLActionResponse,
+							RpsLimit:           10,
+							WindowSize:         fastly.ERLSize60,
+							PenaltyBoxDuration: 20,
+						},
+					}, nil
+				},
+				ListVersionsFn: testutil.ListVersions,
+			},
+			Args:       args("rate-limit list --service-id 123 --token abc --version 3"),
+			WantOutput: "ID   NAME     ACTION    RPS LIMIT  WINDOW SIZE  PENALTY BOX DURATION\n123  example  response  10         60           20\n",
+		},
+	}
+
+	for testcaseIdx := range scenarios {
+		testcase := &scenarios[testcaseIdx]
+		t.Run(testcase.Name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			opts := testutil.NewRunOpts(testcase.Args, &stdout)
+			opts.APIClient = mock.APIClient(testcase.API)
+			err := app.Run(opts)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	args := testutil.Args
+	scenarios := []testutil.TestScenario{
+		{
+			Name: "validate UpdateERL API error",
+			API: mock.API{
+				UpdateERLFn: func(i *fastly.UpdateERLInput) (*fastly.ERL, error) {
+					return nil, testutil.Err
+				},
+			},
+			Args:      args("rate-limit update --id 123 --name example --token abc"),
+			WantError: testutil.Err.Error(),
+		},
+		{
+			Name: "validate UpdateERL API success",
+			API: mock.API{
+				UpdateERLFn: func(i *fastly.UpdateERLInput) (*fastly.ERL, error) {
+					return &fastly.ERL{
+						Name: *i.Name,
+						ID:   "123",
+					}, nil
+				},
+			},
+			Args:       args("rate-limit update --id 123 --name example --token abc"),
+			WantOutput: "Updated rate limiter 'example' (123)",
+		},
+	}
+
+	for testcaseIdx := range scenarios {
+		testcase := &scenarios[testcaseIdx]
+		t.Run(testcase.Name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			opts := testutil.NewRunOpts(testcase.Args, &stdout)
+			opts.APIClient = mock.APIClient(testcase.API)
+			err := app.Run(opts)
+			testutil.AssertErrorContains(t, err, testcase.WantError)
+			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
+		})
+	}
+}

--- a/pkg/commands/ratelimit/root.go
+++ b/pkg/commands/ratelimit/root.go
@@ -1,0 +1,28 @@
+package ratelimit
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/global"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	cmd.Base
+	// no flags
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent cmd.Registerer, g *global.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = g
+	c.CmdClause = parent.Command("rate-limit", "Manipulate rate-limiters of the Fastly API and web interface")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(_ io.Reader, _ io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/commands/ratelimit/update.go
+++ b/pkg/commands/ratelimit/update.go
@@ -1,0 +1,188 @@
+package ratelimit
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fastly/cli/pkg/cmd"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/lookup"
+	"github.com/fastly/cli/pkg/manifest"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v7/fastly"
+)
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *UpdateCommand {
+	c := UpdateCommand{
+		Base: cmd.Base{
+			Globals: g,
+		},
+		manifest: m,
+	}
+
+	c.CmdClause = parent.Command("update", "Update a rate limiter by its ID")
+
+	// Required.
+	c.CmdClause.Flag("id", "Alphanumeric string identifying the rate limiter").Required().StringVar(&c.id)
+
+	// Optional.
+	c.CmdClause.Flag("action", "The action to take when a rate limiter violation is detected").HintOptions(rateLimitActionFlagOpts...).EnumVar(&c.action, rateLimitActionFlagOpts...)
+	c.CmdClause.Flag("client-key", "Comma-separated list of VCL variable used to generate a counter key to identify a client").StringVar(&c.clientKeys)
+	c.CmdClause.Flag("http-methods", "Comma-separated list of HTTP methods to apply rate limiting to").StringVar(&c.httpMethods)
+	c.RegisterFlagBool(c.JSONFlag()) // --json
+	c.CmdClause.Flag("logger-type", "Name of the type of logging endpoint to be used when action is `log_only`").HintOptions(rateLimitLoggerFlagOpts...).EnumVar(&c.loggerType, rateLimitLoggerFlagOpts...)
+	c.CmdClause.Flag("name", "A human readable name for the rate limiting rule").StringVar(&c.name)
+	c.CmdClause.Flag("penalty-box-dur", "Length of time in minutes that the rate limiter is in effect after the initial violation is detected").IntVar(&c.penaltyDuration)
+	c.CmdClause.Flag("response-content", "HTTP response body data").StringVar(&c.responseContent)
+	c.CmdClause.Flag("response-content-type", "HTTP Content-Type (e.g. application/json)").StringVar(&c.responseContentType)
+	c.CmdClause.Flag("response-status", "HTTP response status code (e.g. 429)").IntVar(&c.responseStatus)
+	c.CmdClause.Flag("rps-limit", "Upper limit of requests per second allowed by the rate limiter").IntVar(&c.rpsLimit)
+	c.CmdClause.Flag("window-size", "Number of seconds during which the RPS limit must be exceeded in order to trigger a violation").HintOptions(rateLimitWindowSizeFlagOpts...).EnumVar(&c.windowSize, rateLimitWindowSizeFlagOpts...)
+
+	return &c
+}
+
+// UpdateCommand calls the Fastly API to create an appropriate resource.
+type UpdateCommand struct {
+	cmd.Base
+	cmd.JSONOutput
+
+	action              string
+	clientKeys          string
+	httpMethods         string
+	id                  string
+	loggerType          string
+	manifest            manifest.Data
+	name                string
+	penaltyDuration     int
+	responseContent     string
+	responseContentType string
+	responseStatus      int
+	rpsLimit            int
+	windowSize          string
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
+	_, s := c.Globals.Token()
+	if s == lookup.SourceUndefined {
+		return fsterr.ErrNoToken
+	}
+
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	if err := c.responseFlagValidator(); err != nil {
+		return fsterr.RemediationError{
+			Inner:       err,
+			Remediation: "When updating a response, all response flags (--response-content, --response-content-type, --response-status) should be set",
+		}
+	}
+
+	input := c.constructInput()
+
+	o, err := c.Globals.APIClient.UpdateERL(input)
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	text.Success(out, "Updated rate limiter '%s' (%s)", o.Name, o.ID)
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *UpdateCommand) constructInput() *fastly.UpdateERLInput {
+	var input fastly.UpdateERLInput
+	input.ERLID = c.id
+
+	// NOTE: rateLimitActions is defined in ./create.go
+	if c.action != "" {
+		for _, a := range rateLimitActions {
+			if c.action == string(a) {
+				input.Action = fastly.ERLActionPtr(a)
+				break
+			}
+		}
+	}
+
+	if c.clientKeys != "" {
+		clientKeys := strings.Split(strings.ReplaceAll(c.clientKeys, " ", ""), ",")
+		input.ClientKey = &clientKeys
+	}
+
+	if c.httpMethods != "" {
+		httpMethods := strings.Split(strings.ReplaceAll(c.httpMethods, " ", ""), ",")
+		input.HTTPMethods = &httpMethods
+	}
+
+	// NOTE: rateLimitLoggers is defined in ./create.go
+	if c.loggerType != "" {
+		for _, l := range rateLimitLoggers {
+			if c.loggerType == string(l) {
+				input.LoggerType = fastly.ERLLoggerPtr(l)
+				break
+			}
+		}
+	}
+
+	if c.name != "" {
+		input.Name = fastly.String(c.name)
+	}
+
+	if c.penaltyDuration > 0 {
+		input.PenaltyBoxDuration = fastly.Int(c.penaltyDuration)
+	}
+
+	if c.responseContent != "" && c.responseContentType != "" && c.responseStatus > 0 {
+		input.Response = &fastly.ERLResponseType{
+			ERLContent:     c.responseContent,
+			ERLContentType: c.responseContentType,
+			ERLStatus:      c.responseStatus,
+		}
+	}
+
+	if c.rpsLimit > 0 {
+		input.RpsLimit = fastly.Int(c.rpsLimit)
+	}
+
+	// NOTE: rateLimitWindowSizes is defined in ./create.go
+	if c.windowSize != "" {
+		for _, w := range rateLimitWindowSizes {
+			if c.windowSize == fmt.Sprint(w) {
+				input.WindowSize = fastly.ERLWindowSizePtr(w)
+				break
+			}
+		}
+	}
+
+	return &input
+}
+
+// responseFlagValidator ensures if a user specifies one of the response flags,
+// that they must specify ALL of the response flags.
+func (c *UpdateCommand) responseFlagValidator() error {
+	var state int
+	if c.responseContent != "" {
+		state++
+	}
+	if c.responseContentType != "" {
+		state++
+	}
+	if c.responseStatus > 0 {
+		state++
+	}
+	if state > 0 && state < 3 {
+		return errors.New("invalid flag use")
+	}
+	return nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -360,6 +360,12 @@ type API struct {
 	GetResourceFn    func(i *fastly.GetResourceInput) (*fastly.Resource, error)
 	ListResourcesFn  func(i *fastly.ListResourcesInput) ([]*fastly.Resource, error)
 	UpdateResourceFn func(i *fastly.UpdateResourceInput) (*fastly.Resource, error)
+
+	CreateERLFn func(i *fastly.CreateERLInput) (*fastly.ERL, error)
+	DeleteERLFn func(i *fastly.DeleteERLInput) error
+	GetERLFn    func(i *fastly.GetERLInput) (*fastly.ERL, error)
+	ListERLsFn  func(i *fastly.ListERLsInput) ([]*fastly.ERL, error)
+	UpdateERLFn func(i *fastly.UpdateERLInput) (*fastly.ERL, error)
 }
 
 // AllDatacenters implements Interface.
@@ -1825,4 +1831,29 @@ func (m API) ListResources(i *fastly.ListResourcesInput) ([]*fastly.Resource, er
 // UpdateResource implements Interface.
 func (m API) UpdateResource(i *fastly.UpdateResourceInput) (*fastly.Resource, error) {
 	return m.UpdateResourceFn(i)
+}
+
+// CreateERL implements Interface.
+func (m API) CreateERL(i *fastly.CreateERLInput) (*fastly.ERL, error) {
+	return m.CreateERLFn(i)
+}
+
+// DeleteERL implements Interface.
+func (m API) DeleteERL(i *fastly.DeleteERLInput) error {
+	return m.DeleteERLFn(i)
+}
+
+// GetERL implements Interface.
+func (m API) GetERL(i *fastly.GetERLInput) (*fastly.ERL, error) {
+	return m.GetERLFn(i)
+}
+
+// ListERLs implements Interface.
+func (m API) ListERLs(i *fastly.ListERLsInput) ([]*fastly.ERL, error) {
+	return m.ListERLsFn(i)
+}
+
+// UpdateERL implements Interface.
+func (m API) UpdateERL(i *fastly.UpdateERLInput) (*fastly.ERL, error) {
+	return m.UpdateERLFn(i)
 }


### PR DESCRIPTION
## Create

```shell
$ fastly rate-limit create \
  --action response \
  --client-key "req.http.Fastly-Client-IP, req.http.User-Agent" \
  --http-methods "post, put, patch, delete" \
  --name <RATE_LIMITER_NAME> \
  --penalty-box-dur 30 \
  --response-content '{"reason": "Too many requests"}' \
  --response-content-type application/json \
  --response-status 429 \
  --rps-limit 10000 \
  --service-id <SERVICE_ID> \
  --version 1 \
  --window-size 10

SUCCESS: Created rate limiter '<RATE_LIMITER_NAME>' (<RATE_LIMITER_ID>)
```

## Update

```shell
fastly rate-limit update \
  --action response \
  --client-key "req.http.Fastly-Client-IP, req.http.User-Agent" \
  --id <RATE_LIMITER_ID> \
  --http-methods "post, put, patch, delete" \
  --name <RATE_LIMITER_NAME> \
  --penalty-box-dur 30 \
  --response-content '{"reason": "Too many requests"}' \
  --response-content-type application/json \
  --response-status 429 \
  --rps-limit 10000 \
  --window-size 10

SUCCESS: Updated rate limiter '<RATE_LIMITER_NAME>' (<RATE_LIMITER_ID>)

fastly rate-limit update \
  --id <RATE_LIMITER_ID> \
  --name new-name-here

SUCCESS: Updated rate limiter '<RATE_LIMITER_NAME>' (<RATE_LIMITER_ID>)
```

## List

```shell
fastly rate-limit list --version 1 --service-id <SERVICE_ID>
```

## Describe

```shell
fastly rate-limit describe --id <RATE_LIMITER_ID>
```

## Delete

```shell
fastly rate-limit delete --id <RATE_LIMITER_ID>
```