### PR TITLE
feat(compute/init): support post_init

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -153,7 +153,6 @@ jobs:
         env:
           # NOTE: The following lets us focus the test run while debugging.
           # TEST_ARGS: "-run TestDeploy ./pkg/commands/compute/..."
-          TEST_ARGS: "-v -timeout 15m ./..."
           TEST_COMPUTE_INIT: true
           TEST_COMPUTE_BUILD: true
           TEST_COMPUTE_DEPLOY: true

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -153,7 +153,7 @@ jobs:
         env:
           # NOTE: The following lets us focus the test run while debugging.
           # TEST_ARGS: "-run TestDeploy ./pkg/commands/compute/..."
-          TEST_ARGS: "-v"
+          TEST_ARGS: "-v -timeout 15m ./..."
           TEST_COMPUTE_INIT: true
           TEST_COMPUTE_BUILD: true
           TEST_COMPUTE_DEPLOY: true

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -153,6 +153,7 @@ jobs:
         env:
           # NOTE: The following lets us focus the test run while debugging.
           # TEST_ARGS: "-run TestDeploy ./pkg/commands/compute/..."
+          TEST_ARGS: "-v"
           TEST_COMPUTE_INIT: true
           TEST_COMPUTE_BUILD: true
           TEST_COMPUTE_DEPLOY: true

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: config ## Compile program (CGO disabled)
 
 GO_BIN ?= go ## Allows overriding go executable.
 TEST_COMMAND ?= $(GO_BIN) test ## Enables support for tools such as https://github.com/rakyll/gotest
-TEST_ARGS ?= -timeout 15m ./... ## The compute tests can sometimes exceed the default 10m limit
+TEST_ARGS ?= -v -timeout 15m ./... ## The compute tests can sometimes exceed the default 10m limit
 
 GOHOSTOS ?= $(shell go env GOHOSTOS || echo unknown)
 GOHOSTARCH ?= $(shell go env GOHOSTARCH || echo unknown)

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -26,7 +26,7 @@ const IgnoreFilePath = ".fastlyignore"
 
 // CustomPostScriptMessage is the message displayed to a user when there is
 // either a post_init or post_build script defined.
-const CustomPostScriptMessage = "This project has a custom post %s script defined in the fastly.toml manifest"
+const CustomPostScriptMessage = "This project has a custom post_%s script defined in the fastly.toml manifest"
 
 // Flags represents the flags defined for the command.
 type Flags struct {

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -24,9 +24,9 @@ import (
 // IgnoreFilePath is the filepath name of the Fastly ignore file.
 const IgnoreFilePath = ".fastlyignore"
 
-// CustomPostBuildScriptMessage is the message displayed to a user when there is a
-// custom post build script.
-const CustomPostBuildScriptMessage = "This project has a custom post build script defined in the fastly.toml manifest"
+// CustomPostScriptMessage is the message displayed to a user when there is
+// either a post_init or post_build script defined.
+const CustomPostScriptMessage = "This project has a custom post %s script defined in the fastly.toml manifest"
 
 // Flags represents the flags defined for the command.
 type Flags struct {

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -1,7 +1,6 @@
 package compute_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -726,7 +725,7 @@ func TestBuildOther(t *testing.T) {
 			stdin: "N",
 			wantOutput: []string{
 				"echo doing a post build",
-				"Are you sure you want to continue with the post build step?",
+				"Do you want to run this now?",
 			},
 			wantError: "build process stopped by user",
 		},
@@ -743,7 +742,7 @@ func TestBuildOther(t *testing.T) {
 			stdin: "Y",
 			wantOutput: []string{
 				"echo doing a post build",
-				"Are you sure you want to continue with the post build step?",
+				"Do you want to run this now?",
 				"Built package",
 			},
 		},
@@ -760,7 +759,7 @@ func TestBuildOther(t *testing.T) {
 			stdin: "Y",
 			wantOutput: []string{
 				"echo doing a post build",
-				"Are you sure you want to continue with the post build step?",
+				"Do you want to run this now?",
 				"Built package",
 			},
 		},
@@ -777,7 +776,7 @@ func TestBuildOther(t *testing.T) {
 				"doing a post build with no confirmation prompt",
 			},
 			dontWantOutput: []string{
-				"Are you sure you want to continue with the build step?",
+				"Do you want to run this now?",
 			},
 			wantError: "exit status 1", // because we have to trigger an error to see the post_build output
 		},

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -185,7 +185,7 @@ func TestBuildRust(t *testing.T) {
 			}
 			defer os.Chdir(pwd)
 
-			var stdout bytes.Buffer
+			var stdout threadsafe.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
 			opts.ConfigFile = testcase.applicationConfig
 			err = app.Run(opts)
@@ -345,7 +345,7 @@ func TestBuildGo(t *testing.T) {
 			}
 			defer os.Chdir(pwd)
 
-			var stdout bytes.Buffer
+			var stdout threadsafe.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
 			opts.ConfigFile = testcase.applicationConfig
 			err = app.Run(opts)
@@ -651,7 +651,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 				}
 			}
 
-			var stdout bytes.Buffer
+			var stdout threadsafe.Buffer
 			opts := testutil.NewRunOpts(testcase.args, &stdout)
 			err = app.Run(opts)
 			t.Log(stdout.String())

--- a/pkg/commands/compute/compute_test.go
+++ b/pkg/commands/compute/compute_test.go
@@ -6,13 +6,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/fastly/kingpin"
+	"github.com/mholt/archiver/v3"
+
 	"github.com/fastly/cli/pkg/commands/compute"
 	"github.com/fastly/cli/pkg/github"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/kingpin"
-	"github.com/mholt/archiver/v3"
 )
 
 // TestPublishFlagDivergence validates that the manually curated list of flags

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -1193,7 +1193,7 @@ func promptForPostInitContinue(msg, script string, out io.Writer, in io.Reader) 
 	text.Break(out)
 	text.Indent(out, 4, "%s", script)
 
-	label := "\nAre you sure you want to continue with the post init step? [y/N] "
+	label := "\nContinue with the post init step? [y/N] "
 	answer, err := text.AskYesNo(out, label, in)
 	if err != nil {
 		return err

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -1193,7 +1193,7 @@ func promptForPostInitContinue(msg, script string, out io.Writer, in io.Reader) 
 	text.Break(out)
 	text.Indent(out, 4, "%s", script)
 
-	label := "\nContinue with the post_init step? [y/N] "
+	label := "\nDo you want to run this now? [y/N] "
 	answer, err := text.AskYesNo(out, label, in)
 	if err != nil {
 		return err

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -254,10 +254,10 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		spinner.Message(msg)
 
 		s := Shell{}
-		cmd, args := s.Build(postInit)
+		command, args := s.Build(postInit)
 		noTimeout := 0 // zero indicates no timeout
 		err := fstexec.Command(
-			cmd, args, msg, out, spinner, c.Globals.Flags.Verbose, noTimeout, c.Globals.ErrLog,
+			command, args, msg, out, spinner, c.Globals.Flags.Verbose, noTimeout, c.Globals.ErrLog,
 		)
 		if err != nil {
 			return err

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -1193,7 +1193,7 @@ func promptForPostInitContinue(msg, script string, out io.Writer, in io.Reader) 
 	text.Break(out)
 	text.Indent(out, 4, "%s", script)
 
-	label := "\nContinue with the post init step? [y/N] "
+	label := "\nContinue with the post_init step? [y/N] "
 	answer, err := text.AskYesNo(out, label, in)
 	if err != nil {
 		return err

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -206,7 +206,7 @@ func (bt BuildToolchain) promptForPostBuildContinue(msg, script string, out io.W
 	text.Break(out)
 	text.Indent(out, 4, "%s", script)
 
-	label := "\nAre you sure you want to continue with the post build step? [y/N] "
+	label := "\nDo you want to run this now? [y/N] "
 	answer, err := text.AskYesNo(out, label, in)
 	if err != nil {
 		return err

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -93,11 +93,18 @@ var ErrInvalidArchive = RemediationError{
 	Remediation: "Ensure the archive contains all required package files (such as a 'fastly.toml' manifest, and a 'src' folder etc).",
 }
 
-// ErrBuildStopped means the user stopped the build because they were unhappy
+// ErrPostInitStopped means the user stopped the init process because they were
+// unhappy with the custom post_init defined in the fastly.toml manifest file.
+var ErrPostInitStopped = RemediationError{
+	Inner:       fmt.Errorf("init process stopped by user"),
+	Remediation: "Check the [scripts.post_init] in the fastly.toml manifest is safe to execute or skip this prompt using either `--auto-yes` or `--non-interactive`.",
+}
+
+// ErrPostBuildStopped means the user stopped the build because they were unhappy
 // with the custom build defined in the fastly.toml manifest file.
-var ErrBuildStopped = RemediationError{
+var ErrPostBuildStopped = RemediationError{
 	Inner:       fmt.Errorf("build process stopped by user"),
-	Remediation: "Check the [scripts.build] in the fastly.toml manifest is safe to execute or skip this prompt using either `--auto-yes` or `--non-interactive`.",
+	Remediation: "Check the [scripts.post_build] in the fastly.toml manifest is safe to execute or skip this prompt using either `--auto-yes` or `--non-interactive`.",
 }
 
 // ErrInvalidVerboseJSONCombo means the user provided both a --verbose and

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -190,4 +190,5 @@ func appendSpecRef(w io.Writer) error {
 type Scripts struct {
 	Build     string `toml:"build,omitempty"`
 	PostBuild string `toml:"post_build,omitempty"`
+	PostInit  string `toml:"post_init,omitempty"`
 }


### PR DESCRIPTION
In the following example I'm cloning a modified starter kit (one where I've added a `post_init = "npm install"`) and you can see I don't go ahead with the post_install step so the normal `compute init` output is provided.

<img width="1001" alt="Screenshot 2023-08-14 at 17 39 09" src="https://github.com/fastly/cli/assets/180050/3391ac73-d8b0-4e12-9f8d-a088a912c048">

In this example I _do_ go ahead with the post_init step and you can see a `Running [scripts.post_init]...` green tick.

<img width="981" alt="Screenshot 2023-08-14 at 17 39 31" src="https://github.com/fastly/cli/assets/180050/9f582347-a669-4982-b4ca-3acf81374d66">

Finally, after going ahead with the post_init step I then run a `compute build` and we can see there are no errors because all package have been installed already.

<img width="980" alt="Screenshot 2023-08-14 at 17 40 46" src="https://github.com/fastly/cli/assets/180050/5bc02ccf-f071-46d2-b589-a73f853a9f52">
