### PR TITLE
build(scripts): use /usr/bin/env bash to retrieve system bash path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: clean
 
-SHELL := /bin/bash -o pipefail ## Set the shell to use for finding Go files (default: /bin/bash)
+SHELL := /usr/bin/env bash -o pipefail ## Set the shell to use for finding Go files (default: /bin/bash)
+
 
 # Compile program (implicit default target).
 #

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/documentation.sh
+++ b/scripts/documentation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 $1 help --format json > dist/usage.json

--- a/scripts/scaffold-category.sh
+++ b/scripts/scaffold-category.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export CLI_CATEGORY=$1

--- a/scripts/scaffold-update-interfaces.sh
+++ b/scripts/scaffold-update-interfaces.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # UPDATE INTERFACE FILE

--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export CLI_PACKAGE=$1

--- a/scripts/tags.sh
+++ b/scripts/tags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # credit: https://github.com/cli/cli/blob/trunk/script/changelog


### PR DESCRIPTION
Use bash as returned by `/usr/bin/env bash`. In systems such as NixOS this returns a path to a valid bash executable in the current environment.