### PR TITLE
fix(stats/historical): avoid runtime SIGSEGV

### DIFF
--- a/pkg/commands/stats/historical.go
+++ b/pkg/commands/stats/historical.go
@@ -65,11 +65,19 @@ func (c *HistoricalCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := fastly.GetStatsInput{
-		By:      &c.by,
-		From:    &c.from,
-		Region:  &c.region,
 		Service: fastly.ToPointer(serviceID),
-		To:      &c.to,
+	}
+	if c.by != "" {
+		input.By = &c.by
+	}
+	if c.from != "" {
+		input.From = &c.from
+	}
+	if c.region != "" {
+		input.Region = &c.region
+	}
+	if c.to != "" {
+		input.To = &c.to
 	}
 
 	var envelope statsResponse


### PR DESCRIPTION
CLI was triggering a SIGSEGV panic whenever a flag was being passed (like `--from`, regardless of value)...

```
go run cmd/fastly/main.go stats historical --service-id <SOME_ID> --token $FASTLY_API_KEY --from '2024-03-20 12:00:00'
```

The fix was to change how the Kingpin package writes the flag value to memory.