### PR TITLE
fix(profile/create): support sso

### DIFF
--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -72,6 +72,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		if err != nil {
 			return err
 		}
+		text.Break(out)
 	}
 
 	if c.sso {


### PR DESCRIPTION
**Problem:** the existing logic didn't take into account commands that only require the authentication server, and not processing of a token (e.g. `profile create <name> --sso` requires an auth server for the OAuth signin flow but the command itself `profile create` doesn't need a token because its purpose is to _generate_ a token).