### PR TITLE
fix(compute/build): avoid persisting old metadata

### DIFF
--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -86,6 +86,12 @@ type BuildToolchain struct {
 
 // Build compiles the user's source code into a Wasm binary.
 func (bt BuildToolchain) Build() error {
+	// Make sure to delete any pre-existing binary otherwise prior metadata will
+	// continue to be persisted.
+	if _, err := os.Stat(binWasmPath); err == nil {
+		os.Remove(binWasmPath)
+	}
+
 	cmd, args := bt.buildFn(bt.buildScript)
 
 	if bt.verbose {


### PR DESCRIPTION
**Problem:** If you ever compiled a `main.wasm` binary with metadata, and then later compiled with metadata disabled, then the binary would continue to be annotated with the old metadata.
**Solution:** Completely remove the old `main.wasm` binary if it exists before re-compiling.