### PR TITLE
Add TypeScript Starter Kit

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -16,6 +16,7 @@ kits=(
   compute-starter-kit-rust-websockets
   compute-starter-kit-javascript-default
   compute-starter-kit-javascript-empty
+  compute-starter-kit-typescript
   compute-starter-kit-assemblyscript-default
   compute-starter-kit-go-default
 )


### PR DESCRIPTION
This PR adds [compute-starter-kit-typescript](https://github.com/fastly/compute-starter-kit-typescript) to the list of available starter kits.