### PR TITLE
fix(compute/serve): avoid `text.Output` when dealing with large `bytes.Buffer`

### DIFF
--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -138,6 +138,9 @@ func (c *BuildCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		}
 	}(c.Globals.ErrLog)
 
+	if c.Globals.Verbose() {
+		text.Break(out)
+	}
 	err = spinner.Process(fmt.Sprintf("Verifying %s", manifestFilename), func(_ *text.SpinnerWrapper) error {
 		// The check for c.SkipChangeDir here is because we might need to attempt
 		// another read of the manifest file. To explain: if we're skipping the

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -615,7 +615,7 @@ func local(opts localOpts) error {
 		}
 
 		if opts.verbose {
-			text.Info(opts.out, "Watching files for changes (using --watch-dir=%s). To ignore certain files, define patterns within a .fastlyignore config file (uses .fastlyignore from --watch-dir).", root)
+			text.Info(opts.out, "Watching files for changes (using --watch-dir=%s). To ignore certain files, define patterns within a .fastlyignore config file (uses .fastlyignore from --watch-dir).\n\n", root)
 		}
 
 		gi := ignoreFiles(opts.watchDir)

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -809,7 +809,7 @@ func watchFiles(root string, gi *ignore.GitIgnore, verbose bool, s *fstexec.Stre
 
 	if verbose {
 		text.Output(out, "%s\n\n", text.BoldYellow("Watching..."))
-		text.Output(out, buf.String())
+		fmt.Fprintln(out, buf.String()) // IMPORTANT: Avoid text.Output() as it fails to render with large buffer.
 		text.Break(out)
 	}
 


### PR DESCRIPTION
**PROBLEM:**  
Rendering a large `bytes.Buffer` using `.String()` with `text.Output()` fails to render any output.

**SOLUTION:**  
Switch from `text.Output()` to `fmt.Fprintln()`.

**NOTES:**  
There is likely a bug in the underlying `text.Output()` implementation (as it has to parse line breaks and wrap the text at a predefined width) that makes it unsuitable for this particular output. Where as we only need a simple line-by-line output.