### PR TITLE
breaking(objectstore): rename `object-store` command to `kv-store`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v7 v7.5.5
+	github.com/fastly/go-fastly/v8 v8.0.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/otiai10/copy v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:90Ly+6UfUypEF6vvvW5rQIv9opIL8CbmW9FT20LDQoY=
 github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
-github.com/fastly/go-fastly/v7 v7.5.5 h1:M3ePbU6a8BTPZzjaPoU4+O+pQspiBalF5HgVNomHlJI=
-github.com/fastly/go-fastly/v7 v7.5.5/go.mod h1:/Z2GD7NuxV3vVMAyrtckg1WvZVnCuM2Z8ok/z70XTEQ=
+github.com/fastly/go-fastly/v8 v8.0.0 h1:c5y4Cuga1iffDJ75Y4p89EXr9aar9pDRvODiTX+wLlg=
+github.com/fastly/go-fastly/v8 v8.0.0/go.mod h1:m/QWKyZsuH8Ow3tDkRLqlbvbJdxalRGkTT3ZKxZJ4eo=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -4,7 +4,7 @@ import (
 	"crypto/ed25519"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // HTTPClient models a concrete http.Client. It's a consumer contract for some

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -343,14 +343,14 @@ type Interface interface {
 	ListConfigStoreItems(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error)
 	UpdateConfigStoreItem(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
 
-	CreateObjectStore(i *fastly.CreateObjectStoreInput) (*fastly.ObjectStore, error)
-	ListObjectStores(i *fastly.ListObjectStoresInput) (*fastly.ListObjectStoresResponse, error)
-	DeleteObjectStore(i *fastly.DeleteObjectStoreInput) error
-	GetObjectStore(i *fastly.GetObjectStoreInput) (*fastly.ObjectStore, error)
-	ListObjectStoreKeys(i *fastly.ListObjectStoreKeysInput) (*fastly.ListObjectStoreKeysResponse, error)
-	GetObjectStoreKey(i *fastly.GetObjectStoreKeyInput) (string, error)
-	DeleteObjectStoreKey(i *fastly.DeleteObjectStoreKeyInput) error
-	InsertObjectStoreKey(i *fastly.InsertObjectStoreKeyInput) error
+	CreateKVStore(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error)
+	ListKVStores(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error)
+	DeleteKVStore(i *fastly.DeleteKVStoreInput) error
+	GetKVStore(i *fastly.GetKVStoreInput) (*fastly.KVStore, error)
+	ListKVStoreKeys(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error)
+	GetKVStoreKey(i *fastly.GetKVStoreKeyInput) (string, error)
+	DeleteKVStoreKey(i *fastly.DeleteKVStoreKeyInput) error
+	InsertKVStoreKey(i *fastly.InsertKVStoreKeyInput) error
 
 	CreateSecretStore(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error)
 	GetSecretStore(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error)

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/healthcheck"
 	"github.com/fastly/cli/pkg/commands/ip"
 	kvstore "github.com/fastly/cli/pkg/commands/kvstore"
+	"github.com/fastly/cli/pkg/commands/kvstoreentry"
 	"github.com/fastly/cli/pkg/commands/logging"
 	"github.com/fastly/cli/pkg/commands/logging/azureblob"
 	"github.com/fastly/cli/pkg/commands/logging/bigquery"

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/domain"
 	"github.com/fastly/cli/pkg/commands/healthcheck"
 	"github.com/fastly/cli/pkg/commands/ip"
-	kvstore "github.com/fastly/cli/pkg/commands/kvstore"
+	"github.com/fastly/cli/pkg/commands/kvstore"
 	"github.com/fastly/cli/pkg/commands/kvstoreentry"
 	"github.com/fastly/cli/pkg/commands/logging"
 	"github.com/fastly/cli/pkg/commands/logging/azureblob"

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/domain"
 	"github.com/fastly/cli/pkg/commands/healthcheck"
 	"github.com/fastly/cli/pkg/commands/ip"
+	kvstore "github.com/fastly/cli/pkg/commands/kvstore"
 	"github.com/fastly/cli/pkg/commands/logging"
 	"github.com/fastly/cli/pkg/commands/logging/azureblob"
 	"github.com/fastly/cli/pkg/commands/logging/bigquery"
@@ -42,8 +43,6 @@ import (
 	"github.com/fastly/cli/pkg/commands/logging/sumologic"
 	"github.com/fastly/cli/pkg/commands/logging/syslog"
 	"github.com/fastly/cli/pkg/commands/logtail"
-	"github.com/fastly/cli/pkg/commands/objectstore"
-	"github.com/fastly/cli/pkg/commands/objectstoreentry"
 	"github.com/fastly/cli/pkg/commands/pop"
 	"github.com/fastly/cli/pkg/commands/profile"
 	"github.com/fastly/cli/pkg/commands/purge"
@@ -309,16 +308,16 @@ func defineCommands(
 	loggingSyslogDescribe := syslog.NewDescribeCommand(loggingSyslogCmdRoot.CmdClause, g, m)
 	loggingSyslogList := syslog.NewListCommand(loggingSyslogCmdRoot.CmdClause, g, m)
 	loggingSyslogUpdate := syslog.NewUpdateCommand(loggingSyslogCmdRoot.CmdClause, g, m)
-	objectstoreCmdRoot := objectstore.NewRootCommand(app, g)
-	objectstoreCreate := objectstore.NewCreateCommand(objectstoreCmdRoot.CmdClause, g, m)
-	objectstoreDelete := objectstore.NewDeleteCommand(objectstoreCmdRoot.CmdClause, g, m)
-	objectstoreDescribe := objectstore.NewDescribeCommand(objectstoreCmdRoot.CmdClause, g, m)
-	objectstoreList := objectstore.NewListCommand(objectstoreCmdRoot.CmdClause, g, m)
-	objectstoreentryCmdRoot := objectstoreentry.NewRootCommand(app, g)
-	objectstoreentryCreate := objectstoreentry.NewCreateCommand(objectstoreentryCmdRoot.CmdClause, g, m)
-	objectstoreentryDelete := objectstoreentry.NewDeleteCommand(objectstoreentryCmdRoot.CmdClause, g, m)
-	objectstoreentryDescribe := objectstoreentry.NewDescribeCommand(objectstoreentryCmdRoot.CmdClause, g, m)
-	objectstoreentryList := objectstoreentry.NewListCommand(objectstoreentryCmdRoot.CmdClause, g, m)
+	kvstoreCmdRoot := kvstore.NewRootCommand(app, g)
+	kvstoreCreate := kvstore.NewCreateCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreDelete := kvstore.NewDeleteCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreDescribe := kvstore.NewDescribeCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreList := kvstore.NewListCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreentryCmdRoot := kvstoreentry.NewRootCommand(app, g)
+	kvstoreentryCreate := kvstoreentry.NewCreateCommand(kvstoreentryCmdRoot.CmdClause, g, m)
+	kvstoreentryDelete := kvstoreentry.NewDeleteCommand(kvstoreentryCmdRoot.CmdClause, g, m)
+	kvstoreentryDescribe := kvstoreentry.NewDescribeCommand(kvstoreentryCmdRoot.CmdClause, g, m)
+	kvstoreentryList := kvstoreentry.NewListCommand(kvstoreentryCmdRoot.CmdClause, g, m)
 	popCmdRoot := pop.NewRootCommand(app, g)
 	profileCmdRoot := profile.NewRootCommand(app, g)
 	profileCreate := profile.NewCreateCommand(profileCmdRoot.CmdClause, profile.APIClientFactory(opts.APIClient), g)
@@ -660,14 +659,14 @@ func defineCommands(
 		loggingSyslogDescribe,
 		loggingSyslogList,
 		loggingSyslogUpdate,
-		objectstoreCreate,
-		objectstoreDelete,
-		objectstoreDescribe,
-		objectstoreList,
-		objectstoreentryCreate,
-		objectstoreentryDelete,
-		objectstoreentryDescribe,
-		objectstoreentryList,
+		kvstoreCreate,
+		kvstoreDelete,
+		kvstoreDescribe,
+		kvstoreList,
+		kvstoreentryCreate,
+		kvstoreentryDelete,
+		kvstoreentryDescribe,
+		kvstoreentryList,
 		popCmdRoot,
 		profileCmdRoot,
 		profileCreate,

--- a/pkg/app/commands.go
+++ b/pkg/app/commands.go
@@ -157,6 +157,16 @@ func defineCommands(
 	healthcheckList := healthcheck.NewListCommand(healthcheckCmdRoot.CmdClause, g, m)
 	healthcheckUpdate := healthcheck.NewUpdateCommand(healthcheckCmdRoot.CmdClause, g, m)
 	ipCmdRoot := ip.NewRootCommand(app, g)
+	kvstoreCmdRoot := kvstore.NewRootCommand(app, g)
+	kvstoreCreate := kvstore.NewCreateCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreDelete := kvstore.NewDeleteCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreDescribe := kvstore.NewDescribeCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreList := kvstore.NewListCommand(kvstoreCmdRoot.CmdClause, g, m)
+	kvstoreentryCmdRoot := kvstoreentry.NewRootCommand(app, g)
+	kvstoreentryCreate := kvstoreentry.NewCreateCommand(kvstoreentryCmdRoot.CmdClause, g, m)
+	kvstoreentryDelete := kvstoreentry.NewDeleteCommand(kvstoreentryCmdRoot.CmdClause, g, m)
+	kvstoreentryDescribe := kvstoreentry.NewDescribeCommand(kvstoreentryCmdRoot.CmdClause, g, m)
+	kvstoreentryList := kvstoreentry.NewListCommand(kvstoreentryCmdRoot.CmdClause, g, m)
 	logtailCmdRoot := logtail.NewRootCommand(app, g, m)
 	loggingCmdRoot := logging.NewRootCommand(app, g)
 	loggingAzureblobCmdRoot := azureblob.NewRootCommand(loggingCmdRoot.CmdClause, g)
@@ -309,16 +319,6 @@ func defineCommands(
 	loggingSyslogDescribe := syslog.NewDescribeCommand(loggingSyslogCmdRoot.CmdClause, g, m)
 	loggingSyslogList := syslog.NewListCommand(loggingSyslogCmdRoot.CmdClause, g, m)
 	loggingSyslogUpdate := syslog.NewUpdateCommand(loggingSyslogCmdRoot.CmdClause, g, m)
-	kvstoreCmdRoot := kvstore.NewRootCommand(app, g)
-	kvstoreCreate := kvstore.NewCreateCommand(kvstoreCmdRoot.CmdClause, g, m)
-	kvstoreDelete := kvstore.NewDeleteCommand(kvstoreCmdRoot.CmdClause, g, m)
-	kvstoreDescribe := kvstore.NewDescribeCommand(kvstoreCmdRoot.CmdClause, g, m)
-	kvstoreList := kvstore.NewListCommand(kvstoreCmdRoot.CmdClause, g, m)
-	kvstoreentryCmdRoot := kvstoreentry.NewRootCommand(app, g)
-	kvstoreentryCreate := kvstoreentry.NewCreateCommand(kvstoreentryCmdRoot.CmdClause, g, m)
-	kvstoreentryDelete := kvstoreentry.NewDeleteCommand(kvstoreentryCmdRoot.CmdClause, g, m)
-	kvstoreentryDescribe := kvstoreentry.NewDescribeCommand(kvstoreentryCmdRoot.CmdClause, g, m)
-	kvstoreentryList := kvstoreentry.NewListCommand(kvstoreentryCmdRoot.CmdClause, g, m)
 	popCmdRoot := pop.NewRootCommand(app, g)
 	profileCmdRoot := profile.NewRootCommand(app, g)
 	profileCreate := profile.NewCreateCommand(profileCmdRoot.CmdClause, profile.APIClientFactory(opts.APIClient), g)
@@ -508,6 +508,14 @@ func defineCommands(
 		healthcheckList,
 		healthcheckUpdate,
 		ipCmdRoot,
+		kvstoreCreate,
+		kvstoreDelete,
+		kvstoreDescribe,
+		kvstoreList,
+		kvstoreentryCreate,
+		kvstoreentryDelete,
+		kvstoreentryDescribe,
+		kvstoreentryList,
 		logtailCmdRoot,
 		loggingAzureblobCmdRoot,
 		loggingAzureblobCreate,
@@ -660,14 +668,6 @@ func defineCommands(
 		loggingSyslogDescribe,
 		loggingSyslogList,
 		loggingSyslogUpdate,
-		kvstoreCreate,
-		kvstoreDelete,
-		kvstoreDescribe,
-		kvstoreList,
-		kvstoreentryCreate,
-		kvstoreentryDelete,
-		kvstoreentryDescribe,
-		kvstoreentryList,
 		popCmdRoot,
 		profileCmdRoot,
 		profileCreate,

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -19,7 +19,7 @@ import (
 	"github.com/fastly/cli/pkg/profile"
 	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/fastly/kingpin"
 )
 

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -72,8 +72,8 @@ healthcheck
 ip-list
 log-tail
 logging
-object-store
-object-store-entry
+kv-store
+kv-store-entry
 pops
 profile
 purge

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -70,10 +70,10 @@ dictionary-entry
 domain
 healthcheck
 ip-list
-log-tail
-logging
 kv-store
 kv-store-entry
+log-tail
+logging
 pops
 profile
 purge

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/fastly/kingpin"
 )
 

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -16,7 +16,7 @@ import (
 	"github.com/fastly/cli/pkg/env"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/fastly/kingpin"
 )
 

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestOptionalServiceVersionParse(t *testing.T) {

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestACLCreate(t *testing.T) {

--- a/pkg/commands/acl/create.go
+++ b/pkg/commands/acl/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/acl/delete.go
+++ b/pkg/commands/acl/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/acl/describe.go
+++ b/pkg/commands/acl/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/acl/list.go
+++ b/pkg/commands/acl/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/acl/update.go
+++ b/pkg/commands/acl/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestACLEntryCreate(t *testing.T) {

--- a/pkg/commands/aclentry/create.go
+++ b/pkg/commands/aclentry/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/aclentry/delete.go
+++ b/pkg/commands/aclentry/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/aclentry/describe.go
+++ b/pkg/commands/aclentry/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/aclentry/list.go
+++ b/pkg/commands/aclentry/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/aclentry/update.go
+++ b/pkg/commands/aclentry/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreate(t *testing.T) {

--- a/pkg/commands/authtoken/create.go
+++ b/pkg/commands/authtoken/create.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/fastly/kingpin"
 )
 

--- a/pkg/commands/authtoken/delete.go
+++ b/pkg/commands/authtoken/delete.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/authtoken/describe.go
+++ b/pkg/commands/authtoken/describe.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/authtoken/list.go
+++ b/pkg/commands/authtoken/list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -10,7 +10,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestBackendCreate(t *testing.T) {

--- a/pkg/commands/backend/create.go
+++ b/pkg/commands/backend/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create backends.

--- a/pkg/commands/backend/delete.go
+++ b/pkg/commands/backend/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete backends.

--- a/pkg/commands/backend/describe.go
+++ b/pkg/commands/backend/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a backend.

--- a/pkg/commands/backend/list.go
+++ b/pkg/commands/backend/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list backends.

--- a/pkg/commands/backend/update.go
+++ b/pkg/commands/backend/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update backends.

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -49,14 +49,14 @@ func createDictionaryItemOK(i *fastly.CreateDictionaryItemInput) (*fastly.Dictio
 	}, nil
 }
 
-func createObjectStoreOK(i *fastly.CreateObjectStoreInput) (*fastly.ObjectStore, error) {
-	return &fastly.ObjectStore{
+func createKVStoreOK(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+	return &fastly.KVStore{
 		ID:   "example-store",
 		Name: i.Name,
 	}, nil
 }
 
-func createObjectStoreItemOK(i *fastly.InsertObjectStoreKeyInput) error {
+func createKVStoreItemOK(i *fastly.InsertKVStoreKeyInput) error {
 	return nil
 }
 

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -6,7 +6,7 @@ package compute_test
 
 import (
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func getServiceOK(i *fastly.GetServiceInput) (*fastly.Service, error) {

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -24,7 +24,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/undo"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/kennygrant/sanitize"
 	"github.com/mholt/archiver/v3"
 )

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/threadsafe"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NOTE: Some tests don't provide a Service ID via any mechanism (e.g. flag

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -1578,7 +1578,7 @@ func TestDeploy(t *testing.T) {
 		},
 		// NOTE: The following test validates [setup] only works for a new service.
 		{
-			name: "success with setup.object_stores configuration and existing service",
+			name: "success with setup.kv_stores configuration and existing service",
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
@@ -1606,12 +1606,12 @@ func TestDeploy(t *testing.T) {
 			manifest_version = 2
 			language = "rust"
 
-			[setup.object_stores.store_one]
-			description = "My first object store"
-			[setup.object_stores.store_one.items.foo]
+			[setup.kv_stores.store_one]
+			description = "My first kv store"
+			[setup.kv_stores.store_one.items.foo]
 			value = "my default value for foo"
 			description = "a good description about foo"
-			[setup.object_stores.store_one.items.bar]
+			[setup.kv_stores.store_one.items.bar]
 			value = "my default value for bar"
 			description = "a good description about bar"
 			`,
@@ -1621,31 +1621,31 @@ func TestDeploy(t *testing.T) {
 				"SUCCESS: Deployed package (service 123, version 4)",
 			},
 			dontWantOutput: []string{
-				"Configuring object store 'store_one'",
-				"Create an object store key called 'foo'",
-				"Create an object store key called 'bar'",
-				"Creating object store 'store_one'",
-				"Creating object store key 'foo'",
-				"Creating object store key 'bar'",
+				"Configuring kv store 'store_one'",
+				"Create an kv store key called 'foo'",
+				"Create an kv store key called 'bar'",
+				"Creating kv store 'store_one'",
+				"Creating kv store key 'foo'",
+				"Creating kv store key 'bar'",
 			},
 		},
 		{
-			name: "success with setup.object_stores configuration and no existing service",
+			name: "success with setup.kv_stores configuration and no existing service",
 			args: args("compute deploy --token 123"),
 			api: mock.API{
-				ActivateVersionFn:      activateVersionOk,
-				CreateBackendFn:        createBackendOK,
-				CreateObjectStoreFn:    createObjectStoreOK,
-				InsertObjectStoreKeyFn: createObjectStoreItemOK,
-				CreateResourceFn:       createResourceOK,
-				CreateDomainFn:         createDomainOK,
-				CreateServiceFn:        createServiceOK,
-				GetPackageFn:           getPackageOk,
-				GetServiceFn:           getServiceOK,
-				GetServiceDetailsFn:    getServiceDetailsWasm,
-				ListDomainsFn:          listDomainsOk,
-				ListVersionsFn:         testutil.ListVersions,
-				UpdatePackageFn:        updatePackageOk,
+				ActivateVersionFn:   activateVersionOk,
+				CreateBackendFn:     createBackendOK,
+				CreateKVStoreFn:     createKVStoreOK,
+				InsertKVStoreKeyFn:  createKVStoreItemOK,
+				CreateResourceFn:    createResourceOK,
+				CreateDomainFn:      createDomainOK,
+				CreateServiceFn:     createServiceOK,
+				GetPackageFn:        getPackageOk,
+				GetServiceFn:        getServiceOK,
+				GetServiceDetailsFn: getServiceDetailsWasm,
+				ListDomainsFn:       listDomainsOk,
+				ListVersionsFn:      testutil.ListVersions,
+				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
 				{
@@ -1662,12 +1662,12 @@ func TestDeploy(t *testing.T) {
 			manifest_version = 2
 			language = "rust"
 
-			[setup.object_stores.store_one]
-			description = "My first object store"
-			[setup.object_stores.store_one.items.foo]
+			[setup.kv_stores.store_one]
+			description = "My first kv store"
+			[setup.kv_stores.store_one.items.foo]
 			value = "my default value for foo"
 			description = "a good description about foo"
-			[setup.object_stores.store_one.items.bar]
+			[setup.kv_stores.store_one.items.bar]
 			value = "my default value for bar"
 			description = "a good description about bar"
 			`,
@@ -1675,34 +1675,34 @@ func TestDeploy(t *testing.T) {
 				"Y", // when prompted to create a new service
 			},
 			wantOutput: []string{
-				"Configuring object store 'store_one'",
-				"Create an object store key called 'foo'",
-				"Create an object store key called 'bar'",
-				"Creating object store 'store_one'",
-				"Creating object store key 'foo'",
-				"Creating object store key 'bar'",
+				"Configuring kv store 'store_one'",
+				"Create an kv store key called 'foo'",
+				"Create an kv store key called 'bar'",
+				"Creating kv store 'store_one'",
+				"Creating kv store key 'foo'",
+				"Creating kv store key 'bar'",
 				"Uploading package",
 				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
 		{
-			name: "success with setup.object_stores configuration and no existing service and --non-interactive",
+			name: "success with setup.kv_stores configuration and no existing service and --non-interactive",
 			args: args("compute deploy --non-interactive --token 123"),
 			api: mock.API{
-				ActivateVersionFn:      activateVersionOk,
-				CreateBackendFn:        createBackendOK,
-				CreateObjectStoreFn:    createObjectStoreOK,
-				InsertObjectStoreKeyFn: createObjectStoreItemOK,
-				CreateResourceFn:       createResourceOK,
-				CreateDomainFn:         createDomainOK,
-				CreateServiceFn:        createServiceOK,
-				GetPackageFn:           getPackageOk,
-				GetServiceFn:           getServiceOK,
-				GetServiceDetailsFn:    getServiceDetailsWasm,
-				ListDomainsFn:          listDomainsOk,
-				ListVersionsFn:         testutil.ListVersions,
-				UpdatePackageFn:        updatePackageOk,
+				ActivateVersionFn:   activateVersionOk,
+				CreateBackendFn:     createBackendOK,
+				CreateKVStoreFn:     createKVStoreOK,
+				InsertKVStoreKeyFn:  createKVStoreItemOK,
+				CreateResourceFn:    createResourceOK,
+				CreateDomainFn:      createDomainOK,
+				CreateServiceFn:     createServiceOK,
+				GetPackageFn:        getPackageOk,
+				GetServiceFn:        getServiceOK,
+				GetServiceDetailsFn: getServiceDetailsWasm,
+				ListDomainsFn:       listDomainsOk,
+				ListVersionsFn:      testutil.ListVersions,
+				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
 				{
@@ -1719,12 +1719,12 @@ func TestDeploy(t *testing.T) {
 			manifest_version = 2
 			language = "rust"
 
-			[setup.object_stores.store_one]
-			description = "My first object store"
-			[setup.object_stores.store_one.items.foo]
+			[setup.kv_stores.store_one]
+			description = "My first kv store"
+			[setup.kv_stores.store_one.items.foo]
 			value = "my default value for foo"
 			description = "a good description about foo"
-			[setup.object_stores.store_one.items.bar]
+			[setup.kv_stores.store_one.items.bar]
 			value = "my default value for bar"
 			description = "a good description about bar"
 			`,
@@ -1732,31 +1732,31 @@ func TestDeploy(t *testing.T) {
 				"Y", // when prompted to create a new service
 			},
 			wantOutput: []string{
-				"Creating object store 'store_one'",
-				"Creating object store key 'foo'",
-				"Creating object store key 'bar'",
+				"Creating kv store 'store_one'",
+				"Creating kv store key 'foo'",
+				"Creating kv store key 'bar'",
 				"Uploading package",
 				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
 			},
 		},
 		{
-			name: "success with setup.object_stores configuration and no existing service and no predefined values",
+			name: "success with setup.kv_stores configuration and no existing service and no predefined values",
 			args: args("compute deploy --token 123"),
 			api: mock.API{
-				ActivateVersionFn:      activateVersionOk,
-				CreateBackendFn:        createBackendOK,
-				CreateObjectStoreFn:    createObjectStoreOK,
-				InsertObjectStoreKeyFn: createObjectStoreItemOK,
-				CreateResourceFn:       createResourceOK,
-				CreateDomainFn:         createDomainOK,
-				CreateServiceFn:        createServiceOK,
-				GetPackageFn:           getPackageOk,
-				GetServiceFn:           getServiceOK,
-				GetServiceDetailsFn:    getServiceDetailsWasm,
-				ListDomainsFn:          listDomainsOk,
-				ListVersionsFn:         testutil.ListVersions,
-				UpdatePackageFn:        updatePackageOk,
+				ActivateVersionFn:   activateVersionOk,
+				CreateBackendFn:     createBackendOK,
+				CreateKVStoreFn:     createKVStoreOK,
+				InsertKVStoreKeyFn:  createKVStoreItemOK,
+				CreateResourceFn:    createResourceOK,
+				CreateDomainFn:      createDomainOK,
+				CreateServiceFn:     createServiceOK,
+				GetPackageFn:        getPackageOk,
+				GetServiceFn:        getServiceOK,
+				GetServiceDetailsFn: getServiceDetailsWasm,
+				ListDomainsFn:       listDomainsOk,
+				ListVersionsFn:      testutil.ListVersions,
+				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
 				{
@@ -1773,20 +1773,20 @@ func TestDeploy(t *testing.T) {
 			manifest_version = 2
 			language = "rust"
 
-			[setup.object_stores.store_one]
-			[setup.object_stores.store_one.items.foo]
-			[setup.object_stores.store_one.items.bar]
+			[setup.kv_stores.store_one]
+			[setup.kv_stores.store_one.items.foo]
+			[setup.kv_stores.store_one.items.bar]
 			`,
 			stdin: []string{
 				"Y", // when prompted to create a new service
 			},
 			wantOutput: []string{
-				"Configuring object store 'store_one'",
-				"Create an object store key called 'foo'",
-				"Create an object store key called 'bar'",
-				"Creating object store 'store_one'",
-				"Creating object store key 'foo'",
-				"Creating object store key 'bar'",
+				"Configuring kv store 'store_one'",
+				"Create an kv store key called 'foo'",
+				"Create an kv store key called 'bar'",
+				"Creating kv store 'store_one'",
+				"Creating kv store key 'foo'",
+				"Creating kv store key 'bar'",
 				"Uploading package",
 				"Activating service",
 				"SUCCESS: Deployed package (service 12345, version 1)",
@@ -1796,7 +1796,7 @@ func TestDeploy(t *testing.T) {
 			// be present in the stdout/stderr as the [setup/dictionaries]
 			// configuration does not define them.
 			dontWantOutput: []string{
-				"My first object store",
+				"My first kv store",
 				"my default value for foo",
 				"my default value for bar",
 			},

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Backends represents the service state related to backends defined within the

--- a/pkg/commands/compute/setup/dictionary.go
+++ b/pkg/commands/compute/setup/dictionary.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Dictionaries represents the service state related to dictionaries defined

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const defaultTopLevelDomain = "edgecompute.app"

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // KVStores represents the service state related to kv stores defined

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -11,11 +11,11 @@ import (
 	"github.com/fastly/go-fastly/v7/fastly"
 )
 
-// ObjectStores represents the service state related to object stores defined
+// KVStores represents the service state related to kv stores defined
 // within the fastly.toml [setup] configuration.
 //
 // NOTE: It implements the setup.Interface interface.
-type ObjectStores struct {
+type KVStores struct {
 	// Public
 	APIClient      api.Interface
 	AcceptDefaults bool
@@ -23,40 +23,40 @@ type ObjectStores struct {
 	Spinner        text.Spinner
 	ServiceID      string
 	ServiceVersion int
-	Setup          map[string]*manifest.SetupObjectStore
+	Setup          map[string]*manifest.SetupKVStore
 	Stdin          io.Reader
 	Stdout         io.Writer
 
 	// Private
-	required []ObjectStore
+	required []KVStore
 }
 
-// ObjectStore represents the configuration parameters for creating an
-// object store via the API client.
-type ObjectStore struct {
+// KVStore represents the configuration parameters for creating an
+// kv store via the API client.
+type KVStore struct {
 	Name  string
-	Items []ObjectStoreItem
+	Items []KVStoreItem
 }
 
-// ObjectStoreItem represents the configuration parameters for creating
-// object store items via the API client.
-type ObjectStoreItem struct {
+// KVStoreItem represents the configuration parameters for creating
+// kv store items via the API client.
+type KVStoreItem struct {
 	Key   string
 	Value string
 }
 
 // Configure prompts the user for specific values related to the service resource.
-func (o *ObjectStores) Configure() error {
+func (o *KVStores) Configure() error {
 	for name, settings := range o.Setup {
 		if !o.AcceptDefaults && !o.NonInteractive {
 			text.Break(o.Stdout)
-			text.Output(o.Stdout, "Configuring object store '%s'", name)
+			text.Output(o.Stdout, "Configuring kv store '%s'", name)
 			if settings.Description != "" {
 				text.Output(o.Stdout, settings.Description)
 			}
 		}
 
-		var items []ObjectStoreItem
+		var items []KVStoreItem
 
 		for key, item := range settings.Items {
 			dv := "example"
@@ -72,7 +72,7 @@ func (o *ObjectStores) Configure() error {
 
 			if !o.AcceptDefaults && !o.NonInteractive {
 				text.Break(o.Stdout)
-				text.Output(o.Stdout, "Create an object store key called '%s'", key)
+				text.Output(o.Stdout, "Create an kv store key called '%s'", key)
 				if item.Description != "" {
 					text.Output(o.Stdout, item.Description)
 				}
@@ -88,13 +88,13 @@ func (o *ObjectStores) Configure() error {
 				value = dv
 			}
 
-			items = append(items, ObjectStoreItem{
+			items = append(items, KVStoreItem{
 				Key:   key,
 				Value: value,
 			})
 		}
 
-		o.required = append(o.required, ObjectStore{
+		o.required = append(o.required, KVStore{
 			Name:  name,
 			Items: items,
 		})
@@ -104,24 +104,24 @@ func (o *ObjectStores) Configure() error {
 }
 
 // Create calls the relevant API to create the service resource(s).
-func (o *ObjectStores) Create() error {
+func (o *KVStores) Create() error {
 	if o.Spinner == nil {
 		return errors.RemediationError{
-			Inner:       fmt.Errorf("internal logic error: no text.Progress configured for setup.ObjectStores"),
+			Inner:       fmt.Errorf("internal logic error: no text.Progress configured for setup.KVStores"),
 			Remediation: errors.BugRemediation,
 		}
 	}
 
-	for _, objectStore := range o.required {
+	for _, kvStore := range o.required {
 		err := o.Spinner.Start()
 		if err != nil {
 			return err
 		}
-		msg := fmt.Sprintf("Creating object store '%s'", objectStore.Name)
+		msg := fmt.Sprintf("Creating kv store '%s'", kvStore.Name)
 		o.Spinner.Message(msg + "...")
 
-		store, err := o.APIClient.CreateObjectStore(&fastly.CreateObjectStoreInput{
-			Name: objectStore.Name,
+		store, err := o.APIClient.CreateKVStore(&fastly.CreateKVStoreInput{
+			Name: kvStore.Name,
 		})
 		if err != nil {
 			o.Spinner.StopFailMessage(msg)
@@ -129,7 +129,7 @@ func (o *ObjectStores) Create() error {
 			if err != nil {
 				return err
 			}
-			return fmt.Errorf("error creating object store: %w", err)
+			return fmt.Errorf("error creating kv store: %w", err)
 		}
 
 		o.Spinner.StopMessage(msg)
@@ -138,16 +138,16 @@ func (o *ObjectStores) Create() error {
 			return err
 		}
 
-		if len(objectStore.Items) > 0 {
-			for _, item := range objectStore.Items {
+		if len(kvStore.Items) > 0 {
+			for _, item := range kvStore.Items {
 				err := o.Spinner.Start()
 				if err != nil {
 					return err
 				}
-				msg := fmt.Sprintf("Creating object store key '%s'...", item.Key)
+				msg := fmt.Sprintf("Creating kv store key '%s'...", item.Key)
 				o.Spinner.Message(msg)
 
-				err = o.APIClient.InsertObjectStoreKey(&fastly.InsertObjectStoreKeyInput{
+				err = o.APIClient.InsertKVStoreKey(&fastly.InsertKVStoreKeyInput{
 					ID:    store.ID,
 					Key:   item.Key,
 					Value: item.Value,
@@ -158,7 +158,7 @@ func (o *ObjectStores) Create() error {
 					if err != nil {
 						return err
 					}
-					return fmt.Errorf("error creating object store key: %w", err)
+					return fmt.Errorf("error creating kv store key: %w", err)
 				}
 
 				o.Spinner.StopMessage(msg)
@@ -173,10 +173,10 @@ func (o *ObjectStores) Create() error {
 		if err != nil {
 			return err
 		}
-		msg = fmt.Sprintf("Creating resource link between service and object store '%s'...", objectStore.Name)
+		msg = fmt.Sprintf("Creating resource link between service and kv store '%s'...", kvStore.Name)
 		o.Spinner.Message(msg)
 
-		// IMPORTANT: We need to link the object store to the C@E Service.
+		// IMPORTANT: We need to link the kv store to the C@E Service.
 		_, err = o.APIClient.CreateResource(&fastly.CreateResourceInput{
 			ServiceID:      o.ServiceID,
 			ServiceVersion: o.ServiceVersion,
@@ -189,7 +189,7 @@ func (o *ObjectStores) Create() error {
 			if err != nil {
 				return err
 			}
-			return fmt.Errorf("error creating resource link between the service '%s' and the object store '%s': %w", o.ServiceID, store.Name, err)
+			return fmt.Errorf("error creating resource link between the service '%s' and the kv store '%s': %w", o.ServiceID, store.Name, err)
 		}
 
 		o.Spinner.StopMessage(msg)
@@ -204,6 +204,6 @@ func (o *ObjectStores) Create() error {
 
 // Predefined indicates if the service resource has been specified within the
 // fastly.toml file using a [setup] configuration block.
-func (o *ObjectStores) Predefined() bool {
+func (o *KVStores) Predefined() bool {
 	return len(o.Setup) > 0
 }

--- a/pkg/commands/compute/testdata/init/fastly-viceroy-update.toml
+++ b/pkg/commands/compute/testdata/init/fastly-viceroy-update.toml
@@ -35,14 +35,14 @@ name = "Default Rust template"
       baz = """
 qux"""
 
-  [local_server.object_stores]
+  [local_server.kv_stores]
     store_one = [{key = "first", data = "This is some data"}, {key = "second", path = "strings.json"}]
 
-    [[local_server.object_stores.store_two]]
+    [[local_server.kv_stores.store_two]]
       key = "first"
       data = "This is some data"
 
-    [[local_server.object_stores.store_two]]
+    [[local_server.kv_stores.store_two]]
       key = "second"
       file = "strings.json"
 

--- a/pkg/commands/compute/update.go
+++ b/pkg/commands/compute/update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/kennygrant/sanitize"
 )
 

--- a/pkg/commands/configstore/configstore_test.go
+++ b/pkg/commands/configstore/configstore_test.go
@@ -12,7 +12,7 @@ import (
 	fstfmt "github.com/fastly/cli/pkg/fmt"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateStoreCommand(t *testing.T) {

--- a/pkg/commands/configstore/create.go
+++ b/pkg/commands/configstore/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstore/delete.go
+++ b/pkg/commands/configstore/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstore/describe.go
+++ b/pkg/commands/configstore/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstore/helper_test.go
+++ b/pkg/commands/configstore/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func fmtStore(cs *fastly.ConfigStore, csm *fastly.ConfigStoreMetadata) string {

--- a/pkg/commands/configstore/list_services.go
+++ b/pkg/commands/configstore/list_services.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListServicesCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstore/update.go
+++ b/pkg/commands/configstore/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstoreentry/configstoreentry_test.go
+++ b/pkg/commands/configstoreentry/configstoreentry_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateEntryCommand(t *testing.T) {

--- a/pkg/commands/configstoreentry/create.go
+++ b/pkg/commands/configstoreentry/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstoreentry/delete.go
+++ b/pkg/commands/configstoreentry/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstoreentry/describe.go
+++ b/pkg/commands/configstoreentry/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstoreentry/list.go
+++ b/pkg/commands/configstoreentry/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/configstoreentry/update.go
+++ b/pkg/commands/configstoreentry/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/dictionary/create.go
+++ b/pkg/commands/dictionary/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a service.

--- a/pkg/commands/dictionary/delete.go
+++ b/pkg/commands/dictionary/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a service.

--- a/pkg/commands/dictionary/describe.go
+++ b/pkg/commands/dictionary/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a dictionary.

--- a/pkg/commands/dictionary/dictionary_test.go
+++ b/pkg/commands/dictionary/dictionary_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestDictionaryDescribe(t *testing.T) {

--- a/pkg/commands/dictionary/list.go
+++ b/pkg/commands/dictionary/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list dictionaries

--- a/pkg/commands/dictionary/update.go
+++ b/pkg/commands/dictionary/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a dictionary.

--- a/pkg/commands/dictionaryentry/create.go
+++ b/pkg/commands/dictionaryentry/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a dictionary item.

--- a/pkg/commands/dictionaryentry/delete.go
+++ b/pkg/commands/dictionaryentry/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a service.

--- a/pkg/commands/dictionaryentry/describe.go
+++ b/pkg/commands/dictionaryentry/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a dictionary item.

--- a/pkg/commands/dictionaryentry/dictionaryitem_test.go
+++ b/pkg/commands/dictionaryentry/dictionaryitem_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestDictionaryItemDescribe(t *testing.T) {

--- a/pkg/commands/dictionaryentry/list.go
+++ b/pkg/commands/dictionaryentry/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list dictionary items.

--- a/pkg/commands/dictionaryentry/update.go
+++ b/pkg/commands/dictionaryentry/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a dictionary item.

--- a/pkg/commands/domain/create.go
+++ b/pkg/commands/domain/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create domains.

--- a/pkg/commands/domain/delete.go
+++ b/pkg/commands/domain/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete domains.

--- a/pkg/commands/domain/describe.go
+++ b/pkg/commands/domain/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a domain.

--- a/pkg/commands/domain/domain_test.go
+++ b/pkg/commands/domain/domain_test.go
@@ -11,7 +11,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestDomainCreate(t *testing.T) {

--- a/pkg/commands/domain/list.go
+++ b/pkg/commands/domain/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list domains.

--- a/pkg/commands/domain/update.go
+++ b/pkg/commands/domain/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update domains.

--- a/pkg/commands/domain/validate.go
+++ b/pkg/commands/domain/validate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewValidateCommand returns a usable command registered under the parent.

--- a/pkg/commands/healthcheck/create.go
+++ b/pkg/commands/healthcheck/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create healthchecks.

--- a/pkg/commands/healthcheck/delete.go
+++ b/pkg/commands/healthcheck/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete healthchecks.

--- a/pkg/commands/healthcheck/describe.go
+++ b/pkg/commands/healthcheck/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a healthcheck.

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestHealthCheckCreate(t *testing.T) {

--- a/pkg/commands/healthcheck/list.go
+++ b/pkg/commands/healthcheck/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list healthchecks.

--- a/pkg/commands/healthcheck/update.go
+++ b/pkg/commands/healthcheck/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update healthchecks.

--- a/pkg/commands/ip/ip_test.go
+++ b/pkg/commands/ip/ip_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestAllIPs(t *testing.T) {

--- a/pkg/commands/kvstore/create.go
+++ b/pkg/commands/kvstore/create.go
@@ -1,4 +1,4 @@
-package objectstoreentry
+package kvstore
 
 import (
 	"encoding/json"
@@ -13,26 +13,24 @@ import (
 	"github.com/fastly/go-fastly/v7/fastly"
 )
 
-// ListCommand calls the Fastly API to list the keys for a given object store.
-type ListCommand struct {
+// CreateCommand calls the Fastly API to create an kv store.
+type CreateCommand struct {
 	cmd.Base
 	json     bool
 	manifest manifest.Data
-	Input    fastly.ListObjectStoreKeysInput
+	Input    fastly.CreateKVStoreInput
 }
 
-// NewListCommand returns a usable command registered under the parent.
-func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *ListCommand {
-	c := ListCommand{
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *CreateCommand {
+	c := CreateCommand{
 		Base: cmd.Base{
 			Globals: g,
 		},
 		manifest: m,
 	}
-	c.CmdClause = parent.Command("list", "List keys")
-	c.CmdClause.Flag("store-id", "Store ID").Short('s').Required().StringVar(&c.Input.ID)
-
-	// optional
+	c.CmdClause = parent.Command("create", "Create an kv store")
+	c.CmdClause.Flag("name", "Name of KV Store").Short('n').Required().StringVar(&c.Input.Name)
 	c.RegisterFlagBool(cmd.BoolFlagOpts{
 		Name:        cmd.FlagJSONName,
 		Description: cmd.FlagJSONDesc,
@@ -43,12 +41,12 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 }
 
 // Exec invokes the application logic for the command.
-func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
+func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if c.Globals.Verbose() && c.json {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.ListObjectStoreKeys(&c.Input)
+	o, err := c.Globals.APIClient.CreateKVStore(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -67,13 +65,6 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return nil
 	}
 
-	if c.Globals.Flags.Verbose {
-		text.PrintObjectStoreKeys(out, "", o.Data)
-		return nil
-	}
-
-	for _, k := range o.Data {
-		text.Output(out, k)
-	}
+	text.Success(out, "Created kv store %s (name %s)", o.ID, o.Name)
 	return nil
 }

--- a/pkg/commands/kvstore/create.go
+++ b/pkg/commands/kvstore/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an kv store.

--- a/pkg/commands/kvstore/delete.go
+++ b/pkg/commands/kvstore/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an kv store.

--- a/pkg/commands/kvstore/delete.go
+++ b/pkg/commands/kvstore/delete.go
@@ -1,4 +1,4 @@
-package objectstore
+package kvstore
 
 import (
 	"io"
@@ -10,11 +10,11 @@ import (
 	"github.com/fastly/go-fastly/v7/fastly"
 )
 
-// DeleteCommand calls the Fastly API to delete an object store.
+// DeleteCommand calls the Fastly API to delete an kv store.
 type DeleteCommand struct {
 	cmd.Base
 	manifest manifest.Data
-	Input    fastly.DeleteObjectStoreInput
+	Input    fastly.DeleteKVStoreInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -25,19 +25,19 @@ func NewDeleteCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *D
 		},
 		manifest: m,
 	}
-	c.CmdClause = parent.Command("delete", "Delete an object store")
+	c.CmdClause = parent.Command("delete", "Delete an kv store")
 	c.CmdClause.Flag("store-id", "Store ID").Short('s').Required().StringVar(&c.Input.ID)
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
-	err := c.Globals.APIClient.DeleteObjectStore(&c.Input)
+	err := c.Globals.APIClient.DeleteKVStore(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	text.Success(out, "Deleted object store ID %s", c.Input.ID)
+	text.Success(out, "Deleted kv store ID %s", c.Input.ID)
 	return nil
 }

--- a/pkg/commands/kvstore/describe.go
+++ b/pkg/commands/kvstore/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to fetch the value of a key from an kv store.

--- a/pkg/commands/kvstore/doc.go
+++ b/pkg/commands/kvstore/doc.go
@@ -1,0 +1,3 @@
+// Package kvstore contains commands to inspect and manipulate Fastly edge
+// kv stores.
+package kvstore

--- a/pkg/commands/kvstore/insert.go
+++ b/pkg/commands/kvstore/insert.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // InsertKeyCommand calls the Fastly API to insert a key into an kv store.

--- a/pkg/commands/kvstore/insert.go
+++ b/pkg/commands/kvstore/insert.go
@@ -1,4 +1,4 @@
-package objectstore
+package kvstore
 
 import (
 	"io"
@@ -10,11 +10,11 @@ import (
 	"github.com/fastly/go-fastly/v7/fastly"
 )
 
-// InsertKeyCommand calls the Fastly API to insert a key into an object store.
+// InsertKeyCommand calls the Fastly API to insert a key into an kv store.
 type InsertKeyCommand struct {
 	cmd.Base
 	manifest manifest.Data
-	Input    fastly.InsertObjectStoreKeyInput
+	Input    fastly.InsertKVStoreKeyInput
 }
 
 // NewInsertKeyCommand returns a usable command registered under the parent.
@@ -22,8 +22,8 @@ func NewInsertKeyCommand(parent cmd.Registerer, g *global.Data, m manifest.Data)
 	var c InsertKeyCommand
 	c.Globals = g
 	c.manifest = m
-	c.CmdClause = parent.Command("insert", "Insert key/value pair into a Fastly object store")
-	c.CmdClause.Flag("id", "ID of Object Store").Short('n').Required().StringVar(&c.Input.ID)
+	c.CmdClause = parent.Command("insert", "Insert key/value pair into a Fastly kv store")
+	c.CmdClause.Flag("id", "ID of KV Store").Short('n').Required().StringVar(&c.Input.ID)
 	c.CmdClause.Flag("key", "Key to insert").Short('k').Required().StringVar(&c.Input.Key)
 	c.CmdClause.Flag("value", "Value to insert").Required().StringVar(&c.Input.Value)
 
@@ -32,12 +32,12 @@ func NewInsertKeyCommand(parent cmd.Registerer, g *global.Data, m manifest.Data)
 
 // Exec invokes the application logic for the command.
 func (c *InsertKeyCommand) Exec(_ io.Reader, out io.Writer) error {
-	err := c.Globals.APIClient.InsertObjectStoreKey(&c.Input)
+	err := c.Globals.APIClient.InsertKVStoreKey(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	text.Success(out, "Inserted key %s into object store %s", c.Input.Key, c.Input.ID)
+	text.Success(out, "Inserted key %s into kv store %s", c.Input.Key, c.Input.ID)
 	return nil
 }

--- a/pkg/commands/kvstore/list.go
+++ b/pkg/commands/kvstore/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list the available kv stores.

--- a/pkg/commands/kvstore/root.go
+++ b/pkg/commands/kvstore/root.go
@@ -1,4 +1,4 @@
-package objectstoreentry
+package kvstore
 
 import (
 	"io"
@@ -18,7 +18,7 @@ type RootCommand struct {
 func NewRootCommand(parent cmd.Registerer, g *global.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = g
-	c.CmdClause = parent.Command("object-store-entry", "Manipulate Fastly Object Store keys")
+	c.CmdClause = parent.Command("kv-store", "Manipulate Fastly KV Stores")
 	return &c
 }
 

--- a/pkg/commands/kvstoreentry/create.go
+++ b/pkg/commands/kvstoreentry/create.go
@@ -1,4 +1,4 @@
-package objectstoreentry
+package kvstoreentry
 
 import (
 	"io"
@@ -10,11 +10,11 @@ import (
 	"github.com/fastly/go-fastly/v7/fastly"
 )
 
-// CreateCommand calls the Fastly API to insert a key into an object store.
+// CreateCommand calls the Fastly API to insert a key into an kv store.
 type CreateCommand struct {
 	cmd.Base
 	manifest manifest.Data
-	Input    fastly.InsertObjectStoreKeyInput
+	Input    fastly.InsertKVStoreKeyInput
 }
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -34,12 +34,12 @@ func NewCreateCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *C
 
 // Exec invokes the application logic for the command.
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
-	err := c.Globals.APIClient.InsertObjectStoreKey(&c.Input)
+	err := c.Globals.APIClient.InsertKVStoreKey(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	text.Success(out, "Inserted key %s into object store %s", c.Input.Key, c.Input.ID)
+	text.Success(out, "Inserted key %s into kv store %s", c.Input.Key, c.Input.ID)
 	return nil
 }

--- a/pkg/commands/kvstoreentry/create.go
+++ b/pkg/commands/kvstoreentry/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to insert a key into an kv store.

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an kv store.

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -1,4 +1,4 @@
-package objectstoreentry
+package kvstoreentry
 
 import (
 	"io"
@@ -10,11 +10,11 @@ import (
 	"github.com/fastly/go-fastly/v7/fastly"
 )
 
-// DeleteCommand calls the Fastly API to delete an object store.
+// DeleteCommand calls the Fastly API to delete an kv store.
 type DeleteCommand struct {
 	cmd.Base
 	manifest manifest.Data
-	Input    fastly.DeleteObjectStoreKeyInput
+	Input    fastly.DeleteKVStoreKeyInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -33,7 +33,7 @@ func NewDeleteCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *D
 
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
-	err := c.Globals.APIClient.DeleteObjectStoreKey(&c.Input)
+	err := c.Globals.APIClient.DeleteKVStoreKey(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/kvstoreentry/describe.go
+++ b/pkg/commands/kvstoreentry/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to fetch the value of a key from an kv store.

--- a/pkg/commands/kvstoreentry/describe.go
+++ b/pkg/commands/kvstoreentry/describe.go
@@ -1,4 +1,4 @@
-package objectstoreentry
+package kvstoreentry
 
 import (
 	"io"
@@ -11,12 +11,12 @@ import (
 	"github.com/fastly/go-fastly/v7/fastly"
 )
 
-// DescribeCommand calls the Fastly API to fetch the value of a key from an object store.
+// DescribeCommand calls the Fastly API to fetch the value of a key from an kv store.
 type DescribeCommand struct {
 	cmd.Base
 	json     bool
 	manifest manifest.Data
-	Input    fastly.GetObjectStoreKeyInput
+	Input    fastly.GetKVStoreKeyInput
 }
 
 // NewDescribeCommand returns a usable command registered under the parent.
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	value, err := c.Globals.APIClient.GetObjectStoreKey(&c.Input)
+	value, err := c.Globals.APIClient.GetKVStoreKey(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -60,7 +60,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	if c.Globals.Flags.Verbose {
-		text.PrintObjectStoreKeyValue(out, "", c.Input.Key, value)
+		text.PrintKVStoreKeyValue(out, "", c.Input.Key, value)
 		return nil
 	}
 

--- a/pkg/commands/kvstoreentry/doc.go
+++ b/pkg/commands/kvstoreentry/doc.go
@@ -1,0 +1,3 @@
+// Package kvstoreentry contains commands to inspect and manipulate Fastly edge
+// kv stores keys.
+package kvstoreentry

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list the keys for a given kv store.

--- a/pkg/commands/kvstoreentry/root.go
+++ b/pkg/commands/kvstoreentry/root.go
@@ -1,4 +1,4 @@
-package objectstore
+package kvstoreentry
 
 import (
 	"io"
@@ -18,7 +18,7 @@ type RootCommand struct {
 func NewRootCommand(parent cmd.Registerer, g *global.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = g
-	c.CmdClause = parent.Command("object-store", "Manipulate Fastly Object Stores")
+	c.CmdClause = parent.Command("kv-store-entry", "Manipulate Fastly KV Store keys")
 	return &c
 }
 

--- a/pkg/commands/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestBlobStorageCreate(t *testing.T) {

--- a/pkg/commands/logging/azureblob/azureblob_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateBlobStorageInput(t *testing.T) {

--- a/pkg/commands/logging/azureblob/create.go
+++ b/pkg/commands/logging/azureblob/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Azure Blob Storage logging endpoint.

--- a/pkg/commands/logging/azureblob/delete.go
+++ b/pkg/commands/logging/azureblob/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Azure Blob Storage logging endpoint.

--- a/pkg/commands/logging/azureblob/describe.go
+++ b/pkg/commands/logging/azureblob/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Azure Blob Storage logging endpoint.

--- a/pkg/commands/logging/azureblob/list.go
+++ b/pkg/commands/logging/azureblob/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Azure Blob Storage logging endpoints.

--- a/pkg/commands/logging/azureblob/update.go
+++ b/pkg/commands/logging/azureblob/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Azure Blob Storage logging endpoint.

--- a/pkg/commands/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestBigQueryCreate(t *testing.T) {

--- a/pkg/commands/logging/bigquery/bigquery_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateBigQueryInput(t *testing.T) {

--- a/pkg/commands/logging/bigquery/create.go
+++ b/pkg/commands/logging/bigquery/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a BigQuery logging endpoint.

--- a/pkg/commands/logging/bigquery/delete.go
+++ b/pkg/commands/logging/bigquery/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a BigQuery logging endpoint.

--- a/pkg/commands/logging/bigquery/describe.go
+++ b/pkg/commands/logging/bigquery/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a BigQuery logging endpoint.

--- a/pkg/commands/logging/bigquery/list.go
+++ b/pkg/commands/logging/bigquery/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list BigQuery logging endpoints.

--- a/pkg/commands/logging/bigquery/update.go
+++ b/pkg/commands/logging/bigquery/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a BigQuery logging endpoint.

--- a/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCloudfilesCreate(t *testing.T) {

--- a/pkg/commands/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateCloudfilesInput(t *testing.T) {

--- a/pkg/commands/logging/cloudfiles/create.go
+++ b/pkg/commands/logging/cloudfiles/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Cloudfiles logging endpoint.

--- a/pkg/commands/logging/cloudfiles/delete.go
+++ b/pkg/commands/logging/cloudfiles/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Cloudfiles logging endpoint.

--- a/pkg/commands/logging/cloudfiles/describe.go
+++ b/pkg/commands/logging/cloudfiles/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Cloudfiles logging endpoint.

--- a/pkg/commands/logging/cloudfiles/list.go
+++ b/pkg/commands/logging/cloudfiles/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Cloudfiles logging endpoints.

--- a/pkg/commands/logging/cloudfiles/update.go
+++ b/pkg/commands/logging/cloudfiles/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Cloudfiles logging endpoint.

--- a/pkg/commands/logging/datadog/create.go
+++ b/pkg/commands/logging/datadog/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Datadog logging endpoint.

--- a/pkg/commands/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/logging/datadog/datadog_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestDatadogCreate(t *testing.T) {

--- a/pkg/commands/logging/datadog/datadog_test.go
+++ b/pkg/commands/logging/datadog/datadog_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateDatadogInput(t *testing.T) {

--- a/pkg/commands/logging/datadog/delete.go
+++ b/pkg/commands/logging/datadog/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Datadog logging endpoint.

--- a/pkg/commands/logging/datadog/describe.go
+++ b/pkg/commands/logging/datadog/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Datadog logging endpoint.

--- a/pkg/commands/logging/datadog/list.go
+++ b/pkg/commands/logging/datadog/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Datadog logging endpoints.

--- a/pkg/commands/logging/datadog/update.go
+++ b/pkg/commands/logging/datadog/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Datadog logging endpoint.

--- a/pkg/commands/logging/digitalocean/create.go
+++ b/pkg/commands/logging/digitalocean/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a DigitalOcean Spaces logging endpoint.

--- a/pkg/commands/logging/digitalocean/delete.go
+++ b/pkg/commands/logging/digitalocean/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a DigitalOcean Spaces logging endpoint.

--- a/pkg/commands/logging/digitalocean/describe.go
+++ b/pkg/commands/logging/digitalocean/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a DigitalOcean Spaces logging endpoint.

--- a/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestDigitalOceanCreate(t *testing.T) {

--- a/pkg/commands/logging/digitalocean/digitalocean_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateDigitalOceanInput(t *testing.T) {

--- a/pkg/commands/logging/digitalocean/list.go
+++ b/pkg/commands/logging/digitalocean/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list DigitalOcean Spaces logging endpoints.

--- a/pkg/commands/logging/digitalocean/update.go
+++ b/pkg/commands/logging/digitalocean/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a DigitalOcean Spaces logging endpoint.

--- a/pkg/commands/logging/elasticsearch/create.go
+++ b/pkg/commands/logging/elasticsearch/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Elasticsearch logging endpoint.

--- a/pkg/commands/logging/elasticsearch/delete.go
+++ b/pkg/commands/logging/elasticsearch/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Elasticsearch logging endpoint.

--- a/pkg/commands/logging/elasticsearch/describe.go
+++ b/pkg/commands/logging/elasticsearch/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Elasticsearch logging endpoint.

--- a/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestElasticsearchCreate(t *testing.T) {

--- a/pkg/commands/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateElasticsearchInput(t *testing.T) {

--- a/pkg/commands/logging/elasticsearch/list.go
+++ b/pkg/commands/logging/elasticsearch/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Elasticsearch logging endpoints.

--- a/pkg/commands/logging/elasticsearch/update.go
+++ b/pkg/commands/logging/elasticsearch/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Elasticsearch logging endpoint.

--- a/pkg/commands/logging/ftp/create.go
+++ b/pkg/commands/logging/ftp/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an FTP logging endpoint.

--- a/pkg/commands/logging/ftp/delete.go
+++ b/pkg/commands/logging/ftp/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an FTP logging endpoint.

--- a/pkg/commands/logging/ftp/describe.go
+++ b/pkg/commands/logging/ftp/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an FTP logging endpoint.

--- a/pkg/commands/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/logging/ftp/ftp_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestFTPCreate(t *testing.T) {

--- a/pkg/commands/logging/ftp/ftp_test.go
+++ b/pkg/commands/logging/ftp/ftp_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateFTPInput(t *testing.T) {

--- a/pkg/commands/logging/ftp/list.go
+++ b/pkg/commands/logging/ftp/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list FTP logging endpoints.

--- a/pkg/commands/logging/ftp/update.go
+++ b/pkg/commands/logging/ftp/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an FTP logging endpoint.

--- a/pkg/commands/logging/gcs/create.go
+++ b/pkg/commands/logging/gcs/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a GCS logging endpoint.

--- a/pkg/commands/logging/gcs/delete.go
+++ b/pkg/commands/logging/gcs/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a GCS logging endpoint.

--- a/pkg/commands/logging/gcs/describe.go
+++ b/pkg/commands/logging/gcs/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a GCS logging endpoint.

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestGCSCreate(t *testing.T) {

--- a/pkg/commands/logging/gcs/gcs_test.go
+++ b/pkg/commands/logging/gcs/gcs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateGCSInput(t *testing.T) {

--- a/pkg/commands/logging/gcs/list.go
+++ b/pkg/commands/logging/gcs/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list GCS logging endpoints.

--- a/pkg/commands/logging/gcs/update.go
+++ b/pkg/commands/logging/gcs/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a GCS logging endpoint.

--- a/pkg/commands/logging/googlepubsub/create.go
+++ b/pkg/commands/logging/googlepubsub/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/commands/logging/googlepubsub/delete.go
+++ b/pkg/commands/logging/googlepubsub/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/commands/logging/googlepubsub/describe.go
+++ b/pkg/commands/logging/googlepubsub/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestGooglePubSubCreate(t *testing.T) {

--- a/pkg/commands/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateGooglePubSubInput(t *testing.T) {

--- a/pkg/commands/logging/googlepubsub/list.go
+++ b/pkg/commands/logging/googlepubsub/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Google Cloud Pub/Sub logging endpoints.

--- a/pkg/commands/logging/googlepubsub/update.go
+++ b/pkg/commands/logging/googlepubsub/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Google Cloud Pub/Sub logging endpoint.

--- a/pkg/commands/logging/heroku/create.go
+++ b/pkg/commands/logging/heroku/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Heroku logging endpoint.

--- a/pkg/commands/logging/heroku/delete.go
+++ b/pkg/commands/logging/heroku/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Heroku logging endpoint.

--- a/pkg/commands/logging/heroku/describe.go
+++ b/pkg/commands/logging/heroku/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Heroku logging endpoint.

--- a/pkg/commands/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/logging/heroku/heroku_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestHerokuCreate(t *testing.T) {

--- a/pkg/commands/logging/heroku/heroku_test.go
+++ b/pkg/commands/logging/heroku/heroku_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateHerokuInput(t *testing.T) {

--- a/pkg/commands/logging/heroku/list.go
+++ b/pkg/commands/logging/heroku/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Heroku logging endpoints.

--- a/pkg/commands/logging/heroku/update.go
+++ b/pkg/commands/logging/heroku/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Heroku logging endpoint.

--- a/pkg/commands/logging/honeycomb/create.go
+++ b/pkg/commands/logging/honeycomb/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Honeycomb logging endpoint.

--- a/pkg/commands/logging/honeycomb/delete.go
+++ b/pkg/commands/logging/honeycomb/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Honeycomb logging endpoint.

--- a/pkg/commands/logging/honeycomb/describe.go
+++ b/pkg/commands/logging/honeycomb/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Honeycomb logging endpoint.

--- a/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestHoneycombCreate(t *testing.T) {

--- a/pkg/commands/logging/honeycomb/honeycomb_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateHoneycombInput(t *testing.T) {

--- a/pkg/commands/logging/honeycomb/list.go
+++ b/pkg/commands/logging/honeycomb/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Honeycomb logging endpoints.

--- a/pkg/commands/logging/honeycomb/update.go
+++ b/pkg/commands/logging/honeycomb/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Honeycomb logging endpoint.

--- a/pkg/commands/logging/https/create.go
+++ b/pkg/commands/logging/https/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an HTTPS logging endpoint.

--- a/pkg/commands/logging/https/delete.go
+++ b/pkg/commands/logging/https/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an HTTPS logging endpoint.

--- a/pkg/commands/logging/https/describe.go
+++ b/pkg/commands/logging/https/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an HTTPS logging endpoint.

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestHTTPSCreate(t *testing.T) {

--- a/pkg/commands/logging/https/https_test.go
+++ b/pkg/commands/logging/https/https_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateHTTPSInput(t *testing.T) {

--- a/pkg/commands/logging/https/list.go
+++ b/pkg/commands/logging/https/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list HTTPS logging endpoints.

--- a/pkg/commands/logging/https/update.go
+++ b/pkg/commands/logging/https/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an HTTPS logging endpoint.

--- a/pkg/commands/logging/kafka/create.go
+++ b/pkg/commands/logging/kafka/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Kafka logging endpoint.

--- a/pkg/commands/logging/kafka/delete.go
+++ b/pkg/commands/logging/kafka/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Kafka logging endpoint.

--- a/pkg/commands/logging/kafka/describe.go
+++ b/pkg/commands/logging/kafka/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Kafka logging endpoint.

--- a/pkg/commands/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/logging/kafka/kafka_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestKafkaCreate(t *testing.T) {

--- a/pkg/commands/logging/kafka/kafka_test.go
+++ b/pkg/commands/logging/kafka/kafka_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateKafkaInput(t *testing.T) {

--- a/pkg/commands/logging/kafka/list.go
+++ b/pkg/commands/logging/kafka/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Kafka logging endpoints.

--- a/pkg/commands/logging/kafka/update.go
+++ b/pkg/commands/logging/kafka/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Kafka logging endpoint.

--- a/pkg/commands/logging/kinesis/create.go
+++ b/pkg/commands/logging/kinesis/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Amazon Kinesis logging endpoint.

--- a/pkg/commands/logging/kinesis/delete.go
+++ b/pkg/commands/logging/kinesis/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Amazon Kinesis logging endpoint.

--- a/pkg/commands/logging/kinesis/describe.go
+++ b/pkg/commands/logging/kinesis/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Amazon Kinesis logging endpoint.

--- a/pkg/commands/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestKinesisCreate(t *testing.T) {

--- a/pkg/commands/logging/kinesis/kinesis_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateKinesisInput(t *testing.T) {

--- a/pkg/commands/logging/kinesis/list.go
+++ b/pkg/commands/logging/kinesis/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Amazon Kinesis logging endpoints.

--- a/pkg/commands/logging/kinesis/update.go
+++ b/pkg/commands/logging/kinesis/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Amazon Kinesis logging endpoint.

--- a/pkg/commands/logging/loggly/create.go
+++ b/pkg/commands/logging/loggly/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Loggly logging endpoint.

--- a/pkg/commands/logging/loggly/delete.go
+++ b/pkg/commands/logging/loggly/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Loggly logging endpoint.

--- a/pkg/commands/logging/loggly/describe.go
+++ b/pkg/commands/logging/loggly/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Loggly logging endpoint.

--- a/pkg/commands/logging/loggly/list.go
+++ b/pkg/commands/logging/loggly/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Loggly logging endpoints.

--- a/pkg/commands/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/logging/loggly/loggly_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestLogglyCreate(t *testing.T) {

--- a/pkg/commands/logging/loggly/loggly_test.go
+++ b/pkg/commands/logging/loggly/loggly_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateLogglyInput(t *testing.T) {

--- a/pkg/commands/logging/loggly/update.go
+++ b/pkg/commands/logging/loggly/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Loggly logging endpoint.

--- a/pkg/commands/logging/logshuttle/create.go
+++ b/pkg/commands/logging/logshuttle/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Logshuttle logging endpoint.

--- a/pkg/commands/logging/logshuttle/delete.go
+++ b/pkg/commands/logging/logshuttle/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Logshuttle logging endpoint.

--- a/pkg/commands/logging/logshuttle/describe.go
+++ b/pkg/commands/logging/logshuttle/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Logshuttle logging endpoint.

--- a/pkg/commands/logging/logshuttle/list.go
+++ b/pkg/commands/logging/logshuttle/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Logshuttle logging endpoints.

--- a/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestLogshuttleCreate(t *testing.T) {

--- a/pkg/commands/logging/logshuttle/logshuttle_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateLogshuttleInput(t *testing.T) {

--- a/pkg/commands/logging/logshuttle/update.go
+++ b/pkg/commands/logging/logshuttle/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Logshuttle logging endpoint.

--- a/pkg/commands/logging/newrelic/create.go
+++ b/pkg/commands/logging/newrelic/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an appropriate resource.

--- a/pkg/commands/logging/newrelic/delete.go
+++ b/pkg/commands/logging/newrelic/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/logging/newrelic/describe.go
+++ b/pkg/commands/logging/newrelic/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/logging/newrelic/list.go
+++ b/pkg/commands/logging/newrelic/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/logging/newrelic/newrelic_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestNewRelicCreate(t *testing.T) {

--- a/pkg/commands/logging/newrelic/update.go
+++ b/pkg/commands/logging/newrelic/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an appropriate resource.

--- a/pkg/commands/logging/openstack/create.go
+++ b/pkg/commands/logging/openstack/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an OpenStack logging endpoint.

--- a/pkg/commands/logging/openstack/delete.go
+++ b/pkg/commands/logging/openstack/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an OpenStack logging endpoint.

--- a/pkg/commands/logging/openstack/describe.go
+++ b/pkg/commands/logging/openstack/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an OpenStack logging endpoint.

--- a/pkg/commands/logging/openstack/list.go
+++ b/pkg/commands/logging/openstack/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list OpenStack logging endpoints.

--- a/pkg/commands/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/logging/openstack/openstack_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestOpenstackCreate(t *testing.T) {

--- a/pkg/commands/logging/openstack/openstack_test.go
+++ b/pkg/commands/logging/openstack/openstack_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateOpenstackInput(t *testing.T) {

--- a/pkg/commands/logging/openstack/update.go
+++ b/pkg/commands/logging/openstack/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an OpenStack logging endpoint.

--- a/pkg/commands/logging/papertrail/create.go
+++ b/pkg/commands/logging/papertrail/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Papertrail logging endpoint.

--- a/pkg/commands/logging/papertrail/delete.go
+++ b/pkg/commands/logging/papertrail/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Papertrail logging endpoint.

--- a/pkg/commands/logging/papertrail/describe.go
+++ b/pkg/commands/logging/papertrail/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Papertrail logging endpoint.

--- a/pkg/commands/logging/papertrail/list.go
+++ b/pkg/commands/logging/papertrail/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Papertrail logging endpoints.

--- a/pkg/commands/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestPapertrailCreate(t *testing.T) {

--- a/pkg/commands/logging/papertrail/papertrail_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreatePapertrailInput(t *testing.T) {

--- a/pkg/commands/logging/papertrail/update.go
+++ b/pkg/commands/logging/papertrail/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Papertrail logging endpoint.

--- a/pkg/commands/logging/s3/create.go
+++ b/pkg/commands/logging/s3/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an Amazon S3 logging endpoint.

--- a/pkg/commands/logging/s3/delete.go
+++ b/pkg/commands/logging/s3/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an Amazon S3 logging endpoint.

--- a/pkg/commands/logging/s3/describe.go
+++ b/pkg/commands/logging/s3/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an Amazon S3 logging endpoint.

--- a/pkg/commands/logging/s3/list.go
+++ b/pkg/commands/logging/s3/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Amazon S3 logging endpoints.

--- a/pkg/commands/logging/s3/s3_integration_test.go
+++ b/pkg/commands/logging/s3/s3_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestS3Create(t *testing.T) {

--- a/pkg/commands/logging/s3/s3_test.go
+++ b/pkg/commands/logging/s3/s3_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateS3Input(t *testing.T) {

--- a/pkg/commands/logging/s3/update.go
+++ b/pkg/commands/logging/s3/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an Amazon S3 logging endpoint.

--- a/pkg/commands/logging/scalyr/create.go
+++ b/pkg/commands/logging/scalyr/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Scalyr logging endpoint.

--- a/pkg/commands/logging/scalyr/delete.go
+++ b/pkg/commands/logging/scalyr/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Scalyr logging endpoint.

--- a/pkg/commands/logging/scalyr/describe.go
+++ b/pkg/commands/logging/scalyr/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Scalyr logging endpoint.

--- a/pkg/commands/logging/scalyr/list.go
+++ b/pkg/commands/logging/scalyr/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Scalyr logging endpoints.

--- a/pkg/commands/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_integration_test.go
@@ -10,7 +10,7 @@ import (
 	fsterrs "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestScalyrCreate(t *testing.T) {

--- a/pkg/commands/logging/scalyr/scalyr_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateScalyrInput(t *testing.T) {

--- a/pkg/commands/logging/scalyr/update.go
+++ b/pkg/commands/logging/scalyr/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update Scalyr logging endpoints.

--- a/pkg/commands/logging/sftp/create.go
+++ b/pkg/commands/logging/sftp/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create an SFTP logging endpoint.

--- a/pkg/commands/logging/sftp/delete.go
+++ b/pkg/commands/logging/sftp/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete an SFTP logging endpoint.

--- a/pkg/commands/logging/sftp/describe.go
+++ b/pkg/commands/logging/sftp/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe an SFTP logging endpoint.

--- a/pkg/commands/logging/sftp/list.go
+++ b/pkg/commands/logging/sftp/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list SFTP logging endpoints.

--- a/pkg/commands/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/logging/sftp/sftp_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestSFTPCreate(t *testing.T) {

--- a/pkg/commands/logging/sftp/sftp_test.go
+++ b/pkg/commands/logging/sftp/sftp_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateSFTPInput(t *testing.T) {

--- a/pkg/commands/logging/sftp/update.go
+++ b/pkg/commands/logging/sftp/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update an SFTP logging endpoint.

--- a/pkg/commands/logging/splunk/create.go
+++ b/pkg/commands/logging/splunk/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Splunk logging endpoint.

--- a/pkg/commands/logging/splunk/delete.go
+++ b/pkg/commands/logging/splunk/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Splunk logging endpoint.

--- a/pkg/commands/logging/splunk/describe.go
+++ b/pkg/commands/logging/splunk/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Splunk logging endpoint.

--- a/pkg/commands/logging/splunk/list.go
+++ b/pkg/commands/logging/splunk/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Splunk logging endpoints.

--- a/pkg/commands/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/logging/splunk/splunk_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestSplunkCreate(t *testing.T) {

--- a/pkg/commands/logging/splunk/splunk_test.go
+++ b/pkg/commands/logging/splunk/splunk_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateSplunkInput(t *testing.T) {

--- a/pkg/commands/logging/splunk/update.go
+++ b/pkg/commands/logging/splunk/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Splunk logging endpoint.

--- a/pkg/commands/logging/sumologic/create.go
+++ b/pkg/commands/logging/sumologic/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Sumologic logging endpoint.

--- a/pkg/commands/logging/sumologic/delete.go
+++ b/pkg/commands/logging/sumologic/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Sumologic logging endpoint.

--- a/pkg/commands/logging/sumologic/describe.go
+++ b/pkg/commands/logging/sumologic/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Sumologic logging endpoint.

--- a/pkg/commands/logging/sumologic/list.go
+++ b/pkg/commands/logging/sumologic/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Sumologic logging endpoints.

--- a/pkg/commands/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestSumologicCreate(t *testing.T) {

--- a/pkg/commands/logging/sumologic/sumologic_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateSumologicInput(t *testing.T) {

--- a/pkg/commands/logging/sumologic/update.go
+++ b/pkg/commands/logging/sumologic/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Sumologic logging endpoint.

--- a/pkg/commands/logging/syslog/create.go
+++ b/pkg/commands/logging/syslog/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a Syslog logging endpoint.

--- a/pkg/commands/logging/syslog/delete.go
+++ b/pkg/commands/logging/syslog/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete a Syslog logging endpoint.

--- a/pkg/commands/logging/syslog/describe.go
+++ b/pkg/commands/logging/syslog/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a Syslog logging endpoint.

--- a/pkg/commands/logging/syslog/list.go
+++ b/pkg/commands/logging/syslog/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list Syslog logging endpoints.

--- a/pkg/commands/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/logging/syslog/syslog_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestSyslogCreate(t *testing.T) {

--- a/pkg/commands/logging/syslog/syslog_test.go
+++ b/pkg/commands/logging/syslog/syslog_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateSyslogInput(t *testing.T) {

--- a/pkg/commands/logging/syslog/update.go
+++ b/pkg/commands/logging/syslog/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a Syslog logging endpoint.

--- a/pkg/commands/logtail/root.go
+++ b/pkg/commands/logtail/root.go
@@ -21,7 +21,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/tomnomnom/linkheader"
 )
 

--- a/pkg/commands/objectstore/doc.go
+++ b/pkg/commands/objectstore/doc.go
@@ -1,3 +1,0 @@
-// Package objectstore contains commands to inspect and manipulate Fastly edge
-// object stores.
-package objectstore

--- a/pkg/commands/objectstoreentry/doc.go
+++ b/pkg/commands/objectstoreentry/doc.go
@@ -1,3 +1,0 @@
-// Package objectstoreentry contains commands to inspect and manipulate Fastly edge
-// object stores keys.
-package objectstoreentry

--- a/pkg/commands/pop/pop_test.go
+++ b/pkg/commands/pop/pop_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestAllDatacenters(t *testing.T) {

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/profile"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand represents a Kingpin command.

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Scenario is an extension of the base TestScenario.

--- a/pkg/commands/profile/update.go
+++ b/pkg/commands/profile/update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/profile"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // APIClientFactory allows the profile command to regenerate the global Fastly

--- a/pkg/commands/purge/purge_test.go
+++ b/pkg/commands/purge/purge_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestPurgeAll(t *testing.T) {

--- a/pkg/commands/purge/root.go
+++ b/pkg/commands/purge/root.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewRootCommand returns a new command registered in the parent.

--- a/pkg/commands/ratelimit/create.go
+++ b/pkg/commands/ratelimit/create.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // rateLimitActionFlagOpts is a string representation of rateLimitActions

--- a/pkg/commands/ratelimit/delete.go
+++ b/pkg/commands/ratelimit/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/ratelimit/describe.go
+++ b/pkg/commands/ratelimit/describe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/ratelimit/list.go
+++ b/pkg/commands/ratelimit/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/ratelimit/ratelimit_test.go
+++ b/pkg/commands/ratelimit/ratelimit_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreate(t *testing.T) {

--- a/pkg/commands/ratelimit/update.go
+++ b/pkg/commands/ratelimit/update.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/resourcelink/create.go
+++ b/pkg/commands/resourcelink/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a resource link.

--- a/pkg/commands/resourcelink/delete.go
+++ b/pkg/commands/resourcelink/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete service resource links.

--- a/pkg/commands/resourcelink/describe.go
+++ b/pkg/commands/resourcelink/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a service resource link.

--- a/pkg/commands/resourcelink/list.go
+++ b/pkg/commands/resourcelink/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list service resource links

--- a/pkg/commands/resourcelink/resourcelink_test.go
+++ b/pkg/commands/resourcelink/resourcelink_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/resourcelink"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateServiceResourceCommand(t *testing.T) {

--- a/pkg/commands/resourcelink/update.go
+++ b/pkg/commands/resourcelink/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a dictionary.

--- a/pkg/commands/secretstore/create.go
+++ b/pkg/commands/secretstore/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/secretstore/delete.go
+++ b/pkg/commands/secretstore/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/secretstore/describe.go
+++ b/pkg/commands/secretstore/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/secretstore/helper_test.go
+++ b/pkg/commands/secretstore/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func fmtStore(s *fastly.SecretStore) string {

--- a/pkg/commands/secretstore/list.go
+++ b/pkg/commands/secretstore/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/secretstore/secretstore_test.go
+++ b/pkg/commands/secretstore/secretstore_test.go
@@ -12,7 +12,7 @@ import (
 	fstfmt "github.com/fastly/cli/pkg/fmt"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreateStoreCommand(t *testing.T) {

--- a/pkg/commands/secretstoreentry/create.go
+++ b/pkg/commands/secretstoreentry/create.go
@@ -148,7 +148,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if !ck.ValidateSignature(sk) {
+	if !ck.VerifySignature(sk) {
 		err := fmt.Errorf("unable to validate signature of client key")
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/secretstoreentry/create.go
+++ b/pkg/commands/secretstoreentry/create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/secretstoreentry/delete.go
+++ b/pkg/commands/secretstoreentry/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/secretstoreentry/describe.go
+++ b/pkg/commands/secretstoreentry/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/secretstoreentry/helper_test.go
+++ b/pkg/commands/secretstoreentry/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func fmtSecret(s *fastly.Secret) string {

--- a/pkg/commands/secretstoreentry/list.go
+++ b/pkg/commands/secretstoreentry/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/secretstoreentry/secretstoreentry_test.go
+++ b/pkg/commands/secretstoreentry/secretstoreentry_test.go
@@ -18,7 +18,7 @@ import (
 	fstfmt "github.com/fastly/cli/pkg/fmt"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/pkg/commands/service/create.go
+++ b/pkg/commands/service/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CreateCommand calls the Fastly API to create services.

--- a/pkg/commands/service/delete.go
+++ b/pkg/commands/service/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete services.

--- a/pkg/commands/service/describe.go
+++ b/pkg/commands/service/describe.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a service.

--- a/pkg/commands/service/list.go
+++ b/pkg/commands/service/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list services.

--- a/pkg/commands/service/search.go
+++ b/pkg/commands/service/search.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // SearchCommand calls the Fastly API to describe a service.

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestServiceCreate(t *testing.T) {

--- a/pkg/commands/service/update.go
+++ b/pkg/commands/service/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to create services.

--- a/pkg/commands/serviceauth/create.go
+++ b/pkg/commands/serviceauth/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Permissions is a list of supported permission values.

--- a/pkg/commands/serviceauth/delete.go
+++ b/pkg/commands/serviceauth/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeleteCommand calls the Fastly API to delete service authorizations.

--- a/pkg/commands/serviceauth/describe.go
+++ b/pkg/commands/serviceauth/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DescribeCommand calls the Fastly API to describe a service authorization.

--- a/pkg/commands/serviceauth/list.go
+++ b/pkg/commands/serviceauth/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list service authorizations.

--- a/pkg/commands/serviceauth/service_test.go
+++ b/pkg/commands/serviceauth/service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestServiceAuthCreate(t *testing.T) {

--- a/pkg/commands/serviceauth/update.go
+++ b/pkg/commands/serviceauth/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update service authorizations.

--- a/pkg/commands/serviceversion/activate.go
+++ b/pkg/commands/serviceversion/activate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ActivateCommand calls the Fastly API to activate a service version.

--- a/pkg/commands/serviceversion/clone.go
+++ b/pkg/commands/serviceversion/clone.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // CloneCommand calls the Fastly API to clone a service version.

--- a/pkg/commands/serviceversion/deactivate.go
+++ b/pkg/commands/serviceversion/deactivate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // DeactivateCommand calls the Fastly API to deactivate a service version.

--- a/pkg/commands/serviceversion/list.go
+++ b/pkg/commands/serviceversion/list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list services.

--- a/pkg/commands/serviceversion/lock.go
+++ b/pkg/commands/serviceversion/lock.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // LockCommand calls the Fastly API to lock a service version.

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestVersionClone(t *testing.T) {

--- a/pkg/commands/serviceversion/update.go
+++ b/pkg/commands/serviceversion/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // UpdateCommand calls the Fastly API to update a service version.

--- a/pkg/commands/stats/historical.go
+++ b/pkg/commands/stats/historical.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const statusSuccess = "success"

--- a/pkg/commands/stats/historical_test.go
+++ b/pkg/commands/stats/historical_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestHistorical(t *testing.T) {

--- a/pkg/commands/stats/realtime.go
+++ b/pkg/commands/stats/realtime.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // RealtimeCommand exposes the Realtime Metrics API.

--- a/pkg/commands/stats/regions_test.go
+++ b/pkg/commands/stats/regions_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestRegions(t *testing.T) {

--- a/pkg/commands/stats/template.go
+++ b/pkg/commands/stats/template.go
@@ -6,7 +6,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/mitchellh/mapstructure"
 )
 

--- a/pkg/commands/tls/config/config_test.go
+++ b/pkg/commands/tls/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/tls/config/describe.go
+++ b/pkg/commands/tls/config/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const include = "dns_records"

--- a/pkg/commands/tls/config/list.go
+++ b/pkg/commands/tls/config/list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/config/update.go
+++ b/pkg/commands/tls/config/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/activation/activation_test.go
+++ b/pkg/commands/tls/custom/activation/activation_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/tls/custom/activation/create.go
+++ b/pkg/commands/tls/custom/activation/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/activation/delete.go
+++ b/pkg/commands/tls/custom/activation/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/activation/describe.go
+++ b/pkg/commands/tls/custom/activation/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 var include = []string{"tls_certificate", "tls_configuration", "tls_domain"}

--- a/pkg/commands/tls/custom/activation/list.go
+++ b/pkg/commands/tls/custom/activation/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/activation/update.go
+++ b/pkg/commands/tls/custom/activation/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/certificate/certificate_test.go
+++ b/pkg/commands/tls/custom/certificate/certificate_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/tls/custom/certificate/create.go
+++ b/pkg/commands/tls/custom/certificate/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/certificate/delete.go
+++ b/pkg/commands/tls/custom/certificate/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/certificate/describe.go
+++ b/pkg/commands/tls/custom/certificate/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/certificate/list.go
+++ b/pkg/commands/tls/custom/certificate/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const emptyString = ""

--- a/pkg/commands/tls/custom/certificate/update.go
+++ b/pkg/commands/tls/custom/certificate/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/domain/domain_test.go
+++ b/pkg/commands/tls/custom/domain/domain_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/tls/custom/domain/list.go
+++ b/pkg/commands/tls/custom/domain/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const emptyString = ""

--- a/pkg/commands/tls/custom/privatekey/create.go
+++ b/pkg/commands/tls/custom/privatekey/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/privatekey/delete.go
+++ b/pkg/commands/tls/custom/privatekey/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/privatekey/describe.go
+++ b/pkg/commands/tls/custom/privatekey/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/privatekey/list.go
+++ b/pkg/commands/tls/custom/privatekey/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/custom/privatekey/privatekey_test.go
+++ b/pkg/commands/tls/custom/privatekey/privatekey_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/tls/platform/create.go
+++ b/pkg/commands/tls/platform/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/platform/delete.go
+++ b/pkg/commands/tls/platform/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/platform/describe.go
+++ b/pkg/commands/tls/platform/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/platform/list.go
+++ b/pkg/commands/tls/platform/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/platform/platform_test.go
+++ b/pkg/commands/tls/platform/platform_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/tls/platform/update.go
+++ b/pkg/commands/tls/platform/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/subscription/create.go
+++ b/pkg/commands/tls/subscription/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const emptyString = ""

--- a/pkg/commands/tls/subscription/delete.go
+++ b/pkg/commands/tls/subscription/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/tls/subscription/describe.go
+++ b/pkg/commands/tls/subscription/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 var include = []string{"tls_authorizations", "tls_authorizations.globalsign_email_challenge"}

--- a/pkg/commands/tls/subscription/list.go
+++ b/pkg/commands/tls/subscription/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 var states = []string{"pending", "processing", "issued", "renewing"}

--- a/pkg/commands/tls/subscription/subscription_test.go
+++ b/pkg/commands/tls/subscription/subscription_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const (

--- a/pkg/commands/tls/subscription/update.go
+++ b/pkg/commands/tls/subscription/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/user/create.go
+++ b/pkg/commands/user/create.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/user/delete.go
+++ b/pkg/commands/user/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/user/describe.go
+++ b/pkg/commands/user/describe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/user/list.go
+++ b/pkg/commands/user/list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/user/update.go
+++ b/pkg/commands/user/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/lookup"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/user/user_test.go
+++ b/pkg/commands/user/user_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreate(t *testing.T) {

--- a/pkg/commands/vcl/custom/create.go
+++ b/pkg/commands/vcl/custom/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/custom/custom_test.go
+++ b/pkg/commands/vcl/custom/custom_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestVCLCustomCreate(t *testing.T) {

--- a/pkg/commands/vcl/custom/delete.go
+++ b/pkg/commands/vcl/custom/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/custom/describe.go
+++ b/pkg/commands/vcl/custom/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/custom/list.go
+++ b/pkg/commands/vcl/custom/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/custom/update.go
+++ b/pkg/commands/vcl/custom/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/snippet/create.go
+++ b/pkg/commands/vcl/snippet/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Locations is a list of VCL subroutines.

--- a/pkg/commands/vcl/snippet/delete.go
+++ b/pkg/commands/vcl/snippet/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDeleteCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/snippet/describe.go
+++ b/pkg/commands/vcl/snippet/describe.go
@@ -9,7 +9,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewDescribeCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/snippet/list.go
+++ b/pkg/commands/vcl/snippet/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewListCommand returns a usable command registered under the parent.

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestVCLSnippetCreate(t *testing.T) {

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // NewUpdateCommand returns a usable command registered under the parent.

--- a/pkg/commands/version/root.go
+++ b/pkg/commands/version/root.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/github"
 	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/useragent"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func init() {

--- a/pkg/errors/deduce.go
+++ b/pkg/errors/deduce.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Deduce attempts to deduce a RemediationError from a plain error. If the error

--- a/pkg/errors/deduce_test.go
+++ b/pkg/errors/deduce_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestDeduce(t *testing.T) {

--- a/pkg/errors/log.go
+++ b/pkg/errors/log.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/getsentry/sentry-go"
 )
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -218,10 +218,10 @@ type Scripts struct {
 // Setup represents a set of service configuration that works with the code in
 // the package. See https://developer.fastly.com/reference/fastly-toml/.
 type Setup struct {
-	Backends     map[string]*SetupBackend     `toml:"backends,omitempty"`
-	Dictionaries map[string]*SetupDictionary  `toml:"dictionaries,omitempty"`
-	Loggers      map[string]*SetupLogger      `toml:"log_endpoints,omitempty"`
-	ObjectStores map[string]*SetupObjectStore `toml:"object_stores,omitempty"`
+	Backends     map[string]*SetupBackend    `toml:"backends,omitempty"`
+	Dictionaries map[string]*SetupDictionary `toml:"dictionaries,omitempty"`
+	Loggers      map[string]*SetupLogger     `toml:"log_endpoints,omitempty"`
+	KVStores     map[string]*SetupKVStore    `toml:"kv_stores,omitempty"`
 }
 
 // Defined indicates if there is any [setup] configuration in the manifest.
@@ -237,7 +237,7 @@ func (s Setup) Defined() bool {
 	if len(s.Loggers) > 0 {
 		defined = true
 	}
-	if len(s.ObjectStores) > 0 {
+	if len(s.KVStores) > 0 {
 		defined = true
 	}
 
@@ -268,14 +268,14 @@ type SetupLogger struct {
 	Provider string `toml:"provider,omitempty"`
 }
 
-// SetupObjectStore represents a '[setup.object_stores.<T>]' instance.
-type SetupObjectStore struct {
-	Items       map[string]SetupObjectStoreItems `toml:"items,omitempty"`
-	Description string                           `toml:"description,omitempty"`
+// SetupKVStore represents a '[setup.kv_stores.<T>]' instance.
+type SetupKVStore struct {
+	Items       map[string]SetupKVStoreItems `toml:"items,omitempty"`
+	Description string                       `toml:"description,omitempty"`
 }
 
-// SetupObjectStoreItems represents a '[setup.object_stores.<T>.items]' instance.
-type SetupObjectStoreItems struct {
+// SetupKVStoreItems represents a '[setup.kv_stores.<T>.items]' instance.
+type SetupKVStoreItems struct {
 	Value       string `toml:"value,omitempty"`
 	Description string `toml:"description,omitempty"`
 }
@@ -284,7 +284,7 @@ type SetupObjectStoreItems struct {
 type LocalServer struct {
 	Backends     map[string]LocalBackend       `toml:"backends"`
 	Dictionaries map[string]LocalDictionary    `toml:"dictionaries,omitempty"`
-	ObjectStores map[string][]LocalObjectStore `toml:"object_stores,omitempty"`
+	KVStores     map[string][]LocalKVStore     `toml:"kv_stores,omitempty"`
 	SecretStores map[string][]LocalSecretStore `toml:"secret_stores,omitempty"`
 }
 
@@ -303,8 +303,8 @@ type LocalDictionary struct {
 	Contents map[string]string `toml:"contents,omitempty"`
 }
 
-// LocalObjectStore represents an object_store to be mocked by the local testing server.
-type LocalObjectStore struct {
+// LocalKVStore represents an kv_store to be mocked by the local testing server.
+type LocalKVStore struct {
 	Key  string `toml:"key"`
 	File string `toml:"file,omitempty"`
 	Data string `toml:"data,omitempty"`

--- a/pkg/manifest/testdata/fastly-viceroy-update.toml
+++ b/pkg/manifest/testdata/fastly-viceroy-update.toml
@@ -35,14 +35,14 @@ name = "Default Rust template"
       baz = """
 qux"""
 
-  [local_server.object_stores]
+  [local_server.kv_stores]
     store_one = [{key = "first", data = "This is some data"}, {key = "second", file = "strings.json"}]
 
-    [[local_server.object_stores.store_two]]
+    [[local_server.kv_stores.store_two]]
       key = "first"
       data = "This is some data"
 
-    [[local_server.object_stores.store_two]]
+    [[local_server.kv_stores.store_two]]
       key = "second"
       file = "strings.json"
 

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -335,14 +335,14 @@ type API struct {
 	ListConfigStoreItemsFn  func(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error)
 	UpdateConfigStoreItemFn func(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
 
-	CreateObjectStoreFn    func(i *fastly.CreateObjectStoreInput) (*fastly.ObjectStore, error)
-	GetObjectStoreFn       func(i *fastly.GetObjectStoreInput) (*fastly.ObjectStore, error)
-	ListObjectStoresFn     func(i *fastly.ListObjectStoresInput) (*fastly.ListObjectStoresResponse, error)
-	DeleteObjectStoreFn    func(i *fastly.DeleteObjectStoreInput) error
-	ListObjectStoreKeysFn  func(i *fastly.ListObjectStoreKeysInput) (*fastly.ListObjectStoreKeysResponse, error)
-	GetObjectStoreKeyFn    func(i *fastly.GetObjectStoreKeyInput) (string, error)
-	InsertObjectStoreKeyFn func(i *fastly.InsertObjectStoreKeyInput) error
-	DeleteObjectStoreKeyFn func(i *fastly.DeleteObjectStoreKeyInput) error
+	CreateKVStoreFn    func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error)
+	GetKVStoreFn       func(i *fastly.GetKVStoreInput) (*fastly.KVStore, error)
+	ListKVStoresFn     func(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error)
+	DeleteKVStoreFn    func(i *fastly.DeleteKVStoreInput) error
+	ListKVStoreKeysFn  func(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error)
+	GetKVStoreKeyFn    func(i *fastly.GetKVStoreKeyInput) (string, error)
+	InsertKVStoreKeyFn func(i *fastly.InsertKVStoreKeyInput) error
+	DeleteKVStoreKeyFn func(i *fastly.DeleteKVStoreKeyInput) error
 
 	CreateSecretStoreFn func(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error)
 	GetSecretStoreFn    func(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error)
@@ -1718,44 +1718,44 @@ func (m API) UpdateConfigStoreItem(i *fastly.UpdateConfigStoreItemInput) (*fastl
 	return m.UpdateConfigStoreItemFn(i)
 }
 
-// CreateObjectStore implements Interface.
-func (m API) CreateObjectStore(i *fastly.CreateObjectStoreInput) (*fastly.ObjectStore, error) {
-	return m.CreateObjectStoreFn(i)
+// CreateKVStore implements Interface.
+func (m API) CreateKVStore(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+	return m.CreateKVStoreFn(i)
 }
 
-// GetObjectStore implements Interface.
-func (m API) GetObjectStore(i *fastly.GetObjectStoreInput) (*fastly.ObjectStore, error) {
-	return m.GetObjectStoreFn(i)
+// GetKVStore implements Interface.
+func (m API) GetKVStore(i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
+	return m.GetKVStoreFn(i)
 }
 
-// ListObjectStores implements Interface.
-func (m API) ListObjectStores(i *fastly.ListObjectStoresInput) (*fastly.ListObjectStoresResponse, error) {
-	return m.ListObjectStoresFn(i)
+// ListKVStores implements Interface.
+func (m API) ListKVStores(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+	return m.ListKVStoresFn(i)
 }
 
-// DeleteObjectStore implements Interface.
-func (m API) DeleteObjectStore(i *fastly.DeleteObjectStoreInput) error {
-	return m.DeleteObjectStoreFn(i)
+// DeleteKVStore implements Interface.
+func (m API) DeleteKVStore(i *fastly.DeleteKVStoreInput) error {
+	return m.DeleteKVStoreFn(i)
 }
 
-// ListObjectStoreKeys implements Interface.
-func (m API) ListObjectStoreKeys(i *fastly.ListObjectStoreKeysInput) (*fastly.ListObjectStoreKeysResponse, error) {
-	return m.ListObjectStoreKeysFn(i)
+// ListKVStoreKeys implements Interface.
+func (m API) ListKVStoreKeys(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+	return m.ListKVStoreKeysFn(i)
 }
 
-// GetObjectStoreKey implements Interface.
-func (m API) GetObjectStoreKey(i *fastly.GetObjectStoreKeyInput) (string, error) {
-	return m.GetObjectStoreKeyFn(i)
+// GetKVStoreKey implements Interface.
+func (m API) GetKVStoreKey(i *fastly.GetKVStoreKeyInput) (string, error) {
+	return m.GetKVStoreKeyFn(i)
 }
 
-// InsertObjectStoreKey implements Interface.
-func (m API) InsertObjectStoreKey(i *fastly.InsertObjectStoreKeyInput) error {
-	return m.InsertObjectStoreKeyFn(i)
+// InsertKVStoreKey implements Interface.
+func (m API) InsertKVStoreKey(i *fastly.InsertKVStoreKeyInput) error {
+	return m.InsertKVStoreKeyFn(i)
 }
 
-// DeleteObjectStoreKey implements Interface.
-func (m API) DeleteObjectStoreKey(i *fastly.DeleteObjectStoreKeyInput) error {
-	return m.DeleteObjectStoreKeyFn(i)
+// DeleteKVStoreKey implements Interface.
+func (m API) DeleteKVStoreKey(i *fastly.DeleteKVStoreKeyInput) error {
+	return m.DeleteKVStoreKeyFn(i)
 }
 
 // CreateSecretStore implements Interface.

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"crypto/ed25519"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // API is a mock implementation of api.Interface that's used for testing.

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	"errors"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Err represents a generic error.

--- a/pkg/text/backend.go
+++ b/pkg/text/backend.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/configstore.go
+++ b/pkg/text/configstore.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	fsttime "github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/dictionary.go
+++ b/pkg/text/dictionary.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/dictionaryitem.go
+++ b/pkg/text/dictionaryitem.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/dictionaryitem_test.go
+++ b/pkg/text/dictionaryitem_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestPrintDictionaryItem(t *testing.T) {

--- a/pkg/text/healthcheck.go
+++ b/pkg/text/healthcheck.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/objectstore.go
+++ b/pkg/text/objectstore.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/objectstore.go
+++ b/pkg/text/objectstore.go
@@ -9,10 +9,10 @@ import (
 	"github.com/segmentio/textio"
 )
 
-// PrintObjectStore pretty prints a fastly.Dictionary structure in verbose
+// PrintKVStore pretty prints a fastly.Dictionary structure in verbose
 // format to a given io.Writer. Consumers can provide a prefix string which
 // will be used as a prefix to each line, useful for indentation.
-func PrintObjectStore(out io.Writer, prefix string, d *fastly.ObjectStore) {
+func PrintKVStore(out io.Writer, prefix string, d *fastly.KVStore) {
 	out = textio.NewPrefixWriter(out, prefix)
 
 	fmt.Fprintf(out, "\nID: %s\n", d.ID)
@@ -21,10 +21,10 @@ func PrintObjectStore(out io.Writer, prefix string, d *fastly.ObjectStore) {
 	fmt.Fprintf(out, "Last edited (UTC): %s\n", d.UpdatedAt.UTC().Format(time.Format))
 }
 
-// PrintObjectStoreKeys pretty prints a list of object store keys in verbose
+// PrintKVStoreKeys pretty prints a list of kv store keys in verbose
 // format to a given io.Writer. Consumers can provide a prefix string which
 // will be used as a prefix to each line, useful for indentation.
-func PrintObjectStoreKeys(out io.Writer, prefix string, keys []string) {
+func PrintKVStoreKeys(out io.Writer, prefix string, keys []string) {
 	out = textio.NewPrefixWriter(out, prefix)
 
 	for _, k := range keys {
@@ -32,10 +32,10 @@ func PrintObjectStoreKeys(out io.Writer, prefix string, keys []string) {
 	}
 }
 
-// PrintObjectStoreKeyValue pretty prints a value from an object store to a
+// PrintKVStoreKeyValue pretty prints a value from an kv store to a
 // given io.Writer. Consumers can provide a prefix string which will be used as
 // a prefix to each line, useful for indentation.
-func PrintObjectStoreKeyValue(out io.Writer, prefix string, key, value string) {
+func PrintKVStoreKeyValue(out io.Writer, prefix string, key, value string) {
 	out = textio.NewPrefixWriter(out, prefix)
 
 	fmt.Fprintf(out, "Key: %s\n", key)

--- a/pkg/text/resource.go
+++ b/pkg/text/resource.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/secretstore.go
+++ b/pkg/text/secretstore.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 	"github.com/segmentio/textio"
 )
 

--- a/pkg/text/service_test.go
+++ b/pkg/text/service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v7/fastly"
+	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestPrintService(t *testing.T) {


### PR DESCRIPTION
We are renaming object store to kv store so doing the needed changes here.

Blocked by: https://github.com/fastly/go-fastly/pull/422