### PR TITLE
feat: install CLI version command

### DIFF
--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -71,6 +71,7 @@ dictionary
 dictionary-entry
 domain
 healthcheck
+install
 ip-list
 kv-store
 kv-store-entry

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -258,6 +258,7 @@ func IsVerboseAndQuiet(args []string) bool {
 // We hack a solution in ../app/run.go (`configureKingpin` function).
 func IsGlobalFlagsOnly(args []string) bool {
 	// Global flags are defined in ../app/run.go
+	// nosemgrep: trailofbits.go.iterate-over-empty-map.iterate-over-empty-map (false positive)
 	globals := map[string]int{
 		"--accept-defaults": 0,
 		"-d":                0,

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fastly/cli/pkg/commands/dictionaryentry"
 	"github.com/fastly/cli/pkg/commands/domain"
 	"github.com/fastly/cli/pkg/commands/healthcheck"
+	"github.com/fastly/cli/pkg/commands/install"
 	"github.com/fastly/cli/pkg/commands/ip"
 	"github.com/fastly/cli/pkg/commands/kvstore"
 	"github.com/fastly/cli/pkg/commands/kvstoreentry"
@@ -169,6 +170,7 @@ func Define(
 	healthcheckDescribe := healthcheck.NewDescribeCommand(healthcheckCmdRoot.CmdClause, data)
 	healthcheckList := healthcheck.NewListCommand(healthcheckCmdRoot.CmdClause, data)
 	healthcheckUpdate := healthcheck.NewUpdateCommand(healthcheckCmdRoot.CmdClause, data)
+	installRoot := install.NewRootCommand(app, data)
 	ipCmdRoot := ip.NewRootCommand(app, data)
 	kvstoreCmdRoot := kvstore.NewRootCommand(app, data)
 	kvstoreCreate := kvstore.NewCreateCommand(kvstoreCmdRoot.CmdClause, data)
@@ -535,6 +537,7 @@ func Define(
 		healthcheckDescribe,
 		healthcheckList,
 		healthcheckUpdate,
+		installRoot,
 		ipCmdRoot,
 		kvstoreCreate,
 		kvstoreDelete,

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -198,6 +198,7 @@ func (c *DeployCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			return nil // user declined service creation prompt
 		}
 	} else {
+		// nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable (we only reference variable in specific error scenario)
 		serviceVersion, err = c.ExistingServiceVersion(serviceID, out)
 		if err != nil {
 			if errors.Is(err, ErrPackageUnchanged) {

--- a/pkg/commands/compute/validate.go
+++ b/pkg/commands/compute/validate.go
@@ -83,6 +83,7 @@ type ValidateCommand struct {
 //
 // NOTE: This function is also called by the `deploy` command.
 func validatePackageContent(pkgPath string) error {
+	// nosemgrep: trailofbits.go.iterate-over-empty-map.iterate-over-empty-map (false positive)
 	files := map[string]bool{
 		manifest.Filename: false,
 		"main.wasm":       false,

--- a/pkg/commands/install/doc.go
+++ b/pkg/commands/install/doc.go
@@ -1,0 +1,2 @@
+// Package install contains functions for installing a specific CLI version.
+package install

--- a/pkg/commands/install/root.go
+++ b/pkg/commands/install/root.go
@@ -1,0 +1,118 @@
+package install
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/fastly/cli/pkg/cmd"
+	"github.com/fastly/cli/pkg/filesystem"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	cmd.Base
+
+	versionToInstall string
+}
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent cmd.Registerer, g *global.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = g
+	c.CmdClause = parent.Command("install", "Install the specified version of the CLI")
+	c.CmdClause.Arg("version", "CLI release version to install (e.g. 10.8.0)").Required().StringVar(&c.versionToInstall)
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
+	spinner, err := text.NewSpinner(out)
+	if err != nil {
+		return err
+	}
+
+	var downloadedBin string
+	err = spinner.Process(fmt.Sprintf("Fetching release %s", c.versionToInstall), func(_ *text.SpinnerWrapper) error {
+		downloadedBin, err = c.Globals.Versioners.CLI.DownloadVersion(c.versionToInstall)
+		if err != nil {
+			c.Globals.ErrLog.AddWithContext(err, map[string]any{
+				"CLI version to install": c.versionToInstall,
+			})
+			return fmt.Errorf("error downloading release version %s: %w", c.versionToInstall, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(downloadedBin)
+
+	var currentBin string
+	err = spinner.Process("Replacing binary", func(_ *text.SpinnerWrapper) error {
+		execPath, err := os.Executable()
+		if err != nil {
+			c.Globals.ErrLog.Add(err)
+			return fmt.Errorf("error determining executable path: %w", err)
+		}
+
+		currentBin, err = filepath.Abs(execPath)
+		if err != nil {
+			c.Globals.ErrLog.AddWithContext(err, map[string]any{
+				"Executable path": execPath,
+			})
+			return fmt.Errorf("error determining absolute target path: %w", err)
+		}
+
+		// Windows does not permit replacing a running executable, however it will
+		// permit it if you first move the original executable. So we first move the
+		// running executable to a new location, then we move the executable that we
+		// downloaded to the same location as the original.
+		// I've also tested this approach on nix systems and it works fine.
+		//
+		// Reference:
+		// https://github.com/golang/go/issues/21997#issuecomment-331744930
+
+		backup := currentBin + ".bak"
+		if err := os.Rename(currentBin, backup); err != nil {
+			c.Globals.ErrLog.AddWithContext(err, map[string]any{
+				"Executable (source)":      downloadedBin,
+				"Executable (destination)": currentBin,
+			})
+			return fmt.Errorf("error moving the current executable: %w", err)
+		}
+
+		if err = os.Remove(backup); err != nil {
+			c.Globals.ErrLog.Add(err)
+		}
+
+		// Move the downloaded binary to the same location as the current executable.
+		if err := os.Rename(downloadedBin, currentBin); err != nil {
+			c.Globals.ErrLog.AddWithContext(err, map[string]any{
+				"Executable (source)":      downloadedBin,
+				"Executable (destination)": currentBin,
+			})
+			renameErr := err
+
+			// Failing that we'll try to io.Copy downloaded binary to the current binary.
+			if err := filesystem.CopyFile(downloadedBin, currentBin); err != nil {
+				c.Globals.ErrLog.AddWithContext(err, map[string]any{
+					"Executable (source)":      downloadedBin,
+					"Executable (destination)": currentBin,
+				})
+				return fmt.Errorf("error 'copying' latest binary in place: %w (following an error 'moving': %w)", err, renameErr)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	text.Success(out, "\nInstalled version %s.", c.versionToInstall)
+	return nil
+}


### PR DESCRIPTION
This PR adds a new `fastly install <version>` command that allows a user to install a specific version of the CLI.

The rationale for adding this command is if there is a bug in the latest version they have upgraded to, then this will make it easy to revert the version back to a prior version.