### PR TITLE
fix(compute/rust) handling of 'cargo version' output

### DIFF
--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -312,8 +312,8 @@ func (r *Rust) toolchainConstraint() {
 	// #nosec
 	// nosemgrep
 	cmd := exec.Command(args[0], args[1:]...)
-	stdoutStderr, err := cmd.CombinedOutput()
-	output := string(stdoutStderr)
+	stdout, err := cmd.Output()
+	output := string(stdout)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
'cargo version' emits the version string to stdout, so the code should capture only stdout, and parse it for checking the ToolchainConstraint. Capturing stderr and including it in the parsing process can result in bogus version numbers being found and reported (as is happening right now when Rust 1.78 is used in a project directory where .cargo/config exists).