### PR TITLE
fix(github): update wasm-tools path

### DIFF
--- a/Dockerfile-rust
+++ b/Dockerfile-rust
@@ -15,8 +15,6 @@ RUN rustup toolchain install ${RUST_TOOLCHAIN} \
   && useradd -ms /bin/bash fastly
 
 USER fastly
-# this forces the download of the crates index; it will save build time if the image was recently built
-RUN cargo search --limit 0
 
 WORKDIR /app
 ENTRYPOINT ["/usr/bin/fastly"]

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -451,7 +451,7 @@ func (m Metadata) URL() string {
 		// NOTE: We use `m.repo` for wasm-tools instead of `m.binary`.
 		// This is because we append `.exe` to `m.binary` on Windows.
 		// Instead of filtering the extension we just use `m.repo` instead.
-		pattern := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s-%s/%s-%s-%s-%s.%s", m.org, m.repo, m.repo, version, m.repo, version, arch, platform, extension)
+		pattern := fmt.Sprintf("https://github.com/%s/%s/releases/download/v%s/%s-%s-%s-%s.%s", m.org, m.repo, version, m.repo, version, arch, platform, extension)
 		if matched, _ := regexp.MatchString(pattern, a.BrowserDownloadURL); matched {
 			return a.BrowserDownloadURL
 		}


### PR DESCRIPTION
Looks like the latest release of wasm-tools https://github.com/bytecodealliance/wasm-tools/releases/tag/v1.200.0 changed its release assets path.