### PR TITLE
fix(compute/serve): avoid wasm validation when --file is set

### DIFF
--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -66,6 +66,7 @@ type BuildCommand struct {
 	MetadataDisable       bool
 	MetadataFilterEnvVars string
 	MetadataShow          bool
+	ServeFile             bool // skip checking for `binWasmPath` after build as --file might indicate a non-standard named wasm binary
 	SkipChangeDir         bool // set by parent composite commands (e.g. serve, publish)
 }
 

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -52,6 +52,7 @@ func NewAssemblyScript(
 		metadataFilterEnvVars: c.MetadataFilterEnvVars,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
+		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -83,6 +84,8 @@ type AssemblyScript struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
+	// serveFile indicates if --file was passed as part of `compute serve`.
+	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -155,6 +158,7 @@ func (a *AssemblyScript) Build() error {
 		nonInteractive:        a.nonInteractive,
 		out:                   a.output,
 		postBuild:             a.postBuild,
+		serveFile:             a.serveFile,
 		spinner:               a.spinner,
 		timeout:               a.timeout,
 		verbose:               a.verbose,

--- a/pkg/commands/compute/language_go.go
+++ b/pkg/commands/compute/language_go.go
@@ -53,6 +53,7 @@ func NewGo(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
+		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -93,6 +94,8 @@ type Go struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
+	// serveFile indicates if --file was passed as part of `compute serve`.
+	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -187,6 +190,7 @@ func (g *Go) Build() error {
 		nonInteractive:        g.nonInteractive,
 		out:                   g.output,
 		postBuild:             g.postBuild,
+		serveFile:             g.serveFile,
 		spinner:               g.spinner,
 		timeout:               g.timeout,
 		verbose:               g.verbose,

--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -56,6 +56,7 @@ func NewJavaScript(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
+		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -89,6 +90,8 @@ type JavaScript struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
+	// serveFile indicates if --file was passed as part of `compute serve`.
+	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -167,6 +170,7 @@ func (j *JavaScript) Build() error {
 		nonInteractive:        j.nonInteractive,
 		out:                   j.output,
 		postBuild:             j.postBuild,
+		serveFile:             j.serveFile,
 		spinner:               j.spinner,
 		timeout:               j.timeout,
 		verbose:               j.verbose,

--- a/pkg/commands/compute/language_other.go
+++ b/pkg/commands/compute/language_other.go
@@ -29,6 +29,7 @@ func NewOther(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
+		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -62,6 +63,8 @@ type Other struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
+	// serveFile indicates if --file was passed as part of `compute serve`.
+	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -96,6 +99,7 @@ func (o Other) Build() error {
 		nonInteractive:        o.nonInteractive,
 		out:                   o.output,
 		postBuild:             o.postBuild,
+		serveFile:             o.serveFile,
 		spinner:               o.spinner,
 		timeout:               o.timeout,
 		verbose:               o.verbose,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -62,6 +62,7 @@ func NewRust(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
+		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -101,6 +102,8 @@ type Rust struct {
 	postBuild string
 	// projectRoot is the root directory where the Cargo.toml is located.
 	projectRoot string
+	// serveFile indicates if --file was passed as part of `compute serve`.
+	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -172,6 +175,7 @@ func (r *Rust) Build() error {
 		nonInteractive:            r.nonInteractive,
 		out:                       r.output,
 		postBuild:                 r.postBuild,
+		serveFile:                 r.serveFile,
 		spinner:                   r.spinner,
 		timeout:                   r.timeout,
 		verbose:                   r.verbose,

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -83,7 +83,7 @@ func NewServeCommand(parent argparser.Registerer, g *global.Data, build *BuildCo
 	c.CmdClause.Flag("debug", "Run the server in Debug Adapter mode").Hidden().BoolVar(&c.debug)
 	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").Short('C').Action(c.dir.Set).StringVar(&c.dir.Value)
 	c.CmdClause.Flag("env", "The manifest environment config to use (e.g. 'stage' will attempt to read 'fastly.stage.toml')").Action(c.env.Set).StringVar(&c.env.Value)
-	c.CmdClause.Flag("file", "The Wasm file to run").Default("bin/main.wasm").StringVar(&c.file)
+	c.CmdClause.Flag("file", "The Wasm file to run (causes validation checks for ./bin/main.wasm to be skipped)").Default("bin/main.wasm").StringVar(&c.file)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("metadata-disable", "Disable Wasm binary metadata annotations").Action(c.metadataDisable.Set).BoolVar(&c.metadataDisable.Value)
@@ -271,6 +271,9 @@ func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 	}
 	if c.projectDir != "" {
 		c.build.SkipChangeDir = true // we've already changed directory
+	}
+	if c.file != "" {
+		c.build.ServeFile = true
 	}
 	return c.build.Exec(in, out)
 }


### PR DESCRIPTION
## Problem

A customer ran the `compute serve` command with a custom build script. 

The build script produced a non-standard wasm binary filename.

i.e. the file location was not `./bin/main.wasm` (which is the required naming format). 

The CLI's build logic correctly returns an error to suggest that the custom build script did not produce a `./bin/main.wasm`. 

The _problem_ is that the customer also had provided the `--file` flag to the `compute serve` command, which changes the `viceroy` binary invocation such that it will try to load a different wasm binary file. So the _intention_ is very much for the filename of the provided wasm binary to be non-standard (as the default value for `--file` is `./bin/main.wasm`).

## Solution

Track whether the `--file` flag was passed to `compute serve`, and if so, skip any validation steps for the wasm binary as they are not required with regard to the local server behaviour.