### PR TITLE
fix(kvstore): alias object-store

### DIFF
--- a/pkg/commands/kvstore/root.go
+++ b/pkg/commands/kvstore/root.go
@@ -18,7 +18,7 @@ type RootCommand struct {
 func NewRootCommand(parent cmd.Registerer, g *global.Data) *RootCommand {
 	var c RootCommand
 	c.Globals = g
-	c.CmdClause = parent.Command("kv-store", "Manipulate Fastly KV Stores")
+	c.CmdClause = parent.Command("kv-store", "Manipulate Fastly KV Stores").Alias("object-store")
 	return &c
 }
 


### PR DESCRIPTION
Users can now execute `fastly object-store`.

<img width="747" alt="Screenshot 2023-04-19 at 20 02 54" src="https://user-images.githubusercontent.com/180050/233174656-e8154497-a6c9-4101-93ce-ed78f637a21c.png">
