### PR TITLE
resolve GitHub linter issues

### DIFF
--- a/pkg/commands/pop/root.go
+++ b/pkg/commands/pop/root.go
@@ -49,6 +49,7 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	return nil
 }
 
+// Coordinates returns a stringified object of coordinate data.
 func Coordinates(c *fastly.Coordinates) string {
 	if c != nil {
 		return fmt.Sprintf(

--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/fastly/go-fastly/v9/fastly"
@@ -12,6 +13,9 @@ import (
 // mock, ignoring the token and endpoint. It should only be used for tests.
 func APIClient(a API) func(string, string, bool) (api.Interface, error) {
 	return func(token, endpoint string, debugMode bool) (api.Interface, error) {
+		fmt.Printf("token: %s\n", token)
+		fmt.Printf("endpoint: %s\n", endpoint)
+		fmt.Printf("debugMode: %t\n", debugMode)
 		return a, nil
 	}
 }
@@ -26,14 +30,18 @@ type HTTPClient struct {
 	Errors []error
 }
 
+// Get mocks a HTTP Client Get request.
 func (c HTTPClient) Get(p string, _ *fastly.RequestOptions) (*http.Response, error) {
+	fmt.Printf("p: %#v\n", p)
 	// IMPORTANT: Have to increment on defer as index is already 0 by this point.
 	// This is opposite to the Do() method which is -1 at the time it's called.
 	defer func() { c.Index++ }()
 	return c.Responses[c.Index], c.Errors[c.Index]
 }
 
+// Do mocks a HTTP Client Do operation.
 func (c HTTPClient) Do(r *http.Request) (*http.Response, error) {
+	fmt.Printf("r: %#v\n", r)
 	c.Index++
 	return c.Responses[c.Index], c.Errors[c.Index]
 }

--- a/pkg/testutil/args.go
+++ b/pkg/testutil/args.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
@@ -110,11 +111,14 @@ func MockGlobalData(args []string, stdout io.Writer) *global.Data {
 		Env:        config.Environment{},
 		ErrLog:     errors.Log,
 		ExecuteWasmTools: func(bin string, args []string) error {
+			fmt.Printf("bin: %s\n", bin)
+			fmt.Printf("args: %#v\n", args)
 			return nil
 		},
 		HTTPClient: &http.Client{Timeout: time.Second * 5},
 		Manifest:   &md,
 		Opener: func(input string) error {
+			fmt.Printf("%s\n", input)
 			return nil // no-op
 		},
 		Output: stdout,


### PR DESCRIPTION
**NOTE:** For the test/mock files I've decided not to _ the unused args but to print them as that information is useful when running tests (especially when there are test failures).