### PR TITLE
feat(app): improve error messaging when Fastly servers are unresponsive

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -657,7 +657,7 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	}
 	// Set a more meaningful error message when Fastly servers are unresponsive
 	// check if the response code is a 500 or above
-	if resp.StatusCode >= 500 {
+	if resp.StatusCode >= http.StatusInternalServerError {
 		var body string // default to empty string if we fail to read the body
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("the Fastly servers are unresponsive, please check the Fastly Status page (https://fastlystatus.com) and reach out to support if the error persists (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, body)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -658,7 +658,7 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	// Set a more meaningful error message when Fastly servers are unresponsive
 	// check if the response code is a 500 or above
 	if resp.StatusCode >= 500 {
-		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %s, Error Message: %s)", resp.StatusCode, resp.Body)
+		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, resp.Body)
 	}
 
 	openIDConfig, err := io.ReadAll(resp.Body)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -658,8 +658,8 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	// Set a more meaningful error message when Fastly servers are unresponsive
 	// check if the response code is a 500 or above
 	if resp.StatusCode >= http.StatusInternalServerError {
-		var body string // default to empty string if we fail to read the body
-		body, _ := io.ReadAll(resp.Body)
+		var body []byte
+		body, _ = io.ReadAll(resp.Body) // default to empty string if we fail to read the body
 		return nil, fmt.Errorf("the Fastly servers are unresponsive, please check the Fastly Status page (https://fastlystatus.com) and reach out to support if the error persists (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, body)
 	}
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -655,6 +655,11 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	if err != nil {
 		return nil, fmt.Errorf("failed to request OpenID Connect .well-known metadata (%s): %w", metadataEndpoint, err)
 	}
+	// Set a more meaningful error message when Fastly servers are unresponsive
+	// check if the response code is a 500 or above
+	if resp.StatusCode >= 500 {
+		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %s, Error Message: %s)", resp.StatusCode, resp.Body)
+	}
 
 	openIDConfig, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -658,7 +658,9 @@ func configureAuth(apiEndpoint string, args []string, f config.File, c api.HTTPC
 	// Set a more meaningful error message when Fastly servers are unresponsive
 	// check if the response code is a 500 or above
 	if resp.StatusCode >= 500 {
-		return nil, fmt.Errorf("Fastly servers are unresponsive, please check the Status Page (https://fastlystatus.com) and reach out to support if the error persists — More Details: (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, resp.Body)
+		var body string // default to empty string if we fail to read the body
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("the Fastly servers are unresponsive, please check the Fastly Status page (https://fastlystatus.com) and reach out to support if the error persists (HTTP Status Code: %d, Error Message: %s)", resp.StatusCode, body)
 	}
 
 	openIDConfig, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
Thanks to @marceloboeira for the [first incarnation](https://github.com/fastly/cli/pull/1211) of these changes which I butchered via the GitHub UI.