### PR TITLE
fix(toolchain): bump go version to align with updated tinygo constraint

### DIFF
--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -6,7 +6,7 @@ api_endpoint = "https://api.fastly.com"
 [language]
 [language.go]
 tinygo_constraint = ">= 0.26.0-0" # NOTE -0 indicates to the CLI's semver package that we accept pre-releases (TinyGo users commonly use pre-releases).
-toolchain_constraint = ">= 1.17"
+toolchain_constraint = ">= 1.18"
 
 [language.rust]
 toolchain_constraint = ">= 1.56.1"


### PR DESCRIPTION
In https://github.com/fastly/cli/pull/888 we bumped the `tinygo` constraint but we needed to also bump `go` version too.