### PR TITLE
fix(update): Ensure that the CLI binary will be executable after an update

### DIFF
--- a/pkg/commands/update/root.go
+++ b/pkg/commands/update/root.go
@@ -130,6 +130,15 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 				})
 				return fmt.Errorf("error 'copying' latest binary in place: %w (following an error 'moving': %w)", err, renameErr)
 			}
+
+			// G302 (CWE-276): Expect file permissions to be 0600 or less
+			// gosec flagged this:
+			// Disabling as the file was not executable without it and we need all users
+			// to be able to execute the binary.
+			/* #nosec */
+			if err := os.Chmod(currentBin, 0o755); err != nil {
+				return fmt.Errorf("failed to modify permissions on after 'copying' latest binary: %w", err)
+			}
 		}
 		return nil
 	})

--- a/pkg/commands/update/root.go
+++ b/pkg/commands/update/root.go
@@ -135,9 +135,10 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 			// gosec flagged this:
 			// Disabling as the file was not executable without it and we need all users
 			// to be able to execute the binary.
-			/* #nosec */
-			if err := os.Chmod(currentBin, 0o755); err != nil {
-				return fmt.Errorf("failed to modify permissions on after 'copying' latest binary: %w", err)
+			// #nosec
+			err := os.Chmod(currentBin, 0o755)
+			if err != nil {
+				return fmt.Errorf("failed to modify permissions after 'copying' latest binary: %w", err)
 			}
 		}
 		return nil

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -354,7 +354,7 @@ func extractBinary(archive, binaryName, dst, assetBase string, nested bool) (bin
 	// Disabling as the file was not executable without it and we need all users
 	// to be able to execute the binary.
 	/* #nosec */
-	err = os.Chmod(extractedBinary, 0o777)
+	err = os.Chmod(extractedBinary, 0o755)
 	if err != nil {
 		return "", fmt.Errorf("failed to modify permissions on extracted binary: %w", err)
 	}


### PR DESCRIPTION
When the downloaded CLI binary cannot be 'moved' into position (i.e. when it is located on a different filesystem from the target location), it is copied, but the permissions need to be set after the copy so that it will be executable.

Closes #1168.