### PR TITLE
Update tinygo version used in tests

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -88,7 +88,7 @@ jobs:
     needs: [config]
     strategy:
       matrix:
-        tinygo-version: [0.27.0]
+        tinygo-version: [0.31.2]
         go-version: [1.22.x]
         node-version: [18]
         platform: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
Versions of tinygo before 0.31 do not have precompiled darwin-arm64
binaries. To continue using macos-latest runners, we need to update.
