### PR TITLE
feat(compute/build): allow user to specify project directory to build

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -65,3 +65,11 @@ The file is added to `.gitignore` to avoid it being added to the git repository.
 When compiling the CLI for a new release, it will execute [`./scripts/config.sh`](./scripts/config.sh). The script uses [`./.fastly/config.toml`](./.fastly/config.toml) as a template file to then dynamically inject a list of starter kits (pulling their data from their public repositories).
 
 The resulting configuration is then saved to disk at `./pkg/config/config.toml` and embedded into the CLI when compiled.
+
+### Running Compute commands locally
+
+If you need to test the Fastly CLI locally while developing a Compute feature, then use the `--dir` flag (exposed on `compute build`, `compute deploy`, `compute serve` and `compute publish`) to ensure the CLI doesn't attempt to treat the repository directory as your project directory.
+
+```shell
+go run cmd/fastly/main.go compute deploy --verbose --dir ../../test-projects/testing-fastly-cli
+```

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -276,12 +276,7 @@ func Content(flagval string) string {
 	content := flagval
 	if path, err := filepath.Abs(flagval); err == nil {
 		if _, err := os.Stat(path); err == nil {
-			// gosec flagged this:
-			// G304 (CWE-22): Potential file inclusion via variable
-			//
-			// Disabling as we require a user to configure their own environment.
-			/* #nosec */
-			if data, err := os.ReadFile(path); err == nil {
+			if data, err := os.ReadFile(path); err == nil /* #nosec */ {
 				content = string(data)
 			}
 		}

--- a/pkg/commands/authtoken/delete.go
+++ b/pkg/commands/authtoken/delete.go
@@ -123,11 +123,7 @@ func (c *DeleteCommand) constructInputBatch() (*fastly.BatchDeleteTokensInput, e
 
 	if path, err = filepath.Abs(c.file); err == nil {
 		if _, err = os.Stat(path); err == nil {
-			// gosec flagged this:
-			// G304 (CWE-22): Potential file inclusion via variable
-			// Disabling as we trust the source of the path variable.
-			/* #nosec */
-			if file, err = os.Open(path); err == nil {
+			if file, err = os.Open(path); err == nil /* #nosec */ {
 				scanner := bufio.NewScanner(file)
 				for scanner.Scan() {
 					tokens = append(tokens, &fastly.BatchToken{ID: scanner.Text()})

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -56,7 +56,7 @@ func NewBuildCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *Bu
 
 	// NOTE: when updating these flags, be sure to update the composite commands:
 	// `compute publish` and `compute serve`.
-	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").StringVar(&c.Flags.Dir)
+	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").Short('C').StringVar(&c.Flags.Dir)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.Flags.IncludeSrc)
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Flags.Lang)
 	c.CmdClause.Flag("package-name", "Package name").StringVar(&c.Flags.PackageName)

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -30,6 +30,7 @@ const CustomPostScriptMessage = "This project has a custom post_%s script define
 
 // Flags represents the flags defined for the command.
 type Flags struct {
+	Dir         string
 	IncludeSrc  bool
 	Lang        string
 	PackageName string
@@ -50,11 +51,12 @@ type BuildCommand struct {
 func NewBuildCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *BuildCommand {
 	var c BuildCommand
 	c.Globals = g
-	c.Manifest = m
+	c.Manifest = m // TODO: Stop passing a non-mutable 'copy' in any commands.
 	c.CmdClause = parent.Command("build", "Build a Compute@Edge package locally")
 
 	// NOTE: when updating these flags, be sure to update the composite commands:
 	// `compute publish` and `compute serve`.
+	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").StringVar(&c.Flags.Dir)
 	c.CmdClause.Flag("include-source", "Include source code in built package").BoolVar(&c.Flags.IncludeSrc)
 	c.CmdClause.Flag("language", "Language type").StringVar(&c.Flags.Lang)
 	c.CmdClause.Flag("package-name", "Package name").StringVar(&c.Flags.PackageName)
@@ -72,6 +74,25 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		out = io.Discard
 	}
 
+	var projectDir string
+	if c.Flags.Dir != "" {
+		projectDir, err = filepath.Abs(c.Flags.Dir)
+		if err != nil {
+			return fmt.Errorf("failed to construct absolute path to directory '%s': %w", c.Flags.Dir, err)
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory: %w", err)
+		}
+		if err := os.Chdir(projectDir); err != nil {
+			return fmt.Errorf("failed to change working directory to '%s': %w", projectDir, err)
+		}
+		defer os.Chdir(wd)
+		if c.Globals.Verbose() {
+			text.Info(out, "Changed project directory to '%s'\n\n", projectDir)
+		}
+	}
+
 	spinner, err := text.NewSpinner(out)
 	if err != nil {
 		return err
@@ -84,7 +105,11 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	}(c.Globals.ErrLog)
 
 	err = spinner.Process("Verifying fastly.toml", func(_ *text.SpinnerWrapper) error {
-		err = c.Manifest.File.ReadError()
+		if projectDir == "" {
+			err = c.Globals.Manifest.File.ReadError()
+		} else {
+			err = c.Globals.Manifest.File.Read(filepath.Join(projectDir, manifest.Filename))
+		}
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				err = fsterr.ErrReadingManifest
@@ -219,8 +244,8 @@ func packageName(c *BuildCommand) (string, error) {
 	switch {
 	case c.Flags.PackageName != "":
 		name = c.Flags.PackageName
-	case c.Manifest.File.Name != "":
-		name = c.Manifest.File.Name // use the project name as a fallback
+	case c.Globals.Manifest.File.Name != "":
+		name = c.Globals.Manifest.File.Name // use the project name as a fallback
 	default:
 		return "", fsterr.RemediationError{
 			Inner:       fmt.Errorf("package name is missing"),
@@ -242,8 +267,8 @@ func identifyToolchain(c *BuildCommand) (string, error) {
 	switch {
 	case c.Flags.Lang != "":
 		toolchain = c.Flags.Lang
-	case c.Manifest.File.Language != "":
-		toolchain = c.Manifest.File.Language
+	case c.Globals.Manifest.File.Language != "":
+		toolchain = c.Globals.Manifest.File.Language
 	default:
 		return "", fmt.Errorf("language cannot be empty, please provide a language")
 	}
@@ -260,7 +285,7 @@ func language(toolchain string, c *BuildCommand, in io.Reader, out io.Writer, sp
 			Name:            "assemblyscript",
 			SourceDirectory: AsSourceDirectory,
 			Toolchain: NewAssemblyScript(
-				&c.Manifest.File,
+				&c.Globals.Manifest.File,
 				c.Globals,
 				c.Flags,
 				in,
@@ -273,7 +298,7 @@ func language(toolchain string, c *BuildCommand, in io.Reader, out io.Writer, sp
 			Name:            "go",
 			SourceDirectory: GoSourceDirectory,
 			Toolchain: NewGo(
-				&c.Manifest.File,
+				&c.Globals.Manifest.File,
 				c.Globals,
 				c.Flags,
 				in,
@@ -286,7 +311,7 @@ func language(toolchain string, c *BuildCommand, in io.Reader, out io.Writer, sp
 			Name:            "javascript",
 			SourceDirectory: JsSourceDirectory,
 			Toolchain: NewJavaScript(
-				&c.Manifest.File,
+				&c.Globals.Manifest.File,
 				c.Globals,
 				c.Flags,
 				in,
@@ -299,7 +324,7 @@ func language(toolchain string, c *BuildCommand, in io.Reader, out io.Writer, sp
 			Name:            "rust",
 			SourceDirectory: RustSourceDirectory,
 			Toolchain: NewRust(
-				&c.Manifest.File,
+				&c.Globals.Manifest.File,
 				c.Globals,
 				c.Flags,
 				in,
@@ -311,7 +336,7 @@ func language(toolchain string, c *BuildCommand, in io.Reader, out io.Writer, sp
 		language = NewLanguage(&LanguageOptions{
 			Name: "other",
 			Toolchain: NewOther(
-				&c.Manifest.File,
+				&c.Globals.Manifest.File,
 				c.Globals,
 				c.Flags,
 				in,

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -83,7 +83,7 @@ func NewDeployCommand(parent cmd.Registerer, g *global.Data, m manifest.Data) *D
 		Name:        cmd.FlagVersionName,
 	})
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.Comment.Set).StringVar(&c.Comment.Value)
-	c.CmdClause.Flag("dir", "Project directory (default: current directory)").StringVar(&c.Dir)
+	c.CmdClause.Flag("dir", "Project directory (default: current directory)").Short('C').StringVar(&c.Dir)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").StringVar(&c.Domain)
 	c.CmdClause.Flag("package", "Path to a package tar.gz").Short('p').StringVar(&c.PackagePath)
 	c.CmdClause.Flag("status-check-code", "Set the expected status response for the service availability check").IntVar(&c.StatusCheckCode)

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -555,7 +555,7 @@ func TestDeploy(t *testing.T) {
 			},
 		},
 		// NOTE: The following test ensures that if the user runs the CLI from a
-		// directory that isn't a C@E project directory (i.e. it has no manifest
+		// directory that isn't a Compute project directory (i.e. it has no manifest
 		// file present) then the deploy command should try to locate a manifest
 		// inside the given package tar.gz archive.
 		{

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -48,7 +48,7 @@ func NewPublishCommand(parent cmd.Registerer, g *global.Data, build *BuildComman
 	c.CmdClause = parent.Command("publish", "Build and deploy a Compute@Edge package to a Fastly service")
 
 	c.CmdClause.Flag("comment", "Human-readable comment").Action(c.comment.Set).StringVar(&c.comment.Value)
-	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").Action(c.dir.Set).StringVar(&c.dir.Value)
+	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").Short('C').Action(c.dir.Set).StringVar(&c.dir.Value)
 	c.CmdClause.Flag("domain", "The name of the domain associated to the package").Action(c.domain.Set).StringVar(&c.domain.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -80,7 +80,7 @@ func NewServeCommand(parent cmd.Registerer, g *global.Data, build *BuildCommand,
 
 	c.CmdClause.Flag("addr", "The IPv4 address and port to listen on").Default("127.0.0.1:7676").StringVar(&c.addr)
 	c.CmdClause.Flag("debug", "Run the server in Debug Adapter mode").Hidden().BoolVar(&c.debug)
-	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").Action(c.dir.Set).StringVar(&c.dir.Value)
+	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").Short('C').Action(c.dir.Set).StringVar(&c.dir.Value)
 	c.CmdClause.Flag("env", "The environment configuration to use (e.g. stage)").Action(c.env.Set).StringVar(&c.env.Value)
 	c.CmdClause.Flag("file", "The Wasm file to run").Default("bin/main.wasm").StringVar(&c.file)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)

--- a/pkg/commands/purge/root.go
+++ b/pkg/commands/purge/root.go
@@ -236,11 +236,7 @@ func populateKeys(fpath string, errLog fsterr.LogInterface) (keys []string, err 
 
 	if path, err = filepath.Abs(fpath); err == nil {
 		if _, err = os.Stat(path); err == nil {
-			// gosec flagged this:
-			// G304 (CWE-22): Potential file inclusion via variable
-			// Disabling as we trust the source of the fpath variable.
-			/* #nosec */
-			if file, err = os.Open(path); err == nil {
+			if file, err = os.Open(path); err == nil /* #nosec */ {
 				scanner := bufio.NewScanner(file)
 				for scanner.Scan() {
 					keys = append(keys, scanner.Text())

--- a/pkg/testutil/env.go
+++ b/pkg/testutil/env.go
@@ -56,12 +56,7 @@ func NewEnv(opts EnvOpts) (rootdir string) {
 		// given file to disk.
 		createIntermediaryDirectories(f.Dst, rootdir, opts.T)
 
-		// gosec flagged this:
-		// G304 (CWE-22): Potential file inclusion via variable
-		//
-		// Disabling as this is part of our test suite.
-		/* #nosec */
-		if err := os.WriteFile(dst, []byte(src), 0o777); err != nil {
+		if err := os.WriteFile(dst, []byte(src), 0o777); err != nil /* #nosec */ {
 			opts.T.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Customers have often asked for the ability to specify a project directory when building and deploying compute applications.

## compute build

<img width="859" alt="Screenshot 2023-10-13 at 16 48 54" src="https://github.com/fastly/cli/assets/180050/43d21ae4-d016-4dcd-8163-3d17faf760df">

## compute deploy

<img width="942" alt="Screenshot 2023-10-13 at 16 40 41" src="https://github.com/fastly/cli/assets/180050/112d4894-97d5-4358-8eed-4454c5c9e0af">

## compute serve (i.e. build, then serve)

<img width="1103" alt="Screenshot 2023-10-13 at 16 49 11" src="https://github.com/fastly/cli/assets/180050/9d2518e1-6e0b-4140-850f-f7ce4071d6f1">

## compute publish (i.e. build, then deploy)

<img width="869" alt="Screenshot 2023-10-13 at 16 46 32" src="https://github.com/fastly/cli/assets/180050/a84bf42b-805b-4cf1-ba72-26192cab6b71">
