### PR TITLE
fix(app): return error when input is `--` only

### DIFF
--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/fastly/kingpin"
+
 	"github.com/fastly/cli/pkg/cmd"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/kingpin"
 )
 
 // Usage returns a contextual usage string for the application. In order to deal
@@ -290,6 +291,13 @@ func processCommandInput(
 			err = fmt.Errorf("command not specified")
 		}
 		return command, cmdName, help(vars, err)
+	}
+
+	if len(opts.Args) == 1 && opts.Args[0] == "--" {
+		return command, cmdName, fsterr.RemediationError{
+			Inner:       errors.New("-- is invalid input when not followed by a positional argument"),
+			Remediation: "If looking for help output try: `fastly help` for full command list or `fastly --help` for command summary.",
+		}
 	}
 
 	// NOTE: `fastly help`, no flags, or only globals, should skip conditional.


### PR DESCRIPTION
**Problem:**
<img width="941" alt="Screenshot 2023-09-28 at 11 04 05" src="https://github.com/fastly/cli/assets/180050/5caee910-26d8-4918-8620-1232eff24a2f">

**Solution:**
<img width="901" alt="Screenshot 2023-09-28 at 10 41 13" src="https://github.com/fastly/cli/assets/180050/21326838-0137-43d0-87bf-ffe378bb5459">
