### PR TITLE
fix: spinner wraps original error

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -607,7 +607,7 @@ func createService(
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return "", nil, fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return "", nil, spinner.WrapErr(err)
 				}
 
 				return serviceID, serviceVersion, fsterr.RemediationError{
@@ -621,7 +621,7 @@ func createService(
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return "", nil, fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return "", nil, spinner.WrapErr(err)
 				}
 
 				return serviceID, serviceVersion, fsterr.RemediationError{
@@ -1228,7 +1228,7 @@ func checkingServiceAvailability(
 			spinner.StopFailMessage(msg + returnedStatus)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return status, fmt.Errorf(text.SpinnerErrWrapper, spinErr, timeoutErr)
+				return status, spinner.WrapErr(timeoutErr)
 			}
 			return status, timeoutErr
 		case t := <-ticker.C:
@@ -1249,7 +1249,7 @@ func checkingServiceAvailability(
 				spinner.StopFailMessage(msg + returnedStatus)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return status, fmt.Errorf(text.SpinnerErrWrapper, spinErr, pingErr)
+					return status, spinner.WrapErr(pingErr)
 				}
 				return status, pingErr
 			}

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -608,7 +608,7 @@ func createService(
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return "", nil, spinner.WrapErr(err)
+					return "", nil, fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return serviceID, serviceVersion, fsterr.RemediationError{
 					Inner:       err,
@@ -622,7 +622,7 @@ func createService(
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return "", nil, spinner.WrapErr(err)
+					return "", nil, fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return serviceID, serviceVersion, fsterr.RemediationError{
 					Inner:       err,
@@ -1225,7 +1225,7 @@ func checkingServiceAvailability(
 			spinner.StopFailMessage(msg + returnedStatus)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return status, spinner.WrapErr(err)
+				return status, fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return status, fsterr.RemediationError{
 				Inner:       err,
@@ -1246,7 +1246,7 @@ func checkingServiceAvailability(
 				spinner.StopFailMessage(msg + returnedStatus)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return status, spinner.WrapErr(err)
+					return status, fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return status, fsterr.RemediationError{
 					Inner:       err,

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -526,8 +526,8 @@ func manageNoServiceIDFlow(
 	var serviceName string
 
 	// The service name will be whatever is set in the --service-name flag.
-	// If the flag isn't set, and we're able to prompt, we'll ask the user.
 	// If the flag isn't set, and we're non-interactive, we'll use the default.
+	// If the flag isn't set, and we're interactive, we'll prompt the user.
 	switch {
 	case serviceNameFlag.WasSet:
 		serviceName = serviceNameFlag.Value

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -296,10 +296,9 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 				text.Break(out)
 				err := spinner.Start()
 				if err != nil {
-					return err
+					return spinner.WrapErr(err)
 				}
 				spinner.Message(msg + "...")
-
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
@@ -683,10 +682,7 @@ func fetchPackageTemplate(
 
 	// If the user has provided a local file path, we'll recursively copy the
 	// directory to c.dir.
-	fi, err := os.Stat(c.cloneFrom)
-	if err != nil {
-		c.Globals.ErrLog.Add(err)
-	} else if fi.IsDir() {
+	if fi, err := os.Stat(c.cloneFrom); err == nil && fi.IsDir() {
 		if err := cp.Copy(c.cloneFrom, c.dir); err != nil {
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
@@ -695,14 +691,16 @@ func fetchPackageTemplate(
 			}
 			return err
 		}
-
 		spinner.StopMessage(msg)
 		return spinner.Stop()
 	}
+	c.Globals.ErrLog.Add(err)
 
 	req, err := http.NewRequest("GET", c.cloneFrom, nil)
 	if err != nil {
+		err = fmt.Errorf("failed to construct package request URL: %w", err)
 		c.Globals.ErrLog.Add(err)
+
 		if gitRepositoryRegEx.MatchString(c.cloneFrom) {
 			if err := clonePackageFromEndpoint(c.cloneFrom, branch, tag, c.dir); err != nil {
 				spinner.StopFailMessage(msg)
@@ -712,7 +710,6 @@ func fetchPackageTemplate(
 				}
 				return err
 			}
-
 			spinner.StopMessage(msg)
 			return spinner.Stop()
 		}
@@ -720,10 +717,9 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return spinner.WrapErr(err)
 		}
-
-		return fmt.Errorf("failed to construct package request URL: %w", err)
+		return err
 	}
 
 	for _, archive := range archives {
@@ -734,13 +730,14 @@ func fetchPackageTemplate(
 
 	res, err := c.Globals.HTTPClient.Do(req)
 	if err != nil {
+		err = fmt.Errorf("failed to get package: %w", err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
 			return spinner.WrapErr(err)
 		}
-		return fmt.Errorf("failed to get package: %w", err)
+		return err
 	}
 	defer res.Body.Close() // #nosec G307
 
@@ -765,13 +762,14 @@ func fetchPackageTemplate(
 	/* #nosec */
 	f, err := os.Create(filename)
 	if err != nil {
+		err = fmt.Errorf("failed to create local %s archive: %w", filename, err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
 			return spinner.WrapErr(err)
 		}
-		return fmt.Errorf("failed to create local %s archive: %w", filename, err)
+		return err
 	}
 	defer func() {
 		// NOTE: Later on we rename the file to include an extension and the
@@ -786,13 +784,14 @@ func fetchPackageTemplate(
 
 	_, err = io.Copy(f, res.Body)
 	if err != nil {
+		err = fmt.Errorf("failed to write %s archive to disk: %w", filename, err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
 			return spinner.WrapErr(err)
 		}
-		return fmt.Errorf("failed to write %s archive to disk: %w", filename, err)
+		return err
 	}
 
 	// NOTE: We used to `defer` the closing of the file after its creation but
@@ -851,13 +850,14 @@ mimes:
 
 		err = archive.Extract()
 		if err != nil {
+			err = fmt.Errorf("failed to extract %s archive content: %w", filename, err)
 			c.Globals.ErrLog.Add(err)
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
 				return spinner.WrapErr(err)
 			}
-			return fmt.Errorf("failed to extract %s archive content: %w", filename, err)
+			return err
 		}
 
 		spinner.StopMessage(msg)

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -303,7 +303,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return spinner.WrapErr(err)
 				}
 			}
 			return err
@@ -691,7 +691,7 @@ func fetchPackageTemplate(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return spinner.WrapErr(err)
 			}
 			return err
 		}
@@ -708,7 +708,7 @@ func fetchPackageTemplate(
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return spinner.WrapErr(err)
 				}
 				return err
 			}
@@ -738,7 +738,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+			return spinner.WrapErr(err)
 		}
 		return fmt.Errorf("failed to get package: %w", err)
 	}
@@ -750,7 +750,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+			return spinner.WrapErr(err)
 		}
 		return err
 	}
@@ -769,7 +769,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+			return spinner.WrapErr(err)
 		}
 		return fmt.Errorf("failed to create local %s archive: %w", filename, err)
 	}
@@ -790,7 +790,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+			return spinner.WrapErr(err)
 		}
 		return fmt.Errorf("failed to write %s archive to disk: %w", filename, err)
 	}
@@ -839,7 +839,7 @@ mimes:
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return spinner.WrapErr(err)
 				}
 				return err
 			}
@@ -855,7 +855,7 @@ mimes:
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return spinner.WrapErr(err)
 			}
 			return fmt.Errorf("failed to extract %s archive content: %w", filename, err)
 		}
@@ -868,7 +868,7 @@ mimes:
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+			return spinner.WrapErr(err)
 		}
 		return err
 	}

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -294,15 +294,15 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			// But we can't just call StopFailMessage() without first starting the spinner.
 			if c.Globals.Flags.Verbose {
 				text.Break(out)
-				err := spinner.Start()
-				if err != nil {
-					return spinner.WrapErr(err)
+				spinErr := spinner.Start()
+				if spinErr != nil {
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				spinner.Message(msg + "...")
 				spinner.StopFailMessage(msg)
-				spinErr := spinner.StopFail()
+				spinErr = spinner.StopFail()
 				if spinErr != nil {
-					return spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 			return err
@@ -687,7 +687,7 @@ func fetchPackageTemplate(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}
@@ -706,7 +706,7 @@ func fetchPackageTemplate(
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return err
 			}
@@ -717,7 +717,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}
@@ -735,7 +735,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}
@@ -747,7 +747,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}
@@ -767,7 +767,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}
@@ -789,7 +789,7 @@ func fetchPackageTemplate(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}
@@ -838,7 +838,7 @@ mimes:
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return err
 			}
@@ -855,7 +855,7 @@ mimes:
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}
@@ -868,7 +868,7 @@ mimes:
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -303,7 +303,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return spinErr
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 			return err
@@ -691,7 +691,7 @@ func fetchPackageTemplate(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}
@@ -708,7 +708,7 @@ func fetchPackageTemplate(
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return spinErr
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return err
 			}
@@ -735,13 +735,11 @@ func fetchPackageTemplate(
 	res, err := c.Globals.HTTPClient.Do(req)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
-
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
-
 		return fmt.Errorf("failed to get package: %w", err)
 	}
 	defer res.Body.Close() // #nosec G307
@@ -749,13 +747,11 @@ func fetchPackageTemplate(
 	if res.StatusCode != http.StatusOK {
 		err := fmt.Errorf("failed to get package: %s", res.Status)
 		c.Globals.ErrLog.Add(err)
-
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
-
 		return err
 	}
 
@@ -770,13 +766,11 @@ func fetchPackageTemplate(
 	f, err := os.Create(filename)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
-
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
-
 		return fmt.Errorf("failed to create local %s archive: %w", filename, err)
 	}
 	defer func() {
@@ -793,13 +787,11 @@ func fetchPackageTemplate(
 	_, err = io.Copy(f, res.Body)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
-
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
-
 		return fmt.Errorf("failed to write %s archive to disk: %w", filename, err)
 	}
 
@@ -844,13 +836,11 @@ mimes:
 			err := os.Rename(filename, filenameWithExt)
 			if err != nil {
 				c.Globals.ErrLog.Add(err)
-
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return spinErr
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
-
 				return err
 			}
 			filename = filenameWithExt
@@ -862,13 +852,11 @@ mimes:
 		err = archive.Extract()
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
-
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
-
 			return fmt.Errorf("failed to extract %s archive content: %w", filename, err)
 		}
 
@@ -880,7 +868,7 @@ mimes:
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -108,7 +108,7 @@ func (bt BuildToolchain) Build() error {
 			text.Break(bt.out)
 			spinErr := bt.spinner.Start()
 			if spinErr != nil {
-				return fmt.Errorf("failed to start spinner (error: %w) when handling the error: %w", spinErr, err)
+				return bt.spinner.WrapErr(err)
 			}
 			bt.spinner.Message(msg + "...")
 			bt.spinner.StopFailMessage(msg)

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -114,7 +114,7 @@ func (bt BuildToolchain) Build() error {
 			bt.spinner.StopFailMessage(msg)
 			spinErr = bt.spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return bt.spinner.WrapErr(err)
 			}
 		}
 		// WARNING: Don't try to add 'StopFailMessage/StopFail' calls here.
@@ -194,13 +194,13 @@ func (bt BuildToolchain) Build() error {
 				text.Break(bt.out)
 				spinErr := bt.spinner.Start()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return bt.spinner.WrapErr(err)
 				}
 				bt.spinner.Message(msg + "...")
 				bt.spinner.StopFailMessage(msg)
 				spinErr = bt.spinner.StopFail()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return bt.spinner.WrapErr(err)
 				}
 			}
 			// WARNING: Don't try to add 'StopFailMessage/StopFail' calls here.

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -108,13 +108,13 @@ func (bt BuildToolchain) Build() error {
 			text.Break(bt.out)
 			spinErr := bt.spinner.Start()
 			if spinErr != nil {
-				return bt.spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			bt.spinner.Message(msg + "...")
 			bt.spinner.StopFailMessage(msg)
 			spinErr = bt.spinner.StopFail()
 			if spinErr != nil {
-				return bt.spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 		}
 		// WARNING: Don't try to add 'StopFailMessage/StopFail' calls here.
@@ -194,13 +194,13 @@ func (bt BuildToolchain) Build() error {
 				text.Break(bt.out)
 				spinErr := bt.spinner.Start()
 				if spinErr != nil {
-					return bt.spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				bt.spinner.Message(msg + "...")
 				bt.spinner.StopFailMessage(msg)
 				spinErr = bt.spinner.StopFail()
 				if spinErr != nil {
-					return bt.spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 			// WARNING: Don't try to add 'StopFailMessage/StopFail' calls here.

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -106,16 +106,15 @@ func (bt BuildToolchain) Build() error {
 		// But we can't just call StopFailMessage() without first starting the spinner.
 		if bt.verbose {
 			text.Break(bt.out)
-			err := bt.spinner.Start()
-			if err != nil {
-				return err
+			spinErr := bt.spinner.Start()
+			if spinErr != nil {
+				return fmt.Errorf("failed to start spinner (error: %w) when handling the error: %w", spinErr, err)
 			}
 			bt.spinner.Message(msg + "...")
-
 			bt.spinner.StopFailMessage(msg)
-			spinErr := bt.spinner.StopFail()
+			spinErr = bt.spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 		}
 		// WARNING: Don't try to add 'StopFailMessage/StopFail' calls here.
@@ -193,16 +192,15 @@ func (bt BuildToolchain) Build() error {
 			// But we can't just call StopFailMessage() without first starting the spinner.
 			if bt.verbose {
 				text.Break(bt.out)
-				err := bt.spinner.Start()
-				if err != nil {
-					return err
+				spinErr := bt.spinner.Start()
+				if spinErr != nil {
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				bt.spinner.Message(msg + "...")
-
 				bt.spinner.StopFailMessage(msg)
-				spinErr := bt.spinner.StopFail()
+				spinErr = bt.spinner.StopFail()
 				if spinErr != nil {
-					return spinErr
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 			// WARNING: Don't try to add 'StopFailMessage/StopFail' calls here.

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -432,13 +432,14 @@ func installViceroy(
 
 		latestVersion, err = av.LatestVersion()
 		if err != nil {
+			err = fmt.Errorf("error fetching latest version: %w", err)
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
 				return spinner.WrapErr(err)
 			}
 			return fsterr.RemediationError{
-				Inner:       fmt.Errorf("error fetching latest version: %w", err),
+				Inner:       err,
 				Remediation: fsterr.NetworkRemediation,
 			}
 		}
@@ -481,23 +482,26 @@ func installViceroy(
 	}
 
 	if err != nil {
+		err = fmt.Errorf("error downloading Viceroy release: %w", err)
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
 			return spinner.WrapErr(err)
 		}
-		return fmt.Errorf("error downloading Viceroy release: %w", err)
+		return err
 	}
 	defer os.RemoveAll(tmpBin)
 
 	if err := os.Rename(tmpBin, bin); err != nil {
-		if err := filesystem.CopyFile(tmpBin, bin); err != nil {
+		err = fmt.Errorf("failed to rename/move file: %w", err)
+		if copyErr := filesystem.CopyFile(tmpBin, bin); copyErr != nil {
+			err = fmt.Errorf("failed to copy file: %w (original error: %w)", copyErr, err)
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
 				return spinner.WrapErr(err)
 			}
-			return fmt.Errorf("error moving latest Viceroy binary in place: %w", err)
+			return err
 		}
 	}
 

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -435,9 +435,8 @@ func installViceroy(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
-
 			return fsterr.RemediationError{
 				Inner:       fmt.Errorf("error fetching latest version: %w", err),
 				Remediation: fsterr.NetworkRemediation,
@@ -485,7 +484,7 @@ func installViceroy(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return fmt.Errorf("error downloading Viceroy release: %w", err)
 	}
@@ -496,7 +495,7 @@ func installViceroy(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fmt.Errorf("error moving latest Viceroy binary in place: %w", err)
 		}

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -788,7 +788,7 @@ func ignoreFiles(watchDir cmd.OptionalString) *ignore.GitIgnore {
 	if watchDir.WasSet {
 		root = watchDir.Value
 		if !strings.HasPrefix(root, "/") {
-			root = root + "/"
+			root += "/"
 		}
 	}
 

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -435,7 +435,7 @@ func installViceroy(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return spinner.WrapErr(err)
 			}
 			return fsterr.RemediationError{
 				Inner:       fmt.Errorf("error fetching latest version: %w", err),
@@ -484,7 +484,7 @@ func installViceroy(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+			return spinner.WrapErr(err)
 		}
 		return fmt.Errorf("error downloading Viceroy release: %w", err)
 	}
@@ -495,7 +495,7 @@ func installViceroy(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return spinner.WrapErr(err)
 			}
 			return fmt.Errorf("error moving latest Viceroy binary in place: %w", err)
 		}

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -436,7 +436,7 @@ func installViceroy(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fsterr.RemediationError{
 				Inner:       err,
@@ -486,7 +486,7 @@ func installViceroy(
 		spinner.StopFailMessage(msg)
 		spinErr := spinner.StopFail()
 		if spinErr != nil {
-			return spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
 	}
@@ -499,7 +499,7 @@ func installViceroy(
 			spinner.StopFailMessage(msg)
 			spinErr := spinner.StopFail()
 			if spinErr != nil {
-				return spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -101,7 +101,7 @@ func (b *Backends) Create() error {
 				b.Spinner.StopFailMessage(msg)
 				spinErr := b.Spinner.StopFail()
 				if spinErr != nil {
-					return spinErr
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -101,7 +101,7 @@ func (b *Backends) Create() error {
 				b.Spinner.StopFailMessage(msg)
 				spinErr := b.Spinner.StopFail()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return b.Spinner.WrapErr(err)
 				}
 			}
 

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -98,17 +98,14 @@ func (b *Backends) Create() error {
 		_, err := b.APIClient.CreateBackend(opts)
 		if err != nil {
 			if !b.isOriginless() {
+				err = fmt.Errorf("error creating backend: %w", err)
 				b.Spinner.StopFailMessage(msg)
 				spinErr := b.Spinner.StopFail()
 				if spinErr != nil {
 					return b.Spinner.WrapErr(err)
 				}
 			}
-
-			if b.isOriginless() {
-				return fmt.Errorf("error configuring the service: %w", err)
-			}
-			return fmt.Errorf("error creating backend: %w", err)
+			return fmt.Errorf("error configuring the service: %w", err)
 		}
 
 		if !b.isOriginless() {

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -102,7 +102,7 @@ func (b *Backends) Create() error {
 				b.Spinner.StopFailMessage(msg)
 				spinErr := b.Spinner.StopFail()
 				if spinErr != nil {
-					return b.Spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 			return fmt.Errorf("error configuring the service: %w", err)

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -129,7 +129,7 @@ func (o *ConfigStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return o.Spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}
@@ -159,7 +159,7 @@ func (o *ConfigStores) Create() error {
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
-						return o.Spinner.WrapErr(err)
+						return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 					}
 					return err
 				}
@@ -191,7 +191,7 @@ func (o *ConfigStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return o.Spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -128,7 +128,7 @@ func (o *ConfigStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fmt.Errorf("error creating config store: %w", err)
 		}
@@ -157,7 +157,7 @@ func (o *ConfigStores) Create() error {
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
-						return spinErr
+						return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 					}
 					return fmt.Errorf("error creating config store item: %w", err)
 				}
@@ -188,7 +188,7 @@ func (o *ConfigStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fmt.Errorf("error creating resource link between the service '%s' and the config store '%s': %w", o.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -128,7 +128,7 @@ func (o *ConfigStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return o.Spinner.WrapErr(err)
 			}
 			return fmt.Errorf("error creating config store: %w", err)
 		}
@@ -157,7 +157,7 @@ func (o *ConfigStores) Create() error {
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
-						return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+						return o.Spinner.WrapErr(err)
 					}
 					return fmt.Errorf("error creating config store item: %w", err)
 				}
@@ -188,7 +188,7 @@ func (o *ConfigStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return o.Spinner.WrapErr(err)
 			}
 			return fmt.Errorf("error creating resource link between the service '%s' and the config store '%s': %w", o.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -125,12 +125,13 @@ func (o *ConfigStores) Create() error {
 			Name: store.Name,
 		})
 		if err != nil {
+			err = fmt.Errorf("error creating config store: %w", err)
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
 				return o.Spinner.WrapErr(err)
 			}
-			return fmt.Errorf("error creating config store: %w", err)
+			return err
 		}
 
 		o.Spinner.StopMessage(msg)
@@ -154,12 +155,13 @@ func (o *ConfigStores) Create() error {
 					Value:   item.Value,
 				})
 				if err != nil {
+					err = fmt.Errorf("error creating config store item: %w", err)
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
 						return o.Spinner.WrapErr(err)
 					}
-					return fmt.Errorf("error creating config store item: %w", err)
+					return err
 				}
 
 				o.Spinner.StopMessage(msg)
@@ -185,12 +187,13 @@ func (o *ConfigStores) Create() error {
 			ResourceID:     fastly.String(cs.ID),
 		})
 		if err != nil {
+			err = fmt.Errorf("error creating resource link between the service '%s' and the config store '%s': %w", o.ServiceID, store.Name, err)
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
 				return o.Spinner.WrapErr(err)
 			}
-			return fmt.Errorf("error creating resource link between the service '%s' and the config store '%s': %w", o.ServiceID, store.Name, err)
+			return err
 		}
 
 		o.Spinner.StopMessage(msg)

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -172,7 +172,7 @@ func (d *Domains) createDomain(name string, attempt int) error {
 		d.Spinner.StopFailMessage(msg)
 		spinErr := d.Spinner.StopFail()
 		if spinErr != nil {
-			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+			return d.Spinner.WrapErr(err)
 		}
 
 		if attempt > d.RetryLimit {

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -174,7 +174,7 @@ func (d *Domains) createDomain(name string, attempt int) error {
 		d.Spinner.StopFailMessage(msg)
 		spinErr := d.Spinner.StopFail()
 		if spinErr != nil {
-			return d.Spinner.WrapErr(err)
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 
 		if attempt > d.RetryLimit {

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 
 	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 const defaultTopLevelDomain = "edgecompute.app"
@@ -171,7 +172,7 @@ func (d *Domains) createDomain(name string, attempt int) error {
 		d.Spinner.StopFailMessage(msg)
 		spinErr := d.Spinner.StopFail()
 		if spinErr != nil {
-			return spinErr
+			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 
 		if attempt > d.RetryLimit {

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -168,6 +168,8 @@ func (d *Domains) createDomain(name string, attempt int) error {
 		Name:           &name,
 	})
 	if err != nil {
+		err = fmt.Errorf("error creating domain: %w", err)
+
 		// We have to stop the ticker so we can now prompt the user.
 		d.Spinner.StopFailMessage(msg)
 		spinErr := d.Spinner.StopFail()
@@ -204,7 +206,7 @@ func (d *Domains) createDomain(name string, attempt int) error {
 			}
 		}
 
-		return fmt.Errorf("error creating domain: %w", err)
+		return err
 	}
 
 	d.Spinner.StopMessage(msg)

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -128,7 +128,7 @@ func (o *KVStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fmt.Errorf("error creating kv store: %w", err)
 		}
@@ -157,7 +157,7 @@ func (o *KVStores) Create() error {
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
-						return spinErr
+						return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 					}
 					return fmt.Errorf("error creating kv store key: %w", err)
 				}
@@ -188,7 +188,7 @@ func (o *KVStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return spinErr
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fmt.Errorf("error creating resource link between the service '%s' and the kv store '%s': %w", o.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -129,7 +129,7 @@ func (o *KVStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return o.Spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}
@@ -159,7 +159,7 @@ func (o *KVStores) Create() error {
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
-						return o.Spinner.WrapErr(err)
+						return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 					}
 					return err
 				}
@@ -191,7 +191,7 @@ func (o *KVStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return o.Spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -125,12 +125,13 @@ func (o *KVStores) Create() error {
 			Name: kvStore.Name,
 		})
 		if err != nil {
+			err = fmt.Errorf("error creating kv store: %w", err)
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
 				return o.Spinner.WrapErr(err)
 			}
-			return fmt.Errorf("error creating kv store: %w", err)
+			return err
 		}
 
 		o.Spinner.StopMessage(msg)
@@ -154,12 +155,13 @@ func (o *KVStores) Create() error {
 					Value: item.Value,
 				})
 				if err != nil {
+					err = fmt.Errorf("error creating kv store key: %w", err)
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
 						return o.Spinner.WrapErr(err)
 					}
-					return fmt.Errorf("error creating kv store key: %w", err)
+					return err
 				}
 
 				o.Spinner.StopMessage(msg)
@@ -185,12 +187,13 @@ func (o *KVStores) Create() error {
 			ResourceID:     fastly.String(store.ID),
 		})
 		if err != nil {
+			err = fmt.Errorf("error creating resource link between the service '%s' and the kv store '%s': %w", o.ServiceID, store.Name, err)
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
 				return o.Spinner.WrapErr(err)
 			}
-			return fmt.Errorf("error creating resource link between the service '%s' and the kv store '%s': %w", o.ServiceID, store.Name, err)
+			return err
 		}
 
 		o.Spinner.StopMessage(msg)

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -128,7 +128,7 @@ func (o *KVStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return o.Spinner.WrapErr(err)
 			}
 			return fmt.Errorf("error creating kv store: %w", err)
 		}
@@ -157,7 +157,7 @@ func (o *KVStores) Create() error {
 					o.Spinner.StopFailMessage(msg)
 					spinErr := o.Spinner.StopFail()
 					if spinErr != nil {
-						return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+						return o.Spinner.WrapErr(err)
 					}
 					return fmt.Errorf("error creating kv store key: %w", err)
 				}
@@ -188,7 +188,7 @@ func (o *KVStores) Create() error {
 			o.Spinner.StopFailMessage(msg)
 			spinErr := o.Spinner.StopFail()
 			if spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return o.Spinner.WrapErr(err)
 			}
 			return fmt.Errorf("error creating resource link between the service '%s' and the kv store '%s': %w", o.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -128,7 +128,7 @@ func (s *SecretStores) Create() error {
 		if err != nil {
 			s.Spinner.StopFailMessage(msg)
 			if spinErr := s.Spinner.StopFail(); spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return s.Spinner.WrapErr(err)
 			}
 			return fmt.Errorf("error creating secret store %q: %w", secretStore.Name, err)
 		}
@@ -152,7 +152,7 @@ func (s *SecretStores) Create() error {
 			if err != nil {
 				s.Spinner.StopFailMessage(msg)
 				if spinErr := s.Spinner.StopFail(); spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return s.Spinner.WrapErr(err)
 				}
 				return fmt.Errorf("error creating secret store entry %q: %w", entry.Name, err)
 			}
@@ -180,7 +180,7 @@ func (s *SecretStores) Create() error {
 		if err != nil {
 			s.Spinner.StopFailMessage(msg)
 			if spinErr := s.Spinner.StopFail(); spinErr != nil {
-				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+				return s.Spinner.WrapErr(err)
 			}
 			return fmt.Errorf("error creating resource link between the service %q and the secret store %q: %w", s.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -126,11 +126,12 @@ func (s *SecretStores) Create() error {
 			Name: secretStore.Name,
 		})
 		if err != nil {
+			err = fmt.Errorf("error creating secret store %q: %w", secretStore.Name, err)
 			s.Spinner.StopFailMessage(msg)
 			if spinErr := s.Spinner.StopFail(); spinErr != nil {
 				return s.Spinner.WrapErr(err)
 			}
-			return fmt.Errorf("error creating secret store %q: %w", secretStore.Name, err)
+			return err
 		}
 		s.Spinner.StopMessage(msg)
 		if err = s.Spinner.Stop(); err != nil {
@@ -150,11 +151,12 @@ func (s *SecretStores) Create() error {
 				Secret: []byte(entry.Secret),
 			})
 			if err != nil {
+				err = fmt.Errorf("error creating secret store entry %q: %w", entry.Name, err)
 				s.Spinner.StopFailMessage(msg)
 				if spinErr := s.Spinner.StopFail(); spinErr != nil {
 					return s.Spinner.WrapErr(err)
 				}
-				return fmt.Errorf("error creating secret store entry %q: %w", entry.Name, err)
+				return err
 			}
 
 			s.Spinner.StopMessage(msg)
@@ -178,11 +180,12 @@ func (s *SecretStores) Create() error {
 			ResourceID:     fastly.String(store.ID),
 		})
 		if err != nil {
+			err = fmt.Errorf("error creating resource link between the service %q and the secret store %q: %w", s.ServiceID, store.Name, err)
 			s.Spinner.StopFailMessage(msg)
 			if spinErr := s.Spinner.StopFail(); spinErr != nil {
 				return s.Spinner.WrapErr(err)
 			}
-			return fmt.Errorf("error creating resource link between the service %q and the secret store %q: %w", s.ServiceID, store.Name, err)
+			return err
 		}
 
 		s.Spinner.StopMessage(msg)

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/fastly/go-fastly/v8/fastly"
+
 	"github.com/fastly/cli/pkg/api"
 	fsterrors "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v8/fastly"
 )
 
 // SecretStores represents the service state related to secret stores defined
@@ -126,8 +127,8 @@ func (s *SecretStores) Create() error {
 		})
 		if err != nil {
 			s.Spinner.StopFailMessage(msg)
-			if serr := s.Spinner.StopFail(); serr != nil {
-				return serr
+			if spinErr := s.Spinner.StopFail(); spinErr != nil {
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fmt.Errorf("error creating secret store %q: %w", secretStore.Name, err)
 		}
@@ -150,8 +151,8 @@ func (s *SecretStores) Create() error {
 			})
 			if err != nil {
 				s.Spinner.StopFailMessage(msg)
-				if serr := s.Spinner.StopFail(); serr != nil {
-					return serr
+				if spinErr := s.Spinner.StopFail(); spinErr != nil {
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return fmt.Errorf("error creating secret store entry %q: %w", entry.Name, err)
 			}
@@ -178,8 +179,8 @@ func (s *SecretStores) Create() error {
 		})
 		if err != nil {
 			s.Spinner.StopFailMessage(msg)
-			if serr := s.Spinner.StopFail(); serr != nil {
-				return serr
+			if spinErr := s.Spinner.StopFail(); spinErr != nil {
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return fmt.Errorf("error creating resource link between the service %q and the secret store %q: %w", s.ServiceID, store.Name, err)
 		}

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -129,7 +129,7 @@ func (s *SecretStores) Create() error {
 			err = fmt.Errorf("error creating secret store %q: %w", secretStore.Name, err)
 			s.Spinner.StopFailMessage(msg)
 			if spinErr := s.Spinner.StopFail(); spinErr != nil {
-				return s.Spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}
@@ -154,7 +154,7 @@ func (s *SecretStores) Create() error {
 				err = fmt.Errorf("error creating secret store entry %q: %w", entry.Name, err)
 				s.Spinner.StopFailMessage(msg)
 				if spinErr := s.Spinner.StopFail(); spinErr != nil {
-					return s.Spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return err
 			}
@@ -183,7 +183,7 @@ func (s *SecretStores) Create() error {
 			err = fmt.Errorf("error creating resource link between the service %q and the secret store %q: %w", s.ServiceID, store.Name, err)
 			s.Spinner.StopFailMessage(msg)
 			if spinErr := s.Spinner.StopFail(); spinErr != nil {
-				return s.Spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
 		}

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -1,6 +1,7 @@
 package kvstoreentry
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/fastly/go-fastly/v8/fastly"
@@ -77,7 +78,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return spinner.WrapErr(err)
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 			return err

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -1,7 +1,6 @@
 package kvstoreentry
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/fastly/go-fastly/v8/fastly"

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -78,7 +78,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return spinner.WrapErr(err)
 				}
 			}
 			return err

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -1,6 +1,7 @@
 package kvstoreentry
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/fastly/go-fastly/v8/fastly"
@@ -77,7 +78,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 				spinner.StopFailMessage(msg)
 				spinErr := spinner.StopFail()
 				if spinErr != nil {
-					return spinErr
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 			return err

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -141,7 +141,7 @@ func (s *Streaming) Exec() error {
 				s.Spinner.StopFailMessage(s.SpinnerMessage)
 				spinErr := s.Spinner.StopFail()
 				if spinErr != nil {
-					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
+					return s.Spinner.WrapErr(err)
 				}
 			}
 		}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -144,7 +144,7 @@ func (s *Streaming) Exec() error {
 		if !s.Verbose && s.Spinner != nil {
 			s.Spinner.StopFailMessage(s.SpinnerMessage)
 			if spinErr := s.Spinner.StopFail(); spinErr != nil {
-				return s.Spinner.WrapErr(err)
+				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 		}
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -131,6 +131,12 @@ func (s *Streaming) Exec() error {
 	s.Process = cmd.Process
 
 	if err := cmd.Wait(); err != nil {
+		// IMPORTANT: We MUST wrap the original error.
+		// This is because the `compute serve` command requires it for --watch
+		// Specifically we need to check the error message for "killed".
+		// This enables the watching logic to restart the Viceroy binary.
+		err = fmt.Errorf("error during execution process (see 'command output' above): %w", err)
+
 		text.Output(output, divider)
 
 		// If we're in verbose mode, the build output is shown.
@@ -149,11 +155,7 @@ func (s *Streaming) Exec() error {
 		// Display the buffer stored output as we have an error.
 		fmt.Fprintf(s.Output, "%s", buf.String())
 
-		// IMPORTANT: We MUST wrap the original error.
-		// This is because the `compute serve` command requires it for --watch
-		// Specifically we need to check the error message for "killed".
-		// This enables the watching logic to restart the Viceroy binary.
-		return fmt.Errorf("error during execution process (see 'command output' above): %w", err)
+		return err
 	}
 
 	text.Output(output, divider)

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -70,7 +70,7 @@ func (s *Streaming) MonitorSignalsAsync() {
 	// killed the process. The reason this line still exists is for users running
 	// their application locally without the --watch flag and who then execute
 	// Ctrl-C to kill the process.
-	s.Signal(os.Kill)
+	_ = s.Signal(os.Kill)
 }
 
 // Exec executes the compiler command and pipes the child process stdout and

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -141,7 +141,7 @@ func (s *Streaming) Exec() error {
 				s.Spinner.StopFailMessage(s.SpinnerMessage)
 				spinErr := s.Spinner.StopFail()
 				if spinErr != nil {
-					return spinErr
+					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
 		}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -100,7 +100,6 @@ func (s *Streaming) Exec() error {
 
 	// We store all output in a buffer to hide it unless there was an error.
 	var buf threadsafe.Buffer
-
 	var output io.Writer
 	output = &buf
 
@@ -142,13 +141,10 @@ func (s *Streaming) Exec() error {
 		// If we're in verbose mode, the build output is shown.
 		// So in that case we don't want to have a spinner as it'll interweave output.
 		// In non-verbose mode we have a spinner running while the build is happening.
-		if !s.Verbose {
-			if s.Spinner != nil {
-				s.Spinner.StopFailMessage(s.SpinnerMessage)
-				spinErr := s.Spinner.StopFail()
-				if spinErr != nil {
-					return s.Spinner.WrapErr(err)
-				}
+		if !s.Verbose && s.Spinner != nil {
+			s.Spinner.StopFailMessage(s.SpinnerMessage)
+			if spinErr := s.Spinner.StopFail(); spinErr != nil {
+				return s.Spinner.WrapErr(err)
 			}
 		}
 

--- a/pkg/text/spinner.go
+++ b/pkg/text/spinner.go
@@ -35,7 +35,7 @@ type SpinnerProcess func(sp *SpinnerWrapper) error
 // SpinnerWrapper implements the Spinner interface.
 type SpinnerWrapper struct {
 	*yacspin.Spinner
-	stopFailErr error
+	err error
 }
 
 // Process starts/stops the spinner with `msg` and executes `fn` in between.
@@ -60,20 +60,42 @@ func (sp *SpinnerWrapper) Process(msg string, fn SpinnerProcess) error {
 	return sp.Stop()
 }
 
+// Start is a proxy to the underlying spinner implementation. It sets the
+// internal err to the error that is returned from a call to the underlying
+// Start() so it can be used by a call subsequent to WrapErr().
+func (sp *SpinnerWrapper) Start() error {
+	err := sp.Spinner.Start()
+	if err != nil {
+		sp.err = err
+	}
+	return err
+}
+
 // StopFail is a proxy to the underlying spinner implementation. It sets the
-// internal stopFailErr to the error that is returned so it can be used by a
-// call to WrapErr().
+// internal err to the error that is returned from a call to the underlying
+// StopFail() so it can be used by a call subsequent to WrapErr().
 func (sp *SpinnerWrapper) StopFail() error {
 	err := sp.Spinner.StopFail()
 	if err != nil {
-		sp.stopFailErr = err
+		sp.err = err
+	}
+	return err
+}
+
+// Stop is a proxy to the underlying spinner implementation. It sets the
+// internal err to the error that is returned from a call to the underlying
+// Stop() so it can be used by a call subsequent to WrapErr().
+func (sp *SpinnerWrapper) Stop() error {
+	err := sp.Spinner.Stop()
+	if err != nil {
+		sp.err = err
 	}
 	return err
 }
 
 // WrapErr returns a spinner error that wraps err.
 func (sp *SpinnerWrapper) WrapErr(err error) error {
-	return fmt.Errorf(SpinnerErrWrapper, sp.stopFailErr, err)
+	return fmt.Errorf(SpinnerErrWrapper, sp.err, err)
 }
 
 // NewSpinner returns a new instance of a terminal prompt spinner.
@@ -93,7 +115,7 @@ func NewSpinner(out io.Writer) (Spinner, error) {
 	}
 
 	return &SpinnerWrapper{
-		Spinner:     spinner,
-		stopFailErr: nil,
+		Spinner: spinner,
+		err:     nil,
 	}, nil
 }

--- a/pkg/text/spinner.go
+++ b/pkg/text/spinner.go
@@ -22,7 +22,6 @@ type Spinner interface {
 	StopMessage(message string)
 	Stop() error
 	Process(msg string, fn SpinnerProcess) error
-	WrapErr(err error) error
 }
 
 // SpinnerProcess is the logic to execute in between the spinner start/stop.
@@ -58,44 +57,6 @@ func (sp *SpinnerWrapper) Process(msg string, fn SpinnerProcess) error {
 
 	sp.StopMessage(msg)
 	return sp.Stop()
-}
-
-// Start is a proxy to the underlying spinner implementation. It sets the
-// internal err to the error that is returned from a call to the underlying
-// Start() so it can be used by a call subsequent to WrapErr().
-func (sp *SpinnerWrapper) Start() error {
-	err := sp.Spinner.Start()
-	if err != nil {
-		sp.err = err
-	}
-	return err
-}
-
-// StopFail is a proxy to the underlying spinner implementation. It sets the
-// internal err to the error that is returned from a call to the underlying
-// StopFail() so it can be used by a call subsequent to WrapErr().
-func (sp *SpinnerWrapper) StopFail() error {
-	err := sp.Spinner.StopFail()
-	if err != nil {
-		sp.err = err
-	}
-	return err
-}
-
-// Stop is a proxy to the underlying spinner implementation. It sets the
-// internal err to the error that is returned from a call to the underlying
-// Stop() so it can be used by a call subsequent to WrapErr().
-func (sp *SpinnerWrapper) Stop() error {
-	err := sp.Spinner.Stop()
-	if err != nil {
-		sp.err = err
-	}
-	return err
-}
-
-// WrapErr returns a spinner error that wraps err.
-func (sp *SpinnerWrapper) WrapErr(err error) error {
-	return fmt.Errorf(SpinnerErrWrapper, sp.err, err)
 }
 
 // NewSpinner returns a new instance of a terminal prompt spinner.


### PR DESCRIPTION
Some errors are lost if the spinner itself has an error. This PR ensures a spinner error wraps the original error.

It also provides a `spinner.WrapErr()` abstraction.