### PR TITLE
add project-id to  gcs logging setting

### DIFF
--- a/pkg/commands/logging/gcs/create.go
+++ b/pkg/commands/logging/gcs/create.go
@@ -36,6 +36,7 @@ type CreateCommand struct {
 	Path              argparser.OptionalString
 	Period            argparser.OptionalInt
 	Placement         argparser.OptionalString
+	ProjectID         argparser.OptionalString
 	ResponseCondition argparser.OptionalString
 	SecretKey         argparser.OptionalString
 	TimestampFormat   argparser.OptionalString
@@ -75,6 +76,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	common.Path(c.CmdClause, &c.Path)
 	common.Period(c.CmdClause, &c.Period)
 	common.Placement(c.CmdClause, &c.Placement)
+	c.CmdClause.Flag("project-id", "The google project ID").Action(c.ProjectID.Set).StringVar(&c.ProjectID.Value)
 	common.ResponseCondition(c.CmdClause, &c.ResponseCondition)
 	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Action(c.SecretKey.Set).StringVar(&c.SecretKey.Value)
 	c.RegisterFlag(argparser.StringFlagOpts{
@@ -139,6 +141,9 @@ func (c *CreateCommand) ConstructInput(serviceID string, serviceVersion int) (*f
 	}
 	if c.Placement.WasSet {
 		input.Placement = &c.Placement.Value
+	}
+	if c.ProjectID.WasSet {
+		input.ProjectID = &c.ProjectID.Value
 	}
 	if c.ResponseCondition.WasSet {
 		input.ResponseCondition = &c.ResponseCondition.Value

--- a/pkg/commands/logging/gcs/describe.go
+++ b/pkg/commands/logging/gcs/describe.go
@@ -103,6 +103,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		"Name":               fastly.ToValue(o.Name),
 		"Path":               fastly.ToValue(o.Path),
 		"Period":             fastly.ToValue(o.Period),
+		"Project ID":         fastly.ToValue(o.ProjectID),
 		"Placement":          fastly.ToValue(o.Placement),
 		"Response condition": fastly.ToValue(o.ResponseCondition),
 		"Secret key":         fastly.ToValue(o.SecretKey),

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -33,6 +33,15 @@ func TestGCSCreate(t *testing.T) {
 			wantOutput: "Created GCS logging endpoint log (service 123 version 4)",
 		},
 		{
+			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --account-name service-account-id --project-id gcp-prj-id --period 86400 --autoclone"),
+			api: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				CreateGCSFn:    createGCSOK,
+			},
+			wantOutput: "Created GCS logging endpoint log (service 123 version 4)",
+		},
+		{
 			args: args("logging gcs create --service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --autoclone"),
 			api: mock.API{
 				ListVersionsFn: testutil.ListVersions,

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -437,6 +437,7 @@ Name: logs
 Path: logs/
 Period: 3600
 Placement: none
+Project ID: 
 Response condition: Prevent default logging
 Secret key: -----BEGIN RSA PRIVATE KEY-----foo
 Service ID: 123

--- a/pkg/commands/logging/gcs/update.go
+++ b/pkg/commands/logging/gcs/update.go
@@ -36,6 +36,7 @@ type UpdateCommand struct {
 	Path              argparser.OptionalString
 	Period            argparser.OptionalInt
 	Placement         argparser.OptionalString
+	ProjectID         argparser.OptionalString
 	ResponseCondition argparser.OptionalString
 	SecretKey         argparser.OptionalString
 	TimestampFormat   argparser.OptionalString
@@ -76,6 +77,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.CmdClause.Flag("path", "The path to upload logs to (default '/')").Action(c.Path.Set).StringVar(&c.Path.Value)
 	common.Period(c.CmdClause, &c.Period)
 	common.Placement(c.CmdClause, &c.Placement)
+	c.CmdClause.Flag("project-id", "The google project ID").Action(c.ProjectID.Set).StringVar(&c.ProjectID.Value)
 	common.ResponseCondition(c.CmdClause, &c.ResponseCondition)
 	c.CmdClause.Flag("secret-key", "Your GCS account secret key. The private_key field in your service account authentication JSON").Action(c.SecretKey.Set).StringVar(&c.SecretKey.Value)
 	c.RegisterFlag(argparser.StringFlagOpts{
@@ -135,6 +137,9 @@ func (c *UpdateCommand) ConstructInput(serviceID string, serviceVersion int) (*f
 	}
 	if c.Placement.WasSet {
 		input.Placement = &c.Placement.Value
+	}
+	if c.ProjectID.WasSet {
+		input.ProjectID = &c.ProjectID.Value
 	}
 	if c.ResponseCondition.WasSet {
 		input.ResponseCondition = &c.ResponseCondition.Value


### PR DESCRIPTION
Done following tests 

```
./fastly logging gcs create --name gcs4 \
--account-name test-account-id \
--bucket test-bucket-name \
--project-id test-project-id \
--path test-path \
--service-id $MY_SID --version $MY_VER --profile noguxun


./fastly logging gcs update --name gcs4 \
--project-id test-project-id-modified \
--path test-path-modified \
--service-id $MY_SID --version $MY_VER --profile noguxun


make test TEST_ARGS="-run TestGCSCreate ./pkg/commands/logging/gcs"
```