### PR TITLE
feat(compute/build): support Cargo Workspaces

### DIFF
--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -142,7 +142,7 @@ func (r *Rust) Build() error {
 	return bt.Build()
 }
 
-// RustToolchain models a [toolchain] from a rust-toolchain.toml manifest.
+// RustToolchainManifest models a [toolchain] from a rust-toolchain.toml manifest.
 type RustToolchainManifest struct {
 	Toolchain RustToolchain `toml:"toolchain"`
 }

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -89,6 +89,8 @@ type Rust struct {
 	nonInteractive bool
 	// output is the users terminal stdout stream
 	output io.Writer
+	// packageName is the resolved package name from the project Cargo.toml
+	packageName string
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
@@ -110,7 +112,7 @@ func (r *Rust) Build() error {
 		noBuildScript = true
 	}
 
-	err := r.modifyCargoPackageName()
+	err := r.modifyCargoPackageName(noBuildScript)
 	if err != nil {
 		return err
 	}
@@ -140,10 +142,20 @@ func (r *Rust) Build() error {
 	return bt.Build()
 }
 
+// RustToolchain models a [toolchain] from a rust-toolchain.toml manifest.
+type RustToolchainManifest struct {
+	Toolchain RustToolchain `toml:"toolchain"`
+}
+
+// RustToolchain models the rust-toolchain targets.
+type RustToolchain struct {
+	Targets []string `toml:"targets"`
+}
+
 // modifyCargoPackageName validates whether the --bin flag matches the
 // Cargo.toml package name. If it doesn't match, update the default build script
 // to match.
-func (r *Rust) modifyCargoPackageName() error {
+func (r *Rust) modifyCargoPackageName(noBuildScript bool) error {
 	s := "cargo locate-project --quiet"
 	args := strings.Split(s, " ")
 
@@ -184,8 +196,52 @@ func (r *Rust) modifyCargoPackageName() error {
 		return fmt.Errorf("error reading %s manifest: %w", RustManifest, err)
 	}
 
-	if m.Package.Name != RustDefaultPackageName {
-		r.build = fmt.Sprintf(RustDefaultBuildCommand, m.Package.Name)
+	hasCustomBuildScript := !noBuildScript
+
+	switch {
+	case m.Package.Name != "":
+		// If using standard project structure.
+		// Cargo.toml won't be a Workspace, so it will contain a package name.
+		r.packageName = m.Package.Name
+	case len(m.Workspace.Members) > 0 && noBuildScript:
+		// If user has a Cargo Workspace AND no custom script.
+		// We need to identify which Workspace package is their application.
+		// Then extract the package name from its Cargo.toml manifest.
+		// We do this by checking for a rust-toolchain.toml containing a wasm32-wasi target.
+		//
+		// NOTE: This logic will need to change in the future.
+		// Specifically, when we support linking multiple Wasm binaries.
+		for _, m := range m.Workspace.Members {
+			var rtm RustToolchainManifest
+			// G304 (CWE-22): Potential file inclusion via variable.
+			// #nosec
+			data, err := os.ReadFile(filepath.Join(m, "rust-toolchain.toml"))
+			if err != nil {
+				return err
+			}
+			toml.Unmarshal(data, &rtm)
+			if len(rtm.Toolchain.Targets) > 0 && rtm.Toolchain.Targets[0] == "wasm32-wasi" {
+				var cm CargoManifest
+				cm.Read(filepath.Join(m, "Cargo.toml"))
+				r.packageName = cm.Package.Name
+			}
+		}
+	case len(m.Workspace.Members) > 0 && hasCustomBuildScript:
+		// If user has a Cargo Workspace AND a custom script.
+		// Trust their custom script aligns with the relevant Workspace package name.
+		// i.e. we parse the package name specified in their custom script.
+		parts := strings.Split(r.build, " ")
+		for i, p := range parts {
+			if p == "--bin" {
+				r.packageName = parts[i+1]
+				break
+			}
+		}
+	}
+
+	// Ensure the default build script matches the Cargo.toml package name.
+	if noBuildScript && r.packageName != "" && r.packageName != RustDefaultPackageName {
+		r.build = fmt.Sprintf(RustDefaultBuildCommand, r.packageName)
 	}
 
 	return nil
@@ -253,12 +309,8 @@ func (r *Rust) ProcessLocation() error {
 		r.errlog.Add(err)
 		return fmt.Errorf("error reading cargo metadata: %w", err)
 	}
-	var m CargoManifest
-	if err := m.Read(r.projectRoot); err != nil {
-		return fmt.Errorf("error reading %s manifest: %w", RustManifest, err)
-	}
 
-	src := filepath.Join(metadata.TargetDirectory, r.config.WasmWasiTarget, "release", fmt.Sprintf("%s.wasm", m.Package.Name))
+	src := filepath.Join(metadata.TargetDirectory, r.config.WasmWasiTarget, "release", fmt.Sprintf("%s.wasm", r.packageName))
 	dst := filepath.Join(dir, "bin", "main.wasm")
 
 	err = filesystem.CopyFile(src, dst)
@@ -279,7 +331,8 @@ type CargoLocateProject struct {
 // manifest which we are interested in and are read from the Cargo.toml manifest
 // file within the $PWD of the package.
 type CargoManifest struct {
-	Package CargoPackage `toml:"package"`
+	Package   CargoPackage   `toml:"package"`
+	Workspace CargoWorkspace `toml:"workspace"`
 }
 
 // Read the contents of the Cargo.toml manifest from filename.
@@ -288,13 +341,17 @@ func (m *CargoManifest) Read(path string) error {
 	// G304 (CWE-22): Potential file inclusion via variable.
 	// Disabling as we need to load the Cargo.toml from the user's file system.
 	// This file is decoded into a predefined struct, any unrecognised fields are dropped.
-	/* #nosec */
+	// #nosec
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	err = toml.Unmarshal(data, m)
-	return err
+	return toml.Unmarshal(data, m)
+}
+
+// CargoWorkspace models the [workspace] config inside Cargo.toml
+type CargoWorkspace struct {
+	Members []string `toml:"members" json:"members"`
 }
 
 // CargoPackage models the package configuration properties of a Rust Cargo


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/1020

## Problem

The logic flow prior to this PR would cause a user's custom build script to be replaced with a default build script if the package name they set in their Cargo.toml didn't match the 'default' package name of `fastly-compute-project`. 

This issue was further exacerbated when a customer used a [Cargo Workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) to structure their project. As part of a reduced test case I discovered a bug that caused the user's custom build script to be unexpectedly modified and also changed it in such a way that it would break the build step. 

## Solution

This PR modifies the logic flow for a Rust project. 

The updated flow looks like this...

- If using a standard project structure, then the root Cargo.toml won't be a Cargo Workspace, and so it will contain a package name. The CLI will assign that name to `r.packageName` and later on it will use that name to look up the compiled binary and move it to the required `bin/` directory.

- If the user has set up a Cargo Workspace but there is no custom build script, then the CLI needs to identify which Workspace package is their application. It does this by checking if the package has a rust-toolchain.toml containing the target `wasm32-wasi` and if so we extract the package name from that package's relevant Cargo.toml manifest. The CLI will assign that name to `r.packageName` and later on it will use that name to look up the compiled binary and move it to the required `bin/` directory.

  > **NOTE:** This is sufficient for now, but I can see us needing to update this logic in the future when we start supporting the linking of multiple Wasm binaries on the Fastly platform (aka Wasm Components). Because at that point, a Cargo Workspace could well contain multiple 'binary' projects, each producing a Wasm binary that are linked up in some fashion.

- If the user has set up a Cargo Workspace _and_ they define a custom build script, then the CLI will trust their custom script aligns with the relevant Workspace package name (i.e. their custom script is set up to reference the right binary). The CLI will parse the package name specified in their custom script by looking at the value assigned to the `--bin` flag. The CLI will assign that name to `r.packageName` and later on it will use that name to look up the compiled binary and move it to the required `bin/` directory.

  > **NOTE:** The implementation is very basic and presumes the `--bin` value is inserted directly and isn't required to be resolved (e.g. `$some_environment_variable`).

- If there is no custom build script (i.e. the CLI will use a pre-defined default build script), then the CLI will check to see if the package name (assigned to `r.packageName`) matches the default package name `fastly-compute-project`. If not, then it will update the default build script to use whatever package name is assigned to `r.packageName`.

## NOTES

I've tested this PR with different project set ups to validate the new logic flows.

Below is an example Cargo Workspace project I tested this with...

```
.
├── Cargo.lock
├── Cargo.toml
├── bin
│   └── main.wasm
├── compute
│   ├── Cargo.lock
│   ├── Cargo.toml
│   ├── README.md
│   ├── rust-toolchain.toml
│   └── src
│       ├── main.rs
│       └── welcome-to-compute@edge.html
├── fastly.toml
└── pkg
    └── compute.tar.gz

5 directories, 11 files
```

Below is the root workspace `Cargo.toml`...

```toml
[workspace]

members = ["compute"] # << matches compute/ directory name
```

Below is the `compute/Cargo.toml`...

```toml
[package]
name = "my-compute-app"
version = "0.1.0"
authors = []
edition = "2018"
# Remove this line if you want to be able to publish this crate as open source on crates.io.
# Otherwise, `publish = false` prevents an accidental `cargo publish` from revealing private source.
publish = false

[profile.release]
debug = 1

[dependencies]
fastly = "0.9.4"
```

Below is the fastly.toml file I used with the Cargo Workspace (notice it was moved to the root directory, i.e. I moved it out from the `compute/` directory which contains my Compute application)...

```toml
authors = ["integralist@fastly.com"]
description = ""
language = "rust"
manifest_version = 3
name = "compute"
service_id = ""

[scripts]
  build = "cargo build --bin my-compute-app --release --target wasm32-wasi --color always -vv"
```