### PR TITLE
fix(compute/serve): skip build if `--file` set

### DIFF
--- a/pkg/commands/compute/build.go
+++ b/pkg/commands/compute/build.go
@@ -66,7 +66,6 @@ type BuildCommand struct {
 	MetadataDisable       bool
 	MetadataFilterEnvVars string
 	MetadataShow          bool
-	ServeFile             bool // skip checking for `binWasmPath` after build as --file might indicate a non-standard named wasm binary
 	SkipChangeDir         bool // set by parent composite commands (e.g. serve, publish)
 }
 

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -53,7 +53,6 @@ func NewAssemblyScript(
 		metadataFilterEnvVars: c.MetadataFilterEnvVars,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
-		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -85,8 +84,6 @@ type AssemblyScript struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
-	// serveFile indicates if --file was passed as part of `compute serve`.
-	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -159,7 +156,6 @@ func (a *AssemblyScript) Build() error {
 		nonInteractive:        a.nonInteractive,
 		out:                   a.output,
 		postBuild:             a.postBuild,
-		serveFile:             a.serveFile,
 		spinner:               a.spinner,
 		timeout:               a.timeout,
 		verbose:               a.verbose,

--- a/pkg/commands/compute/language_go.go
+++ b/pkg/commands/compute/language_go.go
@@ -53,7 +53,6 @@ func NewGo(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
-		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -94,8 +93,6 @@ type Go struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
-	// serveFile indicates if --file was passed as part of `compute serve`.
-	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -190,7 +187,6 @@ func (g *Go) Build() error {
 		nonInteractive:        g.nonInteractive,
 		out:                   g.output,
 		postBuild:             g.postBuild,
-		serveFile:             g.serveFile,
 		spinner:               g.spinner,
 		timeout:               g.timeout,
 		verbose:               g.verbose,

--- a/pkg/commands/compute/language_javascript.go
+++ b/pkg/commands/compute/language_javascript.go
@@ -57,7 +57,6 @@ func NewJavaScript(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
-		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -91,8 +90,6 @@ type JavaScript struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
-	// serveFile indicates if --file was passed as part of `compute serve`.
-	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -171,7 +168,6 @@ func (j *JavaScript) Build() error {
 		nonInteractive:        j.nonInteractive,
 		out:                   j.output,
 		postBuild:             j.postBuild,
-		serveFile:             j.serveFile,
 		spinner:               j.spinner,
 		timeout:               j.timeout,
 		verbose:               j.verbose,

--- a/pkg/commands/compute/language_other.go
+++ b/pkg/commands/compute/language_other.go
@@ -29,7 +29,6 @@ func NewOther(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
-		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -63,8 +62,6 @@ type Other struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
-	// serveFile indicates if --file was passed as part of `compute serve`.
-	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -99,7 +96,6 @@ func (o Other) Build() error {
 		nonInteractive:        o.nonInteractive,
 		out:                   o.output,
 		postBuild:             o.postBuild,
-		serveFile:             o.serveFile,
 		spinner:               o.spinner,
 		timeout:               o.timeout,
 		verbose:               o.verbose,

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -62,7 +62,6 @@ func NewRust(
 		nonInteractive:        c.Globals.Flags.NonInteractive,
 		output:                out,
 		postBuild:             c.Globals.Manifest.File.Scripts.PostBuild,
-		serveFile:             c.ServeFile,
 		spinner:               spinner,
 		timeout:               c.Flags.Timeout,
 		verbose:               c.Globals.Verbose(),
@@ -102,8 +101,6 @@ type Rust struct {
 	postBuild string
 	// projectRoot is the root directory where the Cargo.toml is located.
 	projectRoot string
-	// serveFile indicates if --file was passed as part of `compute serve`.
-	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -175,7 +172,6 @@ func (r *Rust) Build() error {
 		nonInteractive:            r.nonInteractive,
 		out:                       r.output,
 		postBuild:                 r.postBuild,
-		serveFile:                 r.serveFile,
 		spinner:                   r.spinner,
 		timeout:                   r.timeout,
 		verbose:                   r.verbose,

--- a/pkg/commands/compute/language_toolchain.go
+++ b/pkg/commands/compute/language_toolchain.go
@@ -76,8 +76,6 @@ type BuildToolchain struct {
 	// postBuild is a custom script executed after the build but before the Wasm
 	// binary is added to the .tar.gz archive.
 	postBuild string
-	// serveFile indicates if --file was passed as part of `compute serve`.
-	serveFile bool
 	// spinner is a terminal progress status indicator.
 	spinner text.Spinner
 	// timeout is the build execution threshold.
@@ -177,19 +175,15 @@ func (bt BuildToolchain) Build() error {
 		}
 	}
 
-	// We only validate the build output if --file isn't specified in the
-	// `compute serve` command.
-	if !bt.serveFile {
-		// IMPORTANT: The stat check MUST come after the internalPostBuildCallback.
-		// This is because for Rust it needs to move the binary first.
-		_, err = os.Stat(binWasmPath)
-		if err != nil {
-			return bt.handleError(err)
-		}
-		// NOTE: The logic for checking the Wasm binary is 'valid' is not exhaustive.
-		if err := bt.validateWasm(); err != nil {
-			return err
-		}
+	// IMPORTANT: The stat check MUST come after the internalPostBuildCallback.
+	// This is because for Rust it needs to move the binary first.
+	_, err = os.Stat(binWasmPath)
+	if err != nil {
+		return bt.handleError(err)
+	}
+	// NOTE: The logic for checking the Wasm binary is 'valid' is not exhaustive.
+	if err := bt.validateWasm(); err != nil {
+		return err
 	}
 
 	if bt.postBuild != "" {

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -592,6 +592,7 @@ func local(opts localOpts) error {
 		}
 		text.Output(opts.out, "%s: %s", text.BoldYellow("Manifest"), opts.manifestPath)
 		text.Output(opts.out, "%s: %s", text.BoldYellow("Wasm binary"), opts.file)
+		text.Output(opts.out, "%s: %s", text.BoldYellow("Viceroy command"), strings.Join(args, " "))
 		text.Output(opts.out, "%s: %s", text.BoldYellow("Viceroy binary"), opts.bin)
 
 		// gosec flagged this:

--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -64,7 +64,7 @@ type ServeCommand struct {
 	addr            string
 	debug           bool
 	env             argparser.OptionalString
-	file            string
+	file            argparser.OptionalString
 	profileGuest    bool
 	profileGuestDir argparser.OptionalString
 	projectDir      string
@@ -85,7 +85,7 @@ func NewServeCommand(parent argparser.Registerer, g *global.Data, build *BuildCo
 	c.CmdClause.Flag("debug", "Run the server in Debug Adapter mode").Hidden().BoolVar(&c.debug)
 	c.CmdClause.Flag("dir", "Project directory to build (default: current directory)").Short('C').Action(c.dir.Set).StringVar(&c.dir.Value)
 	c.CmdClause.Flag("env", "The manifest environment config to use (e.g. 'stage' will attempt to read 'fastly.stage.toml')").Action(c.env.Set).StringVar(&c.env.Value)
-	c.CmdClause.Flag("file", fmt.Sprintf("The Wasm file to run (causes validation checks for %s to be skipped)", binWasmPath)).Default(binWasmPath).StringVar(&c.file)
+	c.CmdClause.Flag("file", "The Wasm file to run (causes build process to be skipped)").Action(c.file.Set).StringVar(&c.file.Value)
 	c.CmdClause.Flag("include-source", "Include source code in built package").Action(c.includeSrc.Set).BoolVar(&c.includeSrc.Value)
 	c.CmdClause.Flag("language", "Language type").Action(c.lang.Set).StringVar(&c.lang.Value)
 	c.CmdClause.Flag("metadata-disable", "Disable Wasm binary metadata annotations").Action(c.metadataDisable.Set).BoolVar(&c.metadataDisable.Value)
@@ -145,7 +145,16 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 		manifestPath = filepath.Join(c.projectDir, manifestFilename)
 	}
 
-	if !c.skipBuild {
+	wasmBinaryToRun := binWasmPath
+	if c.file.WasSet {
+		wasmBinaryToRun = c.file.Value
+	}
+
+	// We skip the build if explicitly told to with --skip-build but also when the
+	// user sets --file to specify their own wasm binary to pass to Viceroy. This
+	// is typically for users who compile a Wasm binary using an unsupported
+	// programming language for the Fastly Compute platform.
+	if !c.skipBuild && !c.file.WasSet {
 		err = c.Build(in, out)
 		if err != nil {
 			return err
@@ -169,13 +178,16 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	// If the user doesn't set --skip-build then `compute serve` will call
 	// `compute build` and the logic there will update the manifest in-memory data
 	// with the relevant project directory and environment manifest content.
-	if c.skipBuild {
+	if c.skipBuild || c.file.WasSet {
 		err := c.Globals.Manifest.File.Read(manifestPath)
 		if err != nil {
 			return fmt.Errorf("failed to parse manifest '%s': %w", manifestPath, err)
 		}
 		c.ViceroyVersioner.SetRequestedVersion(c.Globals.Manifest.File.LocalServer.ViceroyVersion)
 		if c.Globals.Verbose() {
+			if c.skipBuild || c.file.WasSet {
+				text.Break(out)
+			}
 			text.Info(out, "Fastly manifest set to: %s\n\n", manifestPath)
 		}
 	}
@@ -210,13 +222,13 @@ func (c *ServeCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			debug:           c.debug,
 			errLog:          c.Globals.ErrLog,
 			extraArgs:       c.ViceroyBinExtraArgs,
-			file:            c.file,
 			manifestPath:    manifestPath,
 			out:             out,
 			profileGuest:    c.profileGuest,
 			profileGuestDir: c.profileGuestDir,
 			restarted:       restart,
 			verbose:         c.Globals.Verbose(),
+			wasmBinPath:     wasmBinaryToRun,
 			watch:           c.watch,
 			watchDir:        c.watchDir,
 		})
@@ -275,9 +287,6 @@ func (c *ServeCommand) Build(in io.Reader, out io.Writer) error {
 	}
 	if c.projectDir != "" {
 		c.build.SkipChangeDir = true // we've already changed directory
-	}
-	if c.file != "" {
-		c.build.ServeFile = true
 	}
 	return c.build.Exec(in, out)
 }
@@ -548,13 +557,13 @@ type localOpts struct {
 	debug           bool
 	errLog          fsterr.LogInterface
 	extraArgs       string
-	file            string
 	manifestPath    string
 	out             io.Writer
 	profileGuest    bool
 	profileGuestDir argparser.OptionalString
 	restarted       bool
 	verbose         bool
+	wasmBinPath     string
 	watch           bool
 	watchDir        argparser.OptionalString
 }
@@ -564,7 +573,7 @@ func local(opts localOpts) error {
 	// NOTE: Viceroy no longer displays errors unless in verbose mode.
 	// This can cause confusion for customers: https://github.com/fastly/cli/issues/913
 	// So regardless of CLI --verbose flag we'll always set verbose for Viceroy.
-	args := []string{"-v", "-C", opts.manifestPath, "--addr", opts.addr, opts.file}
+	args := []string{"-v", "-C", opts.manifestPath, "--addr", opts.addr, opts.wasmBinPath}
 
 	if opts.debug {
 		args = append(args, "--debug")
@@ -591,7 +600,7 @@ func local(opts localOpts) error {
 			text.Break(opts.out)
 		}
 		text.Output(opts.out, "%s: %s", text.BoldYellow("Manifest"), opts.manifestPath)
-		text.Output(opts.out, "%s: %s", text.BoldYellow("Wasm binary"), opts.file)
+		text.Output(opts.out, "%s: %s", text.BoldYellow("Wasm binary"), opts.wasmBinPath)
 		text.Output(opts.out, "%s: %s", text.BoldYellow("Viceroy command"), strings.Join(args, " "))
 		text.Output(opts.out, "%s: %s", text.BoldYellow("Viceroy binary"), opts.bin)
 


### PR DESCRIPTION
Fixes https://github.com/fastly/cli/issues/1198

The `compute build` command was being invoked even when the user passed their own Wasm binary via `compute serve --file <PATH/TO/WASM/BINARY>`. This is unnecessary because if you're passing `--file` then you're indicating that you're not using the Fastly CLI to compile your code as you already have a binary to be used from elsewhere (whether that's an unsupported language like Zig or you have a completely separate build step).

I've modified the `compute serve` command to skip the `compute build` if `--file` is set, and I've also removed some older code where (for some reason) when we _were_ running `compute build` (even though `compute serve --file` was set) we were passing through a flag to the `compute build` command to get it to skip validating the expected `./bin/main.wasm` output, which isn't needed anymore if we just skip the build process entirely.