### PR TITLE
fix(compute/deploy): shorten message to avoid spinner bug

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -14,6 +14,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+	"github.com/kennygrant/sanitize"
+	"github.com/mholt/archiver/v3"
+
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/api/undocumented"
 	"github.com/fastly/cli/pkg/cmd"
@@ -24,9 +28,6 @@ import (
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/undo"
-	"github.com/fastly/go-fastly/v8/fastly"
-	"github.com/kennygrant/sanitize"
-	"github.com/mholt/archiver/v3"
 )
 
 const (
@@ -202,6 +203,8 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	return nil
 }
 
+// validStatusCodeRange checks the status is a valid status code.
+// e.g. >= 100 and <= 999
 func validStatusCodeRange(status int) bool {
 	if status >= 100 && status <= 999 {
 		return true
@@ -1255,6 +1258,8 @@ func checkingServiceAvailability(
 	}
 }
 
+// generateTimeout inserts a dynamically generated message on each tick.
+// It notifies the user what's happening and how long is left on the timer.
 func generateTimeout(d time.Duration) string {
 	remaining := fmt.Sprintf("timeout: %v", d.Round(time.Second))
 	return fmt.Sprintf(" (app is being deployed across Fastly's global network | %s)...", remaining)

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -1262,7 +1262,7 @@ func checkingServiceAvailability(
 // It notifies the user what's happening and how long is left on the timer.
 func generateTimeout(d time.Duration) string {
 	remaining := fmt.Sprintf("timeout: %v", d.Round(time.Second))
-	return fmt.Sprintf(" (app is being deployed across Fastly's global network | %s)...", remaining)
+	return fmt.Sprintf(" (app deploying across Fastly's global network | %s)...", remaining)
 }
 
 // pingServiceURL indicates if the service returned a non-5xx response (or


### PR DESCRIPTION
**Problem:** third-party package has a bug where long messages breaks the spinner.
**Solution:** workaround the bug by shortening the message.
**Notes:** I discovered this when creating a split terminal pane ([bug report](https://github.com/theckman/yacspin/issues/73)).

The workaround isn't perfect obviously because the terminal width depends on the user. So I've shortened this to a point where I think it probably works for most people. We've not had reports from users complaining about the spinner being broken so I don't think in practice this affects a lot of people, but worth shortening the message down regardless.