### PR TITLE
fix: reinstate support for [setup.object_stores]

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -1282,6 +1282,7 @@ func pingServiceURL(serviceURL string, httpClient api.HTTPClient, expectedStatus
 	if err != nil {
 		return false, 0, err
 	}
+	defer resp.Body.Close()
 
 	// We check for the user's defined status code expectation.
 	// Otherwise we'll default to checking for a non-500.

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -1313,7 +1313,9 @@ func pingServiceURL(serviceURL string, httpClient api.HTTPClient, expectedStatus
 	if err != nil {
 		return false, 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// We check for the user's defined status code expectation.
 	// Otherwise we'll default to checking for a non-500.

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -98,9 +98,9 @@ func (b *Backends) Create() error {
 		if err != nil {
 			if !b.isOriginless() {
 				b.Spinner.StopFailMessage(msg)
-				err := b.Spinner.StopFail()
-				if err != nil {
-					return err
+				spinErr := b.Spinner.StopFail()
+				if spinErr != nil {
+					return spinErr
 				}
 			}
 

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -6,12 +6,13 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/commands/backend"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // Backends represents the service state related to backends defined within the

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ConfigStores represents the service state related to config stores defined

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -125,9 +125,9 @@ func (o *ConfigStores) Create() error {
 		})
 		if err != nil {
 			o.Spinner.StopFailMessage(msg)
-			err := o.Spinner.StopFail()
-			if err != nil {
-				return err
+			spinErr := o.Spinner.StopFail()
+			if spinErr != nil {
+				return spinErr
 			}
 			return fmt.Errorf("error creating config store: %w", err)
 		}
@@ -154,9 +154,9 @@ func (o *ConfigStores) Create() error {
 				})
 				if err != nil {
 					o.Spinner.StopFailMessage(msg)
-					err := o.Spinner.StopFail()
-					if err != nil {
-						return err
+					spinErr := o.Spinner.StopFail()
+					if spinErr != nil {
+						return spinErr
 					}
 					return fmt.Errorf("error creating config store item: %w", err)
 				}
@@ -185,9 +185,9 @@ func (o *ConfigStores) Create() error {
 		})
 		if err != nil {
 			o.Spinner.StopFailMessage(msg)
-			err := o.Spinner.StopFail()
-			if err != nil {
-				return err
+			spinErr := o.Spinner.StopFail()
+			if spinErr != nil {
+				return spinErr
 			}
 			return fmt.Errorf("error creating resource link between the service '%s' and the config store '%s': %w", o.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -107,7 +107,7 @@ func (o *KVStores) Configure() error {
 func (o *KVStores) Create() error {
 	if o.Spinner == nil {
 		return errors.RemediationError{
-			Inner:       fmt.Errorf("internal logic error: no text.Progress configured for setup.KVStores"),
+			Inner:       fmt.Errorf("internal logic error: no spinner configured for setup.KVStores"),
 			Remediation: errors.BugRemediation,
 		}
 	}

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -125,9 +125,9 @@ func (o *KVStores) Create() error {
 		})
 		if err != nil {
 			o.Spinner.StopFailMessage(msg)
-			err := o.Spinner.StopFail()
-			if err != nil {
-				return err
+			spinErr := o.Spinner.StopFail()
+			if spinErr != nil {
+				return spinErr
 			}
 			return fmt.Errorf("error creating kv store: %w", err)
 		}
@@ -154,9 +154,9 @@ func (o *KVStores) Create() error {
 				})
 				if err != nil {
 					o.Spinner.StopFailMessage(msg)
-					err := o.Spinner.StopFail()
-					if err != nil {
-						return err
+					spinErr := o.Spinner.StopFail()
+					if spinErr != nil {
+						return spinErr
 					}
 					return fmt.Errorf("error creating kv store key: %w", err)
 				}
@@ -185,9 +185,9 @@ func (o *KVStores) Create() error {
 		})
 		if err != nil {
 			o.Spinner.StopFailMessage(msg)
-			err := o.Spinner.StopFail()
-			if err != nil {
-				return err
+			spinErr := o.Spinner.StopFail()
+			if spinErr != nil {
+				return spinErr
 			}
 			return fmt.Errorf("error creating resource link between the service '%s' and the kv store '%s': %w", o.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // KVStores represents the service state related to kv stores defined

--- a/pkg/commands/service/list.go
+++ b/pkg/commands/service/list.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/cmd"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // ListCommand calls the Fastly API to list services.

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -16,7 +16,7 @@ import (
 // manifest file schema.
 type File struct {
 	// Args is necessary to track the subcommand called (see: File.Read method).
-	Args            []string
+	Args            []string    `toml:"omitempty"`
 	Authors         []string    `toml:"authors"`
 	Description     string      `toml:"description"`
 	Language        string      `toml:"language"`

--- a/pkg/manifest/setup.go
+++ b/pkg/manifest/setup.go
@@ -6,6 +6,7 @@ type Setup struct {
 	Backends     map[string]*SetupBackend     `toml:"backends,omitempty"`
 	ConfigStores map[string]*SetupConfigStore `toml:"config_stores,omitempty"`
 	Loggers      map[string]*SetupLogger      `toml:"log_endpoints,omitempty"`
+	ObjectStores map[string]*SetupKVStore     `toml:"object_stores,omitempty"`
 	KVStores     map[string]*SetupKVStore     `toml:"kv_stores,omitempty"`
 	SecretStores map[string]*SetupSecretStore `toml:"secret_stores,omitempty"`
 }


### PR DESCRIPTION
We weren't quite ready to drop support for `[setup.object_store]`.

Tested with...

```toml
authors = [""]
description = ""
language = "go"
manifest_version = 3
name = "testing-fastly-cli"
service_id = ""

[setup]

  [setup.object_stores]

    [setup.object_stores.testing-v9]
      description = "My first store"
```

<img width="718" alt="Screenshot 2023-04-19 at 17 52 33" src="https://user-images.githubusercontent.com/180050/233145765-d7fd923f-a35a-4c44-9108-62968212e9aa.png">