### PR TITLE
Add support for specifying location when creating KV stores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v9 v9.2.2
+	github.com/fastly/go-fastly/v9 v9.3.0
 	github.com/hashicorp/cap v0.6.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v9 v9.3.0
+	github.com/fastly/go-fastly/v9 v9.3.1
 	github.com/hashicorp/cap v0.6.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2 h1:S6Dco8FtAhEI/qkg/00H6RdEGC+MCy5GPiQ+xweNRFE=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v9 v9.2.2 h1:YNoinvf9vlPmsIbR6weT6XQ0l8nNPjS5DjC7ILwwaE8=
-github.com/fastly/go-fastly/v9 v9.2.2/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.3.0 h1:n5TYhp6GBkHebqL8A/BqoW+yxQfwOyzPvHPF1yEibbA=
+github.com/fastly/go-fastly/v9 v9.3.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2 h1:S6Dco8FtAhEI/qkg/00H6RdEGC+MCy5GPiQ+xweNRFE=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v9 v9.3.0 h1:n5TYhp6GBkHebqL8A/BqoW+yxQfwOyzPvHPF1yEibbA=
-github.com/fastly/go-fastly/v9 v9.3.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/go-fastly/v9 v9.3.1 h1:2UZUe8Kkz60aPrkDV82dpHkEqsT/J2qxOZxFhWEJJ2k=
 github.com/fastly/go-fastly/v9 v9.3.1/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2 h1:S
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
 github.com/fastly/go-fastly/v9 v9.3.0 h1:n5TYhp6GBkHebqL8A/BqoW+yxQfwOyzPvHPF1yEibbA=
 github.com/fastly/go-fastly/v9 v9.3.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.3.1 h1:2UZUe8Kkz60aPrkDV82dpHkEqsT/J2qxOZxFhWEJJ2k=
+github.com/fastly/go-fastly/v9 v9.3.1/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/commands/kvstore/create.go
+++ b/pkg/commands/kvstore/create.go
@@ -19,6 +19,9 @@ type CreateCommand struct {
 	Input fastly.CreateKVStoreInput
 }
 
+// locations is a list of supported regional location options.
+var locations = []string{"US", "EU", "ASIA", "AUS"}
+
 // NewCreateCommand returns a usable command registered under the parent.
 func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateCommand {
 	c := CreateCommand{
@@ -28,6 +31,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	}
 	c.CmdClause = parent.Command("create", "Create a KV Store")
 	c.CmdClause.Flag("name", "Name of KV Store").Short('n').Required().StringVar(&c.Input.Name)
+	c.CmdClause.Flag("location", "Regional location of KV Store").Short('l').HintOptions(locations...).EnumVar(&c.Input.Location, locations...)
 	c.RegisterFlagBool(c.JSONFlag()) // --json
 	return &c
 }

--- a/pkg/commands/kvstore/create.go
+++ b/pkg/commands/kvstore/create.go
@@ -29,10 +29,12 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 			Globals: g,
 		},
 	}
+
 	c.CmdClause = parent.Command("create", "Create a KV Store")
-	c.CmdClause.Flag("name", "Name of KV Store").Short('n').Required().StringVar(&c.Input.Name)
-	c.CmdClause.Flag("location", "Regional location of KV Store").Short('l').HintOptions(locations...).EnumVar(&c.Input.Location, locations...)
 	c.RegisterFlagBool(c.JSONFlag()) // --json
+	c.CmdClause.Flag("location", "Regional location of KV Store").Short('l').HintOptions(locations...).EnumVar(&c.Input.Location, locations...)
+	c.CmdClause.Flag("name", "Name of KV Store").Short('n').Required().StringVar(&c.Input.Name)
+
 	return &c
 }
 

--- a/pkg/commands/kvstore/kvstore_test.go
+++ b/pkg/commands/kvstore/kvstore_test.go
@@ -73,6 +73,8 @@ func TestCreateStoreCommand(t *testing.T) {
 			}),
 		},
 		{
+			// NOTE: The following tests only validate support for the --location flag.
+			// Location/region indicators are not exposed for us to validate.
 			Args: testutil.Args(fmt.Sprintf("%s create --name %s --location %s", kvstore.RootName, storeName, storeLocation)),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
@@ -85,6 +87,8 @@ func TestCreateStoreCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Created KV Store '%s' (%s)", storeName, storeID),
 		},
 		{
+			// NOTE: The following tests only validate support for the --location flag.
+			// Location/region indicators are not exposed for us to validate.
 			Args: testutil.Args(fmt.Sprintf("%s create --name %s --location %s --json", kvstore.RootName, storeName, storeLocation)),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {

--- a/pkg/commands/kvstore/kvstore_test.go
+++ b/pkg/commands/kvstore/kvstore_test.go
@@ -21,8 +21,9 @@ import (
 
 func TestCreateStoreCommand(t *testing.T) {
 	const (
-		storeName = "test123"
-		storeID   = "store-id-123"
+		storeName     = "test123"
+		storeLocation = "EU"
+		storeID       = "store-id-123"
 	)
 	now := time.Now()
 
@@ -54,6 +55,37 @@ func TestCreateStoreCommand(t *testing.T) {
 		},
 		{
 			Args: testutil.Args(fmt.Sprintf("%s create --name %s --json", kvstore.RootName, storeName)),
+			API: mock.API{
+				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+					return &fastly.KVStore{
+						StoreID:   storeID,
+						Name:      i.Name,
+						CreatedAt: &now,
+						UpdatedAt: &now,
+					}, nil
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(&fastly.KVStore{
+				StoreID:   storeID,
+				Name:      storeName,
+				CreatedAt: &now,
+				UpdatedAt: &now,
+			}),
+		},
+		{
+			Args: testutil.Args(fmt.Sprintf("%s create --name %s --location %s", kvstore.RootName, storeName, storeLocation)),
+			API: mock.API{
+				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+					return &fastly.KVStore{
+						StoreID: storeID,
+						Name:    i.Name,
+					}, nil
+				},
+			},
+			WantOutput: fstfmt.Success("Created KV Store '%s' (%s)", storeName, storeID),
+		},
+		{
+			Args: testutil.Args(fmt.Sprintf("%s create --name %s --location %s --json", kvstore.RootName, storeName, storeLocation)),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{


### PR DESCRIPTION
:wave: This PR adds the ability to specify the regional location when creating a new KV store using the Fastly CLI.

Changes made:

- Update go-fastly to 9.3.0
- Add a new `location` flag to the fastly kvstore create command. Allows specifying the region from a list of supported locations (US, EU, ASIA, AUS).
- Add new test cases to validate creating a KV store with a specific location.