### PR TITLE
remove(compute/init): assemblyscript

### DIFF
--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -48,7 +48,7 @@ type InitCommand struct {
 }
 
 // Languages is a list of supported language options.
-var Languages = []string{"rust", "javascript", "go", "assemblyscript", "other"}
+var Languages = []string{"rust", "javascript", "go", "other"}
 
 // NewInitCommand returns a usable command registered under the parent.
 func NewInitCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *InitCommand {

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -35,13 +35,6 @@ func TestInit(t *testing.T) {
 			Branch: "main",
 		},
 	}
-	skAS := []config.StarterKit{
-		{
-			Name:   "Default",
-			Path:   "https://github.com/fastly/compute-starter-kit-assemblyscript-default",
-			Branch: "main",
-		},
-	}
 
 	scenarios := []struct {
 		name             string
@@ -327,16 +320,6 @@ func TestInit(t *testing.T) {
 			manifest:         `manifest_version = 2`,
 			manifestPath:     "foo",
 			manifestIncludes: `name = "foo`,
-		},
-		{
-			name: "with AssemblyScript language",
-			args: args("compute init --language assemblyscript"),
-			configFile: config.File{
-				StarterKits: config.StarterKitLanguages{
-					AssemblyScript: skAS,
-				},
-			},
-			manifestIncludes: `name = "fastly-temp`,
 		},
 		{
 			name: "with JavaScript language",

--- a/pkg/commands/compute/language.go
+++ b/pkg/commands/compute/language.go
@@ -38,11 +38,6 @@ func NewLanguages(kits config.StarterKitLanguages) []*Language {
 			StarterKits: kits.Go,
 		}),
 		NewLanguage(&LanguageOptions{
-			Name:        "assemblyscript",
-			DisplayName: "AssemblyScript",
-			StarterKits: kits.AssemblyScript,
-		}),
-		NewLanguage(&LanguageOptions{
 			Name:        "other",
 			DisplayName: "Other ('bring your own' Wasm binary)",
 		}),

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -87,6 +87,11 @@ type AssemblyScript struct {
 
 // Build compiles the user's source code into a Wasm binary.
 func (a *AssemblyScript) Build() error {
+	text.Deprecated(a.output, "The Fastly AssemblyScript SDK is being deprecated in favor of the more up-to-date and feature-rich JavaScript SDK. You can learn more about the JavaScript SDK on our DeveloperHub Page - https://developer.fastly.com/learning/compute/javascript/")
+	if !a.verbose {
+		text.Break(a.output)
+	}
+
 	var noBuildScript bool
 	if a.build == "" {
 		a.build = AsDefaultBuildCommand

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -87,7 +87,7 @@ type AssemblyScript struct {
 
 // Build compiles the user's source code into a Wasm binary.
 func (a *AssemblyScript) Build() error {
-	text.Deprecated(a.output, "The Fastly AssemblyScript SDK is being deprecated in favor of the more up-to-date and feature-rich JavaScript SDK. You can learn more about the JavaScript SDK on our DeveloperHub Page - https://developer.fastly.com/learning/compute/javascript/")
+	text.Deprecated(a.output, "The Fastly AssemblyScript SDK is being deprecated in favor of the more up-to-date and feature-rich JavaScript SDK. You can learn more about the JavaScript SDK on our Developer Hub Page - https://developer.fastly.com/learning/compute/javascript/")
 	if !a.verbose {
 		text.Break(a.output)
 	}

--- a/pkg/text/text.go
+++ b/pkg/text/text.go
@@ -182,6 +182,12 @@ func Break(w io.Writer) {
 	fmt.Fprintln(w)
 }
 
+// Deprecated is a wrapper for fmt.Fprintf with a bold red "DEPRECATED: " prefix.
+func Deprecated(w io.Writer, format string, args ...any) {
+	format = strings.TrimRight(format, "\r\n") + "\n"
+	fmt.Fprintf(w, "\n"+Wrap(BoldRed("DEPRECATED: ")+format, DefaultTextWidth)+"\n", args...)
+}
+
 // Error is a wrapper for fmt.Fprintf with a bold red "ERROR: " prefix.
 func Error(w io.Writer, format string, args ...any) {
 	format = strings.TrimRight(format, "\r\n") + "\n"


### PR DESCRIPTION
This PR removes AssemblyScript from the `compute init` output but will still build a pre-existing project.

See https://github.com/fastly/cli/pull/1001 for a draft PR (breaking) that removes AssemblyScript completely.

<img width="820" alt="Screenshot 2023-08-31 at 12 08 45" src="https://github.com/fastly/cli/assets/180050/22f28a55-02ba-4221-af90-7c5f01be727f">
