### PR TITLE
fix(compute/serve): don't fail the serve workflow if github errors

### DIFF
--- a/pkg/commands/compute/serve.go
+++ b/pkg/commands/compute/serve.go
@@ -476,6 +476,8 @@ func (c *ServeCommand) InstallViceroy(
 		// IMPORTANT: We declare separately so to shadow `err` from parent scope.
 		var latestVersion string
 
+		// NOTE: We won't stop the user because although we can't request the latest
+		// version of the tool, the user may have a local version already installed.
 		err = spinner.Process("Checking latest Viceroy release", func(_ *text.SpinnerWrapper) error {
 			latestVersion, err = c.ViceroyVersioner.LatestVersion()
 			if err != nil {
@@ -487,7 +489,7 @@ func (c *ServeCommand) InstallViceroy(
 			return nil
 		})
 		if err != nil {
-			return err
+			return nil // short-circuit the rest of this function
 		}
 
 		viceroyConfig := c.Globals.Config.Viceroy


### PR DESCRIPTION
Some users on Darwin/AMD64 would see an error when running `compute serve`.

This would be when the CLI attempts to call the GitHub API to check for the latest version of the Viceroy tool.

Viceroy currently doesn't support this ARCH and so the endpoint would return a 5xx which the CLI would then return to the user and stop the overall process from running.

We shouldn't stop the process because the user could have a local version of Viceroy already installed and ready to use.