### PR TITLE
pkg/errors: fix error message for missing KV store entry key flag

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -147,7 +147,7 @@ var ErrNoSTDINData = RemediationError{
 
 // ErrInvalidKVCombo means the user omitted either the key or value flag.
 var ErrInvalidKVCombo = RemediationError{
-	Inner:       fmt.Errorf("--key-name and --value are required"),
+	Inner:       fmt.Errorf("--key and --value are required"),
 	Remediation: "Please add both flags or alternatively use either --stdin or --file.",
 }
 


### PR DESCRIPTION
`--key-name` was renamed to `--key` but this error message was missed.
