### PR TITLE
feat(compute/serve): support arbitrary arguments to Viceroy

### DIFF
--- a/pkg/commands/compute/compute_test.go
+++ b/pkg/commands/compute/compute_test.go
@@ -104,6 +104,7 @@ func TestFlagDivergenceServe(t *testing.T) {
 		"profile-guest",
 		"profile-guest-dir",
 		"skip-build",
+		"viceroy-args",
 		"viceroy-check",
 		"viceroy-path",
 		"watch",


### PR DESCRIPTION
This is done via the `--viceroy-args` parameter, e.g.,

  `fastly compute serve --viceroy-args="--unknown-import-behavior=zero-or-null"`