### PR TITLE
fix(secretstore): pagination + support for json

### DIFF
--- a/pkg/commands/secretstore/helper_test.go
+++ b/pkg/commands/secretstore/helper_test.go
@@ -3,8 +3,9 @@ package secretstore_test
 import (
 	"bytes"
 
-	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/go-fastly/v8/fastly"
+
+	"github.com/fastly/cli/pkg/text"
 )
 
 func fmtStore(s *fastly.SecretStore) string {
@@ -13,7 +14,7 @@ func fmtStore(s *fastly.SecretStore) string {
 	return b.String()
 }
 
-func fmtStores(s *fastly.SecretStores) string {
+func fmtStores(s []fastly.SecretStore) string {
 	var b bytes.Buffer
 	text.PrintSecretStoresTbl(&b, s)
 	return b.String()

--- a/pkg/commands/secretstore/secretstore_test.go
+++ b/pkg/commands/secretstore/secretstore_test.go
@@ -276,8 +276,7 @@ func TestListStoresCommand(t *testing.T) {
 
 	stores := &fastly.SecretStores{
 		Meta: fastly.SecretStoreMeta{
-			Limit:      123,
-			NextCursor: "abc",
+			Limit: 123,
 		},
 		Data: []fastly.SecretStore{
 			{ID: storeID, Name: storeName},
@@ -299,7 +298,6 @@ func TestListStoresCommand(t *testing.T) {
 				},
 			},
 			wantAPIInvoked: true,
-			wantOutput:     fmtStores(&fastly.SecretStores{}),
 		},
 		{
 			args: "list",
@@ -319,7 +317,7 @@ func TestListStoresCommand(t *testing.T) {
 				},
 			},
 			wantAPIInvoked: true,
-			wantOutput:     fmtStores(stores),
+			wantOutput:     fmtStores(stores.Data),
 		},
 		{
 			args: "list --json",
@@ -329,7 +327,7 @@ func TestListStoresCommand(t *testing.T) {
 				},
 			},
 			wantAPIInvoked: true,
-			wantOutput:     fstfmt.EncodeJSON(stores),
+			wantOutput:     fstfmt.EncodeJSON([]fastly.SecretStore{stores.Data[0]}),
 		},
 	}
 
@@ -351,7 +349,7 @@ func TestListStoresCommand(t *testing.T) {
 			err := app.Run(opts)
 
 			testutil.AssertErrorContains(t, err, testcase.wantError)
-			testutil.AssertString(t, testcase.wantOutput, stdout.String())
+			testutil.AssertStringContains(t, stdout.String(), testcase.wantOutput)
 			if apiInvoked != testcase.wantAPIInvoked {
 				t.Fatalf("API ListSecretStores invoked = %v, want %v", apiInvoked, testcase.wantAPIInvoked)
 			}

--- a/pkg/text/secretstore.go
+++ b/pkg/text/secretstore.go
@@ -10,25 +10,14 @@ import (
 )
 
 // PrintSecretStoresTbl displays store data in a table format.
-func PrintSecretStoresTbl(out io.Writer, stores *fastly.SecretStores) {
+func PrintSecretStoresTbl(out io.Writer, stores []fastly.SecretStore) {
 	tbl := NewTable(out)
 	tbl.AddHeader("Name", "ID")
 
-	if stores == nil {
-		tbl.Print()
-		return
-	}
-
-	for _, s := range stores.Data {
-		// avoid gosec loop aliasing check :/
-		s := s
-		tbl.AddLine(s.Name, s.ID)
+	for _, store := range stores {
+		tbl.AddLine(store.Name, store.ID)
 	}
 	tbl.Print()
-
-	if stores.Meta.NextCursor != "" {
-		fmt.Fprintf(out, "\nNext cursor: %s\n", stores.Meta.NextCursor)
-	}
 }
 
 // PrintSecretsTbl displays secrets data in a table format.


### PR DESCRIPTION
## Without this PR

**I have 14 stores but only 10 are returned...**
<img width="885" alt="Screenshot 2023-08-04 at 17 47 16" src="https://github.com/fastly/cli/assets/180050/b869cd20-dd60-49f4-8ac9-b4f128ffface">

**With --json flag it only handles the first page of data...**
<img width="838" alt="Screenshot 2023-08-04 at 17 48 47" src="https://github.com/fastly/cli/assets/180050/71f0b286-f234-4e09-ab07-c30fbb9c264b">

## With this PR

**All 14 stores are returned...**
<img width="688" alt="Screenshot 2023-08-04 at 17 45 25" src="https://github.com/fastly/cli/assets/180050/ded437e0-59fe-4bcc-b89d-a6826323ac8f">

**Also, we get `--json` working by auto-following all cursors...**
<img width="638" alt="Screenshot 2023-08-04 at 17 45 52" src="https://github.com/fastly/cli/assets/180050/aa96a739-00c6-4835-ae04-4367ccbf7521">