### PR TITLE
 Adds --cert-path argument to tls-custom certificate update command to pass in a path to a certificate file

### DIFF
--- a/pkg/commands/tls/custom/certificate/certificate_test.go
+++ b/pkg/commands/tls/custom/certificate/certificate_test.go
@@ -255,22 +255,34 @@ func TestTLSCustomCertList(t *testing.T) {
 }
 
 func TestTLSCustomCertUpdate(t *testing.T) {
+	var content string
 	args := testutil.Args
 	scenarios := []testutil.TestScenario{
-		{
-			Name:      "validate missing --cert-blob flag",
-			Args:      args("tls-custom certificate update --id example"),
-			WantError: "required flag --cert-blob not provided",
-		},
 		{
 			Name:      validateMissingIDFlag,
 			Args:      args("tls-custom certificate update --cert-blob example"),
 			WantError: "required flag --id not provided",
 		},
 		{
+			Name:      "validate missing --cert-blob and --cert-path flags",
+			Args:      args("tls-custom certificate create"),
+			WantError: "neither --cert-path or --cert-blob provided, one must be provided",
+		},
+		{
+			Name:      "validate specifying both --cert-blob and --cert-path flags",
+			Args:      args("tls-custom certificate create --cert-blob foo --cert-path bar"),
+			WantError: "cert-path and cert-blob provided, only one can be specified",
+		},
+		{
+			Name:      "validate invalid --cert-path arg",
+			Args:      args("tls-custom certificate create --cert-path ............"),
+			WantError: "error reading cert-path",
+		},
+		{
 			Name: validateAPIError,
 			API: mock.API{
-				UpdateCustomTLSCertificateFn: func(_ *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+					content = certInput.CertBlob
 					return nil, testutil.Err
 				},
 			},
@@ -280,7 +292,8 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				UpdateCustomTLSCertificateFn: func(_ *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+					content = certInput.CertBlob
 					return &fastly.CustomTLSCertificate{
 						ID: mockResponseID,
 					}, nil
@@ -292,7 +305,8 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess + " with --name for different output",
 			API: mock.API{
-				UpdateCustomTLSCertificateFn: func(_ *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+					content = certInput.CertBlob
 					return &fastly.CustomTLSCertificate{
 						ID:   mockResponseID,
 						Name: "Updated",
@@ -301,6 +315,19 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 			},
 			Args:       args("tls-custom certificate update --cert-blob example --id example --name example"),
 			WantOutput: "Updated TLS Certificate 'Updated' (previously: 'example')",
+		},
+		{
+			Name: "validate custom cert is submitted",
+			API: mock.API{
+				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+					content = certInput.CertBlob
+					return &fastly.CustomTLSCertificate{
+						ID: mockResponseID,
+					}, nil
+				},
+			},
+			Args:       args("tls-custom certificate update --id example --cert-path ./testdata/certificate.crt"),
+			WantOutput: "SUCCESS: Updated TLS Certificate '123'",
 		},
 	}
 
@@ -316,6 +343,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 			err := app.Run(testcase.Args, nil)
 			testutil.AssertErrorContains(t, err, testcase.WantError)
 			testutil.AssertStringContains(t, stdout.String(), testcase.WantOutput)
+			testutil.AssertPathContentFlag("cert-path", testcase.WantError, testcase.Args, "certificate.crt", content, t)
 		})
 	}
 }

--- a/pkg/commands/tls/custom/certificate/update.go
+++ b/pkg/commands/tls/custom/certificate/update.go
@@ -1,7 +1,10 @@
 package certificate
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/fastly/go-fastly/v9/fastly"
 
@@ -16,8 +19,10 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.CmdClause = parent.Command("update", "Replace a TLS certificate with a newly reissued TLS certificate, or update a TLS certificate's name")
 	c.Globals = g
 
-	// Required.
-	c.CmdClause.Flag("cert-blob", "The PEM-formatted certificate blob").Required().StringVar(&c.certBlob)
+	// Required
+	// cert-blob and cert-path are mutually exclusive. One is required.
+	c.CmdClause.Flag("cert-blob", "The PEM-formatted certificate blob, mutually exclusive with --cert-path").StringVar(&c.certBlob)
+	c.CmdClause.Flag("cert-path", "Filepath to a PEM-formatted certificate, mutually exclusive with --cert-blob").StringVar(&c.certPath)
 	c.CmdClause.Flag("id", "Alphanumeric string identifying a TLS certificate").Required().StringVar(&c.id)
 
 	// Optional.
@@ -30,13 +35,17 @@ type UpdateCommand struct {
 	argparser.Base
 
 	certBlob string
+	certPath string
 	id       string
 	name     string
 }
 
 // Exec invokes the application logic for the command.
 func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
-	input := c.constructInput()
+	input, err := c.constructInput()
+	if err != nil {
+		return err
+	}
 
 	r, err := c.Globals.APIClient.UpdateCustomTLSCertificate(input)
 	if err != nil {
@@ -56,15 +65,40 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 }
 
 // constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
-func (c *UpdateCommand) constructInput() *fastly.UpdateCustomTLSCertificateInput {
+func (c *UpdateCommand) constructInput() (*fastly.UpdateCustomTLSCertificateInput, error) {
 	var input fastly.UpdateCustomTLSCertificateInput
 
+	if c.certPath == "" && c.certBlob == "" {
+		return nil, fmt.Errorf("neither --cert-path or --cert-blob provided, one must be provided")
+	}
+
+	if c.certPath != "" && c.certBlob != "" {
+		return nil, fmt.Errorf("cert-path and cert-blob provided, only one can be specified")
+	}
+
 	input.ID = c.id
-	input.CertBlob = c.certBlob
+
+	if c.certBlob != "" {
+		input.CertBlob = c.certBlob
+	}
+
+	if c.certPath != "" {
+		path, err := filepath.Abs(c.certPath)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing cert-path '%s': %q", c.certPath, err)
+		}
+
+		data, err := os.ReadFile(path) // #nosec
+		if err != nil {
+			return nil, fmt.Errorf("error reading cert-path '%s': %q", c.certPath, err)
+		}
+
+		input.CertBlob = string(data)
+	}
 
 	if c.name != "" {
 		input.Name = c.name
 	}
 
-	return &input
+	return &input, nil
 }


### PR DESCRIPTION
Adds --cert-path argument to `tls-custom certificate update` command to pass in a path to a certificate file
Previously users were required to pass in the full certificate contents via the --cert-blob argument, which is cumbersome and error-prone. This allows users to specify a path to a certificate making this command easier to use.

The new argument --cert-path is mutually exclusive with --cert-blob and the command will return an error if both are specified.

This is a near duplicate of https://github.com/fastly/cli/pull/1189 except for the `update` command vs `create`