### PR TITLE
Handle Fastly API unresponsiveness Errors on Authentication

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -657,7 +657,7 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	}
 	// Set a more meaningful error message when Fastly servers are unresponsive
 	// check if the response code is a 500 or above
-	if resp.StatusCode >= 500 {
+	if resp.StatusCode >= http.StatusInternalServerError {
 		var body string // default to empty string if we fail to read the body
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("the Fastly servers are unresponsive, please check the Fastly Status page (https://fastlystatus.com) and reach out to support if the error persists (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, body)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -658,7 +658,7 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	// Set a more meaningful error message when Fastly servers are unresponsive
 	// check if the response code is a 500 or above
 	if resp.StatusCode >= 500 {
-		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %s, Error Message: %s)", resp.StatusCode, resp.Body)
+		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, resp.Body)
 	}
 
 	openIDConfig, err := io.ReadAll(resp.Body)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -655,6 +655,11 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	if err != nil {
 		return nil, fmt.Errorf("failed to request OpenID Connect .well-known metadata (%s): %w", metadataEndpoint, err)
 	}
+	// Set a more meaningful error message when Fastly servers are unresponsive
+	// check if the response code is a 500 or above
+	if resp.StatusCode >= 500 {
+		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %s, Error Message: %s)", resp.StatusCode, resp.Body)
+	}
 
 	openIDConfig, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -658,7 +658,9 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	// Set a more meaningful error message when Fastly servers are unresponsive
 	// check if the response code is a 500 or above
 	if resp.StatusCode >= 500 {
-		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, resp.Body)
+		var body string // default to empty string if we fail to read the body
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("the Fastly servers are unresponsive, please check the Fastly Status page (https://fastlystatus.com) and reach out to support if the error persists (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, body)
 	}
 
 	openIDConfig, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
When Fastly servers are unresponsive (indicated by a 5xx response), the CLI currently shows a cryptic error message due to unexpected values in the response body (e.g., unable to parse body as JSON).

The last incident caused the CLI to display:

> ERROR: failed to configure authentication processes: failed to unmarshal OpenID Connect .well-known metadata: invalid character 'I' looking for beginning of value

The 'I' referred to the "Internal Server Error" in the response body, which is unclear/unactionable from a user perspective.

This change introduces a validation to handle this specific scenario:

If the authentication request returns a 5xx status code, it is now recognized as an error. The CLI will display a more actionable message, informing clients that the error is likely due to an outage or incident on the Fastly side. Clients can then check the status page or contact support.

Context:
* https://github.com/fastly/cli/issues/1210
* https://www.fastlystatus.com/incident/376536