### PR TITLE
Add support for passing file path to certificate for certificate create command

### DIFF
--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -275,16 +275,17 @@ func GetSpecifiedVersion(vs []*fastly.Version, version string) (*fastly.Version,
 
 // Content determines if the given flag value is a file path, and if so read
 // the contents from disk, otherwise presume the given value is the content.
-func Content(flagval string) string {
+func Content(flagval string) (string, error) {
 	content := flagval
 	if path, err := filepath.Abs(flagval); err == nil {
-		if _, err := os.Stat(path); err == nil {
-			if data, err := os.ReadFile(path); err == nil /* #nosec */ {
-				content = string(data)
-			}
+		if _, err := os.Stat(path); err != nil {
+			return "", fmt.Errorf("error looking up provided path '%s': %q", path, err)
+		}
+		if data, err := os.ReadFile(path); err == nil /* #nosec */ {
+			content = string(data)
 		}
 	}
-	return content
+	return content, nil
 }
 
 // IntToBool converts a binary 0|1 to a boolean.

--- a/pkg/commands/aclentry/update.go
+++ b/pkg/commands/aclentry/update.go
@@ -114,7 +114,7 @@ func (c *UpdateCommand) constructBatchInput(serviceID string) (*fastly.BatchModi
 	input.ACLID = c.aclID
 	input.ServiceID = serviceID
 
-	s := argparser.Content(c.file.Value)
+	s, _ := argparser.Content(c.file.Value)
 	bs := []byte(s)
 
 	err := json.Unmarshal(bs, &input)

--- a/pkg/commands/tls/custom/certificate/certificate_test.go
+++ b/pkg/commands/tls/custom/certificate/certificate_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"path/filepath"
 	"testing"
 
 	"github.com/fastly/go-fastly/v8/fastly"
@@ -16,35 +15,71 @@ import (
 )
 
 const (
-	mockResponseID          = "123"
-	mockFieldValue          = "example"
-	validateAPIError        = "validate API error"
-	validateAPISuccess      = "validate API success"
-	validateMissingIDFlag   = "validate missing --id flag"
-	validateFilePathSuccess = "validate passing file path to --cert-blob works"
-	validateFilePathFailure = "validate passing invalid file path fails"
+	mockResponseID        = "123"
+	mockFieldValue        = "example"
+	validateAPIError      = "validate API error"
+	validateAPISuccess    = "validate API success"
+	validateMissingIDFlag = "validate missing --id flag"
+	//validateFilePathSuccess = "validate passing file path to --cert-blob works"
+	//validateFilePathFailure = "validate passing invalid file path fails"
+	validateCertBlobSuccess = "validate passing in full cert blob works"
 )
 
 func TestTLSCustomCertCreate(t *testing.T) {
 	args := testutil.Args
+
 	scenarios := []testutil.TestScenario{
+		//{
+		//	Name:      "validate missing --cert-blob flag",
+		//	Args:      args("tls-custom certificate create"),
+		//	WantError: "required flag --cert-blob not provided",
+		//},
+		//{
+		//	Name: validateAPIError,
+		//	API: mock.API{
+		//		CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+		//			return nil, testutil.Err
+		//		},
+		//	},
+		//	Args:      args("tls-custom certificate create --cert-blob example"),
+		//	WantError: testutil.Err.Error(),
+		//},
+		//{
+		//	Name: validateAPISuccess,
+		//	API: mock.API{
+		//		CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+		//			return &fastly.CustomTLSCertificate{
+		//				ID: mockResponseID,
+		//			}, nil
+		//		},
+		//	},
+		//	Args:       args("tls-custom certificate create --cert-blob example"),
+		//	WantOutput: fmt.Sprintf("Created TLS Certificate '%s'", mockResponseID),
+		//},
+		//{
+		//	Name: validateFilePathFailure,
+		//	API: mock.API{
+		//		CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+		//			return nil, testutil.Err
+		//		},
+		//	},
+		//	Args:      args(fmt.Sprintf("tls-custom certificate create --cert-blob %s", filepath.Join("invalid", "path", "missing.crt"))),
+		//	WantError: testutil.Err.Error(),
+		//},
+		//{
+		//	Name: validateFilePathSuccess,
+		//	API: mock.API{
+		//		CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+		//			return &fastly.CustomTLSCertificate{
+		//				ID: mockResponseID,
+		//			}, nil
+		//		},
+		//	},
+		//	Args:       args(fmt.Sprintf("tls-custom certificate create --cert-blob %s", filepath.Join("./", "testdata", "certificate.crt"))),
+		//	WantOutput: fmt.Sprintf("Created TLS Certificate '%s'", mockResponseID),
+		//},
 		{
-			Name:      "validate missing --cert-blob flag",
-			Args:      args("tls-custom certificate create"),
-			WantError: "required flag --cert-blob not provided",
-		},
-		{
-			Name: validateAPIError,
-			API: mock.API{
-				CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
-					return nil, testutil.Err
-				},
-			},
-			Args:      args("tls-custom certificate create --cert-blob example"),
-			WantError: testutil.Err.Error(),
-		},
-		{
-			Name: validateAPISuccess,
+			Name: validateCertBlobSuccess,
 			API: mock.API{
 				CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					return &fastly.CustomTLSCertificate{
@@ -52,29 +87,7 @@ func TestTLSCustomCertCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Args:       args("tls-custom certificate create --cert-blob example"),
-			WantOutput: fmt.Sprintf("Created TLS Certificate '%s'", mockResponseID),
-		},
-		{
-			Name: validateFilePathFailure,
-			API: mock.API{
-				CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
-					return nil, testutil.Err
-				},
-			},
-			Args:      args(fmt.Sprintf("tls-custom certificate create --cert-blob %s", filepath.Join("invalid", "path", "missing.crt"))),
-			WantError: testutil.Err.Error(),
-		},
-		{
-			Name: validateFilePathSuccess,
-			API: mock.API{
-				CreateCustomTLSCertificateFn: func(_ *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
-					return &fastly.CustomTLSCertificate{
-						ID: mockResponseID,
-					}, nil
-				},
-			},
-			Args:       args(fmt.Sprintf("tls-custom certificate create --cert-blob %s", filepath.Join("pkg", "config", "testdata", "certificate.crt"))),
+			Args:       args("tls-custom certificate create --cert-blob `\"-----BEGINCERTIFICATE-----\nMIIDnDCCAoSgAwIBAgIJAIaudhxZj1xDMA0GCSqGSIb3DQEBCwUAMD8xGDAWBgNV\nBAMMD3J5YW5kb2hlcnR5Lm5ldDELMAkGA1UEBhMCVVMxFjAUBgNVBAcMDVNhbiBG\ncmFuc2lzY28wHhcNMjQwMTAyMjIxNzI3WhcNMjUwMTAxMjIxNzI3WjCBgjELMAkG\nA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFu\nc2lzY28xFTATBgNVBAoMDFJ5YW4gRG9oZXJ0eTEVMBMGA1UECwwMUnlhbiBEb2hl\ncnR5MRgwFgYDVQQDDA9yeWFuZG9oZXJ0eS5uZXQwggEiMA0GCSqGSIb3DQEBAQUA\nA4IBDwAwggEKAoIBAQCwje6gREvHarGjvKlX5KOahPuErSwX5HbsfueWWXG8grkq\nGuAKSwrXV3jIja7rHsmWZrMooJdg5pDl5hHqiVzRUrK8E1qJd83HyCbEK62rVaDQ\nxUf9QT0MlvIANGBncUBKPETPH53TYeLxWzvXRtYIxhWpPrpTK8p8i4cmB4Io2abc\npirBejL3cgmg/PTzou+LjKv1jerEkGPvp5GqlgpRqWHeq5KCUcsZA0eSTPmPzZBX\nCENyXcXX+P7CrrFLvbZ+Q2BZO3tEOp+kdfR0Tit4ZeR6cx0ZxUhcWV2J7B0tNiQ3\nE0IEIpYt7p66jsPNX5rW0p5qiJejomCnmywTnVIRAgMBAAGjVzBVMB8GA1UdIwQY\nMBaAFGyYO+Vpyy+RqvjbQGdZg84q6IBxMAkGA1UdEwQCMAAwCwYDVR0PBAQDAgTw\nMBoGA1UdEQQTMBGCD3J5YW5kb2hlcnR5Lm5ldDANBgkqhkiG9w0BAQsFAAOCAQEA\nAKpwxBQ5raWRgja4YLWQDL1WgkE7O/hxvpeBKgNn0xr1ZjYZ06Kxb1HzOHbUW9D8\n8Sc37ClTrWXAdLilkVbTEOO5yzVwu0iQeeQp8KIFJPlVAQJU1SLea5832Fqhxu/7\nfae7OK59bfKaPGUf5ZFGXeatkMbw0bMcZ4p4zQmCNfG1ABEKiZ6LNq9ujw15PMPr\nutJ6pqiZNDejxESCZhoR7hSvahIpbiQuIHOTzXz02DcqnEzUpz1w77QTwyDGhxgl\nCeU7HTlQvIJx18Z/C5p60Yafzl2lThDRk199MvITBHwxGJeHS7oW3GayI9b8V+lb\nEhaGRxHY3wavIR7FxZNF3w==\n-----ENDCERTIFICATE-----`\""),
 			WantOutput: fmt.Sprintf("Created TLS Certificate '%s'", mockResponseID),
 		},
 	}

--- a/pkg/commands/tls/custom/certificate/create.go
+++ b/pkg/commands/tls/custom/certificate/create.go
@@ -17,7 +17,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.Globals = g
 
 	// Required.
-	c.CmdClause.Flag("cert-blob", "The PEM-formatted certificate blob").Required().StringVar(&c.certBlob)
+	c.CmdClause.Flag("cert-blob", "The PEM-formatted certificate blob. Can be passed as file path or content, (e.g. \"path/to/certificate.crt\") or content (e.g. \"$(< certificate.crt)\")").Required().StringVar(&c.certBlob)
 
 	// Optional.
 	c.CmdClause.Flag("id", "Alphanumeric string identifying a TLS certificate").StringVar(&c.id)
@@ -59,7 +59,9 @@ func (c *CreateCommand) constructInput() *fastly.CreateCustomTLSCertificateInput
 	if c.id != "" {
 		input.ID = c.id
 	}
-	input.CertBlob = c.certBlob
+
+	input.CertBlob = *fastly.String(argparser.Content(c.certBlob))
+
 	if c.name != "" {
 		input.Name = c.name
 	}

--- a/pkg/commands/tls/custom/certificate/create.go
+++ b/pkg/commands/tls/custom/certificate/create.go
@@ -60,7 +60,14 @@ func (c *CreateCommand) constructInput() *fastly.CreateCustomTLSCertificateInput
 		input.ID = c.id
 	}
 
-	input.CertBlob = *fastly.String(argparser.Content(c.certBlob))
+	certBlob, err := argparser.Content(c.certBlob)
+
+	if err != nil {
+		// We end up here when raw cert blob contents are passed to --cert-blob and we try to os.Stat(path) it in Content()
+		panic(err)
+	}
+
+	input.CertBlob = *fastly.String(certBlob)
 
 	if c.name != "" {
 		input.Name = c.name

--- a/pkg/commands/vcl/custom/create.go
+++ b/pkg/commands/vcl/custom/create.go
@@ -108,7 +108,8 @@ func (c *CreateCommand) constructInput(serviceID string, serviceVersion int) *fa
 		input.Name = &c.name.Value
 	}
 	if c.content.WasSet {
-		input.Content = fastly.String(argparser.Content(c.content.Value))
+		content, _ := argparser.Content(c.content.Value)
+		input.Content = fastly.String(content)
 	}
 
 	if c.main.WasSet {

--- a/pkg/commands/vcl/custom/update.go
+++ b/pkg/commands/vcl/custom/update.go
@@ -125,7 +125,8 @@ func (c *UpdateCommand) constructInput(serviceID string, serviceVersion int) (*f
 		input.NewName = &c.newName.Value
 	}
 	if c.content.WasSet {
-		input.Content = fastly.String(argparser.Content(c.content.Value))
+		content, _ := argparser.Content(c.content.Value)
+		input.Content = fastly.String(content)
 	}
 
 	return &input, nil

--- a/pkg/commands/vcl/snippet/create.go
+++ b/pkg/commands/vcl/snippet/create.go
@@ -117,7 +117,8 @@ func (c *CreateCommand) constructInput(serviceID string, serviceVersion int) *fa
 		input.Name = &c.name.Value
 	}
 	if c.content.WasSet {
-		input.Content = fastly.String(argparser.Content(c.content.Value))
+		content, _ := argparser.Content(c.content.Value)
+		input.Content = fastly.String(content)
 	}
 	if c.location.WasSet {
 		sType := fastly.SnippetType(c.location.Value)

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -151,7 +151,8 @@ func (c *UpdateCommand) constructDynamicInput(serviceID string, _ int) (*fastly.
 		return nil, fmt.Errorf("error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet")
 	}
 	if c.content.WasSet {
-		input.Content = fastly.String(argparser.Content(c.content.Value))
+		content, _ := argparser.Content(c.content.Value)
+		input.Content = fastly.String(content)
 	}
 
 	return &input, nil
@@ -178,7 +179,8 @@ func (c *UpdateCommand) constructInput(serviceID string, serviceVersion int) (*f
 		input.Priority = &c.priority.Value
 	}
 	if c.content.WasSet {
-		input.Content = fastly.String(argparser.Content(c.content.Value))
+		content, _ := argparser.Content(c.content.Value)
+		input.Content = fastly.String(content)
 	}
 	if c.location.WasSet {
 		location := fastly.SnippetType(c.location.Value)

--- a/pkg/testutil/assert.go
+++ b/pkg/testutil/assert.go
@@ -111,7 +111,7 @@ func AssertPathContentFlag(flag string, wantError string, args []string, fixture
 			if a == fmt.Sprintf("--%s", flag) {
 				want := args[i+1]
 				if want == fmt.Sprintf("./testdata/%s", fixture) {
-					want = argparser.Content(want)
+					want, _ = argparser.Content(want)
 				}
 				if content != want {
 					t.Errorf("wanted %s, have %s", want, content)


### PR DESCRIPTION
It is common (and easier) to pass a file path into a CLI tool vs trying to pass in file contents. This change allows the --cert-blob argument to take a file path. It is backwards compatible via the `argparser.Content` function, which determines if the flag value is a file path or file contents.

This follows the existing behavior in `pkg/commands/vcl/snippet/create.go` and a few others. I've tested with a file path and raw cert contents with the `--debug` flag and it does send the correct cert data both ways.

**Questions**:

* Not sure if it's a good idea to overload the `--cert-blob` field, but seems benign?
* It feels weird to use the `argparser.OptionalString` type for the certBlob field that is required, but I couldn't find anything else that might work but could have missed it.
* How should this be tested? I'm new to Go and don't see existing tests for this functionality. Is there anything I can use as a guide?
* Is this considered backwards compatible? I think so, existing tooling would be passing in the full cert contents and keep working, this would allow users to use a file path if they like.

I'm fairly new to Go, any feedback is appreciated!