### PR TITLE
refactor(compute/deploy): add setup message for existing service users

### DIFF
--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -203,6 +203,9 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			}
 			return err
 		}
+		if c.Globals.Manifest.File.Setup.Defined() && !c.Globals.Flags.Quiet {
+			text.Info(out, "\nProcessing of the %s [setup] configuration happens only for a new service. Once a service is created, any further changes to the service or its resources must be made manually.", manifestFilename)
+		}
 	}
 
 	var sr ServiceResources


### PR DESCRIPTION
We show a message to users who execute `compute deploy` with a `[setup]` to explain the setup block is only processed once when creating the service. For some users, either with an existing service or who maybe missed the message the first time they deployed their service, it can be helpful to show that message on each deploy as a reminder.