### PR TITLE
feat(compute): clone starter kit source with init --from=serviceID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v9 v9.3.2
+	github.com/fastly/go-fastly/v9 v9.4.1-0.20240528142352-98043629c62b
 	github.com/hashicorp/cap v0.6.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v9 v9.4.1-0.20240528142352-98043629c62b
+	github.com/fastly/go-fastly/v9 v9.5.0
 	github.com/hashicorp/cap v0.6.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2 h1:S6Dco8FtAhEI/qkg/00H6RdEGC+MCy5GPiQ+xweNRFE=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v9 v9.4.1-0.20240528142352-98043629c62b h1:HQUIkh+eFQrba3FO3iXc9GmZh4eM+FOqbjIQVJE04fQ=
-github.com/fastly/go-fastly/v9 v9.4.1-0.20240528142352-98043629c62b/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.5.0 h1:FOZtOA7Dn9DgKQM2hOixP2oKF/49bA5Gf0MpH1eRVUI=
+github.com/fastly/go-fastly/v9 v9.5.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2 h1:S6Dco8FtAhEI/qkg/00H6RdEGC+MCy5GPiQ+xweNRFE=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v9 v9.3.2 h1:bchK1DbVf2P/3PT19Vtkx6rB9rxKPCJJs42/0Gbga0M=
-github.com/fastly/go-fastly/v9 v9.3.2/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.4.1-0.20240528142352-98043629c62b h1:HQUIkh+eFQrba3FO3iXc9GmZh4eM+FOqbjIQVJE04fQ=
+github.com/fastly/go-fastly/v9 v9.4.1-0.20240528142352-98043629c62b/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -336,7 +336,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 			if pack.Metadata != nil {
 				clonedFrom := fastly.ToValue(pack.Metadata.ClonedFrom)
 				if serviceVersion > 1 {
-					out.Write([]byte("Service has active versions, not fetching starter kit source"))
+					text.Info(out, "\nService has active versions, not fetching starter kit source\n\n")
 				} else if gitRepositoryRegEx.MatchString(clonedFrom) {
 					err = spinner.Process("Initializing file structure from selected starter kit", func(*text.SpinnerWrapper) error {
 						err := c.ClonePackageFromEndpoint(clonedFrom, "", "")

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -66,7 +66,7 @@ func NewInitCommand(parent argparser.Registerer, g *global.Data) *InitCommand {
 	c.CmdClause.Flag("author", "Author(s) of the package").Short('a').StringsVar(&g.Manifest.File.Authors)
 	c.CmdClause.Flag("branch", "Git branch name to clone from package template repository").Hidden().StringVar(&c.branch)
 	c.CmdClause.Flag("directory", "Destination to write the new package, defaulting to the current directory").Short('p').StringVar(&c.dir)
-	c.CmdClause.Flag("from", "Local project directory, or Git repository URL, or URL referencing a .zip/.tar.gz file, containing a package template").Short('f').StringVar(&c.CloneFrom)
+	c.CmdClause.Flag("from", "Local project directory, or Git repository URL, or URL referencing a .zip/.tar.gz file, containing a package template, or an existing service ID created from a starter kit").Short('f').StringVar(&c.CloneFrom)
 	c.CmdClause.Flag("language", "Language of the package").Short('l').HintOptions(Languages...).EnumVar(&c.language, Languages...)
 	c.CmdClause.Flag("tag", "Git tag name to clone from package template repository").Hidden().StringVar(&c.tag)
 

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -567,7 +567,7 @@ func TestInit_ExistingService(t *testing.T) {
 					},
 				}, nil
 			},
-			expectInOutput: []string{"Fetching package template..."},
+			expectInOutput: []string{"Initializing file structure from selected starter kit..."},
 		},
 		{
 			name: "service has an unreachable cloned_from value",
@@ -594,6 +594,32 @@ func TestInit_ExistingService(t *testing.T) {
 				}, nil
 			},
 			expectInError: "could not fetch original source code",
+		},
+		{
+			name: "service has active version greater than 1",
+			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			getServiceDetails: func(*fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
+				return &fastly.ServiceDetail{
+					ServiceID: serviceID,
+					Name:      fastly.NullString("cloned-service"),
+					Comment:   fastly.NullString(""),
+					Type:      fastly.NullString("wasm"),
+					ActiveVersion: &fastly.Version{
+						Number: fastly.ToPointer(2),
+					},
+				}, nil
+			},
+			getPackage: func(*fastly.GetPackageInput) (*fastly.Package, error) {
+				return &fastly.Package{
+					ServiceID: serviceID,
+					PackageID: fastly.NullString("hVPTrHgswnF5KFwFKoQz1f"),
+					Metadata: &fastly.PackageMetadata{
+						ClonedFrom: fastly.ToPointer("https://github.com/fastly/fake-template"),
+						Language:   fastly.ToPointer("rust"),
+					},
+				}, nil
+			},
+			expectInOutput: []string{"not fetching starter kit source"},
 		},
 	}
 


### PR DESCRIPTION
When we initialize an empty service with `compute init --from=<serviceID>`, we don't have the source code. This change attempts to look at the `cloned_from` metadata and use that to fetch the rest of the project.