### PR TITLE
fix: move auth setup so it doesn't run for non-token based commands

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -161,26 +161,6 @@ var Init = func(args []string, stdin io.Reader) (*global.Data, error) {
 	}, nil
 }
 
-// accountEndpoint parses the account endpoint from multiple locations.
-func accountEndpoint(args []string, e config.Environment, cfg config.File) string {
-	// Check for flag override.
-	for i, a := range args {
-		if a == "--account" && i+1 < len(args) {
-			return args[i+1]
-		}
-	}
-	// Check for environment override.
-	if e.AccountEndpoint != "" {
-		return e.AccountEndpoint
-	}
-	// Check for internal config override.
-	if cfg.Fastly.AccountEndpoint != global.DefaultAccountEndpoint && cfg.Fastly.AccountEndpoint != "" {
-		return cfg.Fastly.AccountEndpoint
-	}
-	// Otherwise return the default account endpoint.
-	return global.DefaultAccountEndpoint
-}
-
 // Exec constructs the application including all of the subcommands, parses the
 // args, invokes the client factory with the token to create a Fastly API
 // client, and executes the chosen command, using the provided io.Reader and
@@ -714,4 +694,24 @@ func configureAuth(args []string, f config.File, c *http.Client, e config.Enviro
 	router.HandleFunc("/callback", authServer.HandleCallback())
 
 	return authServer, nil
+}
+
+// accountEndpoint parses the account endpoint from multiple locations.
+func accountEndpoint(args []string, e config.Environment, cfg config.File) string {
+	// Check for flag override.
+	for i, a := range args {
+		if a == "--account" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	// Check for environment override.
+	if e.AccountEndpoint != "" {
+		return e.AccountEndpoint
+	}
+	// Check for internal config override.
+	if cfg.Fastly.AccountEndpoint != global.DefaultAccountEndpoint && cfg.Fastly.AccountEndpoint != "" {
+		return cfg.Fastly.AccountEndpoint
+	}
+	// Otherwise return the default account endpoint.
+	return global.DefaultAccountEndpoint
 }

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -631,8 +631,7 @@ func commandCollectsData(command string) bool {
 // requires an API token.
 func commandRequiresToken(command string) bool {
 	switch command {
-	case "compute init", "compute metadata":
-		// NOTE: Most `compute` commands require a token except init/metadata.
+	case "compute init", "compute metadata", "compute serve":
 		return false
 	}
 	command = strings.Split(command, " ")[0]

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -52,8 +52,6 @@ type Runner interface {
 	// RefreshAccessToken constructs and calls the token_endpoint with the
 	// refresh token so we can refresh and return the access token.
 	RefreshAccessToken(refreshToken string) (JWT, error)
-	// SetEndpoint sets the API endpoint.
-	SetAPIEndpoint(endpoint string)
 	// Start starts a local server for handling authentication processing.
 	Start() error
 	// ValidateAndRetrieveAPIToken verifies the signature and the claims and
@@ -145,11 +143,6 @@ func (s Server) GetJWT(authorizationCode string) (JWT, error) {
 	}
 
 	return j, nil
-}
-
-// SetAPIEndpoint sets the API endpoint.
-func (s *Server) SetAPIEndpoint(endpoint string) {
-	s.APIEndpoint = endpoint
 }
 
 // SetVerifier sets the code verifier endpoint.

--- a/pkg/commands/version/root.go
+++ b/pkg/commands/version/root.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fastly/go-fastly/v8/fastly"
 
@@ -44,7 +45,7 @@ func NewRootCommand(parent cmd.Registerer, g *global.Data) *RootCommand {
 // Exec implements the command interface.
 func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	fmt.Fprintf(out, "Fastly CLI version %s (%s)\n", revision.AppVersion, revision.GitCommit)
-	fmt.Fprintf(out, "Built with %s\n", revision.GoVersion)
+	fmt.Fprintf(out, "Built with %s (%s)\n", revision.GoVersion, Now().Format("2006-01-02"))
 
 	viceroy := filepath.Join(github.InstallDir, c.Globals.Versioners.Viceroy.BinaryName())
 	// gosec flagged this:
@@ -68,3 +69,6 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 func IsPreRelease(version string) bool {
 	return strings.Contains(version, "-")
 }
+
+// Now is exposed so that we may mock it from our test file.
+var Now = time.Now

--- a/pkg/commands/version/version_test.go
+++ b/pkg/commands/version/version_test.go
@@ -9,8 +9,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/commands/version"
 	"github.com/fastly/cli/pkg/github"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/testutil"
@@ -66,6 +68,11 @@ func TestVersion(t *testing.T) {
 		_ = os.Chdir(pwd)
 	}()
 
+	// Mock the time output to be zero value
+	version.Now = func() (t time.Time) {
+		return t
+	}
+
 	var stdout bytes.Buffer
 	args := testutil.Args("version")
 	opts := testutil.MockGlobalData(args, &stdout)
@@ -83,10 +90,11 @@ func TestVersion(t *testing.T) {
 
 	t.Log(stdout.String())
 
+	var mockTime time.Time
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, strings.Join([]string{
 		"Fastly CLI version v0.0.0-unknown (unknown)",
-		fmt.Sprintf("Built with go version %s unknown/unknown", runtime.Version()),
+		fmt.Sprintf("Built with go version %s unknown/unknown (%s)", runtime.Version(), mockTime.Format("2006-01-02")),
 		"Viceroy version: viceroy 0.0.0",
 		"",
 	}, "\n"), stdout.String())


### PR DESCRIPTION
## Problem
A user reported that `compute serve` was failing to run when they didn't have an internet connection.

This was happening because of an error related to a new (currently unreleased) SSO feature within the CLI.

The CLI was attempting to make a network call and due to the lack of connectivity, was causing the process to stop.

## Solution

I've moved the auth processing tasks so that they only run when the user executes a command that requires an API token.

I've also added `compute serve` to the list of commands that don't require an API token.