### PR TITLE
fix(kvstore): delete all keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fastly/cli
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v9 v9.2.2
+	github.com/fastly/go-fastly/v9 v9.3.1
 	github.com/hashicorp/cap v0.6.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2 h1:S6Dco8FtAhEI/qkg/00H6RdEGC+MCy5GPiQ+xweNRFE=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v9 v9.2.2 h1:YNoinvf9vlPmsIbR6weT6XQ0l8nNPjS5DjC7ILwwaE8=
-github.com/fastly/go-fastly/v9 v9.2.2/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.3.1 h1:2UZUe8Kkz60aPrkDV82dpHkEqsT/J2qxOZxFhWEJJ2k=
+github.com/fastly/go-fastly/v9 v9.3.1/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/commands/kvstore/delete.go
+++ b/pkg/commands/kvstore/delete.go
@@ -19,11 +19,9 @@ type DeleteCommand struct {
 	argparser.Base
 	argparser.JSONOutput
 
-	batchSize    int
-	deleteAll    bool
-	poolSize     int
-	requestLimit int
-	Input        fastly.DeleteKVStoreInput
+	deleteAll bool
+	poolSize  int
+	Input     fastly.DeleteKVStoreInput
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -40,10 +38,8 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 	// Optional.
 	c.CmdClause.Flag("all", "Delete all entries within the store").Short('a').BoolVar(&c.deleteAll)
-	c.CmdClause.Flag("batch-size", "Splits each thread pool's work into nested concurrent batches (ignored when set without the --all flag)").Default(strconv.Itoa(kvstoreentry.DeleteKeysBatchSize)).Short('b').IntVar(&c.batchSize)
+	c.CmdClause.Flag("concurrency", "The thread pool size (ignored when set without the --all flag)").Default(strconv.Itoa(kvstoreentry.DeleteKeysPoolSize)).Short('r').IntVar(&c.poolSize)
 	c.RegisterFlagBool(c.JSONFlag()) // --json
-	c.CmdClause.Flag("pool-size", "The thread pool size, each thread handles a maximum of 1000 keys (ignored when set without the --all flag)").Default(strconv.Itoa(kvstoreentry.DeleteKeysPoolSize)).Short('c').IntVar(&c.poolSize)
-	c.CmdClause.Flag("request-limit", "The maximum number of API requests to allow (ignored when set without the --all flag)").Default(strconv.Itoa(kvstoreentry.DeleteKeysRequestLimit)).Short('r').IntVar(&c.requestLimit)
 	return &c
 }
 
@@ -58,11 +54,9 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 			Base: argparser.Base{
 				Globals: c.Globals,
 			},
-			BatchSize:    c.batchSize,
-			PoolSize:     c.poolSize,
-			DeleteAll:    c.deleteAll,
-			RequestLimit: c.requestLimit,
-			StoreID:      c.Input.StoreID,
+			PoolSize:  c.poolSize,
+			DeleteAll: c.deleteAll,
+			StoreID:   c.Input.StoreID,
 		}
 		if err := dc.DeleteAllKeys(out); err != nil {
 			return err

--- a/pkg/commands/kvstore/delete.go
+++ b/pkg/commands/kvstore/delete.go
@@ -46,12 +46,23 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 }
 
 // Exec invokes the application logic for the command.
-func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
+func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 	if c.Globals.Verbose() && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
 	if c.deleteAll {
+		if !c.Globals.Flags.AutoYes && !c.Globals.Flags.NonInteractive {
+			text.Warning(out, "This will delete ALL entries from your store!\n\n")
+			cont, err := text.AskYesNo(out, "Are you sure you want to continue? [y/N]: ", in)
+			if err != nil {
+				return err
+			}
+			if !cont {
+				return nil
+			}
+			text.Break(out)
+		}
 		dc := kvstoreentry.DeleteCommand{
 			Base: argparser.Base{
 				Globals: c.Globals,

--- a/pkg/commands/kvstore/delete.go
+++ b/pkg/commands/kvstore/delete.go
@@ -20,6 +20,7 @@ type DeleteCommand struct {
 	argparser.JSONOutput
 
 	deleteAll bool
+	maxErrors int
 	poolSize  int
 	Input     fastly.DeleteKVStoreInput
 }
@@ -40,6 +41,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.CmdClause.Flag("all", "Delete all entries within the store").Short('a').BoolVar(&c.deleteAll)
 	c.CmdClause.Flag("concurrency", "The thread pool size (ignored when set without the --all flag)").Default(strconv.Itoa(kvstoreentry.DeleteKeysPoolSize)).Short('r').IntVar(&c.poolSize)
 	c.RegisterFlagBool(c.JSONFlag()) // --json
+	c.CmdClause.Flag("max-errors", "The number of errors to accept before stopping (ignored when set without the --all flag)").Default(strconv.Itoa(kvstoreentry.DeleteKeysMaxErrors)).Short('m').IntVar(&c.maxErrors)
 	return &c
 }
 
@@ -54,8 +56,9 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 			Base: argparser.Base{
 				Globals: c.Globals,
 			},
-			PoolSize:  c.poolSize,
 			DeleteAll: c.deleteAll,
+			MaxErrors: c.maxErrors,
+			PoolSize:  c.poolSize,
 			StoreID:   c.Input.StoreID,
 		}
 		if err := dc.DeleteAllKeys(out); err != nil {

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -3,7 +3,7 @@ package kvstoreentry
 import (
 	"fmt"
 	"io"
-	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -15,19 +15,28 @@ import (
 	"github.com/fastly/cli/pkg/text"
 )
 
-// deleteKeysConcurrencyLimit is used to limit the concurrency when deleting ALL keys.
-// This is effectively the 'thread pool' size.
-const deleteKeysConcurrencyLimit int = 100
+// DeleteKeysPoolSize is the goroutine/thread-pool size when deleting ALL keys.
+const DeleteKeysPoolSize int = 1
+
+// DeleteKeysBatchSize is used to split the list of 1000 keys into batches.
+// NOTE: The Fastly API returns a maximum of 1000 results per page.
+const DeleteKeysBatchSize int = 50
+
+// DeleteKeysRequestLimit is used to restrict the number of open connections.
+const DeleteKeysRequestLimit int = 100
 
 // DeleteCommand calls the Fastly API to delete an kv store.
 type DeleteCommand struct {
 	argparser.Base
 	argparser.JSONOutput
+	key argparser.OptionalString
 
-	concurrency argparser.OptionalInt
-	deleteAll   bool
-	key         argparser.OptionalString
-	storeID     string
+	// NOTE: Public fields can be set via `kv-store delete`.
+	BatchSize    int
+	DeleteAll    bool
+	PoolSize     int
+	RequestLimit int
+	StoreID      string
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -40,13 +49,15 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.CmdClause = parent.Command("delete", "Delete a key")
 
 	// Required.
-	c.CmdClause.Flag("store-id", "Store ID").Short('s').Required().StringVar(&c.storeID)
+	c.CmdClause.Flag("store-id", "Store ID").Short('s').Required().StringVar(&c.StoreID)
 
 	// Optional.
-	c.CmdClause.Flag("all", "Delete all entries within the store").Short('a').BoolVar(&c.deleteAll)
-	c.CmdClause.Flag("concurrency", "Control thread pool size (ignored when set without the --all flag)").Short('c').Action(c.concurrency.Set).IntVar(&c.concurrency.Value)
+	c.CmdClause.Flag("all", "Delete all entries within the store").Short('a').BoolVar(&c.DeleteAll)
+	c.CmdClause.Flag("batch-size", "Splits each thread pool's work into nested concurrent batches (ignored when set without the --all flag)").Default(strconv.Itoa(DeleteKeysBatchSize)).Short('b').IntVar(&c.BatchSize)
 	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.CmdClause.Flag("key", "Key name").Short('k').Action(c.key.Set).StringVar(&c.key.Value)
+	c.CmdClause.Flag("request-limit", "The maximum number of API requests to allow (ignored when set without the --all flag)").Default(strconv.Itoa(DeleteKeysRequestLimit)).Short('c').IntVar(&c.RequestLimit)
+	c.CmdClause.Flag("pool-size", "The thread pool size, each thread handles a maximum of 1000 keys (ignored when set without the --all flag)").Default(strconv.Itoa(DeleteKeysPoolSize)).Short('r').IntVar(&c.PoolSize)
 
 	return &c
 }
@@ -57,17 +68,17 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 	// TODO: Support --json for bulk deletions.
-	if c.deleteAll && c.JSONOutput.Enabled {
+	if c.DeleteAll && c.JSONOutput.Enabled {
 		return fsterr.ErrInvalidDeleteAllJSONKeyCombo
 	}
-	if c.deleteAll && c.key.WasSet {
+	if c.DeleteAll && c.key.WasSet {
 		return fsterr.ErrInvalidDeleteAllKeyCombo
 	}
-	if !c.deleteAll && !c.key.WasSet {
+	if !c.DeleteAll && !c.key.WasSet {
 		return fsterr.ErrMissingDeleteAllKeyCombo
 	}
 
-	if c.deleteAll {
+	if c.DeleteAll {
 		if !c.Globals.Flags.AutoYes && !c.Globals.Flags.NonInteractive {
 			text.Warning(out, "This will delete ALL entries from your store!\n\n")
 			cont, err := text.AskYesNo(out, "Are you sure you want to continue? [y/N]: ", in)
@@ -79,11 +90,11 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 			}
 			text.Break(out)
 		}
-		return c.deleteAllKeys(out)
+		return c.DeleteAllKeys(out)
 	}
 
 	input := fastly.DeleteKVStoreKeyInput{
-		StoreID: c.storeID,
+		StoreID: c.StoreID,
 		Key:     c.key.Value,
 	}
 
@@ -100,33 +111,93 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 			Deleted bool   `json:"deleted"`
 		}{
 			c.key.Value,
-			c.storeID,
+			c.StoreID,
 			true,
 		}
 		_, err := c.WriteJSON(out, o)
 		return err
 	}
 
-	text.Success(out, "Deleted key '%s' from KV Store '%s'", c.key.Value, c.storeID)
+	text.Success(out, "Deleted key '%s' from KV Store '%s'", c.key.Value, c.StoreID)
 	return nil
 }
 
-func (c *DeleteCommand) deleteAllKeys(out io.Writer) error {
+// DeleteAllKeys deletes all keys within the specified KV Store.
+// NOTE: It's a public method as it can be called via `kv-store delete --all`.
+func (c *DeleteCommand) DeleteAllKeys(out io.Writer) error {
 	p := c.Globals.APIClient.NewListKVStoreKeysPaginator(&fastly.ListKVStoreKeysInput{
-		StoreID: c.storeID,
+		StoreID: c.StoreID,
 	})
 
 	var (
 		mu sync.Mutex
 		wg sync.WaitGroup
 	)
-	poolSize := deleteKeysConcurrencyLimit
-	if c.concurrency.WasSet {
-		poolSize = c.concurrency.Value
-	}
-	semaphore := make(chan struct{}, poolSize)
-
+	poolSemaphore := make(chan struct{}, c.PoolSize)
+	requestSemaphore := make(chan struct{}, c.RequestLimit)
+	failedKeysStopCh := make(chan struct{})
+	failedKeysCh := make(chan string, 1000)
 	failedKeys := []string{}
+
+	spinnerMessage := "deleting keys"
+	var spinner text.Spinner
+
+	if !c.Globals.Verbose() {
+		var err error
+		spinner, err = text.NewSpinner(out)
+		if err != nil {
+			return err
+		}
+		err = spinner.Start()
+		if err != nil {
+			return err
+		}
+		spinner.Message(spinnerMessage + "...")
+	}
+
+	// Rather than locking a mutex on every single error, we use a goroutine that
+	// pulls from the channel whenever it's full.
+	go func() {
+		for {
+			select {
+			case <-failedKeysStopCh:
+				return
+			default:
+				if len(failedKeysCh) == cap(failedKeysCh) {
+					mu.Lock()
+					for range len(failedKeysCh) {
+						failedKeys = append(failedKeys, <-failedKeysCh)
+					}
+					mu.Unlock()
+				}
+			}
+		}
+	}()
+
+	// EXAMPLE USAGE:
+	//
+	// --pool-size 1 --batch-size 50 --request-limit 50
+	//
+	// EXPLANATION: given 5000 keys.
+	//
+	// --pool-size 1
+	//
+	// We restrict the number of threads in the pool to 1.
+	// The Fastly API returns 1000 keys per pagination page.
+	// This means we only process 1000 keys at a time.
+	// The pool size, is how many 'pages' we'll process concurrently.
+	//
+	// --batch-size 50
+	//
+	// We divide up the 1000 keys into separate batches of 50.
+	// This would mean concurrently processing 1000 keys across 20 threads.
+	// So each thread would process 50 API requests across those 20 threads.
+	// e.g. 1000/50=20
+	//
+	// --request-limit 50
+	//
+	// Although we're allowing 20 threads to handle 50 requests per thread, we are
+	// actually restricting the total number of API requests to 50.
 
 	for p.Next() {
 		// IMPORTANT: Use copies of the keys when processing data concurrently.
@@ -134,36 +205,95 @@ func (c *DeleteCommand) deleteAllKeys(out io.Writer) error {
 		copiedKeys := make([]string, len(keys))
 		copy(copiedKeys, keys)
 
+		poolSemaphore <- struct{}{}
 		wg.Add(1)
+
 		go func(keys []string) {
-			semaphore <- struct{}{}
-			defer func() { <-semaphore }()
+			var wgBatch sync.WaitGroup
+			defer func() { <-poolSemaphore }()
 			defer wg.Done()
 
-			sort.Strings(keys)
-			for _, key := range keys {
-				text.Output(out, "Deleting key: %s", key)
-				err := c.Globals.APIClient.DeleteKVStoreKey(&fastly.DeleteKVStoreKeyInput{StoreID: c.storeID, Key: key})
-				if err != nil {
-					c.Globals.ErrLog.Add(fmt.Errorf("failed to delete key '%s': %s", key, err))
-					mu.Lock()
-					failedKeys = append(failedKeys, key)
-					mu.Unlock()
+			total := len(keys)
+			for i := 0; i < total; i += c.BatchSize {
+				end := i + c.BatchSize
+				if end > total {
+					end = total
 				}
+				seg := keys[i:end]
+
+				wgBatch.Add(1)
+				go func(seg []string) {
+					defer wgBatch.Done()
+					for _, key := range seg {
+						if c.Globals.Verbose() {
+							text.Output(out, "Deleting key: %s", key)
+						}
+						requestSemaphore <- struct{}{}
+						err := c.Globals.APIClient.DeleteKVStoreKey(&fastly.DeleteKVStoreKeyInput{StoreID: c.StoreID, Key: key})
+						<-requestSemaphore
+						if err != nil {
+							c.Globals.ErrLog.Add(fmt.Errorf("failed to delete key '%s': %s", key, err))
+							failedKeysCh <- key
+						}
+					}
+				}(seg)
 			}
-		}(keys)
+
+			// The paginator calls .Next() even when there are zero keys.
+			// So to avoid a deadlock we check the key length before waiting.
+			if total > 0 {
+				wgBatch.Wait()
+			}
+		}(copiedKeys)
 	}
 
 	wg.Wait()
-	close(semaphore)
+	close(poolSemaphore)
+	close(requestSemaphore)
+	close(failedKeysCh)
+	failedKeysStopCh <- struct{}{}
+	if len(failedKeysCh) > 0 {
+		for range len(failedKeysCh) {
+			failedKeys = append(failedKeys, <-failedKeysCh)
+		}
+	}
 
+	// The pagination might have an error, and so we'll make sure to print any
+	// failed API requests at the same time.
 	if err := p.Err(); err != nil {
-		return fmt.Errorf("failed to delete keys: %s", err)
-	}
-	if len(failedKeys) > 0 {
-		return fmt.Errorf("failed to delete keys: %s", strings.Join(failedKeys, ", "))
+		if len(failedKeys) > 0 {
+			err = fmt.Errorf("failed to delete keys (error: %s) when handling a pagination error: %w)", strings.Join(failedKeys, ", "), err)
+		}
+		retErr := fmt.Errorf("failed to paginate keys: %w", err)
+		if !c.Globals.Verbose() {
+			spinner.StopFailMessage(spinnerMessage)
+			spinErr := spinner.StopFail()
+			if spinErr != nil {
+				return fmt.Errorf("failed to stop spinner (error: %w) when handling the error: %w", spinErr, retErr)
+			}
+			return retErr
+		}
 	}
 
-	text.Success(out, "\nDeleted all keys from KV Store '%s'", c.storeID)
+	// There could be failed API requests even if the pagination didn't fail
+	if len(failedKeys) > 0 {
+		retErr := fmt.Errorf("failed to delete keys: %s", strings.Join(failedKeys, ", "))
+		if !c.Globals.Verbose() {
+			spinner.StopFailMessage(spinnerMessage)
+			spinErr := spinner.StopFail()
+			if spinErr != nil {
+				return fmt.Errorf("failed to stop spinner (error: %w) when handling the error: %w", spinErr, retErr)
+			}
+			return retErr
+		}
+		return retErr
+	}
+
+	if !c.Globals.Verbose() {
+		spinner.StopMessage(spinnerMessage)
+		_ = spinner.Stop()
+	}
+
+	text.Success(out, "\nDeleted all keys from KV Store '%s'", c.StoreID)
 	return nil
 }

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -181,7 +181,7 @@ func (c *DeleteCommand) DeleteAllKeys(out io.Writer) error {
 		if err != nil {
 			return fmt.Errorf("failed to stop spinner: %w", err)
 		}
-		text.Error(out, "failed to delete %d keys", len(errorsCh))
+		return fmt.Errorf("failed to delete %d keys", len(errorsCh))
 	} else {
 		spinner.StopMessage(spinnerMessage)
 		if err := spinner.Stop(); err != nil {

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -139,7 +139,7 @@ func (c *DeleteCommand) DeleteAllKeys(out io.Writer) error {
 	})
 
 	errorsCh := make(chan string, c.MaxErrors)
-	keysCh := make(chan string, 1000)
+	keysCh := make(chan string, 1000) // number correlates to pagination page size
 
 	var (
 		failedKeys []string

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/fastly/go-fastly/v9/fastly"
@@ -15,15 +14,9 @@ import (
 	"github.com/fastly/cli/pkg/text"
 )
 
-// DeleteKeysPoolSize is the goroutine/thread-pool size when deleting ALL keys.
-const DeleteKeysPoolSize int = 1
-
-// DeleteKeysBatchSize is used to split the list of 1000 keys into batches.
-// NOTE: The Fastly API returns a maximum of 1000 results per page.
-const DeleteKeysBatchSize int = 50
-
-// DeleteKeysRequestLimit is used to restrict the number of open connections.
-const DeleteKeysRequestLimit int = 100
+// DeleteKeysPoolSize is the goroutine/thread-pool size.
+// Each pool will take a 'key' from a channel and issue a DELETE request.
+const DeleteKeysPoolSize int = 100
 
 // DeleteCommand calls the Fastly API to delete an kv store.
 type DeleteCommand struct {
@@ -32,11 +25,9 @@ type DeleteCommand struct {
 	key argparser.OptionalString
 
 	// NOTE: Public fields can be set via `kv-store delete`.
-	BatchSize    int
-	DeleteAll    bool
-	PoolSize     int
-	RequestLimit int
-	StoreID      string
+	DeleteAll bool
+	PoolSize  int
+	StoreID   string
 }
 
 // NewDeleteCommand returns a usable command registered under the parent.
@@ -53,11 +44,9 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 	// Optional.
 	c.CmdClause.Flag("all", "Delete all entries within the store").Short('a').BoolVar(&c.DeleteAll)
-	c.CmdClause.Flag("batch-size", "Splits each thread pool's work into nested concurrent batches (ignored when set without the --all flag)").Default(strconv.Itoa(DeleteKeysBatchSize)).Short('b').IntVar(&c.BatchSize)
 	c.RegisterFlagBool(c.JSONFlag()) // --json
 	c.CmdClause.Flag("key", "Key name").Short('k').Action(c.key.Set).StringVar(&c.key.Value)
-	c.CmdClause.Flag("request-limit", "The maximum number of API requests to allow (ignored when set without the --all flag)").Default(strconv.Itoa(DeleteKeysRequestLimit)).Short('c').IntVar(&c.RequestLimit)
-	c.CmdClause.Flag("pool-size", "The thread pool size, each thread handles a maximum of 1000 keys (ignored when set without the --all flag)").Default(strconv.Itoa(DeleteKeysPoolSize)).Short('r').IntVar(&c.PoolSize)
+	c.CmdClause.Flag("concurrency", "The thread pool size (ignored when set without the --all flag)").Default(strconv.Itoa(DeleteKeysPoolSize)).Short('r').IntVar(&c.PoolSize)
 
 	return &c
 }
@@ -125,173 +114,79 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 // DeleteAllKeys deletes all keys within the specified KV Store.
 // NOTE: It's a public method as it can be called via `kv-store delete --all`.
 func (c *DeleteCommand) DeleteAllKeys(out io.Writer) error {
+	spinnerMessage := "Acquiring keys"
+	var spinner text.Spinner
+
+	var err error
+	spinner, err = text.NewSpinner(out)
+	if err != nil {
+		return err
+	}
+	err = spinner.Start()
+	if err != nil {
+		return err
+	}
+	spinner.Message(spinnerMessage + "...")
+
 	p := c.Globals.APIClient.NewListKVStoreKeysPaginator(&fastly.ListKVStoreKeysInput{
 		StoreID: c.StoreID,
 	})
 
-	var (
-		mu sync.Mutex
-		wg sync.WaitGroup
-	)
-	poolSemaphore := make(chan struct{}, c.PoolSize)
-	requestSemaphore := make(chan struct{}, c.RequestLimit)
-	failedKeysStopCh := make(chan struct{})
-	failedKeysCh := make(chan string, 1000)
-	failedKeys := []string{}
-
-	spinnerMessage := "deleting keys"
-	var spinner text.Spinner
-
-	if !c.Globals.Verbose() {
-		var err error
-		spinner, err = text.NewSpinner(out)
-		if err != nil {
-			return err
-		}
-		err = spinner.Start()
-		if err != nil {
-			return err
-		}
-		spinner.Message(spinnerMessage + "...")
-	}
-
-	// Rather than locking a mutex on every single error, we use a goroutine that
-	// pulls from the channel whenever it's full.
-	go func() {
-		for {
-			select {
-			case <-failedKeysStopCh:
-				return
-			default:
-				if len(failedKeysCh) == cap(failedKeysCh) {
-					mu.Lock()
-					for range len(failedKeysCh) {
-						failedKeys = append(failedKeys, <-failedKeysCh)
-					}
-					mu.Unlock()
-				}
-			}
-		}
-	}()
-
-	// EXAMPLE USAGE:
-	//
-	// --pool-size 1 --batch-size 50 --request-limit 50
-	//
-	// EXPLANATION: given 5000 keys.
-	//
-	// --pool-size 1
-	//
-	// We restrict the number of threads in the pool to 1.
-	// The Fastly API returns 1000 keys per pagination page.
-	// This means we only process 1000 keys at a time.
-	// The pool size, is how many 'pages' we'll process concurrently.
-	//
-	// --batch-size 50
-	//
-	// We divide up the 1000 keys into separate batches of 50.
-	// This would mean concurrently processing 1000 keys across 20 threads.
-	// So each thread would process 50 API requests across those 20 threads.
-	// e.g. 1000/50=20
-	//
-	// --request-limit 50
-	//
-	// Although we're allowing 20 threads to handle 50 requests per thread, we are
-	// actually restricting the total number of API requests to 50.
+	var keys []string
 
 	for p.Next() {
-		// IMPORTANT: Use copies of the keys when processing data concurrently.
-		keys := p.Keys()
-		copiedKeys := make([]string, len(keys))
-		copy(copiedKeys, keys)
+		keys = append(keys, p.Keys()...)
+	}
 
-		poolSemaphore <- struct{}{}
+	spinner.StopMessage(spinnerMessage)
+	if err := spinner.Stop(); err != nil {
+		return fmt.Errorf("failed to stop spinner: %w", err)
+	}
+
+	spinnerMessage = "Deleting keys"
+	err = spinner.Start()
+	if err != nil {
+		return err
+	}
+	spinner.Message(spinnerMessage + "...")
+
+	errorsCh := make(chan string, len(keys))
+	keysCh := make(chan string, len(keys))
+
+	for _, key := range keys {
+		keysCh <- key
+	}
+	close(keysCh)
+
+	var wg sync.WaitGroup
+
+	for range c.PoolSize {
 		wg.Add(1)
-
-		go func(keys []string) {
-			var wgBatch sync.WaitGroup
-			defer func() { <-poolSemaphore }()
+		go func() {
 			defer wg.Done()
-
-			total := len(keys)
-			for i := 0; i < total; i += c.BatchSize {
-				end := i + c.BatchSize
-				if end > total {
-					end = total
+			for key := range keysCh {
+				err := c.Globals.APIClient.DeleteKVStoreKey(&fastly.DeleteKVStoreKeyInput{StoreID: c.StoreID, Key: key})
+				if err != nil {
+					errorsCh <- key
 				}
-				seg := keys[i:end]
-
-				wgBatch.Add(1)
-				go func(seg []string) {
-					defer wgBatch.Done()
-					for _, key := range seg {
-						if c.Globals.Verbose() {
-							text.Output(out, "Deleting key: %s", key)
-						}
-						requestSemaphore <- struct{}{}
-						err := c.Globals.APIClient.DeleteKVStoreKey(&fastly.DeleteKVStoreKeyInput{StoreID: c.StoreID, Key: key})
-						<-requestSemaphore
-						if err != nil {
-							c.Globals.ErrLog.Add(fmt.Errorf("failed to delete key '%s': %s", key, err))
-							failedKeysCh <- key
-						}
-					}
-				}(seg)
 			}
-
-			// The paginator calls .Next() even when there are zero keys.
-			// So to avoid a deadlock we check the key length before waiting.
-			if total > 0 {
-				wgBatch.Wait()
-			}
-		}(copiedKeys)
+		}()
 	}
 
 	wg.Wait()
-	close(poolSemaphore)
-	close(requestSemaphore)
-	close(failedKeysCh)
-	failedKeysStopCh <- struct{}{}
-	if len(failedKeysCh) > 0 {
-		for range len(failedKeysCh) {
-			failedKeys = append(failedKeys, <-failedKeysCh)
-		}
-	}
 
-	// The pagination might have an error, and so we'll make sure to print any
-	// failed API requests at the same time.
-	if err := p.Err(); err != nil {
-		if len(failedKeys) > 0 {
-			err = fmt.Errorf("failed to delete keys (error: %s) when handling a pagination error: %w)", strings.Join(failedKeys, ", "), err)
+	if len(errorsCh) > 0 {
+		spinner.StopFailMessage(spinnerMessage)
+		err := spinner.StopFail()
+		if err != nil {
+			return fmt.Errorf("failed to stop spinner: %w", err)
 		}
-		retErr := fmt.Errorf("failed to paginate keys: %w", err)
-		if !c.Globals.Verbose() {
-			spinner.StopFailMessage(spinnerMessage)
-			spinErr := spinner.StopFail()
-			if spinErr != nil {
-				return fmt.Errorf("failed to stop spinner (error: %w) when handling the error: %w", spinErr, retErr)
-			}
-			return retErr
-		}
-	}
-
-	// There could be failed API requests even if the pagination didn't fail
-	if len(failedKeys) > 0 {
-		retErr := fmt.Errorf("failed to delete keys: %s", strings.Join(failedKeys, ", "))
-		if !c.Globals.Verbose() {
-			spinner.StopFailMessage(spinnerMessage)
-			spinErr := spinner.StopFail()
-			if spinErr != nil {
-				return fmt.Errorf("failed to stop spinner (error: %w) when handling the error: %w", spinErr, retErr)
-			}
-			return retErr
-		}
-		return retErr
-	}
-
-	if !c.Globals.Verbose() {
+		text.Error(out, "failed to delete %d keys", len(errorsCh))
+	} else {
 		spinner.StopMessage(spinnerMessage)
-		_ = spinner.Stop()
+		if err := spinner.Stop(); err != nil {
+			return fmt.Errorf("failed to stop spinner: %w", err)
+		}
 	}
 
 	text.Success(out, "\nDeleted all keys from KV Store '%s'", c.StoreID)

--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -213,12 +213,7 @@ func TestDeleteCommand(t *testing.T) {
 					return nil
 				},
 			},
-			WantOutput: fmt.Sprintf(`Deleting key: bar
-Deleting key: baz
-Deleting key: foo
-
-SUCCESS: Deleted all keys from KV Store '%s'
-`, storeID),
+			WantOutput: "deleting keys...",
 		},
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --all --auto-yes", kvstoreentry.RootName, storeID)),
@@ -233,7 +228,7 @@ SUCCESS: Deleted all keys from KV Store '%s'
 					return errors.New("whoops")
 				},
 			},
-			WantError: "failed to delete keys: bar, baz, foo",
+			WantError: "failed to delete keys: foo, bar, baz",
 		},
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --all --auto-yes", kvstoreentry.RootName, storeID)),
@@ -244,7 +239,7 @@ SUCCESS: Deleted all keys from KV Store '%s'
 					}
 				},
 			},
-			WantError: "failed to delete keys: whoops",
+			WantError: "failed to paginate keys: whoops",
 		},
 	}
 

--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -213,7 +213,7 @@ func TestDeleteCommand(t *testing.T) {
 					return nil
 				},
 			},
-			WantOutput: "deleting keys...",
+			WantOutput: "Deleting keys...",
 		},
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --all --auto-yes", kvstoreentry.RootName, storeID)),
@@ -228,18 +228,7 @@ func TestDeleteCommand(t *testing.T) {
 					return errors.New("whoops")
 				},
 			},
-			WantError: "failed to delete keys: foo, bar, baz",
-		},
-		{
-			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --all --auto-yes", kvstoreentry.RootName, storeID)),
-			API: mock.API{
-				NewListKVStoreKeysPaginatorFn: func(i *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
-					return &mockKVStoresEntriesPaginator{
-						err: errors.New("whoops"),
-					}
-				},
-			},
-			WantError: "failed to paginate keys: whoops",
+			WantError: "failed to delete 3 keys",
 		},
 	}
 

--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -45,7 +45,7 @@ func TestCreateCommand(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: testutil.Args(fmt.Sprintf("%s create --store-id %s --key %s --value %s", kvstoreentry.RootName, storeID, itemKey, itemValue)),
 				API: mock.API{
-					InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+					InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 						return errors.New("invalid request")
 					},
 				},
@@ -56,7 +56,7 @@ func TestCreateCommand(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: testutil.Args(fmt.Sprintf("%s create --store-id %s --key %s --value %s", kvstoreentry.RootName, storeID, itemKey, itemValue)),
 				API: mock.API{
-					InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+					InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 						return nil
 					},
 				},
@@ -67,7 +67,7 @@ func TestCreateCommand(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: testutil.Args(fmt.Sprintf("%s create --store-id %s --key %s --value %s --json", kvstoreentry.RootName, storeID, itemKey, itemValue)),
 				API: mock.API{
-					InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+					InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 						return nil
 					},
 				},
@@ -79,7 +79,7 @@ func TestCreateCommand(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: testutil.Args(fmt.Sprintf("%s create --store-id %s --stdin", kvstoreentry.RootName, storeID)),
 				API: mock.API{
-					BatchModifyKVStoreKeyFn: func(i *fastly.BatchModifyKVStoreKeyInput) error {
+					BatchModifyKVStoreKeyFn: func(_ *fastly.BatchModifyKVStoreKeyInput) error {
 						return nil
 					},
 				},
@@ -90,7 +90,7 @@ func TestCreateCommand(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: testutil.Args(fmt.Sprintf("%s create --store-id %s --file %s", kvstoreentry.RootName, storeID, filepath.Join("testdata", "data.json"))),
 				API: mock.API{
-					BatchModifyKVStoreKeyFn: func(i *fastly.BatchModifyKVStoreKeyInput) error {
+					BatchModifyKVStoreKeyFn: func(_ *fastly.BatchModifyKVStoreKeyInput) error {
 						return nil
 					},
 				},
@@ -103,7 +103,7 @@ func TestCreateCommand(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: testutil.Args(fmt.Sprintf("%s create --store-id %s --dir %s", kvstoreentry.RootName, storeID, filepath.Join("testdata", "example"))),
 				API: mock.API{
-					InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+					InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 						return nil
 					},
 				},
@@ -116,7 +116,7 @@ func TestCreateCommand(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: testutil.Args(fmt.Sprintf("%s create --store-id %s --dir %s --dir-allow-hidden", kvstoreentry.RootName, storeID, filepath.Join("testdata", "example"))),
 				API: mock.API{
-					InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+					InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 						return nil
 					},
 				},
@@ -176,7 +176,7 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --key %s", kvstoreentry.RootName, storeID, itemKey)),
 			API: mock.API{
-				DeleteKVStoreKeyFn: func(i *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return errors.New("invalid request")
 				},
 			},
@@ -185,7 +185,7 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --key %s", kvstoreentry.RootName, storeID, itemKey)),
 			API: mock.API{
-				DeleteKVStoreKeyFn: func(i *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -194,7 +194,7 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --key %s --json", kvstoreentry.RootName, storeID, itemKey)),
 			API: mock.API{
-				DeleteKVStoreKeyFn: func(i *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -203,13 +203,13 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --all --auto-yes", kvstoreentry.RootName, storeID)),
 			API: mock.API{
-				NewListKVStoreKeysPaginatorFn: func(i *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
+				NewListKVStoreKeysPaginatorFn: func(_ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
 					return &mockKVStoresEntriesPaginator{
 						next: true,
 						keys: []string{"foo", "bar", "baz"},
 					}
 				},
-				DeleteKVStoreKeyFn: func(i *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -218,13 +218,13 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s delete --store-id %s --all --auto-yes", kvstoreentry.RootName, storeID)),
 			API: mock.API{
-				NewListKVStoreKeysPaginatorFn: func(i *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
+				NewListKVStoreKeysPaginatorFn: func(_ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
 					return &mockKVStoresEntriesPaginator{
 						next: true,
 						keys: []string{"foo", "bar", "baz"},
 					}
 				},
-				DeleteKVStoreKeyFn: func(i *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return errors.New("whoops")
 				},
 			},
@@ -264,7 +264,7 @@ func TestDescribeCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s describe --store-id %s --key %s", kvstoreentry.RootName, storeID, itemKey)),
 			API: mock.API{
-				GetKVStoreKeyFn: func(i *fastly.GetKVStoreKeyInput) (string, error) {
+				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
 					return "", errors.New("invalid request")
 				},
 			},
@@ -273,7 +273,7 @@ func TestDescribeCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s describe --store-id %s --key %s", kvstoreentry.RootName, storeID, itemKey)),
 			API: mock.API{
-				GetKVStoreKeyFn: func(i *fastly.GetKVStoreKeyInput) (string, error) {
+				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
 					return itemValue, nil
 				},
 			},
@@ -282,7 +282,7 @@ func TestDescribeCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s describe --store-id %s --key %s --json", kvstoreentry.RootName, storeID, itemKey)),
 			API: mock.API{
-				GetKVStoreKeyFn: func(i *fastly.GetKVStoreKeyInput) (string, error) {
+				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
 					return itemValue, nil
 				},
 			},
@@ -322,7 +322,7 @@ func TestListCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s list --store-id %s", kvstoreentry.RootName, storeID)),
 			API: mock.API{
-				ListKVStoreKeysFn: func(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -331,7 +331,7 @@ func TestListCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s list --store-id %s", kvstoreentry.RootName, storeID)),
 			API: mock.API{
-				ListKVStoreKeysFn: func(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return &fastly.ListKVStoreKeysResponse{Data: testItems}, nil
 				},
 			},
@@ -340,7 +340,7 @@ func TestListCommand(t *testing.T) {
 		{
 			Args: testutil.Args(fmt.Sprintf("%s list --store-id %s --json", kvstoreentry.RootName, storeID)),
 			API: mock.API{
-				ListKVStoreKeysFn: func(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return &fastly.ListKVStoreKeysResponse{Data: testItems}, nil
 				},
 			},


### PR DESCRIPTION
This PR fixes the performance issues with deleting all keys from a KV Store and requires https://github.com/fastly/go-fastly/releases/tag/v9.3.1

This PR also adds support for configuring the deletion of keys via the `fastly kv-store delete --all` command (as customers didn't expect to find that behaviour inside of `fastly kv-store-entry delete --all`)