### PR TITLE
fastly backend create: override host cannot be an empty string

### DIFF
--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -67,7 +67,7 @@ func TestBackendCreate(t *testing.T) {
 			},
 			WantOutput: "Created backend www.test.com (service 123 version 4)",
 		},
-		// We test that setting a host override does not result in an error
+		// We test that setting an invalid host override does not result in an error
 		{
 			Args: args("backend create --service-id 123 --version 1 --address 127.0.0.1 --override-host overrite-set --name www.test.com --autoclone --port 8080"),
 			API: mock.API{

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -69,7 +69,7 @@ func TestBackendCreate(t *testing.T) {
 		},
 		// We test that setting an invalid host override does not result in an error
 		{
-			Args: args("backend create --service-id 123 --version 1 --address 127.0.0.1 --override-host overrite-set --name www.test.com --autoclone --port 8080"),
+			Args: args("backend create --service-id 123 --version 1 --address 127.0.0.1 --override-host invalid-host-override --name www.test.com --autoclone --port 8080"),
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),

--- a/pkg/commands/backend/create.go
+++ b/pkg/commands/backend/create.go
@@ -215,7 +215,9 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	if input.Address != nil && !c.overrideHost.WasSet && !c.sslCertHostname.WasSet && !c.sslSNIHostname.WasSet {
 		overrideHost, sslSNIHostname, sslCertHostname := SetBackendHostDefaults(*input.Address)
-		input.OverrideHost = &overrideHost
+		if overrideHost != "" {
+			input.OverrideHost = &overrideHost
+		}
 		input.SSLSNIHostname = &sslSNIHostname
 		input.SSLCertHostname = &sslCertHostname
 	} else {


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/935

But there may be better ways of doing this (revisiting `SetBackendHostDefaults()` role or signature would be maybe a more elegant choice?)