### PR TITLE
feat(compute): notify the API of progress to update the UI

### DIFF
--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -2241,7 +2241,6 @@ func TestDeploy(t *testing.T) {
 }
 
 func TestDeploy_ActivateBeacon(t *testing.T) {
-	//
 	// We're going to chdir to a deploy environment,
 	// so save the PWD to return to, afterwards.
 	pwd, err := os.Getwd()
@@ -2285,7 +2284,7 @@ func TestDeploy_ActivateBeacon(t *testing.T) {
 		Status:     http.StatusText(http.StatusNoContent),
 		Body:       io.NopCloser(bytes.NewBufferString("")),
 	}, nil)
-	fmt.Printf("recording HTTP with...\n%#v\n", recordingHTTP)
+
 	manifestContent := `
 	name = "package"
 	manifest_version = 2

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -256,7 +256,6 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// that isn't natively supported by the platform.
 	if c.CloneFrom != "" {
 		if !isExistingService {
-			fmt.Printf("Fetching package from: %s\n", c.CloneFrom)
 			err = c.FetchPackageTemplate(branch, tag, file.Archives, spinner, out)
 			if err != nil {
 				c.Globals.ErrLog.AddWithContext(err, map[string]any{

--- a/pkg/internal/beacon/beacon.go
+++ b/pkg/internal/beacon/beacon.go
@@ -1,0 +1,54 @@
+package beacon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/fastly/cli/pkg/api/undocumented"
+	"github.com/fastly/cli/pkg/global"
+)
+
+const (
+	StatusSuccess = "success"
+	StatusFail    = "fail"
+)
+
+type Event struct {
+	Name    string         `json:"event"`
+	Status  string         `json:"status"`
+	Payload map[string]any `json:"payload"`
+}
+
+const beaconNotify = "/cli/%s/notify"
+
+func Notify(g *global.Data, serviceID string, e Event) error {
+	headers := []undocumented.HTTPHeader{
+		{
+			Key:   "Content-Type",
+			Value: "application/json",
+		},
+	}
+
+	body, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+
+	co := undocumented.CallOptions{
+		APIEndpoint: "https://fastly-notification-relay.edgecompute.app",
+		Path:        fmt.Sprintf(beaconNotify, serviceID),
+		Method:      http.MethodPost,
+		HTTPHeaders: headers,
+		HTTPClient:  g.HTTPClient,
+		Body:        bytes.NewReader(body),
+	}
+
+	_, err = undocumented.Call(co)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/internal/beacon/beacon.go
+++ b/pkg/internal/beacon/beacon.go
@@ -10,11 +10,14 @@ import (
 	"github.com/fastly/cli/pkg/global"
 )
 
+// Common event statuses or results.
 const (
 	StatusSuccess = "success"
 	StatusFail    = "fail"
 )
 
+// Event represents something that happened that we need to signal to
+// the notification relay.
 type Event struct {
 	Name    string         `json:"event"`
 	Status  string         `json:"status"`
@@ -23,6 +26,8 @@ type Event struct {
 
 const beaconNotify = "/cli/%s/notify"
 
+// Notify emits an Event for the given serviceID to the notification
+// relay.
 func Notify(g *global.Data, serviceID string, e Event) error {
 	headers := []undocumented.HTTPHeader{
 		{

--- a/pkg/internal/beacon/beacon_test.go
+++ b/pkg/internal/beacon/beacon_test.go
@@ -1,0 +1,63 @@
+package beacon_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/internal/beacon"
+	"github.com/fastly/cli/pkg/testutil"
+)
+
+func TestNotify(t *testing.T) {
+	args := testutil.Args("compute deploy")
+	out := bytes.NewBuffer(nil)
+	g := testutil.MockGlobalData(args, out)
+	m := &mockHTTPClient{
+		resp: &http.Response{
+			StatusCode: http.StatusNoContent,
+			Status:     http.StatusText(http.StatusNoContent),
+			Body:       io.NopCloser(strings.NewReader("")),
+		},
+	}
+	g.HTTPClient = m
+
+	err := beacon.Notify(g, "service-id", beacon.Event{
+		Name:   "test-event",
+		Status: beacon.StatusSuccess,
+	})
+
+	testutil.AssertNoError(t, err)
+	testutil.AssertEqual(t, "/cli/service-id/notify", m.req.URL.Path)
+	testutil.AssertEqual(t, "fastly-notification-relay.edgecompute.app", m.req.URL.Host)
+
+	rawData, err := io.ReadAll(m.req.Body)
+	testutil.AssertNoError(t, err)
+	defer m.req.Body.Close()
+
+	var data map[string]any
+	err = json.Unmarshal(rawData, &data)
+	testutil.AssertNoError(t, err)
+
+	name, ok := data["event"].(string)
+	testutil.AssertBool(t, true, ok)
+	testutil.AssertEqual(t, "test-event", name)
+
+	result, ok := data["status"].(string)
+	testutil.AssertBool(t, true, ok)
+	testutil.AssertEqual(t, "success", result)
+}
+
+type mockHTTPClient struct {
+	req  *http.Request
+	resp *http.Response
+	err  error
+}
+
+func (m *mockHTTPClient) Do(r *http.Request) (*http.Response, error) {
+	m.req = r
+	return m.resp, m.err
+}

--- a/pkg/internal/beacon/doc.go
+++ b/pkg/internal/beacon/doc.go
@@ -1,0 +1,4 @@
+// Package beacon sends notifications of events to the
+// fastly-notification-relay, which we use to synchronize state between
+// the UI and the CLI.
+package beacon

--- a/pkg/testutil/assert.go
+++ b/pkg/testutil/assert.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -119,5 +120,29 @@ func AssertPathContentFlag(flag string, wantError string, args []string, fixture
 				break
 			}
 		}
+	}
+}
+
+// Borrowed from https://github.com/stretchr/testify/blob/v1.9.0/assert/assertions.go#L778-L784
+func getLen(x any) (l int, ok bool) {
+	v := reflect.ValueOf(x)
+	defer func() {
+		ok = recover() == nil
+	}()
+	return v.Len(), true
+}
+
+// AssertLength fails a test scenario if the given slice or string does
+// not have the expected length.
+func AssertLength(t *testing.T, want int, have any) {
+	t.Helper()
+	l, ok := getLen(have)
+
+	if !ok {
+		t.Fatalf("cannot get len of type %T", have)
+	}
+
+	if l != want {
+		t.Fatalf("wanted %d elements, got %d (%#v)", want, l, have)
 	}
 }

--- a/pkg/testutil/http.go
+++ b/pkg/testutil/http.go
@@ -7,34 +7,38 @@ import (
 	"sync"
 )
 
-type HTTPResult struct {
+type httpResult struct {
 	Response *http.Response
 	Err      error
 }
 
-func (h *HTTPResult) IsZero() bool {
+func (h *httpResult) isZero() bool {
 	return h.Response == nil && h.Err == nil
 }
 
+// RecordingHTTPClient records all requests made through it and
+// returns pre-registered responses or errors in order.
 type RecordingHTTPClient struct {
 	requests     []http.Request
 	counter      int
 	mu           sync.Mutex
-	results      []HTTPResult
-	singleResult HTTPResult
+	results      []httpResult
+	singleResult httpResult
 }
 
+// NewRecordingHTTPClient returns an initialized RecordingHTTPClient.
 func NewRecordingHTTPClient() *RecordingHTTPClient {
 	return &RecordingHTTPClient{}
 }
 
+// Do implements the minimal surface area of net/http.Client.
 func (c *RecordingHTTPClient) Do(r *http.Request) (*http.Response, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.requests = append(c.requests, *r)
 
-	if !c.singleResult.IsZero() {
+	if !c.singleResult.isZero() {
 		return c.singleResult.Response, c.singleResult.Err
 	}
 
@@ -44,24 +48,32 @@ func (c *RecordingHTTPClient) Do(r *http.Request) (*http.Response, error) {
 	return resp.Response, resp.Err
 }
 
+// SingleResponse registers a response or error to use for all requests.
+// It takes precedence over any queued responses.
 func (c *RecordingHTTPClient) SingleResponse(resp *http.Response, err error) {
-	c.singleResult = HTTPResult{
+	c.singleResult = httpResult{
 		Response: resp,
 		Err:      err,
 	}
 }
 
+// QueueResponse sets the given response or error to be returned for
+// requests. Responses are returned for each request in the order they
+// are queued.
 func (c *RecordingHTTPClient) QueueResponse(resp *http.Response, err error) {
-	c.results = append(c.results, HTTPResult{
+	c.results = append(c.results, httpResult{
 		Response: resp,
 		Err:      err,
 	})
 }
 
+// GetRequests returns a slice of all the requests it has recorded.
 func (c *RecordingHTTPClient) GetRequests() []http.Request {
 	return c.requests
 }
 
+// GetRequest retrieves a specific request from the saved requests. It
+// is zero-indexed.
 func (c *RecordingHTTPClient) GetRequest(i int) (r http.Request, ok bool) {
 	if i < len(c.requests) {
 		return c.requests[i], true
@@ -69,6 +81,8 @@ func (c *RecordingHTTPClient) GetRequest(i int) (r http.Request, ok bool) {
 	return r, ok
 }
 
+// NewHTTPResponse fills in the boilerplate needed to create a minimal
+// *http.Response.
 func NewHTTPResponse(statusCode int, headers map[string]string, body io.ReadCloser) *http.Response {
 	if body == nil {
 		body = io.NopCloser(bytes.NewReader(nil))

--- a/pkg/testutil/http.go
+++ b/pkg/testutil/http.go
@@ -1,0 +1,86 @@
+package testutil
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"sync"
+)
+
+type HTTPResult struct {
+	Response *http.Response
+	Err      error
+}
+
+func (h *HTTPResult) IsZero() bool {
+	return h.Response == nil && h.Err == nil
+}
+
+type RecordingHTTPClient struct {
+	requests     []http.Request
+	counter      int
+	mu           sync.Mutex
+	results      []HTTPResult
+	singleResult HTTPResult
+}
+
+func NewRecordingHTTPClient() *RecordingHTTPClient {
+	return &RecordingHTTPClient{}
+}
+
+func (c *RecordingHTTPClient) Do(r *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.requests = append(c.requests, *r)
+
+	if !c.singleResult.IsZero() {
+		return c.singleResult.Response, c.singleResult.Err
+	}
+
+	curr := c.counter
+	resp := c.results[curr]
+	c.counter++
+	return resp.Response, resp.Err
+}
+
+func (c *RecordingHTTPClient) SingleResponse(resp *http.Response, err error) {
+	c.singleResult = HTTPResult{
+		Response: resp,
+		Err:      err,
+	}
+}
+
+func (c *RecordingHTTPClient) QueueResponse(resp *http.Response, err error) {
+	c.results = append(c.results, HTTPResult{
+		Response: resp,
+		Err:      err,
+	})
+}
+
+func (c *RecordingHTTPClient) GetRequests() []http.Request {
+	return c.requests
+}
+
+func (c *RecordingHTTPClient) GetRequest(i int) (r http.Request, ok bool) {
+	if i < len(c.requests) {
+		return c.requests[i], true
+	}
+	return r, ok
+}
+
+func NewHTTPResponse(statusCode int, headers map[string]string, body io.ReadCloser) *http.Response {
+	if body == nil {
+		body = io.NopCloser(bytes.NewReader(nil))
+	}
+	h := http.Header{}
+	for header, value := range headers {
+		h.Add(header, value)
+	}
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Body:       body,
+		Header:     h,
+	}
+}


### PR DESCRIPTION
Creates a new internal `beacon` package to send certain events and results back to the API so that we can update the UI based on actions from the CLI. We're adding these to `compute init` and `compute deploy` initially.

Not ready for review but wanted to get the full cross-platform test suite running.

TODO:
- [x] Fill in the rest of the `compute deploy` payload and test
- [x] Decide how/if to deal with errors
- [x] Add the beacon to `compute init`