### PR TITLE
fix(compute/build): normalise and bucket heap allocations

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       # NOTE: Manage GitHub Actions cache via https://github.com/fastly/cli/actions/caches
       # This is useful if you need to clear the cache when a dependency doesn't update correctly.
       #
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         tinygo-version: [0.27.0]
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         node-version: [18]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -76,9 +76,11 @@ jobs:
       - name: "Run revive"
         run: make revive
         shell: bash
-      - name: "Static analysis check"
-        run: make staticcheck
-        shell: bash
+      # FIXME: Put back staticcheck once it fixes https://github.com/dominikh/go-tools/issues/1496
+      #
+      # - name: "Static analysis check"
+      #   run: make staticcheck
+      #   shell: bash
       - name: "Security audit"
         run: make gosec
         shell: bash

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Go"
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.x'
+          go-version: '1.22.x'
       - name: "Set GOHOSTOS and GOHOSTARCH"
         run: echo "GOHOSTOS=$(go env GOHOSTOS)" >> $GITHUB_ENV && echo "GOHOSTARCH=$(go env GOHOSTARCH)" >> $GITHUB_ENV
       - name: "Install Rust"

--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -830,7 +830,7 @@ func bytesToMB(bytes uint64) uint64 {
 }
 
 // bucketMB determines a consistent bucket size for heap allocation.
-// NOTE: This is to avoid building a package with a fluctuation hashsum.
+// NOTE: This is to avoid building a package with a fluctuating hashsum.
 // e.g. `fastly compute hash-files` should be consistent unless memory increase is significant.
 func bucketMB(mb uint64) string {
 	switch {


### PR DESCRIPTION
## Problem

We started annotating Wasm binaries with additional metadata and part of that data was the number of memory heap allocations. Including this metric means every time you build a package (even if you have changed ZERO lines of code) it'll produce a package with a different hash (e.g. `fastly compute hash-files`). This behaviour breaks Terraform's ability to reason about whether the package has changed, as each time you build the amount of memory used to create the package is variable/fluctuating.

## Solution

We're going to bucket the memory allocation numbers to provide a consistent output. If the memory allocations increase significantly then the bucket value will change (as we're considering the change significant enough to be considered some kind of important code/dependency change).

## Screenshots

Below demonstrates me building a package twice (no code changes) and the memory allocation value is now consistent (`2-5MB`):

<img width="953" alt="Screenshot 2024-02-14 at 17 07 53" src="https://github.com/fastly/cli/assets/180050/71e9a615-0774-429f-b7d3-046ced6ecd8b">

The following demonstrates me building a package twice (no code changes) and the hash produced is thus the same:

<img width="1063" alt="Screenshot 2024-02-14 at 17 23 27" src="https://github.com/fastly/cli/assets/180050/9ca84a3a-fe6f-4222-afac-10a366d7eed8">
