### PR TITLE
fix(errors/log): support allowing errors to Sentry

### DIFF
--- a/pkg/commands/aclentry/update.go
+++ b/pkg/commands/aclentry/update.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -122,18 +122,20 @@ func (c *UpdateCommand) constructBatchInput(serviceID string) (*fastly.BatchModi
 	err := json.Unmarshal(bs, &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"File": s,
+			fsterr.AllowInstrumentation: true,
+			"File":                      s,
 		})
 		return nil, err
 	}
 
 	if len(input.Entries) == 0 {
-		err := errors.RemediationError{
+		err := fsterr.RemediationError{
 			Inner:       fmt.Errorf("missing 'entries' %s", c.file.Value),
 			Remediation: "Consult the API documentation for the JSON format: https://developer.fastly.com/reference/api/acls/acl-entry/#bulk-update-acl-entries",
 		}
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"File": string(bs),
+			fsterr.AllowInstrumentation: true,
+			"File":                      string(bs),
 		})
 		return nil, err
 	}
@@ -146,7 +148,7 @@ func (c *UpdateCommand) constructInput(serviceID string) (*fastly.UpdateACLEntry
 	var input fastly.UpdateACLEntryInput
 
 	if !c.id.WasSet {
-		return nil, errors.ErrNoID
+		return nil, fsterr.ErrNoID
 	}
 
 	input.ACLID = c.aclID

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -169,7 +169,8 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 	if err := language.Build(); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Language": language.Name,
+			fsterr.AllowInstrumentation: true,
+			"Language":                  language.Name,
 		})
 		return err
 	}
@@ -202,8 +203,9 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	err = CreatePackageArchive(files, dest)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Files":       files,
-			"Destination": dest,
+			fsterr.AllowInstrumentation: true,
+			"Files":                     files,
+			"Destination":               dest,
 		})
 
 		spinner.StopFailMessage(msg)
@@ -247,7 +249,8 @@ func (c *BuildCommand) includeSourceCode(files []string, srcDir string) ([]strin
 		binFiles, err := GetNonIgnoredFiles("bin", ignoreFiles)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Ignore files": ignoreFiles,
+				fsterr.AllowInstrumentation: true,
+				"Ignore files":              ignoreFiles,
 			})
 			return empty, err
 		}
@@ -256,8 +259,9 @@ func (c *BuildCommand) includeSourceCode(files []string, srcDir string) ([]strin
 		srcFiles, err := GetNonIgnoredFiles(srcDir, ignoreFiles)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Source directory": srcDir,
-				"Ignore files":     ignoreFiles,
+				fsterr.AllowInstrumentation: true,
+				"Source directory":          srcDir,
+				"Ignore files":              ignoreFiles,
 			})
 			return empty, err
 		}

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -280,7 +280,8 @@ func validatePackage(
 	pkgPath, err = packagePath(packageFlag, projectName, source)
 	if err != nil {
 		errLog.AddWithContext(err, map[string]any{
-			"Package path": packageFlag,
+			fsterr.AllowInstrumentation: true,
+			"Package path":              packageFlag,
 		})
 		return pkgPath, hashSum, err
 	}
@@ -288,7 +289,8 @@ func validatePackage(
 	pkgSize, err := packageSize(pkgPath)
 	if err != nil {
 		errLog.AddWithContext(err, map[string]any{
-			"Package path": pkgPath,
+			fsterr.AllowInstrumentation: true,
+			"Package path":              pkgPath,
 		})
 		return pkgPath, hashSum, fsterr.RemediationError{
 			Inner:       fmt.Errorf("error reading package size: %w", err),
@@ -317,8 +319,9 @@ func validatePackage(
 		return nil
 	}); err != nil {
 		errLog.AddWithContext(err, map[string]any{
-			"Package path": pkgPath,
-			"Package size": pkgSize,
+			fsterr.AllowInstrumentation: true,
+			"Package path":              pkgPath,
+			"Package size":              pkgSize,
 		})
 		return pkgPath, hashSum, err
 	}
@@ -553,7 +556,8 @@ func manageNoServiceIDFlow(
 	// have succeeded and so there will be no error.
 	if err != nil && packageFlag == "" {
 		errLog.AddWithContext(err, map[string]any{
-			"Service ID": serviceID,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
 		})
 		return serviceID, serviceVersion, err
 	}

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -124,7 +124,8 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	dst, err := verifyDestination(c.dir, spinner, out)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Directory": c.dir,
+			fsterr.AllowInstrumentation: true,
+			"Directory":                 c.dir,
 		})
 		return err
 	}
@@ -140,8 +141,9 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	name, desc, authors, err := promptOrReturn(c.Globals.Flags, c.manifest, c.dir, email, in, out)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Description": desc,
-			"Directory":   c.dir,
+			fsterr.AllowInstrumentation: true,
+			"Description":               desc,
+			"Directory":                 c.dir,
 		})
 		return err
 	}
@@ -176,10 +178,11 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		from, branch, tag, err = promptForStarterKit(c.Globals.Flags, language.StarterKits, in, out)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"From":           c.cloneFrom,
-				"Branch":         c.branch,
-				"Tag":            c.tag,
-				"Manifest Exist": false,
+				fsterr.AllowInstrumentation: true,
+				"From":                      c.cloneFrom,
+				"Branch":                    c.branch,
+				"Tag":                       c.tag,
+				"Manifest Exist":            false,
 			})
 			return err
 		}
@@ -199,10 +202,11 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		err = fetchPackageTemplate(c, branch, tag, file.Archives, spinner, out)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"From":      from,
-				"Branch":    branch,
-				"Tag":       tag,
-				"Directory": c.dir,
+				fsterr.AllowInstrumentation: true,
+				"From":                      from,
+				"Branch":                    branch,
+				"Tag":                       tag,
+				"Directory":                 c.dir,
 			})
 			return err
 		}
@@ -211,9 +215,10 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	mf, err = updateManifest(mf, spinner, c.dir, name, desc, authors, language)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Directory":   c.dir,
-			"Description": desc,
-			"Language":    language,
+			fsterr.AllowInstrumentation: true,
+			"Directory":                 c.dir,
+			"Description":               desc,
+			"Language":                  language,
 		})
 		return err
 	}

--- a/pkg/commands/compute/pack.go
+++ b/pkg/commands/compute/pack.go
@@ -58,6 +58,7 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	err = filesystem.MakeDirectoryIfNotExists(bindir)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			fsterr.AllowInstrumentation: true,
 			"Wasm directory (relative)": bindir,
 		})
 		return err
@@ -66,13 +67,15 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	src, err := filepath.Abs(c.wasmBinary)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Path (absolute)": src,
+			fsterr.AllowInstrumentation: true,
+			"Path (absolute)":           src,
 		})
 		return err
 	}
 	dst, err := filepath.Abs(bin)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			fsterr.AllowInstrumentation:   true,
 			"Wasm destination (relative)": bin,
 		})
 		return err
@@ -87,6 +90,7 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 
 	if err := filesystem.CopyFile(src, dst); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			fsterr.AllowInstrumentation:   true,
 			"Path (absolute)":             src,
 			"Wasm destination (absolute)": dst,
 		})
@@ -130,8 +134,9 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	dst = fmt.Sprintf("pkg/package/%s", manifest.Filename)
 	if err := filesystem.CopyFile(src, dst); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Manifest (destination)": dst,
-			"Manifest (source)":      src,
+			fsterr.AllowInstrumentation: true,
+			"Manifest (destination)":    dst,
+			"Manifest (source)":         src,
 		})
 
 		spinner.StopFailMessage(msg)
@@ -164,8 +169,9 @@ func (c *PackCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 		dst := fmt.Sprintf("%s.tar.gz", dir)
 		if err = tar.Archive(src, dst); err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Tar source":      dir,
-				"Tar destination": dst,
+				fsterr.AllowInstrumentation: true,
+				"Tar source":                dir,
+				"Tar destination":           dst,
 			})
 
 			spinner.StopFailMessage(msg)

--- a/pkg/commands/compute/update.go
+++ b/pkg/commands/compute/update.go
@@ -104,8 +104,9 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	defer func() {
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Service ID":      serviceID,
-				"Service Version": serviceVersion.Number,
+				fsterr.AllowInstrumentation: true,
+				"Service ID":                serviceID,
+				"Service Version":           serviceVersion.Number,
 			})
 		}
 	}()

--- a/pkg/commands/compute/validate.go
+++ b/pkg/commands/compute/validate.go
@@ -42,14 +42,16 @@ func (c *ValidateCommand) Exec(_ io.Reader, out io.Writer) error {
 	p, err := filepath.Abs(packagePath)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Path": c.path,
+			fsterr.AllowInstrumentation: true,
+			"Path":                      c.path,
 		})
 		return fmt.Errorf("error reading file path: %w", err)
 	}
 
 	if err := validate(p, nil); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Path": c.path,
+			fsterr.AllowInstrumentation: true,
+			"Path":                      c.path,
 		})
 		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("failed to validate package: %w", err),

--- a/pkg/commands/dictionary/update.go
+++ b/pkg/commands/dictionary/update.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/fastly/cli/pkg/cmd"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -82,7 +82,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
-			"Service Version": errors.ServiceVersion(serviceVersion),
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
 		})
 		return err
 	}
@@ -91,7 +91,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceVersion = serviceVersion.Number
 
 	if !c.newname.WasSet && !c.writeOnly.WasSet {
-		return errors.RemediationError{Inner: fmt.Errorf("error parsing arguments: required flag --new-name or --write-only not provided"), Remediation: "To fix this error, provide at least one of the aforementioned flags"}
+		return fsterr.RemediationError{Inner: fmt.Errorf("error parsing arguments: required flag --new-name or --write-only not provided"), Remediation: "To fix this error, provide at least one of the aforementioned flags"}
 	}
 
 	if c.newname.WasSet {
@@ -102,8 +102,9 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		writeOnly, err := strconv.ParseBool(c.writeOnly.Value)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Service ID":      serviceID,
-				"Service Version": serviceVersion.Number,
+				fsterr.AllowInstrumentation: true,
+				"Service ID":                serviceID,
+				"Service Version":           serviceVersion.Number,
 			})
 			return err
 		}

--- a/pkg/commands/logging/bigquery/create.go
+++ b/pkg/commands/logging/bigquery/create.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/logging/common"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -148,7 +148,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
-			"Service Version": errors.ServiceVersion(serviceVersion),
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
 		})
 		return err
 	}
@@ -156,8 +156,9 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input, err := c.ConstructInput(serviceID, serviceVersion.Number)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":      serviceID,
-			"Service Version": serviceVersion.Number,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
+			"Service Version":           serviceVersion.Number,
 		})
 		return err
 	}

--- a/pkg/commands/logging/bigquery/update.go
+++ b/pkg/commands/logging/bigquery/update.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/logging/common"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -151,7 +151,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
-			"Service Version": errors.ServiceVersion(serviceVersion),
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
 		})
 		return err
 	}
@@ -159,8 +159,9 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input, err := c.ConstructInput(serviceID, serviceVersion.Number)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":      serviceID,
-			"Service Version": serviceVersion.Number,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
+			"Service Version":           serviceVersion.Number,
 		})
 		return err
 	}

--- a/pkg/commands/logging/cloudfiles/create.go
+++ b/pkg/commands/logging/cloudfiles/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/logging/common"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -187,7 +187,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
-			"Service Version": errors.ServiceVersion(serviceVersion),
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
 		})
 		return err
 	}
@@ -195,8 +195,9 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input, err := c.ConstructInput(serviceID, serviceVersion.Number)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":      serviceID,
-			"Service Version": serviceVersion.Number,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
+			"Service Version":           serviceVersion.Number,
 		})
 		return err
 	}

--- a/pkg/commands/logging/cloudfiles/update.go
+++ b/pkg/commands/logging/cloudfiles/update.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fastly/cli/pkg/cmd"
 	"github.com/fastly/cli/pkg/commands/logging/common"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -187,7 +187,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
-			"Service Version": errors.ServiceVersion(serviceVersion),
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
 		})
 		return err
 	}
@@ -195,8 +195,9 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input, err := c.ConstructInput(serviceID, serviceVersion.Number)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":      serviceID,
-			"Service Version": serviceVersion.Number,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
+			"Service Version":           serviceVersion.Number,
 		})
 		return err
 	}

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -133,7 +133,8 @@ func (c *CreateCommand) validateToken(token, endpoint string, spinner text.Spinn
 	client, err := c.clientFactory(token, endpoint)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Endpoint": endpoint,
+			fsterr.AllowInstrumentation: true,
+			"Endpoint":                  endpoint,
 		})
 
 		spinner.StopFailMessage(msg)
@@ -229,8 +230,9 @@ func (c *CreateCommand) persistCfg() error {
 	case err != nil && errors.Is(err, fs.ErrNotExist):
 		if err := os.MkdirAll(dir, config.DirectoryPermissions); err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Directory":   dir,
-				"Permissions": config.DirectoryPermissions,
+				fsterr.AllowInstrumentation: true,
+				"Directory":                 dir,
+				"Permissions":               config.DirectoryPermissions,
 			})
 			return fmt.Errorf("error creating config file directory: %w", err)
 		}

--- a/pkg/commands/profile/update.go
+++ b/pkg/commands/profile/update.go
@@ -151,7 +151,8 @@ func (c *UpdateCommand) validateToken(token, endpoint string, spinner text.Spinn
 	client, err := c.clientFactory(token, endpoint)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Endpoint": endpoint,
+			fsterr.AllowInstrumentation: true,
+			"Endpoint":                  endpoint,
 		})
 
 		spinner.StopFailMessage(msg)

--- a/pkg/commands/serviceauth/create.go
+++ b/pkg/commands/serviceauth/create.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -60,8 +61,9 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	serviceID, source, flag, err := cmd.ServiceID(c.serviceName, c.manifest, c.Globals.APIClient, c.Globals.ErrLog)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":   c.manifest.Flag.ServiceID,
-			"Service Name": c.serviceName.Value,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                c.manifest.Flag.ServiceID,
+			"Service Name":              c.serviceName.Value,
 		})
 		return err
 	}

--- a/pkg/commands/stats/historical.go
+++ b/pkg/commands/stats/historical.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/go-fastly/v8/fastly"
@@ -83,7 +84,8 @@ func (c *HistoricalCommand) Exec(_ io.Reader, out io.Writer) error {
 		err := writeBlocksJSON(out, serviceID, envelope.Data)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Service ID": serviceID,
+				fsterr.AllowInstrumentation: true,
+				"Service ID":                serviceID,
 			})
 		}
 
@@ -92,7 +94,8 @@ func (c *HistoricalCommand) Exec(_ io.Reader, out io.Writer) error {
 		err := writeBlocks(out, serviceID, envelope.Data)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Service ID": serviceID,
+				fsterr.AllowInstrumentation: true,
+				"Service ID":                serviceID,
 			})
 		}
 	}

--- a/pkg/commands/update/root.go
+++ b/pkg/commands/update/root.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/fastly/cli/pkg/cmd"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/github"
 	"github.com/fastly/cli/pkg/global"
@@ -75,8 +76,9 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	tmpBin, err := c.av.Download()
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Current CLI version": current,
-			"Latest CLI version":  latest,
+			fsterr.AllowInstrumentation: true,
+			"Current CLI version":       current,
+			"Latest CLI version":        latest,
 		})
 
 		spinner.StopFailMessage(msg)
@@ -118,7 +120,8 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	currentPath, err := filepath.Abs(execPath)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Executable path": execPath,
+			fsterr.AllowInstrumentation: true,
+			"Executable path":           execPath,
 		})
 
 		spinner.StopFailMessage(msg)
@@ -150,8 +153,9 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err := os.Rename(tmpBin, currentPath); err != nil {
 		if err := filesystem.CopyFile(tmpBin, currentPath); err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Executable (source)":      tmpBin,
-				"Executable (destination)": currentPath,
+				fsterr.AllowInstrumentation: true,
+				"Executable (source)":       tmpBin,
+				"Executable (destination)":  currentPath,
 			})
 
 			spinner.StopFailMessage(msg)

--- a/pkg/commands/vcl/custom/update.go
+++ b/pkg/commands/vcl/custom/update.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -81,7 +81,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
-			"Service Version": errors.ServiceVersion(serviceVersion),
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
 		})
 		return err
 	}
@@ -89,8 +89,9 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input, err := c.constructInput(serviceID, serviceVersion.Number)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":      serviceID,
-			"Service Version": serviceVersion.Number,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
+			"Service Version":           serviceVersion.Number,
 		})
 		return err
 	}

--- a/pkg/commands/vcl/snippet/describe.go
+++ b/pkg/commands/vcl/snippet/describe.go
@@ -96,8 +96,9 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		input, err := c.constructDynamicInput(serviceID, serviceVersion.Number)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Service ID":      serviceID,
-				"Service Version": serviceVersion.Number,
+				fsterr.AllowInstrumentation: true,
+				"Service ID":                serviceID,
+				"Service Version":           serviceVersion.Number,
 			})
 			return err
 		}
@@ -115,8 +116,9 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	input, err := c.constructInput(serviceID, serviceVersion.Number)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":      serviceID,
-			"Service Version": serviceVersion.Number,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
+			"Service Version":           serviceVersion.Number,
 		})
 		return err
 	}

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
-	"github.com/fastly/cli/pkg/errors"
+	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
@@ -92,7 +92,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
-			"Service Version": errors.ServiceVersion(serviceVersion),
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
 		})
 		return err
 	}
@@ -101,8 +101,9 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		input, err := c.constructDynamicInput(serviceID, serviceVersion.Number)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"Service ID":      serviceID,
-				"Service Version": serviceVersion.Number,
+				fsterr.AllowInstrumentation: true,
+				"Service ID":                serviceID,
+				"Service Version":           serviceVersion.Number,
 			})
 			return err
 		}
@@ -121,8 +122,9 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input, err := c.constructInput(serviceID, serviceVersion.Number)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
-			"Service ID":      serviceID,
-			"Service Version": serviceVersion.Number,
+			fsterr.AllowInstrumentation: true,
+			"Service ID":                serviceID,
+			"Service Version":           serviceVersion.Number,
 		})
 		return err
 	}


### PR DESCRIPTION
**Problem:** reporting Fastly API errors to Sentry exhausts service limits.
**Solution:** only report errors that are actual Fastly CLI logic bugs (as those are _actionable_ errors).
**Note:** the primary affected file is `pkg/errors/log.go` as that filters out errors before sending to Sentry.