### PR TITLE
Improve output message for fastly.toml related errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,9 @@ version: 2
 updates:
   # Dependencies listed in go.mod
   - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "weekly"
-
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -42,6 +42,7 @@ func FastlyAPIClient(token, endpoint string) (api.Interface, error) {
 // and returned to the caller. This includes usage text.
 func Run(opts RunOpts) error {
 	var md manifest.Data
+	md.File.Args = opts.Args
 	md.File.SetErrLog(opts.ErrLog)
 	md.File.SetOutput(opts.Stdout)
 	_ = md.File.Read(manifest.Filename)

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -86,7 +86,7 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if err != nil {
 		return err
 	}
-	msg := "Verifying package manifest"
+	msg := "Verifying fastly.toml"
 	spinner.Message(msg + "...")
 
 	err = c.Manifest.File.ReadError()

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -38,7 +38,7 @@ func TestBuildRust(t *testing.T) {
 		{
 			name:                 "no fastly.toml manifest",
 			args:                 args("compute build"),
-			wantError:            "error reading package manifest",
+			wantError:            "error reading fastly.toml",
 			wantRemediationError: "Run `fastly compute init` to ensure a correctly configured manifest.",
 		},
 		{
@@ -223,7 +223,7 @@ func TestBuildGo(t *testing.T) {
 		{
 			name:                 "no fastly.toml manifest",
 			args:                 args("compute build"),
-			wantError:            "error reading package manifest",
+			wantError:            "error reading fastly.toml",
 			wantRemediationError: "Run `fastly compute init` to ensure a correctly configured manifest.",
 		},
 		{
@@ -383,7 +383,7 @@ func TestBuildJavaScript(t *testing.T) {
 		{
 			name:                 "no fastly.toml manifest",
 			args:                 args("compute build"),
-			wantError:            "error reading package manifest",
+			wantError:            "error reading fastly.toml",
 			wantRemediationError: "Run `fastly compute init` to ensure a correctly configured manifest.",
 		},
 		{
@@ -535,7 +535,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 		{
 			name:                 "no fastly.toml manifest",
 			args:                 args("compute build"),
-			wantError:            "error reading package manifest",
+			wantError:            "error reading fastly.toml",
 			wantRemediationError: "Run `fastly compute init` to ensure a correctly configured manifest.",
 		},
 		{

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -684,13 +684,13 @@ func cleanupService(apiClient api.Interface, serviceID string, m manifest.Data, 
 // manifest will continue to hold a reference to it).
 func updateManifestServiceID(m *manifest.File, manifestFilename string, serviceID string) error {
 	if err := m.Read(manifestFilename); err != nil {
-		return fmt.Errorf("error reading package manifest: %w", err)
+		return fmt.Errorf("error reading fastly.toml: %w", err)
 	}
 
 	m.ServiceID = serviceID
 
 	if err := m.Write(manifestFilename); err != nil {
-		return fmt.Errorf("error saving package manifest: %w", err)
+		return fmt.Errorf("error saving fastly.toml: %w", err)
 	}
 
 	return nil

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -360,6 +360,9 @@ func readManifestFromPackageArchive(data *manifest.Data, packageFlag string, ver
 
 	err = data.File.Read(manifestPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			err = fsterr.ErrReadingManifest
+		}
 		return err
 	}
 

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -107,7 +107,7 @@ func TestDeploy(t *testing.T) {
 		{
 			name:                 "no fastly.toml manifest",
 			args:                 args("compute deploy --token 123"),
-			wantError:            "error reading package manifest",
+			wantError:            "error reading fastly.toml",
 			wantRemediationError: errors.ComputeInitRemediation,
 			noManifest:           true,
 		},

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -960,7 +960,7 @@ func updateManifest(
 	if err != nil {
 		return m, err
 	}
-	msg := "Reading package manifest"
+	msg := "Reading fastly.toml"
 	spinner.Message(msg + "...")
 
 	mp := filepath.Join(path, manifest.Filename)
@@ -981,7 +981,7 @@ func updateManifest(
 					if spinErr != nil {
 						return m, spinErr
 					}
-					return m, fmt.Errorf("error saving package manifest: %w", err)
+					return m, fmt.Errorf("error saving fastly.toml: %w", err)
 				}
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
@@ -997,7 +997,7 @@ func updateManifest(
 		if spinErr != nil {
 			return m, spinErr
 		}
-		return m, fmt.Errorf("error reading package manifest: %w", err)
+		return m, fmt.Errorf("error reading fastly.toml: %w", err)
 	}
 
 	spinner.StopMessage(msg)
@@ -1087,7 +1087,7 @@ func updateManifest(
 		if spinErr != nil {
 			return m, spinErr
 		}
-		return m, fmt.Errorf("error saving package manifest: %w", err)
+		return m, fmt.Errorf("error saving fastly.toml: %w", err)
 	}
 
 	spinner.StopMessage(msg)

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -72,7 +72,7 @@ func TestInit(t *testing.T) {
 			stdin: "foobar", // expect the first prompt to be for the package name.
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 			},
 			manifestIncludes: `name = "foobar"`,
 		},
@@ -86,7 +86,7 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 			},
 			manifestIncludes: `description = ""`, // expect this to be empty
 		},
@@ -100,7 +100,7 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 			},
 			manifestIncludes: `authors = ["test@example.com"]`,
 		},
@@ -114,7 +114,7 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 			},
 			manifestIncludes: `authors = ["test1@example.com", "test2@example.com"]`,
 		},
@@ -133,7 +133,7 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"SUCCESS: Initialized package",
 			},
 		},
@@ -152,7 +152,7 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"SUCCESS: Initialized package",
 			},
 		},
@@ -171,7 +171,7 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"SUCCESS: Initialized package",
 			},
 		},
@@ -190,12 +190,12 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"SUCCESS: Initialized package",
 			},
 		},
 		{
-			name: "with existing package manifest",
+			name: "with existing fastly.toml",
 			args: args("compute init --auto-yes"), // --force will ignore a directory that isn't empty
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
@@ -210,12 +210,12 @@ func TestInit(t *testing.T) {
 			description = "test"
 			authors = ["test@fastly.com"]`,
 			wantOutput: []string{
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"Initializing package",
 			},
 		},
 		{
-			name: "with existing package manifest",
+			name: "with existing fastly.toml",
 			args: args("compute init --auto-yes"), // --force will ignore a directory that isn't empty
 			configFile: config.File{
 				StarterKits: config.StarterKitLanguages{
@@ -230,7 +230,7 @@ func TestInit(t *testing.T) {
 			description = "test"
 			authors = ["test@fastly.com"]`,
 			wantOutput: []string{
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"Saving manifest changes",
 				"Initializing package",
 			},
@@ -254,7 +254,7 @@ func TestInit(t *testing.T) {
 			wantOutput: []string{
 				"Author (email): Language:",
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"Saving manifest changes",
 				"Initializing package",
 			},
@@ -287,7 +287,7 @@ func TestInit(t *testing.T) {
 			},
 			wantOutput: []string{
 				"Fetching package template",
-				"Reading package manifest",
+				"Reading fastly.toml",
 				"Saving manifest changes",
 				"Initializing package",
 			},

--- a/pkg/commands/service/delete.go
+++ b/pkg/commands/service/delete.go
@@ -101,12 +101,12 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	if source == manifest.SourceFile {
 		if err := c.manifest.File.Read(manifest.Filename); err != nil {
 			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error reading package manifest: %w", err)
+			return fmt.Errorf("error reading fastly.toml: %w", err)
 		}
 		c.manifest.File.ServiceID = ""
 		if err := c.manifest.File.Write(manifest.Filename); err != nil {
 			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error updating package manifest: %w", err)
+			return fmt.Errorf("error updating fastly.toml: %w", err)
 		}
 	}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -30,7 +30,7 @@ var ErrNoToken = RemediationError{
 	Remediation: AuthRemediation,
 }
 
-// ErrNoServiceID means no --service-id or service_id package manifest value has
+// ErrNoServiceID means no --service-id or service_id fastly.toml value has
 // been provided.
 var ErrNoServiceID = RemediationError{
 	Inner:       fmt.Errorf("error reading service: no service ID found"),
@@ -70,15 +70,15 @@ var ErrNoID = RemediationError{
 	Remediation: IDRemediation,
 }
 
-// ErrReadingManifest means there was a problem reading the package manifest.
+// ErrReadingManifest means there was a problem reading the fastly.toml.
 var ErrReadingManifest = RemediationError{
-	Inner:       fmt.Errorf("error reading package manifest"),
+	Inner:       fmt.Errorf("error reading fastly.toml"),
 	Remediation: "Ensure the Fastly CLI is being run within a directory containing a fastly.toml file. " + ComputeInitRemediation,
 }
 
-// ErrParsingManifest means there was a problem unmarshalling the package manifest.
+// ErrParsingManifest means there was a problem unmarshalling the fastly.toml.
 var ErrParsingManifest = RemediationError{
-	Inner:       fmt.Errorf("error parsing package manifest"),
+	Inner:       fmt.Errorf("error parsing fastly.toml"),
 	Remediation: ComputeInitRemediation,
 }
 

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -89,9 +89,9 @@ var ConfigRemediation = strings.Join([]string{
 }, " ")
 
 // ServiceIDRemediation suggests provide a service ID via --service-id flag or
-// package manifest.
+// fastly.toml.
 var ServiceIDRemediation = strings.Join([]string{
-	"Please provide one via the --service-id or --service-name flag, or by setting the FASTLY_SERVICE_ID environment variable, or within your package manifest",
+	"Please provide one via the --service-id or --service-name flag, or by setting the FASTLY_SERVICE_ID environment variable, or within your fastly.toml",
 }, " ")
 
 // CustomerIDRemediation suggests provide a customer ID via --customer-id flag

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -13,6 +13,8 @@ import (
 // File represents all of the configuration parameters in the fastly.toml
 // manifest file schema.
 type File struct {
+	// Args is necessary to track the subcommand called (see: File.Read method).
+	Args            []string
 	Authors         []string    `toml:"authors"`
 	Description     string      `toml:"description"`
 	Language        string      `toml:"language"`
@@ -67,7 +69,10 @@ func (f *File) Read(path string) (err error) {
 	/* #nosec */
 	tree, err := toml.LoadFile(path)
 	if err != nil {
-		f.logErr(err)
+		// IMPORTANT: Only `fastly compute` references the fastly.toml file.
+		if len(f.Args) > 0 && f.Args[0] == "compute" {
+			f.logErr(err) // only log error if user executed `compute` subcommand.
+		}
 		return err
 	}
 


### PR DESCRIPTION
**Problem:** Running `compute publish` within a directory missing a fastly.toml manifest would result in an ambiguous error.
**Solution:**
<img width="1920" alt="Screenshot 2023-04-17 at 14 36 32" src="https://user-images.githubusercontent.com/180050/232500924-0d284f52-43bc-4e38-ab87-46b0706ffae7.png">
