### PR TITLE
feat: support viceroy pinning

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+	"github.com/fastly/kingpin"
+
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/commands/update"
 	"github.com/fastly/cli/pkg/commands/version"
@@ -19,8 +22,6 @@ import (
 	"github.com/fastly/cli/pkg/profile"
 	"github.com/fastly/cli/pkg/revision"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v8/fastly"
-	"github.com/fastly/kingpin"
 )
 
 // FastlyAPIClient is a ClientFactory that returns a real Fastly API client
@@ -41,12 +42,6 @@ func FastlyAPIClient(token, endpoint string) (api.Interface, error) {
 // io.Writer. All error-related information should be encoded into an error type
 // and returned to the caller. This includes usage text.
 func Run(opts RunOpts) error {
-	var md manifest.Data
-	md.File.Args = opts.Args
-	md.File.SetErrLog(opts.ErrLog)
-	md.File.SetOutput(opts.Stdout)
-	_ = md.File.Read(manifest.Filename)
-
 	// The g will hold generally-applicable configuration parameters
 	// from a variety of sources, and is provided to each concrete command.
 	g := global.Data{
@@ -54,7 +49,7 @@ func Run(opts RunOpts) error {
 		ErrLog:     opts.ErrLog,
 		Config:     opts.ConfigFile,
 		HTTPClient: opts.HTTPClient,
-		Manifest:   md,
+		Manifest:   *opts.Manifest,
 		Output:     opts.Stdout,
 		Path:       opts.ConfigPath,
 	}
@@ -94,7 +89,7 @@ func Run(opts RunOpts) error {
 	app.Flag("token", tokenHelp).HintAction(env.Vars).Short('t').StringVar(&g.Flags.Token)
 	app.Flag("verbose", "Verbose logging").Short('v').BoolVar(&g.Flags.Verbose)
 
-	commands := defineCommands(app, &g, md, opts)
+	commands := defineCommands(app, &g, *opts.Manifest, opts)
 	command, name, err := processCommandInput(opts, app, &g, commands)
 	if err != nil {
 		return err
@@ -113,7 +108,7 @@ func Run(opts RunOpts) error {
 	}
 
 	if g.Flags.Quiet {
-		md.File.SetQuiet(true)
+		opts.Manifest.File.SetQuiet(true)
 	}
 
 	token, source := g.Token()
@@ -123,11 +118,11 @@ func Run(opts RunOpts) error {
 			source,
 			opts.Stdout,
 			env.Token,
-			determineProfile(md.File.Profile, g.Flags.Profile, g.Config.Profiles),
+			determineProfile(opts.Manifest.File.Profile, g.Flags.Profile, g.Config.Profiles),
 		)
 	}
 
-	token, err = profile.Init(token, &md, &g, opts.Stdin, opts.Stdout)
+	token, err = profile.Init(token, opts.Manifest, &g, opts.Stdin, opts.Stdout)
 	if err != nil {
 		return err
 	}
@@ -198,6 +193,7 @@ type RunOpts struct {
 	Env        config.Environment
 	ErrLog     fsterr.LogInterface
 	HTTPClient api.HTTPClient
+	Manifest   *manifest.Data
 	Stdin      io.Reader
 	Stdout     io.Writer
 	Versioners Versioners

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -121,6 +121,7 @@ whoami
 			}()
 
 			opts := testutil.NewRunOpts(testcase.Args, &stdout)
+
 			err := app.Run(opts)
 			if err != nil {
 				errors.Deduce(err).Print(&stderr)

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestACLCreate(t *testing.T) {

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestACLEntryCreate(t *testing.T) {

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 func TestCreate(t *testing.T) {

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -294,7 +294,7 @@ func GetViceroy(
 		msg := "Checking latest Viceroy release"
 		spinner.Message(msg + "...")
 
-		v, err := av.Version()
+		v, err := av.LatestVersion()
 		if err != nil {
 			g.ErrLog.Add(err)
 

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -403,7 +403,7 @@ func installViceroy(spinner text.Spinner, av github.AssetVersioner, bin string) 
 	msg := "Fetching latest Viceroy release"
 	spinner.Message(msg + "...")
 
-	tmpBin, err := av.Download()
+	tmpBin, err := av.DownloadLatest()
 	if err != nil {
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
@@ -506,7 +506,7 @@ func updateViceroy(
 		msg := "Fetching latest Viceroy release"
 		spinner.Message(msg + "...")
 
-		tmpBin, err := av.Download()
+		tmpBin, err := av.DownloadLatest()
 		if err != nil {
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()

--- a/pkg/commands/secretstoreentry/create.go
+++ b/pkg/commands/secretstoreentry/create.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// Maximum secret length, as defined at https://developer.fastly.com/reference/api/secret-store.
+	// Maximum secret length, as defined at https://developer.fastly.com/reference/api/services/resources/secret-store-secret/
 	maxSecretKiB = 64
 	maxSecretLen = maxSecretKiB * 1024
 )

--- a/pkg/commands/update/check.go
+++ b/pkg/commands/update/check.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+
 	"github.com/fastly/cli/pkg/github"
 )
 
@@ -17,13 +18,13 @@ func Check(currentVersion string, av github.AssetVersioner) (current, latest sem
 		return current, latest, false
 	}
 
-	s, err := av.Version()
+	v, err := av.LatestVersion()
 	if err != nil {
 		return current, latest, false
 	}
 
 	// nosemgrep (invalid-usage-of-modified-variable)
-	latest, err = semver.Parse(s)
+	latest, err = semver.Parse(v)
 	if err != nil {
 		return current, latest, false
 	}

--- a/pkg/commands/update/root.go
+++ b/pkg/commands/update/root.go
@@ -73,7 +73,7 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	msg = "Fetching latest release"
 	spinner.Message(msg + "...")
 
-	tmpBin, err := c.av.Download()
+	tmpBin, err := c.av.DownloadLatest()
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			fsterr.AllowInstrumentation: true,

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -218,7 +218,7 @@ type AssetVersioner interface {
 	// BinaryName returns the configured binary output name.
 	BinaryName() string
 	// Download downloads the asset from the specified endpoint.
-	Download() (bin string, err error)
+	Download(endpoint string) (bin string, err error)
 	// DownloadLatest downloads the latest version of the asset.
 	DownloadLatest() (bin string, err error)
 	// DownloadVersion downloads the specified version of the asset.

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -9,9 +9,10 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/mholt/archiver"
+
 	"github.com/fastly/cli/pkg/api"
 	fstruntime "github.com/fastly/cli/pkg/runtime"
-	"github.com/mholt/archiver"
 )
 
 const (
@@ -23,7 +24,7 @@ const (
 func New(opts Opts) *Asset {
 	binary := opts.Binary
 	if fstruntime.Windows && filepath.Ext(binary) == "" {
-		binary = binary + ".exe"
+		binary += ".exe"
 	}
 
 	return &Asset{

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -71,8 +71,8 @@ func (g Asset) BinaryName() string {
 	return g.binary
 }
 
-// Download retrieves the binary archive format from GitHub.
-func (g *Asset) Download() (bin string, err error) {
+// DownloadLatest retrieves the latest binary archive format from GitHub.
+func (g *Asset) DownloadLatest() (bin string, err error) {
 	endpoint, err := g.URL()
 	if err != nil {
 		return "", err
@@ -164,6 +164,7 @@ func (g *Asset) metadata() (m Metadata, err error) {
 	if err != nil {
 		return m, fmt.Errorf("failed to request GitHub metadata: %w", err)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return m, fmt.Errorf("failed to request GitHub metadata: %s", res.Status)
 	}
@@ -193,8 +194,8 @@ type Metadata struct {
 type AssetVersioner interface {
 	// BinaryName returns the configured binary output name.
 	BinaryName() string
-	// Download implements the Versioner interface.
-	Download() (bin string, err error)
+	// DownloadLatest downloads the latest version of the asset.
+	DownloadLatest() (bin string, err error)
 	// URL returns the asset URL if set, otherwise calls the API metadata endpoint.
 	URL() (url string, err error)
 	// LatestVersion returns the latest version.

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -131,8 +131,8 @@ func (g *Asset) URL() (url string, err error) {
 	return g.url, nil
 }
 
-// Version returns the asset Version if set, otherwise calls the API metadata endpoint.
-func (g *Asset) Version() (version string, err error) {
+// LatestVersion returns the asset LatestVersion if set, otherwise calls the API metadata endpoint.
+func (g *Asset) LatestVersion() (version string, err error) {
 	if g.version != "" {
 		return g.version, nil
 	}
@@ -197,8 +197,8 @@ type AssetVersioner interface {
 	Download() (bin string, err error)
 	// URL returns the asset URL if set, otherwise calls the API metadata endpoint.
 	URL() (url string, err error)
-	// Version returns the asset Version if set, otherwise calls the API metadata endpoint.
-	Version() (version string, err error)
+	// LatestVersion returns the latest version.
+	LatestVersion() (version string, err error)
 }
 
 // createArchive copies the DevHub response body data into a temporary archive

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -57,7 +57,7 @@ func TestDownloadArchiveExtract(t *testing.T) {
 
 			// IMPORTANT: This is a real network end-to-end integration test.
 			// Meaning, we are making a real request to the DevHub endpoint.
-			bin, err := a.Download()
+			bin, err := a.DownloadLatest()
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/pkg/mock/versioner.go
+++ b/pkg/mock/versioner.go
@@ -15,12 +15,22 @@ func (av AssetVersioner) BinaryName() string {
 	return av.BinaryFilename
 }
 
-// Download implements github.Versioner interface.
-func (av AssetVersioner) Download() (string, error) {
+// DownloadLatest implements github.Versioner interface.
+func (av AssetVersioner) DownloadLatest() (string, error) {
 	if av.DownloadOK {
 		return av.DownloadedFile, nil
 	}
 	return "", fmt.Errorf("not implemented")
+}
+
+// DownloadVersion implements github.Versioner interface.
+func (av AssetVersioner) DownloadVersion(version string) (string, error) {
+	return "", nil
+}
+
+// Download implements github.Versioner interface.
+func (av AssetVersioner) Download(endpoint string) (string, error) {
+	return "", nil
 }
 
 // URL implements github.Versioner interface.
@@ -28,7 +38,7 @@ func (av AssetVersioner) URL() (string, error) {
 	return "", nil
 }
 
-// Version implements github.Versioner interface.
-func (av AssetVersioner) Version() (string, error) {
+// LatestVersion implements github.Versioner interface.
+func (av AssetVersioner) LatestVersion() (string, error) {
 	return av.AssetVersion, nil
 }

--- a/pkg/testutil/args.go
+++ b/pkg/testutil/args.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/config"
 	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/mock"
 )
 
@@ -55,6 +56,12 @@ func Args(args string) []string {
 // while the majority of fields will be pre-populated and only those fields
 // commonly changed for testing purposes will need to be provided.
 func NewRunOpts(args []string, stdout io.Writer) app.RunOpts {
+	var md manifest.Data
+	md.File.Args = args
+	md.File.SetErrLog(errors.Log)
+	md.File.SetOutput(stdout)
+	_ = md.File.Read(manifest.Filename)
+
 	return app.RunOpts{
 		ConfigPath: "/dev/null",
 		Args:       args,
@@ -63,6 +70,7 @@ func NewRunOpts(args []string, stdout io.Writer) app.RunOpts {
 		ErrLog:     errors.Log,
 		ConfigFile: config.File{},
 		HTTPClient: &http.Client{Timeout: time.Second * 5},
+		Manifest:   &md,
 		Stdout:     stdout,
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/905

> **NOTE:** Once this PR is merged and published in a new CLI release, we'll need to ensure the https://developer.fastly.com/reference/compute/fastly-toml/ reference is updated to include a `viceroy_version` field. 

```toml
[local_server]
viceroy_version = 0.5.0
```