### PR TITLE
fix(sso): update output to reflect default profile behaviour

### DIFF
--- a/pkg/commands/sso/sso_test.go
+++ b/pkg/commands/sso/sso_test.go
@@ -87,7 +87,7 @@ func TestSSO(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: args("sso"),
 				WantOutputs: []string{
-					"We're going to authenticate the 'user' profile.",
+					"We're going to authenticate the 'user' profile",
 					"We need to open your browser to authenticate you.",
 					"Session token (persisted to your local configuration): 123",
 				},
@@ -108,7 +108,7 @@ func TestSSO(t *testing.T) {
 			TestScenario: testutil.TestScenario{
 				Args: args("sso test_user"),
 				WantOutputs: []string{
-					"We're going to authenticate the 'test_user' profile.",
+					"We're going to authenticate the 'test_user' profile",
 					"We need to open your browser to authenticate you.",
 					"Session token (persisted to your local configuration): 123",
 				},


### PR DESCRIPTION
> **NOTE:** Remediation errors that explain how to create a profile were added in a separate PR (already merged).

This PR ensures we error early if `fastly sso` is called directly with an invalid profile name.

It also updates the output to reflect that the profile specified will become the new default profile.