### PR TITLE
fix(errors): ensure help output is displayed

### DIFF
--- a/cmd/fastly/main.go
+++ b/cmd/fastly/main.go
@@ -2,10 +2,7 @@
 package main
 
 import (
-	"errors"
 	"os"
-
-	"github.com/fatih/color"
 
 	"github.com/fastly/cli/pkg/app"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -13,28 +10,9 @@ import (
 
 func main() {
 	if err := app.Run(os.Args, os.Stdin); err != nil {
-		if skipExit := processErr(err, os.Args); skipExit {
+		if skipExit := fsterr.Process(err, os.Args, os.Stdout); skipExit {
 			return
 		}
 		os.Exit(1)
 	}
-}
-
-// processErr persists the error log to disk and deduces the error type.
-func processErr(err error, args []string) (skipExit bool) {
-	// NOTE: We persist any error log entries to disk before attempting to handle
-	// a possible error response from app.Run as there could be errors recorded
-	// during the execution flow but were otherwise handled without bubbling an
-	// error back the call stack, and so if the user still experiences something
-	// unexpected we will have a record of any errors that happened along the way.
-	logErr := fsterr.Log.Persist(fsterr.LogPath, args[1:])
-	if logErr != nil {
-		fsterr.Deduce(logErr).Print(color.Error)
-	}
-	exitError := fsterr.SkipExitError{}
-	if errors.As(err, &exitError) {
-		return exitError.Skip
-	}
-	fsterr.Deduce(err).Print(color.Error)
-	return false
 }

--- a/pkg/errors/process.go
+++ b/pkg/errors/process.go
@@ -1,0 +1,35 @@
+package errors
+
+import (
+	"errors"
+	"io"
+
+	"github.com/fatih/color"
+
+	"github.com/fastly/cli/pkg/text"
+)
+
+// Process persists the error log to disk and deduces the error type.
+func Process(err error, args []string, out io.Writer) (skipExit bool) {
+	text.Break(out)
+
+	// NOTE: We persist any error log entries to disk before attempting to handle
+	// a possible error response from app.Run as there could be errors recorded
+	// during the execution flow but were otherwise handled without bubbling an
+	// error back the call stack, and so if the user still experiences something
+	// unexpected we will have a record of any errors that happened along the way.
+	logErr := Log.Persist(LogPath, args[1:])
+	if logErr != nil {
+		Deduce(logErr).Print(color.Error)
+	}
+
+	// IMPORTANT: Deduce/Print needs to happen before checking for Skip.
+	// This is so the help output can be printed.
+	Deduce(err).Print(color.Error)
+
+	exitError := SkipExitError{}
+	if errors.As(err, &exitError) {
+		return exitError.Skip
+	}
+	return false
+}


### PR DESCRIPTION
An earlier refactor moved a call to Deduce/Print further down the function and when dealing with 'Skip Exit' behaviour, this caused the help output to no longer be printed.