### PR TITLE
secret store: Add --recreate and --recreate-must options

### DIFF
--- a/pkg/commands/secretstoreentry/create.go
+++ b/pkg/commands/secretstoreentry/create.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 
 	"github.com/fastly/go-fastly/v8/fastly"
@@ -57,8 +58,20 @@ func NewCreateCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *C
 	c.RegisterFlag(cmd.StoreIDFlag(&c.Input.ID))  // --store-id
 
 	// Optional.
-	c.RegisterFlag(secretFileFlag(&c.secretFile))       // --file
-	c.RegisterFlagBool(c.JSONFlag())                    // --json
+	c.RegisterFlag(secretFileFlag(&c.secretFile)) // --file
+	c.RegisterFlagBool(c.JSONFlag())              // --json
+	c.RegisterFlagBool(cmd.BoolFlagOpts{
+		Name:        "recreate",
+		Description: "Create or recreate if a secret of the same name already exists within the store",
+		Dst:         &c.recreate,
+		Required:    false,
+	})
+	c.RegisterFlagBool(cmd.BoolFlagOpts{
+		Name:        "recreate-must",
+		Description: "Recreate secret of the same name which must already exist within the store",
+		Dst:         &c.recreateMust,
+		Required:    false,
+	})
 	c.RegisterFlagBool(secretStdinFlag(&c.secretSTDIN)) // --stdin
 
 	return &c
@@ -69,10 +82,12 @@ type CreateCommand struct {
 	cmd.Base
 	cmd.JSONOutput
 
-	Input       fastly.CreateSecretInput
-	manifest    manifest.Data
-	secretFile  string
-	secretSTDIN bool
+	Input        fastly.CreateSecretInput
+	manifest     manifest.Data
+	recreate     bool
+	recreateMust bool
+	secretFile   string
+	secretSTDIN  bool
 }
 
 var errMultipleSecretValue = fsterr.RemediationError{
@@ -92,6 +107,18 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 	if c.secretFile != "" && c.secretSTDIN {
 		return errMultipleSecretValue
+	}
+
+	switch {
+	case c.recreate && c.recreateMust:
+		return fsterr.RemediationError{
+			Inner:       fmt.Errorf("invalid flag combination, --recreate and --recreate-must"),
+			Remediation: "Use either --recreate or --recreate-must, not both.",
+		}
+	case c.recreate:
+		c.Input.Method = http.MethodPut
+	case c.recreateMust:
+		c.Input.Method = http.MethodPatch
 	}
 
 	// Read secret's value: either from STDIN, a file, or prompt.
@@ -165,12 +192,15 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	// TODO: Use this approach across the code base.
 	if ok, err := c.WriteJSON(out, o); ok {
 		return err
 	}
 
-	text.Success(out, "Created secret '%s' in Secret Store '%s' (digest: %s)", o.Name, c.Input.ID, hex.EncodeToString(o.Digest))
+	action := "Created"
+	if o.Recreated {
+		action = "Recreated"
+	}
+	text.Success(out, "%s secret '%s' in Secret Store '%s' (digest: %s)", action, o.Name, c.Input.ID, hex.EncodeToString(o.Digest))
 
 	return nil
 }

--- a/pkg/commands/secretstoreentry/secretstoreentry_test.go
+++ b/pkg/commands/secretstoreentry/secretstoreentry_test.go
@@ -96,8 +96,8 @@ func TestCreateSecretCommand(t *testing.T) {
 			wantError: "unable to read from STDIN",
 		},
 		{
-			args:      fmt.Sprintf("create --store-id %s --name %s --stdin --recreate --recreate-must", storeID, secretName),
-			wantError: "invalid flag combination, --recreate and --recreate-must",
+			args:      fmt.Sprintf("create --store-id %s --name %s --stdin --recreate --recreate-allow", storeID, secretName),
+			wantError: "invalid flag combination, --recreate and --recreate-allow",
 		},
 		// Read from STDIN.
 		{
@@ -167,7 +167,7 @@ func TestCreateSecretCommand(t *testing.T) {
 		},
 		// CreateOrRecreate
 		{
-			args: fmt.Sprintf("create --store-id %s --name %s --file %s --json --recreate", storeID, secretName, secretFile),
+			args: fmt.Sprintf("create --store-id %s --name %s --file %s --json --recreate-allow", storeID, secretName, secretFile),
 			api: mock.API{
 				CreateClientKeyFn: mockCreateClientKey,
 				GetSigningKeyFn:   mockGetSigningKey,
@@ -194,7 +194,7 @@ func TestCreateSecretCommand(t *testing.T) {
 		},
 		// Recreate
 		{
-			args: fmt.Sprintf("create --store-id %s --name %s --file %s --json --recreate-must", storeID, secretName, secretFile),
+			args: fmt.Sprintf("create --store-id %s --name %s --file %s --json --recreate", storeID, secretName, secretFile),
 			api: mock.API{
 				CreateClientKeyFn: mockCreateClientKey,
 				GetSigningKeyFn:   mockGetSigningKey,


### PR DESCRIPTION
This works in combination with https://github.com/fastly/go-fastly/pull/433 which adds support for the `CreateSecretInput.Method` field.

Secret names must be unique within a store.
The method effects how duplicate names are handled:

- `POST`:  Default. Create a secret; error if one already exists with the same name.
- `PUT` / `--recreate-allow`:   Create or recreate a secret.
- `PATCH` / `--recreate`: Recreate a secret and error if one does not already exist with the same name.

~**DRAFT** until https://github.com/fastly/go-fastly/pull/433 is merged and a new release is created.~