### PR TITLE
Enable env var hints for `--token`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -91,7 +91,7 @@ func Run(opts RunOpts) error {
 	app.Flag("non-interactive", "Do not prompt for user input - suitable for CI processes. Equivalent to --accept-defaults and --auto-yes").Short('i').BoolVar(&g.Flags.NonInteractive)
 	app.Flag("profile", "Switch account profile for single command execution (see also: 'fastly profile switch')").Short('o').StringVar(&g.Flags.Profile)
 	app.Flag("quiet", "Silence all output except direct command output. This won't prevent interactive prompts (see: --accept-defaults, --auto-yes, --non-interactive)").Short('q').BoolVar(&g.Flags.Quiet)
-	app.Flag("token", tokenHelp).Short('t').StringVar(&g.Flags.Token)
+	app.Flag("token", tokenHelp).HintAction(env.Vars).Short('t').StringVar(&g.Flags.Token)
 	app.Flag("verbose", "Verbose logging").Short('v').BoolVar(&g.Flags.Verbose)
 
 	commands := defineCommands(app, &g, md, opts)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,5 +1,13 @@
 package env
 
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fastly/cli/pkg/runtime"
+)
+
 const (
 	// Token is the env var we look in for the Fastly API token.
 	// gosec flagged this:
@@ -17,3 +25,30 @@ const (
 	// CustomerID is the env var we look in for a Customer ID.
 	CustomerID = "FASTLY_CUSTOMER_ID"
 )
+
+// Vars returns a slice of environment variables appropriate to platform.
+// *nix: $HOME, $USER, ...
+// Windows: %HOME%, %USER%, ...
+func Vars() []string {
+	vars := []string{}
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		vars = append(vars, toVar(pair[0]))
+	}
+	return vars
+}
+
+func toVar(v string) string {
+	if runtime.Windows {
+		return toWin(v)
+	}
+	return toNix(v)
+}
+
+func toNix(v string) string {
+	return fmt.Sprintf("\\$%s", v)
+}
+
+func toWin(v string) string {
+	return fmt.Sprintf("%%%s%%", v)
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,43 @@
+package env
+
+import (
+	"runtime"
+	"testing"
+
+	"golang.org/x/exp/slices"
+)
+
+func TestVars(t *testing.T) {
+	tcs := []struct {
+		os       string
+		vars     map[string]string
+		expected []string
+	}{
+		{
+			os:       "windows",
+			expected: []string{"%HOME%", "%PATH%"},
+		},
+		{
+			os:       "darwin",
+			expected: []string{"\\$HOME", "\\$PATH"},
+		},
+		{
+			os:       "linux",
+			expected: []string{"\\$HOME", "\\$PATH"},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.os, func(t *testing.T) {
+			vars := Vars()
+			if runtime.GOOS == tc.os {
+				for _, v := range tc.expected {
+					if !slices.Contains(vars, v) {
+						t.Errorf("expected %s in %v", v, vars)
+					}
+				}
+			} else {
+				t.Skip()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Example:

```
$ ./fastly list service --token $FASTLY<tab>
$FASTLY_ACCOUNT_DEV         $FASTLY_ACCOUNT_SALJA_PROD
$FASTLY_ACCOUNT_PROD        $FASTLY_ACCOUNT_SANDBOX
$FASTLY_ACCOUNT_SALJA_DEV
```