### PR TITLE
fix(manifest): re-raise remediation error to avoid go-toml wrapping issue

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -54,7 +54,7 @@ var ErrMissingManifestVersion = RemediationError{
 // version has been specified.
 var ErrUnrecognisedManifestVersion = RemediationError{
 	Inner:       fmt.Errorf("unrecognised manifest_version found in the fastly.toml"),
-	Remediation: CLIUpdateRemediation,
+	Remediation: UnrecognisedManifestVersionRemediation,
 }
 
 // ErrIncompatibleManifestVersion means the manifest_version defined is no

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -123,10 +123,12 @@ var PackageSizeRemediation = strings.Join([]string{
 	"https://developer.fastly.com/learning/compute/#limitations-and-constraints",
 }, " ")
 
-// CLIUpdateRemediation suggests updating the installed CLI version.
-var CLIUpdateRemediation = strings.Join([]string{
-	"Please try updating the installed CLI version using:",
-	"`fastly update`.",
+// UnrecognisedManifestVersionRemediation suggests steps to resolve an issue
+// where the project contains a manifest_version that is larger than what the
+// current CLI version supports.
+var UnrecognisedManifestVersionRemediation = strings.Join([]string{
+	"Please try updating the installed CLI version using: `fastly update`.",
+	"See also https://developer.fastly.com/reference/fastly-toml/ to check your fastly.toml manifest is up-to-date with the latest data model.",
 	BugRemediation,
 }, " ")
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	toml "github.com/pelletier/go-toml"
+
 	"github.com/fastly/cli/pkg/env"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/threadsafe"
-	"github.com/google/go-cmp/cmp"
-	toml "github.com/pelletier/go-toml"
 )
 
 func TestManifest(t *testing.T) {
@@ -101,6 +102,9 @@ func TestManifest(t *testing.T) {
 
 			err = m.Read(path)
 
+			output := stdout.String()
+			t.Log(output)
+
 			// If we expect an invalid config, then assert we get the right error.
 			if !tc.valid {
 				testutil.AssertErrorContains(t, err, tc.expectedError.Error())
@@ -116,10 +120,6 @@ func TestManifest(t *testing.T) {
 			if m.ManifestVersion != manifest.ManifestLatestVersion {
 				t.Fatalf("manifest_version '%d' doesn't match latest '%d'", m.ManifestVersion, manifest.ManifestLatestVersion)
 			}
-
-			output := stdout.String()
-
-			t.Log(output)
 
 			if tc.expectedOutput != "" && !strings.Contains(output, tc.expectedOutput) {
 				t.Fatalf("got: %s, want: %s", output, tc.expectedOutput)


### PR DESCRIPTION
**Problem:** go-toml consumes and flattens our custom error type so the remediation information is lost.
**Solution:** manually check for our error message and then reassign the original custom error.