### PR TITLE
fix(compute/validate): remove broken decompression bomb check

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -582,6 +582,10 @@ func createService(
 	errLog fsterr.LogInterface,
 	out io.Writer,
 ) (serviceID string, serviceVersion *fastly.Version, err error) {
+	if !f.AcceptDefaults && !f.NonInteractive {
+		text.Break(out)
+	}
+
 	err = spinner.Start()
 	if err != nil {
 		return "", nil, err

--- a/pkg/commands/compute/validate.go
+++ b/pkg/commands/compute/validate.go
@@ -118,9 +118,6 @@ func packageFiles(path string, fn func(archiver.File) error) error {
 	}
 	defer tr.Close()
 
-	// Track overall package size
-	var pkgSize int64
-
 	for {
 		f, err := tr.Read()
 		if err == io.EOF {
@@ -128,13 +125,6 @@ func packageFiles(path string, fn func(archiver.File) error) error {
 		}
 		if err != nil {
 			return fmt.Errorf("error reading package: %w", err)
-		}
-
-		// Avoids G110: Potential DoS vulnerability via decompression bomb (gosec).
-		pkgSize += f.Size()
-		if pkgSize > MaxPackageSize {
-			f.Close()
-			return fmt.Errorf("package size exceeded 100MB limit")
 		}
 
 		header, ok := f.Header.(*tar.Header)


### PR DESCRIPTION
Not only does this not serve any value here in the CLI (as it only mimics logic that should, and does, exist elsewhere in the Fastly stack). It is also incorrect because it's summing up the individual 'uncompressed' file sizes and comparing them to a 'compressed' limit.