### PR TITLE
Pass a cert-file argument instead of full cert blob.

### DIFF
--- a/pkg/commands/tls/custom/certificate/create.go
+++ b/pkg/commands/tls/custom/certificate/create.go
@@ -1,7 +1,10 @@
 package certificate
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/fastly/go-fastly/v9/fastly"
 
@@ -16,8 +19,10 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.CmdClause = parent.Command("create", "Create a TLS certificate").Alias("add")
 	c.Globals = g
 
-	// Required.
-	c.CmdClause.Flag("cert-blob", "The PEM-formatted certificate blob").Required().StringVar(&c.certBlob)
+	// Required
+	// cert-blob and cert-path are mutually exclusive. One is required.
+	c.CmdClause.Flag("cert-blob", "The PEM-formatted certificate blob, mutually exclusive with --cert-path").StringVar(&c.certBlob)
+	c.CmdClause.Flag("cert-path", "Filepath to a PEM-formatted certificate, mutually exclusive with --cert-blob").StringVar(&c.certPath)
 
 	// Optional.
 	c.CmdClause.Flag("id", "Alphanumeric string identifying a TLS certificate").StringVar(&c.id)
@@ -31,13 +36,17 @@ type CreateCommand struct {
 	argparser.Base
 
 	certBlob string
+	certPath string
 	id       string
 	name     string
 }
 
 // Exec invokes the application logic for the command.
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
-	input := c.constructInput()
+	input, err := c.constructInput()
+	if err != nil {
+		return err
+	}
 
 	r, err := c.Globals.APIClient.CreateCustomTLSCertificate(input)
 	if err != nil {
@@ -53,16 +62,42 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
-func (c *CreateCommand) constructInput() *fastly.CreateCustomTLSCertificateInput {
+func (c *CreateCommand) constructInput() (*fastly.CreateCustomTLSCertificateInput, error) {
 	var input fastly.CreateCustomTLSCertificateInput
+
+	if c.certPath == "" && c.certBlob == "" {
+		return nil, fmt.Errorf("neither --cert-path or --cert-blob provided, one must be provided")
+	}
+
+	if c.certPath != "" && c.certBlob != "" {
+		return nil, fmt.Errorf("cert-path and cert-blob provided, only one can be specified")
+	}
 
 	if c.id != "" {
 		input.ID = c.id
 	}
-	input.CertBlob = c.certBlob
+
+	if c.certBlob != "" {
+		input.CertBlob = c.certBlob
+	}
+
+	if c.certPath != "" {
+		path, err := filepath.Abs(c.certPath)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing cert-path '%s': %q", c.certPath, err)
+		}
+
+		data, err := os.ReadFile(path) // #nosec
+		if err != nil {
+			return nil, fmt.Errorf("error reading cert-path '%s': %q", c.certPath, err)
+		}
+
+		input.CertBlob = string(data)
+	}
+
 	if c.name != "" {
 		input.Name = c.name
 	}
 
-	return &input
+	return &input, nil
 }

--- a/pkg/commands/tls/custom/certificate/testdata/certificate.crt
+++ b/pkg/commands/tls/custom/certificate/testdata/certificate.crt
@@ -1,0 +1,1 @@
+this is a fake cert


### PR DESCRIPTION
WIP, needs help!

Preliminary work in progress to allow a user to specify a filename for their custom cert. I've tested it manually and now I want some good tests to verify that the cli reads the file and passes it to the API.

I'm having trouble with figuring out how to get the contents of the certblob that is passed to the mock api and verifying it is correct. Line 75 in  `pkg/commands/tls/custom/certificate/certificate_test.go` shows where the value can be read, but afaict there's no access to the testcase object.

I'd love some help/advice on what the best way to do this is, I'm still new to Golang, especially wrt tests!