### PR TITLE
feat(compute/build): support env_vars for JavaScript/Rust

### DIFF
--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -51,6 +51,7 @@ func NewJavaScript(
 
 		autoYes:        globals.Flags.AutoYes,
 		build:          fastlyManifest.Scripts.Build,
+		env:            fastlyManifest.Scripts.EnvVars,
 		errlog:         globals.ErrLog,
 		input:          in,
 		nonInteractive: globals.Flags.NonInteractive,
@@ -70,6 +71,8 @@ type JavaScript struct {
 	autoYes bool
 	// build is a shell command defined in fastly.toml using [scripts.build].
 	build string
+	// env is environment variables to be set.
+	env []string
 	// errlog is an abstraction for recording errors to disk.
 	errlog fsterr.LogInterface
 	// input is the user's terminal stdin stream
@@ -115,6 +118,7 @@ func (j *JavaScript) Build() error {
 		autoYes:        j.autoYes,
 		buildFn:        j.Shell.Build,
 		buildScript:    j.build,
+		env:            j.env,
 		errlog:         j.errlog,
 		in:             j.input,
 		nonInteractive: j.nonInteractive,

--- a/pkg/commands/compute/language_other.go
+++ b/pkg/commands/compute/language_other.go
@@ -23,6 +23,7 @@ func NewOther(
 
 		autoYes:        globals.Flags.AutoYes,
 		build:          fastlyManifest.Scripts.Build,
+		env:            fastlyManifest.Scripts.EnvVars,
 		errlog:         globals.ErrLog,
 		input:          in,
 		nonInteractive: globals.Flags.NonInteractive,
@@ -42,6 +43,8 @@ type Other struct {
 	autoYes bool
 	// build is a shell command defined in fastly.toml using [scripts.build].
 	build string
+	// env is environment variables to be set.
+	env []string
 	// errlog is an abstraction for recording errors to disk.
 	errlog fsterr.LogInterface
 	// input is the user's terminal stdin stream
@@ -68,6 +71,7 @@ func (o Other) Build() error {
 		autoYes:        o.autoYes,
 		buildFn:        o.Shell.Build,
 		buildScript:    o.build,
+		env:            o.env,
 		errlog:         o.errlog,
 		in:             o.input,
 		nonInteractive: o.nonInteractive,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	toml "github.com/pelletier/go-toml"
+
 	"github.com/fastly/cli/pkg/config"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/filesystem"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	toml "github.com/pelletier/go-toml"
 )
 
 // RustDefaultBuildCommand is a build command compiled into the CLI binary so it
@@ -56,6 +57,7 @@ func NewRust(
 		autoYes:        globals.Flags.AutoYes,
 		build:          fastlyManifest.Scripts.Build,
 		config:         globals.Config.Language.Rust,
+		env:            fastlyManifest.Scripts.EnvVars,
 		errlog:         globals.ErrLog,
 		input:          in,
 		nonInteractive: globals.Flags.NonInteractive,
@@ -77,6 +79,8 @@ type Rust struct {
 	build string
 	// config is the Rust specific application configuration.
 	config config.Rust
+	// env is environment variables to be set.
+	env []string
 	// errlog is an abstraction for recording errors to disk.
 	errlog fsterr.LogInterface
 	// input is the user's terminal stdin stream
@@ -121,6 +125,7 @@ func (r *Rust) Build() error {
 		autoYes:                   r.autoYes,
 		buildFn:                   r.Shell.Build,
 		buildScript:               r.build,
+		env:                       r.env,
 		errlog:                    r.errlog,
 		in:                        r.input,
 		internalPostBuildCallback: r.ProcessLocation,


### PR DESCRIPTION
Example of build environment being set...

<img width="961" alt="Monosnap  cts:testing-fastly-cli 2023-09-18 11-31-45" src="https://github.com/fastly/cli/assets/180050/b42224b7-49c2-4b09-ae01-fe017930ae08">

Another example demonstrating it with post_build...

<img width="736" alt="Monosnap  cts:testing-fastly-cli 2023-09-18 11-56-15" src="https://github.com/fastly/cli/assets/180050/ff8a06ac-ff32-4501-9c2c-16ca444b0a04">
