### PR TITLE
refactor(ci): disable setup-go caching to avoid later cache restoration errors

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -98,6 +98,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          # IMPORTANT: Disable caching to prevent cache restore errors later.
+          cache: false
       - uses: Integralist/setup-tinygo@v1.0.0
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
@@ -108,13 +110,6 @@ jobs:
         run: |
           echo "gobuild=$(go env GOCACHE)" >> $GITHUB_OUTPUT  # speed up `go test` runs
           echo "gomod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT # speed up use of third-party modules
-      - name: Clear cache directory first before trying to restore from cache
-        # The issue doesn't occur on Windows, only nix systems.
-        if: runner.os != 'Windows'
-        run: sudo rm -rf $(go env GOMODCACHE) && sudo rm -rf $(go env GOCACHE)
-        shell: bash
-        # This workaround was recommended in the following issue report.
-        # https://github.com/actions/cache/issues/1104
       - name: Go Build Cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
To solve the issue with cache restoration we originally deleted the relevant Go directories created when using the setup-go action, but turns out you can just disable the default caching mechanism built into the action. So that's what this PR does.