### PR TITLE
Various fixes to prepare for 10.10.0 release

### DIFF
--- a/.github/dependencies.txt
+++ b/.github/dependencies.txt
@@ -1,4 +1,4 @@
 github.com/goreleaser/goreleaser@latest
 github.com/mgechev/revive@latest
 github.com/securego/gosec/v2/cmd/gosec@latest
-honnef.co/go/tools/cmd/staticcheck@2023.1
+honnef.co/go/tools/cmd/staticcheck@2023.1.7

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -76,11 +76,9 @@ jobs:
       - name: "Run revive"
         run: make revive
         shell: bash
-      # FIXME: Put back staticcheck once it fixes https://github.com/dominikh/go-tools/issues/1496
-      #
-      # - name: "Static analysis check"
-      #   run: make staticcheck
-      #   shell: bash
+      - name: "Static analysis check"
+        run: make staticcheck
+        shell: bash
       - name: "Security audit"
         run: make gosec
         shell: bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 1. Ensure any relevant `FIXME` notes in the code are addressed (e.g. `FIXME: remove this feature before next major release`).
 1. Rebase latest remote main branch locally (`git pull --rebase origin main`).
 1. Ensure all analysis checks and tests are passing (`time TEST_COMPUTE_INIT=1 TEST_COMPUTE_BUILD=1 TEST_COMPUTE_DEPLOY=1 make all`).
-1. Ensure goreleaser builds locally (`make release GORELEASER_ARGS="--skip=validate --skip=post-hooks --clean"`).
+1. Ensure goreleaser builds locally (`make release GORELEASER_ARGS="--snapshot --skip=validate --skip=post-hooks --clean"`).
 1. Open a new PR to update CHANGELOG ([example](https://github.com/fastly/cli/pull/273))<sup>[1](#note1)</sup>.
 1. Merge CHANGELOG.
 1. Rebase latest remote main branch locally (`git pull --rebase origin main`).

--- a/pkg/commands/alerts/alerts_test.go
+++ b/pkg/commands/alerts/alerts_test.go
@@ -502,9 +502,7 @@ type flagList struct {
 
 func (t *flagList) Add(flag flag) *flagList {
 	newTuples := flagList{}
-	for i := range t.Flags {
-		newTuples.Flags = append(newTuples.Flags, t.Flags[i])
-	}
+	newTuples.Flags = append(newTuples.Flags, t.Flags...)
 	newTuples.Flags = append(newTuples.Flags, flag)
 	return &newTuples
 }

--- a/pkg/commands/alerts/common.go
+++ b/pkg/commands/alerts/common.go
@@ -8,11 +8,6 @@ import (
 	"github.com/fastly/go-fastly/v9/fastly"
 )
 
-const (
-	defaultEvaluationType   = "above_threshold"
-	defaultEvaluationPeriod = "5m"
-)
-
 // evaluationType is a list of supported evaluation types.
 var evaluationType = []string{"above_threshold", "all_above_threshold", "below_threshold", "percent_absolute", "percent_decrease", "percent_increase"}
 

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -362,7 +362,7 @@ func (r *Rust) checkCargoConfigFileName(rustVersion *semver.Version) error {
 
 	if c.Check(rustVersion) {
 		text.Warning(r.output, filenameMsg)
-		return fmt.Errorf("The build cannot proceed with Rust version '%s' as the file must be named .cargo/config.toml", rustVersion)
+		return fmt.Errorf("the build cannot proceed with Rust version '%s' as the file must be named .cargo/config.toml", rustVersion)
 	}
 
 	text.Warning(r.output, filenameMsg+". The file should be renamed to .cargo/config.toml to be compatible with Rust 1.78.0 or later\n\n")


### PR DESCRIPTION
* ci: re-enable staticcheck and update to 2023.1.7

* style(commands/alerts): fix linter issues

* style(compute/rust): fix linter issues

* doc(RELEASE.md): ensure that goreleaser test command works even if no tags are present