### PR TITLE
fix(text): prompt colour

### DIFF
--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -86,6 +86,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		return err
 	}
 	if !cont {
+		text.Break(out)
 		return fsterr.RemediationError{
 			Inner:       fmt.Errorf("project directory not empty"),
 			Remediation: fsterr.ExistingDirRemediation,

--- a/pkg/text/color.go
+++ b/pkg/text/color.go
@@ -1,6 +1,8 @@
 package text
 
-import "github.com/fatih/color"
+import (
+	"github.com/fatih/color"
+)
 
 // Bold is a Sprint-class function that makes the arguments bold.
 var Bold = color.New(color.Bold).SprintFunc()
@@ -20,8 +22,12 @@ var BoldGreen = color.New(color.Bold, color.FgGreen).SprintFunc()
 // Reset is a Sprint-class function that resets the color for the arguments.
 var Reset = color.New(color.Reset).SprintFunc()
 
-// Prompt is a Sprint-class function that makes the arguments bold and grey.
-var Prompt = color.New(color.Bold, color.FgHiBlack).SprintFunc()
+// Prompt is a Sprint-class function that makes the arguments bold and uses the
+// default colour for the terminal.
+//
+// IMPORTANT: Be careful modifying with Black or White as this can break themes.
+// e.g. Black with Solarized Dark makes the text invisible!
+var Prompt = color.New(color.Bold).SprintFunc()
 
 // ColorFn is a function returned from a color.SprintFunc() call.
 type ColorFn func(a ...any) string


### PR DESCRIPTION
Switch back to using the default terminal text colour for prompts.

## macOS Terminal

<img width="1100" alt="Screenshot 2023-11-15 at 14 48 18" src="https://github.com/fastly/cli/assets/180050/07b81fc0-bf49-47b0-91ef-de02127c24da">

<img width="952" alt="Screenshot 2023-11-15 at 14 48 34" src="https://github.com/fastly/cli/assets/180050/00869239-1d2b-4b60-b35b-fa34b29a71ee">

<img width="1106" alt="Screenshot 2023-11-15 at 14 48 46" src="https://github.com/fastly/cli/assets/180050/d215c7f3-c8b2-405f-b240-26b1a366ce88">

## Alacritty

<img width="1178" alt="Screenshot 2023-11-15 at 14 49 11" src="https://github.com/fastly/cli/assets/180050/bac290b5-8539-4a96-9c7b-67139eaf80a2">

## Warp

<img width="1270" alt="Screenshot 2023-11-15 at 14 49 39" src="https://github.com/fastly/cli/assets/180050/2ac9ec7b-99af-4035-88ee-dc36985366d6">
