### PR TITLE
refactor: consistent `--json` implementation

### DIFF
--- a/pkg/commands/acl/describe.go
+++ b/pkg/commands/acl/describe.go
@@ -1,7 +1,6 @@
 package acl
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -32,12 +31,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -57,8 +51,8 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
-	json           bool
 	manifest       manifest.Data
 	name           string
 	serviceName    cmd.OptionalServiceNameID
@@ -67,7 +61,7 @@ type DescribeCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,7 +84,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, serviceVersion.Number)
 
-	a, err := c.Globals.APIClient.GetACL(input)
+	o, err := c.Globals.APIClient.GetACL(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -99,7 +93,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, a)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
@@ -115,19 +113,6 @@ func (c *DescribeCommand) constructInput(serviceID string, serviceVersion int) *
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, a *fastly.ACL) error {
-	if c.json {
-		data, err := json.Marshal(a)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	if !c.Globals.Verbose() {
 		fmt.Fprintf(out, "\nService ID: %s\n", a.ServiceID)
 	}

--- a/pkg/commands/acl/list.go
+++ b/pkg/commands/acl/list.go
@@ -1,7 +1,6 @@
 package acl
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -32,12 +31,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -57,8 +51,8 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
-	json           bool
 	manifest       manifest.Data
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
@@ -66,7 +60,7 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +83,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, serviceVersion.Number)
 
-	as, err := c.Globals.APIClient.ListACLs(input)
+	o, err := c.Globals.APIClient.ListACLs(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,10 +92,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		c.printVerbose(out, serviceVersion.Number, as)
+		c.printVerbose(out, serviceVersion.Number, o)
 	} else {
-		err = c.printSummary(out, as)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -145,19 +143,6 @@ func (c *ListCommand) printVerbose(out io.Writer, serviceVersion int, as []*fast
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, as []*fastly.ACL) error {
-	if c.json {
-		data, err := json.Marshal(as)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("SERVICE ID", "VERSION", "NAME", "ID")
 	for _, a := range as {

--- a/pkg/commands/authtoken/describe.go
+++ b/pkg/commands/authtoken/describe.go
@@ -1,7 +1,6 @@
 package authtoken
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -24,20 +23,15 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	}
 	c.CmdClause = parent.Command("describe", "Get the current API token").Alias("get")
 
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	return &c
 }
 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
-	json     bool
 	manifest manifest.Data
 }
 
@@ -47,34 +41,25 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	if s == lookup.SourceUndefined {
 		return fsterr.ErrNoToken
 	}
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	r, err := c.Globals.APIClient.GetTokenSelf()
+	o, err := c.Globals.APIClient.GetTokenSelf()
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	return c.print(out, r)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, r *fastly.Token) error {
-	if c.json {
-		data, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	fmt.Fprintf(out, "\nID: %s\n", r.ID)
 	fmt.Fprintf(out, "Name: %s\n", r.Name)
 	fmt.Fprintf(out, "User ID: %s\n", r.UserID)

--- a/pkg/commands/authtoken/list.go
+++ b/pkg/commands/authtoken/list.go
@@ -1,7 +1,6 @@
 package authtoken
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -31,21 +30,16 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 		Dst:         &c.customerID.Value,
 		Action:      c.customerID.Set,
 	})
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	return &c
 }
 
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	customerID cmd.OptionalCustomerID
-	json       bool
 	manifest   manifest.Data
 }
 
@@ -55,13 +49,13 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	if s == lookup.SourceUndefined {
 		return fsterr.ErrNoToken
 	}
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	var (
 		err error
-		rs  []*fastly.Token
+		o   []*fastly.Token
 	)
 
 	if err = c.customerID.Parse(); err == nil {
@@ -72,23 +66,27 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 		input := c.constructInput()
 
-		rs, err = c.Globals.APIClient.ListCustomerTokens(input)
+		o, err = c.Globals.APIClient.ListCustomerTokens(input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err
 		}
 	} else {
-		rs, err = c.Globals.APIClient.ListTokens()
+		o, err = c.Globals.APIClient.ListTokens()
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err
 		}
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		c.printVerbose(out, rs)
+		c.printVerbose(out, o)
 	} else {
-		err = c.printSummary(out, rs)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -132,19 +130,6 @@ func (c *ListCommand) printVerbose(out io.Writer, rs []*fastly.Token) {
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, rs []*fastly.Token) error {
-	if c.json {
-		data, err := json.Marshal(rs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("NAME", "TOKEN ID", "USER ID", "SCOPE", "SERVICES")
 	for _, r := range rs {

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -135,7 +135,7 @@ func TestBackendList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
 			},
-			WantOutput: `[{"Address":"www.test.com","AutoLoadbalance":false,"BetweenBytesTimeout":0,"Comment":"test","ConnectTimeout":0,"CreatedAt":null,"DeletedAt":null,"ErrorThreshold":0,"FirstByteTimeout":0,"HealthCheck":"","Hostname":"","KeepAliveTime":0,"MaxConn":0,"MaxTLSVersion":"","MinTLSVersion":"","Name":"test.com","OverrideHost":"","Port":80,"RequestCondition":"","SSLCACert":"","SSLCertHostname":"","SSLCheckCert":false,"SSLCiphers":"","SSLClientCert":"","SSLClientKey":"","SSLHostname":"","SSLSNIHostname":"","ServiceID":"123","ServiceVersion":1,"Shield":"","UpdatedAt":null,"UseSSL":false,"Weight":0},{"Address":"www.example.com","AutoLoadbalance":false,"BetweenBytesTimeout":0,"Comment":"example","ConnectTimeout":0,"CreatedAt":null,"DeletedAt":null,"ErrorThreshold":0,"FirstByteTimeout":0,"HealthCheck":"","Hostname":"","KeepAliveTime":0,"MaxConn":0,"MaxTLSVersion":"","MinTLSVersion":"","Name":"example.com","OverrideHost":"","Port":443,"RequestCondition":"","SSLCACert":"","SSLCertHostname":"","SSLCheckCert":false,"SSLCiphers":"","SSLClientCert":"","SSLClientKey":"","SSLHostname":"","SSLSNIHostname":"","ServiceID":"123","ServiceVersion":1,"Shield":"","UpdatedAt":null,"UseSSL":false,"Weight":0}]`,
+			WantOutput: listBackendsJSONOutput,
 		},
 		{
 			Args: args("backend list --service-id 123 --version 1 --json --verbose"),
@@ -378,6 +378,81 @@ func listBackendsOK(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
 func listBackendsError(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
 	return nil, errTest
 }
+
+var listBackendsJSONOutput = strings.TrimSpace(`
+[
+  {
+    "Address": "www.test.com",
+    "AutoLoadbalance": false,
+    "BetweenBytesTimeout": 0,
+    "Comment": "test",
+    "ConnectTimeout": 0,
+    "CreatedAt": null,
+    "DeletedAt": null,
+    "ErrorThreshold": 0,
+    "FirstByteTimeout": 0,
+    "HealthCheck": "",
+    "Hostname": "",
+    "KeepAliveTime": 0,
+    "MaxConn": 0,
+    "MaxTLSVersion": "",
+    "MinTLSVersion": "",
+    "Name": "test.com",
+    "OverrideHost": "",
+    "Port": 80,
+    "RequestCondition": "",
+    "SSLCACert": "",
+    "SSLCertHostname": "",
+    "SSLCheckCert": false,
+    "SSLCiphers": "",
+    "SSLClientCert": "",
+    "SSLClientKey": "",
+    "SSLHostname": "",
+    "SSLSNIHostname": "",
+    "ServiceID": "123",
+    "ServiceVersion": 1,
+    "Shield": "",
+    "UpdatedAt": null,
+    "UseSSL": false,
+    "Weight": 0
+  },
+  {
+    "Address": "www.example.com",
+    "AutoLoadbalance": false,
+    "BetweenBytesTimeout": 0,
+    "Comment": "example",
+    "ConnectTimeout": 0,
+    "CreatedAt": null,
+    "DeletedAt": null,
+    "ErrorThreshold": 0,
+    "FirstByteTimeout": 0,
+    "HealthCheck": "",
+    "Hostname": "",
+    "KeepAliveTime": 0,
+    "MaxConn": 0,
+    "MaxTLSVersion": "",
+    "MinTLSVersion": "",
+    "Name": "example.com",
+    "OverrideHost": "",
+    "Port": 443,
+    "RequestCondition": "",
+    "SSLCACert": "",
+    "SSLCertHostname": "",
+    "SSLCheckCert": false,
+    "SSLCiphers": "",
+    "SSLClientCert": "",
+    "SSLClientKey": "",
+    "SSLHostname": "",
+    "SSLSNIHostname": "",
+    "ServiceID": "123",
+    "ServiceVersion": 1,
+    "Shield": "",
+    "UpdatedAt": null,
+    "UseSSL": false,
+    "Weight": 0
+  }
+]
+`) + "\n"
 
 var listBackendsShortOutput = strings.TrimSpace(`
 SERVICE  VERSION  NAME         ADDRESS          PORT  COMMENT

--- a/pkg/commands/backend/describe.go
+++ b/pkg/commands/backend/describe.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -15,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a backend.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetBackendInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +84,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	backend, err := c.Globals.APIClient.GetBackend(&c.Input)
+	o, err := c.Globals.APIClient.GetBackend(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,24 +93,15 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, backend)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, b *fastly.Backend) error {
-	if c.json {
-		data, err := json.Marshal(b)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	if !c.Globals.Verbose() {
 		fmt.Fprintf(out, "\nService ID: %s\n", b.ServiceID)
 	}

--- a/pkg/commands/backend/list.go
+++ b/pkg/commands/backend/list.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list backends.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListBackendsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +84,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	backends, err := c.Globals.APIClient.ListBackends(&c.Input)
+	o, err := c.Globals.APIClient.ListBackends(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,23 +93,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(backends)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME", "ADDRESS", "PORT", "COMMENT")
-		for _, backend := range backends {
+		for _, backend := range o {
 			tw.AddLine(backend.ServiceID, backend.ServiceVersion, backend.Name, backend.Address, backend.Port, backend.Comment)
 		}
 		tw.Print()
@@ -122,8 +108,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, backend := range backends {
-		fmt.Fprintf(out, "\tBackend %d/%d\n", i+1, len(backends))
+	for i, backend := range o {
+		fmt.Fprintf(out, "\tBackend %d/%d\n", i+1, len(o))
 		text.PrintBackend(out, "\t\t", backend)
 	}
 	fmt.Fprintln(out)

--- a/pkg/commands/domain/list.go
+++ b/pkg/commands/domain/list.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list domains.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListDomainsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +84,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	domains, err := c.Globals.APIClient.ListDomains(&c.Input)
+	o, err := c.Globals.APIClient.ListDomains(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,23 +93,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(domains)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME", "COMMENT")
-		for _, domain := range domains {
+		for _, domain := range o {
 			tw.AddLine(domain.ServiceID, domain.ServiceVersion, domain.Name, domain.Comment)
 		}
 		tw.Print()
@@ -122,8 +108,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, domain := range domains {
-		fmt.Fprintf(out, "\tDomain %d/%d\n", i+1, len(domains))
+	for i, domain := range o {
+		fmt.Fprintf(out, "\tDomain %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tName: %s\n", domain.Name)
 		fmt.Fprintf(out, "\t\tComment: %v\n", domain.Comment)
 	}

--- a/pkg/commands/healthcheck/list.go
+++ b/pkg/commands/healthcheck/list.go
@@ -1,7 +1,6 @@
 package healthcheck
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list healthchecks.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListHealthChecksInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +84,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	healthChecks, err := c.Globals.APIClient.ListHealthChecks(&c.Input)
+	o, err := c.Globals.APIClient.ListHealthChecks(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,33 +93,24 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(healthChecks)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME", "METHOD", "HOST", "PATH")
-		for _, healthCheck := range healthChecks {
-			tw.AddLine(healthCheck.ServiceID, healthCheck.ServiceVersion, healthCheck.Name, healthCheck.Method, healthCheck.Host, healthCheck.Path)
+		for _, hc := range o {
+			tw.AddLine(hc.ServiceID, hc.ServiceVersion, hc.Name, hc.Method, hc.Host, hc.Path)
 		}
 		tw.Print()
 		return nil
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, healthCheck := range healthChecks {
-		fmt.Fprintf(out, "\tHealthcheck %d/%d\n", i+1, len(healthChecks))
-		text.PrintHealthCheck(out, "\t\t", healthCheck)
+	for i, hc := range o {
+		fmt.Fprintf(out, "\tHealthcheck %d/%d\n", i+1, len(o))
+		text.PrintHealthCheck(out, "\t\t", hc)
 	}
 	fmt.Fprintln(out)
 

--- a/pkg/commands/kvstore/describe.go
+++ b/pkg/commands/kvstore/describe.go
@@ -1,8 +1,6 @@
 package kvstore
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,7 +14,8 @@ import (
 // DescribeCommand calls the Fastly API to fetch the value of a key from an kv store.
 type DescribeCommand struct {
 	cmd.Base
-	json     bool
+	cmd.JSONOutput
+
 	manifest manifest.Data
 	Input    fastly.GetKVStoreInput
 }
@@ -33,19 +32,14 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	c.CmdClause.Flag("store-id", "Store ID").Short('s').Required().StringVar(&c.Input.ID)
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -55,17 +49,8 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(o)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	text.PrintKVStore(out, "", o)

--- a/pkg/commands/kvstoreentry/describe.go
+++ b/pkg/commands/kvstoreentry/describe.go
@@ -14,7 +14,8 @@ import (
 // DescribeCommand calls the Fastly API to fetch the value of a key from an kv store.
 type DescribeCommand struct {
 	cmd.Base
-	json     bool
+	cmd.JSONOutput
+
 	manifest manifest.Data
 	Input    fastly.GetKVStoreKeyInput
 }
@@ -32,19 +33,14 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	c.CmdClause.Flag("key-name", "Key name").Short('k').Required().StringVar(&c.Input.Key)
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -54,7 +50,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if c.json {
+	if c.JSONOutput.Enabled {
 		text.Output(out, `{"%s": "%s"}`, c.Input.Key, value)
 		return nil
 	}

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -1,8 +1,6 @@
 package kvstoreentry
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,7 +14,8 @@ import (
 // ListCommand calls the Fastly API to list the keys for a given kv store.
 type ListCommand struct {
 	cmd.Base
-	json     bool
+	cmd.JSONOutput
+
 	manifest manifest.Data
 	Input    fastly.ListKVStoreKeysInput
 }
@@ -33,18 +32,13 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	c.CmdClause.Flag("store-id", "Store ID").Short('s').Required().StringVar(&c.Input.ID)
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	return &c
 }
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -54,17 +48,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(o)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	if c.Globals.Flags.Verbose {

--- a/pkg/commands/logging/azureblob/describe.go
+++ b/pkg/commands/logging/azureblob/describe.go
@@ -1,8 +1,6 @@
 package azureblob
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe an Azure Blob Storage logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetBlobStorageInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,7 +84,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	azureblob, err := c.Globals.APIClient.GetBlobStorage(&c.Input)
+	o, err := c.Globals.APIClient.GetBlobStorage(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -99,39 +93,31 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(azureblob)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
+
 	lines := text.Lines{
-		"Account name":       azureblob.AccountName,
-		"Compression codec":  azureblob.CompressionCodec,
-		"Container":          azureblob.Container,
-		"File max bytes":     azureblob.FileMaxBytes,
-		"Format version":     azureblob.FormatVersion,
-		"Format":             azureblob.Format,
-		"GZip level":         azureblob.GzipLevel,
-		"Message type":       azureblob.MessageType,
-		"Name":               azureblob.Name,
-		"Path":               azureblob.Path,
-		"Period":             azureblob.Period,
-		"Placement":          azureblob.Placement,
-		"Public key":         azureblob.PublicKey,
-		"Response condition": azureblob.ResponseCondition,
-		"SAS token":          azureblob.SASToken,
-		"Timestamp format":   azureblob.TimestampFormat,
-		"Version":            azureblob.ServiceVersion,
+		"Account name":       o.AccountName,
+		"Compression codec":  o.CompressionCodec,
+		"Container":          o.Container,
+		"File max bytes":     o.FileMaxBytes,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"GZip level":         o.GzipLevel,
+		"Message type":       o.MessageType,
+		"Name":               o.Name,
+		"Path":               o.Path,
+		"Period":             o.Period,
+		"Placement":          o.Placement,
+		"Public key":         o.PublicKey,
+		"Response condition": o.ResponseCondition,
+		"SAS token":          o.SASToken,
+		"Timestamp format":   o.TimestampFormat,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = azureblob.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/bigquery/describe.go
+++ b/pkg/commands/logging/bigquery/describe.go
@@ -1,8 +1,6 @@
 package bigquery
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a BigQuery logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetBigQueryInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,7 +84,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	bq, err := c.Globals.APIClient.GetBigQuery(&c.Input)
+	o, err := c.Globals.APIClient.GetBigQuery(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -99,36 +93,27 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(bq)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Account name":       bq.AccountName,
-		"Dataset":            bq.Dataset,
-		"Format version":     bq.FormatVersion,
-		"Format":             bq.Format,
-		"Name":               bq.Name,
-		"Placement":          bq.Placement,
-		"Project ID":         bq.ProjectID,
-		"Response condition": bq.ResponseCondition,
-		"Secret key":         bq.SecretKey,
-		"Table":              bq.Table,
-		"Template suffix":    bq.Template,
-		"User":               bq.User,
-		"Version":            bq.ServiceVersion,
+		"Account name":       o.AccountName,
+		"Dataset":            o.Dataset,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Project ID":         o.ProjectID,
+		"Response condition": o.ResponseCondition,
+		"Secret key":         o.SecretKey,
+		"Table":              o.Table,
+		"Template suffix":    o.Template,
+		"User":               o.User,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = bq.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/bigquery/list.go
+++ b/pkg/commands/logging/bigquery/list.go
@@ -1,7 +1,6 @@
 package bigquery
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list BigQuery logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListBigQueriesInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +84,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	bqs, err := c.Globals.APIClient.ListBigQueries(&c.Input)
+	o, err := c.Globals.APIClient.ListBigQueries(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,23 +93,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(bqs)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, bq := range bqs {
+		for _, bq := range o {
 			tw.AddLine(bq.ServiceID, bq.ServiceVersion, bq.Name)
 		}
 		tw.Print()
@@ -122,8 +108,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, bq := range bqs {
-		fmt.Fprintf(out, "\tBigQuery %d/%d\n", i+1, len(bqs))
+	for i, bq := range o {
+		fmt.Fprintf(out, "\tBigQuery %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", bq.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", bq.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", bq.Name)

--- a/pkg/commands/logging/cloudfiles/list.go
+++ b/pkg/commands/logging/cloudfiles/list.go
@@ -1,7 +1,6 @@
 package cloudfiles
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Cloudfiles logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListCloudfilesInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +84,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	cloudfiles, err := c.Globals.APIClient.ListCloudfiles(&c.Input)
+	o, err := c.Globals.APIClient.ListCloudfiles(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,23 +93,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(cloudfiles)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, cloudfile := range cloudfiles {
+		for _, cloudfile := range o {
 			tw.AddLine(cloudfile.ServiceID, cloudfile.ServiceVersion, cloudfile.Name)
 		}
 		tw.Print()
@@ -122,8 +108,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, cloudfile := range cloudfiles {
-		fmt.Fprintf(out, "\tCloudfiles %d/%d\n", i+1, len(cloudfiles))
+	for i, cloudfile := range o {
+		fmt.Fprintf(out, "\tCloudfiles %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", cloudfile.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", cloudfile.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", cloudfile.Name)

--- a/pkg/commands/logging/datadog/describe.go
+++ b/pkg/commands/logging/datadog/describe.go
@@ -1,8 +1,6 @@
 package datadog
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Datadog logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetDatadogInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,36 +84,28 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	datadog, err := c.Globals.APIClient.GetDatadog(&c.Input)
+	o, err := c.Globals.APIClient.GetDatadog(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(datadog)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
+
 	lines := text.Lines{
-		"Format version":     datadog.FormatVersion,
-		"Format":             datadog.Format,
-		"Name":               datadog.Name,
-		"Placement":          datadog.Placement,
-		"Region":             datadog.Region,
-		"Response condition": datadog.ResponseCondition,
-		"Token":              datadog.Token,
-		"Version":            datadog.ServiceVersion,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Region":             o.Region,
+		"Response condition": o.ResponseCondition,
+		"Token":              o.Token,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = datadog.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/datadog/list.go
+++ b/pkg/commands/logging/datadog/list.go
@@ -1,7 +1,6 @@
 package datadog
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Datadog logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListDatadogInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	datadogs, err := c.Globals.APIClient.ListDatadog(&c.Input)
+	o, err := c.Globals.APIClient.ListDatadog(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(datadogs)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, datadog := range datadogs {
+		for _, datadog := range o {
 			tw.AddLine(datadog.ServiceID, datadog.ServiceVersion, datadog.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, datadog := range datadogs {
-		fmt.Fprintf(out, "\tDatadog %d/%d\n", i+1, len(datadogs))
+	for i, datadog := range o {
+		fmt.Fprintf(out, "\tDatadog %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", datadog.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", datadog.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", datadog.Name)

--- a/pkg/commands/logging/digitalocean/describe.go
+++ b/pkg/commands/logging/digitalocean/describe.go
@@ -1,8 +1,6 @@
 package digitalocean
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a DigitalOcean Spaces logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetDigitalOceanInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,45 +84,36 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	digitalocean, err := c.Globals.APIClient.GetDigitalOcean(&c.Input)
+	o, err := c.Globals.APIClient.GetDigitalOcean(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(digitalocean)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Access key":         digitalocean.AccessKey,
-		"Bucket":             digitalocean.BucketName,
-		"Domain":             digitalocean.Domain,
-		"Format version":     digitalocean.FormatVersion,
-		"Format":             digitalocean.Format,
-		"GZip level":         digitalocean.GzipLevel,
-		"Message type":       digitalocean.MessageType,
-		"Name":               digitalocean.Name,
-		"Path":               digitalocean.Path,
-		"Period":             digitalocean.Period,
-		"Placement":          digitalocean.Placement,
-		"Public key":         digitalocean.PublicKey,
-		"Response condition": digitalocean.ResponseCondition,
-		"Secret key":         digitalocean.SecretKey,
-		"Timestamp format":   digitalocean.TimestampFormat,
-		"Version":            digitalocean.ServiceVersion,
+		"Access key":         o.AccessKey,
+		"Bucket":             o.BucketName,
+		"Domain":             o.Domain,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"GZip level":         o.GzipLevel,
+		"Message type":       o.MessageType,
+		"Name":               o.Name,
+		"Path":               o.Path,
+		"Period":             o.Period,
+		"Placement":          o.Placement,
+		"Public key":         o.PublicKey,
+		"Response condition": o.ResponseCondition,
+		"Secret key":         o.SecretKey,
+		"Timestamp format":   o.TimestampFormat,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = digitalocean.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/digitalocean/list.go
+++ b/pkg/commands/logging/digitalocean/list.go
@@ -1,7 +1,6 @@
 package digitalocean
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list DigitalOcean Spaces logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListDigitalOceansInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	digitaloceans, err := c.Globals.APIClient.ListDigitalOceans(&c.Input)
+	o, err := c.Globals.APIClient.ListDigitalOceans(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(digitaloceans)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, digitalocean := range digitaloceans {
+		for _, digitalocean := range o {
 			tw.AddLine(digitalocean.ServiceID, digitalocean.ServiceVersion, digitalocean.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, digitalocean := range digitaloceans {
-		fmt.Fprintf(out, "\tDigitalOcean %d/%d\n", i+1, len(digitaloceans))
+	for i, digitalocean := range o {
+		fmt.Fprintf(out, "\tDigitalOcean %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", digitalocean.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", digitalocean.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", digitalocean.Name)

--- a/pkg/commands/logging/elasticsearch/list.go
+++ b/pkg/commands/logging/elasticsearch/list.go
@@ -1,7 +1,6 @@
 package elasticsearch
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Elasticsearch logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListElasticsearchInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	elasticsearchs, err := c.Globals.APIClient.ListElasticsearch(&c.Input)
+	o, err := c.Globals.APIClient.ListElasticsearch(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(elasticsearchs)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, elasticsearch := range elasticsearchs {
+		for _, elasticsearch := range o {
 			tw.AddLine(elasticsearch.ServiceID, elasticsearch.ServiceVersion, elasticsearch.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, elasticsearch := range elasticsearchs {
-		fmt.Fprintf(out, "\tElasticsearch %d/%d\n", i+1, len(elasticsearchs))
+	for i, elasticsearch := range o {
+		fmt.Fprintf(out, "\tElasticsearch %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", elasticsearch.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", elasticsearch.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", elasticsearch.Name)

--- a/pkg/commands/logging/ftp/list.go
+++ b/pkg/commands/logging/ftp/list.go
@@ -1,7 +1,6 @@
 package ftp
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list FTP logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListFTPsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	ftps, err := c.Globals.APIClient.ListFTPs(&c.Input)
+	o, err := c.Globals.APIClient.ListFTPs(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(ftps)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, ftp := range ftps {
+		for _, ftp := range o {
 			tw.AddLine(ftp.ServiceID, ftp.ServiceVersion, ftp.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, ftp := range ftps {
-		fmt.Fprintf(out, "\tFTP %d/%d\n", i+1, len(ftps))
+	for i, ftp := range o {
+		fmt.Fprintf(out, "\tFTP %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", ftp.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", ftp.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", ftp.Name)

--- a/pkg/commands/logging/gcs/describe.go
+++ b/pkg/commands/logging/gcs/describe.go
@@ -1,8 +1,6 @@
 package gcs
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a GCS logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetGCSInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,45 +84,36 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	gcs, err := c.Globals.APIClient.GetGCS(&c.Input)
+	o, err := c.Globals.APIClient.GetGCS(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(gcs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Account name":       gcs.AccountName,
-		"Bucket":             gcs.Bucket,
-		"Compression codec":  gcs.CompressionCodec,
-		"Format version":     gcs.FormatVersion,
-		"Format":             gcs.Format,
-		"GZip level":         gcs.GzipLevel,
-		"Message type":       gcs.MessageType,
-		"Name":               gcs.Name,
-		"Path":               gcs.Path,
-		"Period":             gcs.Period,
-		"Placement":          gcs.Placement,
-		"Response condition": gcs.ResponseCondition,
-		"Secret key":         gcs.SecretKey,
-		"Timestamp format":   gcs.TimestampFormat,
-		"User":               gcs.User,
-		"Version":            gcs.ServiceVersion,
+		"Account name":       o.AccountName,
+		"Bucket":             o.Bucket,
+		"Compression codec":  o.CompressionCodec,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"GZip level":         o.GzipLevel,
+		"Message type":       o.MessageType,
+		"Name":               o.Name,
+		"Path":               o.Path,
+		"Period":             o.Period,
+		"Placement":          o.Placement,
+		"Response condition": o.ResponseCondition,
+		"Secret key":         o.SecretKey,
+		"Timestamp format":   o.TimestampFormat,
+		"User":               o.User,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = gcs.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/gcs/list.go
+++ b/pkg/commands/logging/gcs/list.go
@@ -1,7 +1,6 @@
 package gcs
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list GCS logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListGCSsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	gcss, err := c.Globals.APIClient.ListGCSs(&c.Input)
+	o, err := c.Globals.APIClient.ListGCSs(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(gcss)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, gcs := range gcss {
+		for _, gcs := range o {
 			tw.AddLine(gcs.ServiceID, gcs.ServiceVersion, gcs.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, gcs := range gcss {
-		fmt.Fprintf(out, "\tGCS %d/%d\n", i+1, len(gcss))
+	for i, gcs := range o {
+		fmt.Fprintf(out, "\tGCS %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", gcs.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", gcs.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", gcs.Name)

--- a/pkg/commands/logging/googlepubsub/describe.go
+++ b/pkg/commands/logging/googlepubsub/describe.go
@@ -1,8 +1,6 @@
 package googlepubsub
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Google Cloud Pub/Sub logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetPubsubInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,40 +84,31 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	googlepubsub, err := c.Globals.APIClient.GetPubsub(&c.Input)
+	o, err := c.Globals.APIClient.GetPubsub(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(googlepubsub)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Account name":       googlepubsub.AccountName,
-		"Format version":     googlepubsub.FormatVersion,
-		"Format":             googlepubsub.Format,
-		"Name":               googlepubsub.Name,
-		"Placement":          googlepubsub.Placement,
-		"Project ID":         googlepubsub.ProjectID,
-		"Response condition": googlepubsub.ResponseCondition,
-		"Secret key":         googlepubsub.SecretKey,
-		"Topic":              googlepubsub.Topic,
-		"User":               googlepubsub.User,
-		"Version":            googlepubsub.ServiceVersion,
+		"Account name":       o.AccountName,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Project ID":         o.ProjectID,
+		"Response condition": o.ResponseCondition,
+		"Secret key":         o.SecretKey,
+		"Topic":              o.Topic,
+		"User":               o.User,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = googlepubsub.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/googlepubsub/list.go
+++ b/pkg/commands/logging/googlepubsub/list.go
@@ -1,7 +1,6 @@
 package googlepubsub
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Google Cloud Pub/Sub logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListPubsubsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	googlepubsubs, err := c.Globals.APIClient.ListPubsubs(&c.Input)
+	o, err := c.Globals.APIClient.ListPubsubs(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(googlepubsubs)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, googlepubsub := range googlepubsubs {
+		for _, googlepubsub := range o {
 			tw.AddLine(googlepubsub.ServiceID, googlepubsub.ServiceVersion, googlepubsub.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, googlepubsub := range googlepubsubs {
-		fmt.Fprintf(out, "\tGoogle Cloud Pub/Sub %d/%d\n", i+1, len(googlepubsubs))
+	for i, googlepubsub := range o {
+		fmt.Fprintf(out, "\tGoogle Cloud Pub/Sub %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", googlepubsub.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", googlepubsub.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", googlepubsub.Name)

--- a/pkg/commands/logging/heroku/describe.go
+++ b/pkg/commands/logging/heroku/describe.go
@@ -1,8 +1,6 @@
 package heroku
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Heroku logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetHerokuInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,37 +84,28 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	heroku, err := c.Globals.APIClient.GetHeroku(&c.Input)
+	o, err := c.Globals.APIClient.GetHeroku(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(heroku)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Format version":     heroku.FormatVersion,
-		"Format":             heroku.Format,
-		"Name":               heroku.Name,
-		"Placement":          heroku.Placement,
-		"Response condition": heroku.ResponseCondition,
-		"Token":              heroku.Token,
-		"URL":                heroku.URL,
-		"Version":            heroku.ServiceVersion,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Response condition": o.ResponseCondition,
+		"Token":              o.Token,
+		"URL":                o.URL,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = heroku.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/honeycomb/describe.go
+++ b/pkg/commands/logging/honeycomb/describe.go
@@ -1,8 +1,6 @@
 package honeycomb
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Honeycomb logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetHoneycombInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,37 +84,28 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	honeycomb, err := c.Globals.APIClient.GetHoneycomb(&c.Input)
+	o, err := c.Globals.APIClient.GetHoneycomb(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(honeycomb)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Dataset":            honeycomb.Dataset,
-		"Format version":     honeycomb.FormatVersion,
-		"Format":             honeycomb.Format,
-		"Name":               honeycomb.Name,
-		"Placement":          honeycomb.Placement,
-		"Response condition": honeycomb.ResponseCondition,
-		"Token":              honeycomb.Token,
-		"Version":            honeycomb.ServiceVersion,
+		"Dataset":            o.Dataset,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Response condition": o.ResponseCondition,
+		"Token":              o.Token,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = honeycomb.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/honeycomb/list.go
+++ b/pkg/commands/logging/honeycomb/list.go
@@ -1,7 +1,6 @@
 package honeycomb
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Honeycomb logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListHoneycombsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	honeycombs, err := c.Globals.APIClient.ListHoneycombs(&c.Input)
+	o, err := c.Globals.APIClient.ListHoneycombs(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(honeycombs)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, honeycomb := range honeycombs {
+		for _, honeycomb := range o {
 			tw.AddLine(honeycomb.ServiceID, honeycomb.ServiceVersion, honeycomb.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, honeycomb := range honeycombs {
-		fmt.Fprintf(out, "\tHoneycomb %d/%d\n", i+1, len(honeycombs))
+	for i, honeycomb := range o {
+		fmt.Fprintf(out, "\tHoneycomb %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", honeycomb.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", honeycomb.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", honeycomb.Name)

--- a/pkg/commands/logging/https/list.go
+++ b/pkg/commands/logging/https/list.go
@@ -1,7 +1,6 @@
 package https
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list HTTPS logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListHTTPSInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	httpss, err := c.Globals.APIClient.ListHTTPS(&c.Input)
+	o, err := c.Globals.APIClient.ListHTTPS(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(httpss)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, https := range httpss {
+		for _, https := range o {
 			tw.AddLine(https.ServiceID, https.ServiceVersion, https.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, https := range httpss {
-		fmt.Fprintf(out, "\tHTTPS %d/%d\n", i+1, len(httpss))
+	for i, https := range o {
+		fmt.Fprintf(out, "\tHTTPS %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", https.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", https.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", https.Name)

--- a/pkg/commands/logging/kafka/list.go
+++ b/pkg/commands/logging/kafka/list.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Kafka logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListKafkasInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	kafkas, err := c.Globals.APIClient.ListKafkas(&c.Input)
+	o, err := c.Globals.APIClient.ListKafkas(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(kafkas)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, kafka := range kafkas {
+		for _, kafka := range o {
 			tw.AddLine(kafka.ServiceID, kafka.ServiceVersion, kafka.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, kafka := range kafkas {
-		fmt.Fprintf(out, "\tKafka %d/%d\n", i+1, len(kafkas))
+	for i, kafka := range o {
+		fmt.Fprintf(out, "\tKafka %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", kafka.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", kafka.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", kafka.Name)

--- a/pkg/commands/logging/kinesis/describe.go
+++ b/pkg/commands/logging/kinesis/describe.go
@@ -1,8 +1,6 @@
 package kinesis
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe an Amazon Kinesis logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetKinesisInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,45 +84,36 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	kinesis, err := c.Globals.APIClient.GetKinesis(&c.Input)
+	o, err := c.Globals.APIClient.GetKinesis(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(kinesis)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Format version":     kinesis.FormatVersion,
-		"Format":             kinesis.Format,
-		"Name":               kinesis.Name,
-		"Placement":          kinesis.Placement,
-		"Region":             kinesis.Region,
-		"Response condition": kinesis.ResponseCondition,
-		"Stream name":        kinesis.StreamName,
-		"Version":            kinesis.ServiceVersion,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Region":             o.Region,
+		"Response condition": o.ResponseCondition,
+		"Stream name":        o.StreamName,
+		"Version":            o.ServiceVersion,
 	}
 
-	if kinesis.AccessKey != "" || kinesis.SecretKey != "" {
-		lines["Access key"] = kinesis.AccessKey
-		lines["Secret key"] = kinesis.SecretKey
+	if o.AccessKey != "" || o.SecretKey != "" {
+		lines["Access key"] = o.AccessKey
+		lines["Secret key"] = o.SecretKey
 	}
-	if kinesis.IAMRole != "" {
-		lines["IAM role"] = kinesis.IAMRole
+	if o.IAMRole != "" {
+		lines["IAM role"] = o.IAMRole
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = kinesis.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/loggly/list.go
+++ b/pkg/commands/logging/loggly/list.go
@@ -1,7 +1,6 @@
 package loggly
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Loggly logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListLogglyInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	logglys, err := c.Globals.APIClient.ListLoggly(&c.Input)
+	o, err := c.Globals.APIClient.ListLoggly(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(logglys)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, loggly := range logglys {
+		for _, loggly := range o {
 			tw.AddLine(loggly.ServiceID, loggly.ServiceVersion, loggly.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, loggly := range logglys {
-		fmt.Fprintf(out, "\tLoggly %d/%d\n", i+1, len(logglys))
+	for i, loggly := range o {
+		fmt.Fprintf(out, "\tLoggly %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", loggly.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", loggly.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", loggly.Name)

--- a/pkg/commands/logging/logshuttle/describe.go
+++ b/pkg/commands/logging/logshuttle/describe.go
@@ -1,8 +1,6 @@
 package logshuttle
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Logshuttle logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetLogshuttleInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,37 +84,28 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	logshuttle, err := c.Globals.APIClient.GetLogshuttle(&c.Input)
+	o, err := c.Globals.APIClient.GetLogshuttle(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(logshuttle)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Format version":     logshuttle.FormatVersion,
-		"Format":             logshuttle.Format,
-		"Name":               logshuttle.Name,
-		"Placement":          logshuttle.Placement,
-		"Response condition": logshuttle.ResponseCondition,
-		"Token":              logshuttle.Token,
-		"URL":                logshuttle.URL,
-		"Version":            logshuttle.ServiceVersion,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Response condition": o.ResponseCondition,
+		"Token":              o.Token,
+		"URL":                o.URL,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = logshuttle.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/logshuttle/list.go
+++ b/pkg/commands/logging/logshuttle/list.go
@@ -1,7 +1,6 @@
 package logshuttle
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Logshuttle logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListLogshuttlesInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	logshuttles, err := c.Globals.APIClient.ListLogshuttles(&c.Input)
+	o, err := c.Globals.APIClient.ListLogshuttles(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(logshuttles)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, logshuttle := range logshuttles {
+		for _, logshuttle := range o {
 			tw.AddLine(logshuttle.ServiceID, logshuttle.ServiceVersion, logshuttle.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, logshuttle := range logshuttles {
-		fmt.Fprintf(out, "\tLogshuttle %d/%d\n", i+1, len(logshuttles))
+	for i, logshuttle := range o {
+		fmt.Fprintf(out, "\tLogshuttle %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", logshuttle.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", logshuttle.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", logshuttle.Name)

--- a/pkg/commands/logging/newrelic/list.go
+++ b/pkg/commands/logging/newrelic/list.go
@@ -1,7 +1,6 @@
 package newrelic
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -32,12 +31,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -57,8 +51,8 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
-	json           bool
 	manifest       manifest.Data
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
@@ -66,7 +60,7 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +83,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, serviceVersion.Number)
 
-	l, err := c.Globals.APIClient.ListNewRelic(input)
+	o, err := c.Globals.APIClient.ListNewRelic(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,10 +92,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		c.printVerbose(out, serviceVersion.Number, l)
+		c.printVerbose(out, serviceVersion.Number, o)
 	} else {
-		err = c.printSummary(out, l)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -148,19 +146,6 @@ func (c *ListCommand) printVerbose(out io.Writer, serviceVersion int, ls []*fast
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, nrs []*fastly.NewRelic) error {
-	if c.json {
-		data, err := json.Marshal(nrs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("SERVICE ID", "VERSION", "NAME")
 	for _, nr := range nrs {

--- a/pkg/commands/logging/openstack/describe.go
+++ b/pkg/commands/logging/openstack/describe.go
@@ -1,8 +1,6 @@
 package openstack
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe an OpenStack logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetOpenstackInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,46 +84,37 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	openstack, err := c.Globals.APIClient.GetOpenstack(&c.Input)
+	o, err := c.Globals.APIClient.GetOpenstack(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(openstack)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Access key":         openstack.AccessKey,
-		"Bucket":             openstack.BucketName,
-		"Compression codec":  openstack.CompressionCodec,
-		"Format version":     openstack.FormatVersion,
-		"Format":             openstack.Format,
-		"GZip level":         openstack.GzipLevel,
-		"Message type":       openstack.MessageType,
-		"Name":               openstack.Name,
-		"Path":               openstack.Path,
-		"Period":             openstack.Period,
-		"Placement":          openstack.Placement,
-		"Public key":         openstack.PublicKey,
-		"Response condition": openstack.ResponseCondition,
-		"Timestamp format":   openstack.TimestampFormat,
-		"URL":                openstack.URL,
-		"User":               openstack.User,
-		"Version":            openstack.ServiceVersion,
+		"Access key":         o.AccessKey,
+		"Bucket":             o.BucketName,
+		"Compression codec":  o.CompressionCodec,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"GZip level":         o.GzipLevel,
+		"Message type":       o.MessageType,
+		"Name":               o.Name,
+		"Path":               o.Path,
+		"Period":             o.Period,
+		"Placement":          o.Placement,
+		"Public key":         o.PublicKey,
+		"Response condition": o.ResponseCondition,
+		"Timestamp format":   o.TimestampFormat,
+		"URL":                o.URL,
+		"User":               o.User,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = openstack.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/openstack/list.go
+++ b/pkg/commands/logging/openstack/list.go
@@ -1,7 +1,6 @@
 package openstack
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list OpenStack logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListOpenstackInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	openstacks, err := c.Globals.APIClient.ListOpenstack(&c.Input)
+	o, err := c.Globals.APIClient.ListOpenstack(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(openstacks)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, openstack := range openstacks {
+		for _, openstack := range o {
 			tw.AddLine(openstack.ServiceID, openstack.ServiceVersion, openstack.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, openstack := range openstacks {
-		fmt.Fprintf(out, "\tOpenstack %d/%d\n", i+1, len(openstacks))
+	for i, openstack := range o {
+		fmt.Fprintf(out, "\tOpenstack %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", openstack.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", openstack.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", openstack.Name)

--- a/pkg/commands/logging/papertrail/describe.go
+++ b/pkg/commands/logging/papertrail/describe.go
@@ -1,8 +1,6 @@
 package papertrail
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Papertrail logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetPapertrailInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,37 +84,28 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	papertrail, err := c.Globals.APIClient.GetPapertrail(&c.Input)
+	o, err := c.Globals.APIClient.GetPapertrail(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(papertrail)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Address":            papertrail.Address,
-		"Format version":     papertrail.FormatVersion,
-		"Format":             papertrail.Format,
-		"Name":               papertrail.Name,
-		"Placement":          papertrail.Placement,
-		"Port":               papertrail.Port,
-		"Response condition": papertrail.ResponseCondition,
-		"Version":            papertrail.ServiceVersion,
+		"Address":            o.Address,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Port":               o.Port,
+		"Response condition": o.ResponseCondition,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = papertrail.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/papertrail/list.go
+++ b/pkg/commands/logging/papertrail/list.go
@@ -1,7 +1,6 @@
 package papertrail
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Papertrail logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListPapertrailsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	papertrails, err := c.Globals.APIClient.ListPapertrails(&c.Input)
+	o, err := c.Globals.APIClient.ListPapertrails(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(papertrails)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, papertrail := range papertrails {
+		for _, papertrail := range o {
 			tw.AddLine(papertrail.ServiceID, papertrail.ServiceVersion, papertrail.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, papertrail := range papertrails {
-		fmt.Fprintf(out, "\tPapertrail %d/%d\n", i+1, len(papertrails))
+	for i, papertrail := range o {
+		fmt.Fprintf(out, "\tPapertrail %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", papertrail.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", papertrail.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", papertrail.Name)

--- a/pkg/commands/logging/s3/list.go
+++ b/pkg/commands/logging/s3/list.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Amazon S3 logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListS3sInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	s3s, err := c.Globals.APIClient.ListS3s(&c.Input)
+	o, err := c.Globals.APIClient.ListS3s(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(s3s)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, s3 := range s3s {
+		for _, s3 := range o {
 			tw.AddLine(s3.ServiceID, s3.ServiceVersion, s3.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, s3 := range s3s {
-		fmt.Fprintf(out, "\tS3 %d/%d\n", i+1, len(s3s))
+	for i, s3 := range o {
+		fmt.Fprintf(out, "\tS3 %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", s3.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", s3.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", s3.Name)

--- a/pkg/commands/logging/scalyr/describe.go
+++ b/pkg/commands/logging/scalyr/describe.go
@@ -1,8 +1,6 @@
 package scalyr
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Scalyr logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetScalyrInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,37 +84,28 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	scalyr, err := c.Globals.APIClient.GetScalyr(&c.Input)
+	o, err := c.Globals.APIClient.GetScalyr(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(scalyr)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Format version":     scalyr.FormatVersion,
-		"Format":             scalyr.Format,
-		"Name":               scalyr.Name,
-		"Placement":          scalyr.Placement,
-		"Region":             scalyr.Region,
-		"Response condition": scalyr.ResponseCondition,
-		"Token":              scalyr.Token,
-		"Version":            scalyr.ServiceVersion,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Region":             o.Region,
+		"Response condition": o.ResponseCondition,
+		"Token":              o.Token,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = scalyr.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/scalyr/list.go
+++ b/pkg/commands/logging/scalyr/list.go
@@ -1,7 +1,6 @@
 package scalyr
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Scalyr logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListScalyrsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	scalyrs, err := c.Globals.APIClient.ListScalyrs(&c.Input)
+	o, err := c.Globals.APIClient.ListScalyrs(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(scalyrs)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, scalyr := range scalyrs {
+		for _, scalyr := range o {
 			tw.AddLine(scalyr.ServiceID, scalyr.ServiceVersion, scalyr.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, scalyr := range scalyrs {
-		fmt.Fprintf(out, "\tScalyr %d/%d\n", i+1, len(scalyrs))
+	for i, scalyr := range o {
+		fmt.Fprintf(out, "\tScalyr %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", scalyr.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", scalyr.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", scalyr.Name)

--- a/pkg/commands/logging/sftp/describe.go
+++ b/pkg/commands/logging/sftp/describe.go
@@ -1,8 +1,6 @@
 package sftp
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe an SFTP logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetSFTPInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,48 +84,39 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	sftp, err := c.Globals.APIClient.GetSFTP(&c.Input)
+	o, err := c.Globals.APIClient.GetSFTP(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(sftp)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Address":            sftp.Address,
-		"Compression codec":  sftp.CompressionCodec,
-		"Format version":     sftp.FormatVersion,
-		"Format":             sftp.Format,
-		"GZip level":         sftp.GzipLevel,
-		"Message type":       sftp.MessageType,
-		"Name":               sftp.Name,
-		"Password":           sftp.Password,
-		"Path":               sftp.Path,
-		"Period":             sftp.Period,
-		"Placement":          sftp.Placement,
-		"Port":               sftp.Port,
-		"Public key":         sftp.PublicKey,
-		"Response condition": sftp.ResponseCondition,
-		"Secret key":         sftp.SecretKey,
-		"SSH known hosts":    sftp.SSHKnownHosts,
-		"Timestamp format":   sftp.TimestampFormat,
-		"User":               sftp.User,
-		"Version":            sftp.ServiceVersion,
+		"Address":            o.Address,
+		"Compression codec":  o.CompressionCodec,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"GZip level":         o.GzipLevel,
+		"Message type":       o.MessageType,
+		"Name":               o.Name,
+		"Password":           o.Password,
+		"Path":               o.Path,
+		"Period":             o.Period,
+		"Placement":          o.Placement,
+		"Port":               o.Port,
+		"Public key":         o.PublicKey,
+		"Response condition": o.ResponseCondition,
+		"Secret key":         o.SecretKey,
+		"SSH known hosts":    o.SSHKnownHosts,
+		"Timestamp format":   o.TimestampFormat,
+		"User":               o.User,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = sftp.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/sftp/list.go
+++ b/pkg/commands/logging/sftp/list.go
@@ -1,7 +1,6 @@
 package sftp
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list SFTP logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListSFTPsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	sftps, err := c.Globals.APIClient.ListSFTPs(&c.Input)
+	o, err := c.Globals.APIClient.ListSFTPs(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(sftps)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, sftp := range sftps {
+		for _, sftp := range o {
 			tw.AddLine(sftp.ServiceID, sftp.ServiceVersion, sftp.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, sftp := range sftps {
-		fmt.Fprintf(out, "\tSFTP %d/%d\n", i+1, len(sftps))
+	for i, sftp := range o {
+		fmt.Fprintf(out, "\tSFTP %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", sftp.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", sftp.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", sftp.Name)

--- a/pkg/commands/logging/splunk/describe.go
+++ b/pkg/commands/logging/splunk/describe.go
@@ -1,8 +1,6 @@
 package splunk
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Splunk logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetSplunkInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,41 +84,32 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	splunk, err := c.Globals.APIClient.GetSplunk(&c.Input)
+	o, err := c.Globals.APIClient.GetSplunk(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(splunk)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Format version":         splunk.FormatVersion,
-		"Format":                 splunk.Format,
-		"Name":                   splunk.Name,
-		"Placement":              splunk.Placement,
-		"Response condition":     splunk.ResponseCondition,
-		"TLS CA certificate":     splunk.TLSCACert,
-		"TLS client certificate": splunk.TLSClientCert,
-		"TLS client key":         splunk.TLSClientKey,
-		"TLS hostname":           splunk.TLSHostname,
-		"Token":                  splunk.Token,
-		"URL":                    splunk.URL,
-		"Version":                splunk.ServiceVersion,
+		"Format version":         o.FormatVersion,
+		"Format":                 o.Format,
+		"Name":                   o.Name,
+		"Placement":              o.Placement,
+		"Response condition":     o.ResponseCondition,
+		"TLS CA certificate":     o.TLSCACert,
+		"TLS client certificate": o.TLSClientCert,
+		"TLS client key":         o.TLSClientKey,
+		"TLS hostname":           o.TLSHostname,
+		"Token":                  o.Token,
+		"URL":                    o.URL,
+		"Version":                o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = splunk.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/splunk/list.go
+++ b/pkg/commands/logging/splunk/list.go
@@ -1,7 +1,6 @@
 package splunk
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Splunk logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListSplunksInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	splunks, err := c.Globals.APIClient.ListSplunks(&c.Input)
+	o, err := c.Globals.APIClient.ListSplunks(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(splunks)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, splunk := range splunks {
+		for _, splunk := range o {
 			tw.AddLine(splunk.ServiceID, splunk.ServiceVersion, splunk.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, splunk := range splunks {
-		fmt.Fprintf(out, "\tSplunk %d/%d\n", i+1, len(splunks))
+	for i, splunk := range o {
+		fmt.Fprintf(out, "\tSplunk %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", splunk.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", splunk.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", splunk.Name)

--- a/pkg/commands/logging/sumologic/describe.go
+++ b/pkg/commands/logging/sumologic/describe.go
@@ -1,8 +1,6 @@
 package sumologic
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Sumologic logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetSumologicInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,37 +84,28 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	sumologic, err := c.Globals.APIClient.GetSumologic(&c.Input)
+	o, err := c.Globals.APIClient.GetSumologic(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(sumologic)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Format version":     sumologic.FormatVersion,
-		"Format":             sumologic.Format,
-		"Message type":       sumologic.MessageType,
-		"Name":               sumologic.Name,
-		"Placement":          sumologic.Placement,
-		"Response condition": sumologic.ResponseCondition,
-		"URL":                sumologic.URL,
-		"Version":            sumologic.ServiceVersion,
+		"Format version":     o.FormatVersion,
+		"Format":             o.Format,
+		"Message type":       o.MessageType,
+		"Name":               o.Name,
+		"Placement":          o.Placement,
+		"Response condition": o.ResponseCondition,
+		"URL":                o.URL,
+		"Version":            o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = sumologic.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/sumologic/list.go
+++ b/pkg/commands/logging/sumologic/list.go
@@ -1,7 +1,6 @@
 package sumologic
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Sumologic logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListSumologicsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	sumologics, err := c.Globals.APIClient.ListSumologics(&c.Input)
+	o, err := c.Globals.APIClient.ListSumologics(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(sumologics)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, sumologic := range sumologics {
+		for _, sumologic := range o {
 			tw.AddLine(sumologic.ServiceID, sumologic.ServiceVersion, sumologic.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, sumologic := range sumologics {
-		fmt.Fprintf(out, "\tSumologic %d/%d\n", i+1, len(sumologics))
+	for i, sumologic := range o {
+		fmt.Fprintf(out, "\tSumologic %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", sumologic.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", sumologic.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", sumologic.Name)

--- a/pkg/commands/logging/syslog/describe.go
+++ b/pkg/commands/logging/syslog/describe.go
@@ -1,8 +1,6 @@
 package syslog
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/fastly/cli/pkg/cmd"
@@ -16,9 +14,10 @@ import (
 // DescribeCommand calls the Fastly API to describe a Syslog logging endpoint.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.GetSyslogInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -43,12 +42,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -66,7 +60,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,46 +84,37 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	syslog, err := c.Globals.APIClient.GetSyslog(&c.Input)
+	o, err := c.Globals.APIClient.GetSyslog(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if c.json {
-		data, err := json.Marshal(syslog)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	lines := text.Lines{
-		"Address":                syslog.Address,
-		"Format version":         syslog.FormatVersion,
-		"Format":                 syslog.Format,
-		"Hostname":               syslog.Hostname,
-		"IPV4":                   syslog.IPV4,
-		"Message type":           syslog.MessageType,
-		"Name":                   syslog.Name,
-		"Placement":              syslog.Placement,
-		"Port":                   syslog.Port,
-		"Response condition":     syslog.ResponseCondition,
-		"TLS CA certificate":     syslog.TLSCACert,
-		"TLS client certificate": syslog.TLSClientCert,
-		"TLS client key":         syslog.TLSClientKey,
-		"TLS hostname":           syslog.TLSHostname,
-		"Token":                  syslog.Token,
-		"Use TLS":                syslog.UseTLS,
-		"Version":                syslog.ServiceVersion,
+		"Address":                o.Address,
+		"Format version":         o.FormatVersion,
+		"Format":                 o.Format,
+		"Hostname":               o.Hostname,
+		"IPV4":                   o.IPV4,
+		"Message type":           o.MessageType,
+		"Name":                   o.Name,
+		"Placement":              o.Placement,
+		"Port":                   o.Port,
+		"Response condition":     o.ResponseCondition,
+		"TLS CA certificate":     o.TLSCACert,
+		"TLS client certificate": o.TLSClientCert,
+		"TLS client key":         o.TLSClientKey,
+		"TLS hostname":           o.TLSHostname,
+		"Token":                  o.Token,
+		"Use TLS":                o.UseTLS,
+		"Version":                o.ServiceVersion,
 	}
 	if !c.Globals.Verbose() {
-		lines["Service ID"] = syslog.ServiceID
+		lines["Service ID"] = o.ServiceID
 	}
 	text.PrintLines(out, lines)
 

--- a/pkg/commands/logging/syslog/list.go
+++ b/pkg/commands/logging/syslog/list.go
@@ -1,7 +1,6 @@
 package syslog
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,9 +15,10 @@ import (
 // ListCommand calls the Fastly API to list Syslog logging endpoints.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	manifest       manifest.Data
 	Input          fastly.ListSyslogsInput
-	json           bool
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
 }
@@ -42,12 +42,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -65,7 +60,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,29 +84,20 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersion.Number
 
-	syslogs, err := c.Globals.APIClient.ListSyslogs(&c.Input)
+	o, err := c.Globals.APIClient.ListSyslogs(&c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(syslogs)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
 
+	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
 		tw.AddHeader("SERVICE", "VERSION", "NAME")
-		for _, syslog := range syslogs {
+		for _, syslog := range o {
 			tw.AddLine(syslog.ServiceID, syslog.ServiceVersion, syslog.Name)
 		}
 		tw.Print()
@@ -119,8 +105,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, "Version: %d\n", c.Input.ServiceVersion)
-	for i, syslog := range syslogs {
-		fmt.Fprintf(out, "\tSyslog %d/%d\n", i+1, len(syslogs))
+	for i, syslog := range o {
+		fmt.Fprintf(out, "\tSyslog %d/%d\n", i+1, len(o))
 		fmt.Fprintf(out, "\t\tService ID: %s\n", syslog.ServiceID)
 		fmt.Fprintf(out, "\t\tVersion: %d\n", syslog.ServiceVersion)
 		fmt.Fprintf(out, "\t\tName: %s\n", syslog.Name)

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -413,9 +413,20 @@ func TestList(t *testing.T) {
 		},
 		{
 			TestScenario: testutil.TestScenario{
-				Name:       "validate listing profiles with --json displays data correctly",
-				Args:       args("profile list --json"),
-				WantOutput: `{"bar":{"default":false,"email":"bar@example.com","token":"456"},"foo":{"default":false,"email":"foo@example.com","token":"123"}}`,
+				Name: "validate listing profiles with --json displays data correctly",
+				Args: args("profile list --json"),
+				WantOutput: `{
+  "bar": {
+    "default": false,
+    "email": "bar@example.com",
+    "token": "456"
+  },
+  "foo": {
+    "default": false,
+    "email": "foo@example.com",
+    "token": "123"
+  }
+}`,
 			},
 			ConfigFile: config.File{
 				Profiles: config.Profiles{

--- a/pkg/commands/resourcelink/create.go
+++ b/pkg/commands/resourcelink/create.go
@@ -109,7 +109,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = serviceVersion.Number
 
-	resource, err := c.Globals.APIClient.CreateResource(&c.input)
+	o, err := c.Globals.APIClient.CreateResource(&c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"ID":              c.input.ResourceID,
@@ -119,10 +119,10 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if ok, err := c.WriteJSON(out, resource); ok {
+	if ok, err := c.WriteJSON(out, o); ok {
 		return err
 	}
 
-	text.Success(out, "Created service resource link %q (%s) on service %s version %s", resource.Name, resource.ID, resource.ServiceID, resource.ServiceVersion)
+	text.Success(out, "Created service resource link %q (%s) on service %s version %s", o.Name, o.ID, o.ServiceID, o.ServiceVersion)
 	return nil
 }

--- a/pkg/commands/resourcelink/describe.go
+++ b/pkg/commands/resourcelink/describe.go
@@ -88,7 +88,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = serviceVersion.Number
 
-	resource, err := c.Globals.APIClient.GetResource(&c.input)
+	o, err := c.Globals.APIClient.GetResource(&c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"ID":              c.input.ID,
@@ -98,15 +98,15 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if ok, err := c.WriteJSON(out, resource); ok {
+	if ok, err := c.WriteJSON(out, o); ok {
 		return err
 	}
 
 	if !c.Globals.Verbose() {
-		text.Output(out, "Service ID: %s", resource.ServiceID)
+		text.Output(out, "Service ID: %s", o.ServiceID)
 	}
-	text.Output(out, "Service Version: %s", resource.ServiceVersion)
-	text.PrintResource(out, "", resource)
+	text.Output(out, "Service Version: %s", o.ServiceVersion)
+	text.PrintResource(out, "", o)
 
 	return nil
 }

--- a/pkg/commands/resourcelink/list.go
+++ b/pkg/commands/resourcelink/list.go
@@ -83,7 +83,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = serviceVersion.Number
 
-	resources, err := c.Globals.APIClient.ListResources(&c.input)
+	o, err := c.Globals.APIClient.ListResources(&c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      c.input.ServiceID,
@@ -92,7 +92,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if ok, err := c.WriteJSON(out, resources); ok {
+	if ok, err := c.WriteJSON(out, o); ok {
 		return err
 	}
 
@@ -101,8 +101,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 	text.Output(out, "Service Version: %d\n", c.input.ServiceVersion)
 
-	for i, resource := range resources {
-		fmt.Fprintf(out, "Resource Link %d/%d\n", i+1, len(resources))
+	for i, resource := range o {
+		fmt.Fprintf(out, "Resource Link %d/%d\n", i+1, len(o))
 		text.PrintResource(out, "\t", resource)
 		fmt.Fprintln(out)
 	}

--- a/pkg/commands/resourcelink/update.go
+++ b/pkg/commands/resourcelink/update.go
@@ -108,7 +108,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = serviceVersion.Number
 
-	resource, err := c.Globals.APIClient.UpdateResource(&c.input)
+	o, err := c.Globals.APIClient.UpdateResource(&c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"ID":              c.input.ID,
@@ -118,10 +118,10 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	if ok, err := c.WriteJSON(out, resource); ok {
+	if ok, err := c.WriteJSON(out, o); ok {
 		return err
 	}
 
-	text.Success(out, "Updated service resource link %s on service %s version %s", resource.ID, resource.ServiceID, resource.ServiceVersion)
+	text.Success(out, "Updated service resource link %s on service %s version %s", o.ID, o.ServiceID, o.ServiceVersion)
 	return nil
 }

--- a/pkg/commands/service/list.go
+++ b/pkg/commands/service/list.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,8 +15,9 @@ import (
 // ListCommand calls the Fastly API to list services.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
+
 	input fastly.ListServicesInput
-	json  bool
 }
 
 // NewListCommand returns a usable command registered under the parent.
@@ -31,12 +31,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data) *ListCommand {
 
 	// optional
 	c.CmdClause.Flag("direction", "Direction in which to sort results").Default(cmd.PaginationDirection[0]).HintOptions(cmd.PaginationDirection...).EnumVar(&c.input.Direction, cmd.PaginationDirection...)
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.CmdClause.Flag("page", "Page number of data set to fetch").IntVar(&c.input.Page)
 	c.CmdClause.Flag("per-page", "Number of records per page").IntVar(&c.input.PerPage)
 	c.CmdClause.Flag("sort", "Field on which to sort").Default("created").StringVar(&c.input.Sort)
@@ -45,13 +40,13 @@ func NewListCommand(parent cmd.Registerer, g *global.Data) *ListCommand {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	paginator := c.Globals.APIClient.NewListServicesPaginator(&c.input)
 
-	var ss []*fastly.Service
+	var o []*fastly.Service
 	for paginator.HasNext() {
 		data, err := paginator.GetNext()
 		if err != nil {
@@ -60,26 +55,17 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 			})
 			return err
 		}
-		ss = append(ss, data...)
+		o = append(o, data...)
+	}
+
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
 	}
 
 	if !c.Globals.Verbose() {
-		if c.json {
-			data, err := json.Marshal(ss)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(data)
-			if err != nil {
-				c.Globals.ErrLog.Add(err)
-				return fmt.Errorf("error: unable to write data to stdout: %w", err)
-			}
-			return nil
-		}
-
 		tw := text.NewTable(out)
 		tw.AddHeader("NAME", "ID", "TYPE", "ACTIVE VERSION", "LAST EDITED (UTC)")
-		for _, service := range ss {
+		for _, service := range o {
 			updatedAt := "n/a"
 			if service.UpdatedAt != nil {
 				updatedAt = service.UpdatedAt.UTC().Format(time.Format)
@@ -98,8 +84,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return nil
 	}
 
-	for i, service := range ss {
-		fmt.Fprintf(out, "Service %d/%d\n", i+1, len(ss))
+	for i, service := range o {
+		fmt.Fprintf(out, "Service %d/%d\n", i+1, len(o))
 		text.PrintService(out, "\t", service)
 		fmt.Fprintln(out)
 	}

--- a/pkg/commands/serviceauth/service_test.go
+++ b/pkg/commands/serviceauth/service_test.go
@@ -71,9 +71,29 @@ func TestServiceAuthList(t *testing.T) {
 			wantOutput: "AUTH ID  USER ID  SERVICE ID  PERMISSION\n123      456      789         read_only\n",
 		},
 		{
-			args:       args("service-auth list --json"),
-			api:        mock.API{ListServiceAuthorizationsFn: listServiceAuthOK},
-			wantOutput: "{\"Info\":{\"links\":{},\"meta\":{}},\"Items\":[{\"CreatedAt\":null,\"DeletedAt\":null,\"ID\":\"123\",\"Permission\":\"read_only\",\"Service\":{\"ID\":\"789\"},\"UpdatedAt\":null,\"User\":{\"ID\":\"456\"}}]}",
+			args: args("service-auth list --json"),
+			api:  mock.API{ListServiceAuthorizationsFn: listServiceAuthOK},
+			wantOutput: `{
+  "Info": {
+    "links": {},
+    "meta": {}
+  },
+  "Items": [
+    {
+      "CreatedAt": null,
+      "DeletedAt": null,
+      "ID": "123",
+      "Permission": "read_only",
+      "Service": {
+        "ID": "789"
+      },
+      "UpdatedAt": null,
+      "User": {
+        "ID": "456"
+      }
+    }
+  ]
+}`,
 		},
 		{
 			args:       args("service-auth list --verbose"),
@@ -88,6 +108,7 @@ func TestServiceAuthList(t *testing.T) {
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
 			opts.APIClient = mock.APIClient(testcase.api)
 			err := app.Run(opts)
+			t.Log(stdout.String())
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
 		})
@@ -121,9 +142,21 @@ func TestServiceAuthDescribe(t *testing.T) {
 			wantOutput: "Auth ID: 12345\nUser ID: 456\nService ID: 789\nPermission: read_only\n",
 		},
 		{
-			args:       args("service-auth describe --id 123 --json"),
-			api:        mock.API{GetServiceAuthorizationFn: describeServiceAuthOK},
-			wantOutput: "{\"CreatedAt\":null,\"DeletedAt\":null,\"ID\":\"12345\",\"Permission\":\"read_only\",\"Service\":{\"ID\":\"789\"},\"UpdatedAt\":null,\"User\":{\"ID\":\"456\"}}",
+			args: args("service-auth describe --id 123 --json"),
+			api:  mock.API{GetServiceAuthorizationFn: describeServiceAuthOK},
+			wantOutput: `{
+  "CreatedAt": null,
+  "DeletedAt": null,
+  "ID": "12345",
+  "Permission": "read_only",
+  "Service": {
+    "ID": "789"
+  },
+  "UpdatedAt": null,
+  "User": {
+    "ID": "456"
+  }
+}`,
 		},
 	}
 	for testcaseIdx := range scenarios {
@@ -133,6 +166,7 @@ func TestServiceAuthDescribe(t *testing.T) {
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
 			opts.APIClient = mock.APIClient(testcase.api)
 			err := app.Run(opts)
+			t.Log(stdout.String())
 			testutil.AssertErrorContains(t, err, testcase.wantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
 		})

--- a/pkg/commands/tls/config/describe.go
+++ b/pkg/commands/tls/config/describe.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -26,12 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 	// optional
 	c.CmdClause.Flag("include", "Include related objects (comma-separated values)").HintOptions(include).EnumVar(&c.include, include)
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 
 	return &c
 }
@@ -39,22 +33,22 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	id       string
 	include  string
-	json     bool
 	manifest manifest.Data
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.GetCustomTLSConfiguration(input)
+	o, err := c.Globals.APIClient.GetCustomTLSConfiguration(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Configuration ID": c.id,
@@ -62,7 +56,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, r)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
@@ -80,19 +78,6 @@ func (c *DescribeCommand) constructInput() *fastly.GetCustomTLSConfigurationInpu
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, r *fastly.CustomTLSConfiguration) error {
-	if c.json {
-		data, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	fmt.Fprintf(out, "\nID: %s\n", r.ID)
 	fmt.Fprintf(out, "Name: %s\n", r.Name)
 

--- a/pkg/commands/tls/config/list.go
+++ b/pkg/commands/tls/config/list.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -24,12 +23,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	// optional
 	c.CmdClause.Flag("filter-bulk", "Optionally filter by the bulk attribute").Action(c.filterBulk.Set).BoolVar(&c.filterBulk.Value)
 	c.CmdClause.Flag("include", "Include related objects (comma-separated values)").HintOptions(include).EnumVar(&c.include, include)
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.CmdClause.Flag("page", "Page number of data set to fetch").IntVar(&c.pageNumber)
 	c.CmdClause.Flag("per-page", "Number of records per page").IntVar(&c.pageSize)
 
@@ -39,10 +33,10 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	filterBulk cmd.OptionalBool
 	include    string
-	json       bool
 	manifest   manifest.Data
 	pageNumber int
 	pageSize   int
@@ -50,13 +44,13 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	rs, err := c.Globals.APIClient.ListCustomTLSConfigurations(input)
+	o, err := c.Globals.APIClient.ListCustomTLSConfigurations(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter Bulk": c.filterBulk,
@@ -67,10 +61,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		c.printVerbose(out, rs)
+		c.printVerbose(out, o)
 	} else {
-		err = c.printSummary(out, rs)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -144,19 +142,6 @@ func (c *ListCommand) printVerbose(out io.Writer, rs []*fastly.CustomTLSConfigur
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, rs []*fastly.CustomTLSConfiguration) error {
-	if c.json {
-		data, err := json.Marshal(rs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("NAME", "ID", "BULK", "DEFAULT", "TLS PROTOCOLS", "HTTP PROTOCOLS", "DNS RECORDS")
 	for _, r := range rs {

--- a/pkg/commands/tls/custom/activation/describe.go
+++ b/pkg/commands/tls/custom/activation/describe.go
@@ -1,7 +1,6 @@
 package activation
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -26,12 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 	// optional
 	c.CmdClause.Flag("include", "Include related objects (comma-separated values)").HintOptions(include...).EnumVar(&c.include, include...)
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 
 	return &c
 }
@@ -39,22 +33,22 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	id       string
 	include  string
-	json     bool
 	manifest manifest.Data
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.GetTLSActivation(input)
+	o, err := c.Globals.APIClient.GetTLSActivation(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Activation ID": c.id,
@@ -62,7 +56,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, r)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
@@ -80,19 +78,6 @@ func (c *DescribeCommand) constructInput() *fastly.GetTLSActivationInput {
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, r *fastly.TLSActivation) error {
-	if c.json {
-		data, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	fmt.Fprintf(out, "\nID: %s\n", r.ID)
 
 	if r.CreatedAt != nil {

--- a/pkg/commands/tls/custom/certificate/describe.go
+++ b/pkg/commands/tls/custom/certificate/describe.go
@@ -1,7 +1,6 @@
 package certificate
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -23,12 +22,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	c.CmdClause.Flag("id", "Alphanumeric string identifying a TLS certificate").Required().StringVar(&c.id)
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 
 	return &c
 }
@@ -36,21 +30,21 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	id       string
-	json     bool
 	manifest manifest.Data
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.GetCustomTLSCertificate(input)
+	o, err := c.Globals.APIClient.GetCustomTLSCertificate(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Certificate ID": c.id,
@@ -58,7 +52,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, r)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
@@ -72,19 +70,6 @@ func (c *DescribeCommand) constructInput() *fastly.GetCustomTLSCertificateInput 
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, r *fastly.CustomTLSCertificate) error {
-	if c.json {
-		data, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	fmt.Fprintf(out, "\nID: %s\n", r.ID)
 	fmt.Fprintf(out, "Issued to: %s\n", r.IssuedTo)
 	fmt.Fprintf(out, "Issuer: %s\n", r.Issuer)

--- a/pkg/commands/tls/custom/certificate/list.go
+++ b/pkg/commands/tls/custom/certificate/list.go
@@ -1,7 +1,6 @@
 package certificate
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -26,12 +25,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	c.CmdClause.Flag("filter-not-after", "Limit the returned certificates to those that expire prior to the specified date in UTC").StringVar(&c.filterNotAfter)
 	c.CmdClause.Flag("filter-domain", "Limit the returned certificates to those that include the specific domain").StringVar(&c.filterTLSDomainID)
 	c.CmdClause.Flag("include", "Include related objects (comma-separated values)").HintOptions("tls_activations").EnumVar(&c.include, "tls_activations")
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.CmdClause.Flag("page", "Page number of data set to fetch").IntVar(&c.pageNumber)
 	c.CmdClause.Flag("per-page", "Number of records per page").IntVar(&c.pageSize)
 	c.CmdClause.Flag("sort", "The order in which to list the results by creation date").StringVar(&c.sort)
@@ -42,11 +36,11 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	filterNotAfter    string
 	filterTLSDomainID string
 	include           string
-	json              bool
 	manifest          manifest.Data
 	pageNumber        int
 	pageSize          int
@@ -55,13 +49,13 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	rs, err := c.Globals.APIClient.ListCustomTLSCertificates(input)
+	o, err := c.Globals.APIClient.ListCustomTLSCertificates(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter Not After":     c.filterNotAfter,
@@ -74,10 +68,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		printVerbose(out, rs)
+		printVerbose(out, o)
 	} else {
-		err = c.printSummary(out, rs)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -145,19 +143,6 @@ func printVerbose(out io.Writer, rs []*fastly.CustomTLSCertificate) {
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, rs []*fastly.CustomTLSCertificate) error {
-	if c.json {
-		data, err := json.Marshal(rs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("ID", "ISSUED TO", "NAME", "REPLACE", "SIGNATURE ALGORITHM")
 	for _, r := range rs {

--- a/pkg/commands/tls/custom/domain/list.go
+++ b/pkg/commands/tls/custom/domain/list.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -27,12 +26,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	c.CmdClause.Flag("filter-in-use", "Limit the returned domains to those currently using Fastly to terminate TLS with SNI").Action(c.filterInUse.Set).BoolVar(&c.filterInUse.Value)
 	c.CmdClause.Flag("filter-subscription", "Limit the returned domains to those for a given TLS subscription").StringVar(&c.filterTLSSubsID)
 	c.CmdClause.Flag("include", "Include related objects (comma-separated values)").HintOptions("tls_activations").EnumVar(&c.include, "tls_activations")
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.CmdClause.Flag("page", "Page number of data set to fetch").IntVar(&c.pageNumber)
 	c.CmdClause.Flag("per-page", "Number of records per page").IntVar(&c.pageSize)
 	c.CmdClause.Flag("sort", "The order in which to list the results by creation date").StringVar(&c.sort)
@@ -43,12 +37,12 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	filterInUse      cmd.OptionalBool
 	filterTLSCertsID string
 	filterTLSSubsID  string
 	include          string
-	json             bool
 	manifest         manifest.Data
 	pageNumber       int
 	pageSize         int
@@ -57,13 +51,13 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	rs, err := c.Globals.APIClient.ListTLSDomains(input)
+	o, err := c.Globals.APIClient.ListTLSDomains(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter In Use":            c.filterInUse,
@@ -77,10 +71,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		printVerbose(out, rs)
+		printVerbose(out, o)
 	} else {
-		err = c.printSummary(out, rs)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -130,19 +128,6 @@ func printVerbose(out io.Writer, rs []*fastly.TLSDomain) {
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, rs []*fastly.TLSDomain) error {
-	if c.json {
-		data, err := json.Marshal(rs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("ID", "TYPE")
 	for _, r := range rs {

--- a/pkg/commands/tls/platform/describe.go
+++ b/pkg/commands/tls/platform/describe.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -23,12 +22,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	c.CmdClause.Flag("id", "Alphanumeric string identifying a TLS bulk certificate").Required().StringVar(&c.id)
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 
 	return &c
 }
@@ -36,21 +30,21 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	id       string
-	json     bool
 	manifest manifest.Data
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.GetBulkCertificate(input)
+	o, err := c.Globals.APIClient.GetBulkCertificate(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Bulk Certificate ID": c.id,
@@ -58,7 +52,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, r)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
@@ -72,19 +70,6 @@ func (c *DescribeCommand) constructInput() *fastly.GetBulkCertificateInput {
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, r *fastly.BulkCertificate) error {
-	if c.json {
-		data, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	fmt.Fprintf(out, "\nID: %s\n", r.ID)
 
 	if r.NotAfter != nil {

--- a/pkg/commands/tls/platform/list.go
+++ b/pkg/commands/tls/platform/list.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -22,12 +21,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 
 	// optional
 	c.CmdClause.Flag("filter-domain", "Optionally filter by the bulk attribute").StringVar(&c.filterTLSDomainID)
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.CmdClause.Flag("page", "Page number of data set to fetch").IntVar(&c.pageNumber)
 	c.CmdClause.Flag("per-page", "Number of records per page").IntVar(&c.pageSize)
 	c.CmdClause.Flag("sort", "The order in which to list the results by creation date").StringVar(&c.sort)
@@ -38,9 +32,9 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	filterTLSDomainID string
-	json              bool
 	manifest          manifest.Data
 	pageNumber        int
 	pageSize          int
@@ -49,13 +43,13 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	rs, err := c.Globals.APIClient.ListBulkCertificates(input)
+	o, err := c.Globals.APIClient.ListBulkCertificates(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter TLS Domain ID": c.filterTLSDomainID,
@@ -66,10 +60,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		printVerbose(out, rs)
+		printVerbose(out, o)
 	} else {
-		err = c.printSummary(out, rs)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -124,19 +122,6 @@ func printVerbose(out io.Writer, rs []*fastly.BulkCertificate) {
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, rs []*fastly.BulkCertificate) error {
-	if c.json {
-		data, err := json.Marshal(rs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("ID", "REPLACE", "NOT BEFORE", "NOT AFTER", "CREATED")
 	for _, r := range rs {

--- a/pkg/commands/tls/subscription/describe.go
+++ b/pkg/commands/tls/subscription/describe.go
@@ -1,7 +1,6 @@
 package subscription
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -26,12 +25,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 
 	// optional
 	c.CmdClause.Flag("include", "Include related objects (comma-separated values)").HintOptions(include...).EnumVar(&c.include, include...)
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 
 	return &c
 }
@@ -39,22 +33,22 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	id       string
 	include  string
-	json     bool
 	manifest manifest.Data
 }
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.GetTLSSubscription(input)
+	o, err := c.Globals.APIClient.GetTLSSubscription(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Subscription ID": c.id,
@@ -63,7 +57,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, r)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
@@ -81,20 +79,6 @@ func (c *DescribeCommand) constructInput() *fastly.GetTLSSubscriptionInput {
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, r *fastly.TLSSubscription) error {
-	if c.json {
-		data, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-
-		return nil
-	}
-
 	fmt.Fprintf(out, "\nID: %s\n", r.ID)
 	fmt.Fprintf(out, "Certificate Authority: %s\n", r.CertificateAuthority)
 	fmt.Fprintf(out, "State: %s\n", r.State)

--- a/pkg/commands/tls/subscription/list.go
+++ b/pkg/commands/tls/subscription/list.go
@@ -1,7 +1,6 @@
 package subscription
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -27,12 +26,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	c.CmdClause.Flag("filter-domain", "Limit the returned subscriptions to those that include the specific domain").StringVar(&c.filterTLSDomainID)
 	c.CmdClause.Flag("filter-state", "Limit the returned subscriptions by state").HintOptions(states...).EnumVar(&c.filterState, states...)
 	c.CmdClause.Flag("include", "Include related objects (comma-separated values)").HintOptions(include...).EnumVar(&c.include, include...) // include is defined in ./describe.go
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag())                                                                                                        // --json
 	c.CmdClause.Flag("page", "Page number of data set to fetch").IntVar(&c.pageNumber)
 	c.CmdClause.Flag("per-page", "Number of records per page").IntVar(&c.pageSize)
 	c.CmdClause.Flag("sort", "The order in which to list the results by creation date").StringVar(&c.sort)
@@ -43,12 +37,12 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
 	filterHasActiveOrder bool
 	filterState          string
 	filterTLSDomainID    string
 	include              string
-	json                 bool
 	manifest             manifest.Data
 	pageNumber           int
 	pageSize             int
@@ -57,13 +51,13 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	input := c.constructInput()
 
-	rs, err := c.Globals.APIClient.ListTLSSubscriptions(input)
+	o, err := c.Globals.APIClient.ListTLSSubscriptions(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter Active":        c.filterHasActiveOrder,
@@ -77,10 +71,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		c.printVerbose(out, rs)
+		c.printVerbose(out, o)
 	} else {
-		err = c.printSummary(out, rs)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -139,19 +137,6 @@ func (c *ListCommand) printVerbose(out io.Writer, rs []*fastly.TLSSubscription) 
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, rs []*fastly.TLSSubscription) error {
-	if c.json {
-		data, err := json.Marshal(rs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("ID", "CERT AUTHORITY", "STATE", "CREATED")
 	for _, r := range rs {

--- a/pkg/commands/vcl/custom/describe.go
+++ b/pkg/commands/vcl/custom/describe.go
@@ -1,7 +1,6 @@
 package custom
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -32,12 +31,7 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -57,8 +51,8 @@ func NewDescribeCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) 
 // DescribeCommand calls the Fastly API to describe an appropriate resource.
 type DescribeCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
-	json           bool
 	manifest       manifest.Data
 	name           string
 	serviceName    cmd.OptionalServiceNameID
@@ -67,7 +61,7 @@ type DescribeCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -90,7 +84,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, serviceVersion.Number)
 
-	v, err := c.Globals.APIClient.GetVCL(input)
+	o, err := c.Globals.APIClient.GetVCL(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -99,7 +93,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	return c.print(out, v)
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	return c.print(out, o)
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
@@ -115,19 +113,6 @@ func (c *DescribeCommand) constructInput(serviceID string, serviceVersion int) *
 
 // print displays the information returned from the API.
 func (c *DescribeCommand) print(out io.Writer, v *fastly.VCL) error {
-	if c.json {
-		data, err := json.Marshal(v)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	if !c.Globals.Verbose() {
 		fmt.Fprintf(out, "\nService ID: %s\n", v.ServiceID)
 	}

--- a/pkg/commands/vcl/custom/list.go
+++ b/pkg/commands/vcl/custom/list.go
@@ -1,7 +1,6 @@
 package custom
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -32,12 +31,7 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 	})
 
 	// optional
-	c.RegisterFlagBool(cmd.BoolFlagOpts{
-		Name:        cmd.FlagJSONName,
-		Description: cmd.FlagJSONDesc,
-		Dst:         &c.json,
-		Short:       'j',
-	})
+	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.RegisterFlag(cmd.StringFlagOpts{
 		Name:        cmd.FlagServiceIDName,
 		Description: cmd.FlagServiceIDDesc,
@@ -57,8 +51,8 @@ func NewListCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Lis
 // ListCommand calls the Fastly API to list appropriate resources.
 type ListCommand struct {
 	cmd.Base
+	cmd.JSONOutput
 
-	json           bool
 	manifest       manifest.Data
 	serviceName    cmd.OptionalServiceNameID
 	serviceVersion cmd.OptionalServiceVersion
@@ -66,7 +60,7 @@ type ListCommand struct {
 
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
-	if c.Globals.Verbose() && c.json {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
@@ -89,7 +83,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, serviceVersion.Number)
 
-	vs, err := c.Globals.APIClient.ListVCLs(input)
+	o, err := c.Globals.APIClient.ListVCLs(input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -98,10 +92,14 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
 	if c.Globals.Verbose() {
-		c.printVerbose(out, serviceVersion.Number, vs)
+		c.printVerbose(out, serviceVersion.Number, o)
 	} else {
-		err = c.printSummary(out, vs)
+		err = c.printSummary(out, o)
 		if err != nil {
 			return err
 		}
@@ -143,19 +141,6 @@ func (c *ListCommand) printVerbose(out io.Writer, serviceVersion int, vs []*fast
 // printSummary displays the information returned from the API in a summarised
 // format.
 func (c *ListCommand) printSummary(out io.Writer, vs []*fastly.VCL) error {
-	if c.json {
-		data, err := json.Marshal(vs)
-		if err != nil {
-			return err
-		}
-		_, err = out.Write(data)
-		if err != nil {
-			c.Globals.ErrLog.Add(err)
-			return fmt.Errorf("error: unable to write data to stdout: %w", err)
-		}
-		return nil
-	}
-
 	t := text.NewTable(out)
 	t.AddHeader("SERVICE ID", "VERSION", "NAME", "MAIN")
 	for _, v := range vs {


### PR DESCRIPTION
With a new major CLI release imminent it was important to ensure that all `--json` implementations were consistent (prior to this PR they were not and so the output would vary slightly).