### PR TITLE
fix(all commands): --service-name flag should have priority. 

### DIFF
--- a/.tmpl/create.go
+++ b/.tmpl/create.go
@@ -42,7 +42,7 @@ func NewCreateCommand(parent argparser.Registerer, globals *config.Data, data ma
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/.tmpl/delete.go
+++ b/.tmpl/delete.go
@@ -42,7 +42,7 @@ func NewDeleteCommand(parent argparser.Registerer, globals *config.Data, data ma
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/.tmpl/describe.go
+++ b/.tmpl/describe.go
@@ -38,7 +38,7 @@ func NewDescribeCommand(parent argparser.Registerer, globals *config.Data, data 
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/.tmpl/list.go
+++ b/.tmpl/list.go
@@ -39,7 +39,7 @@ func NewListCommand(parent argparser.Registerer, globals *config.Data, data mani
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/.tmpl/update.go
+++ b/.tmpl/update.go
@@ -44,7 +44,7 @@ func NewUpdateCommand(parent argparser.Registerer, globals *config.Data, data ma
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/argparser/cmd.go
+++ b/pkg/argparser/cmd.go
@@ -156,7 +156,7 @@ func ServiceDetails(opts ServiceDetailsOpts) (serviceID string, serviceVersion *
 // NOTE: If Service Name is provided it overrides all other methods of
 // obtaining the Service ID.
 func ServiceID(serviceName OptionalServiceNameID, data manifest.Data, client api.Interface, li fsterr.LogInterface) (serviceID string, source manifest.Source, flag string, err error) {
-	flag = "--service-id"
+	flag = "--" + FlagServiceIDName
 	serviceID, source = data.ServiceID()
 
 	if serviceName.WasSet {
@@ -168,7 +168,7 @@ func ServiceID(serviceName OptionalServiceNameID, data manifest.Data, client api
 			return serviceID, source, flag, err
 		}
 
-		flag = "--service-name"
+		flag = "--" + FlagServiceName
 		serviceID, err = serviceName.Parse(client)
 		if err != nil {
 			if li != nil {

--- a/pkg/argparser/cmd.go
+++ b/pkg/argparser/cmd.go
@@ -153,15 +153,15 @@ func ServiceDetails(opts ServiceDetailsOpts) (serviceID string, serviceVersion *
 
 // ServiceID returns the Service ID and the source of that information.
 //
-// NOTE: If Service ID not provided then check if Service Name provided and use
-// that information to acquire the Service ID.
+// NOTE: If Service Name is provided it overrides all other methods of
+// obtaining the Service ID.
 func ServiceID(serviceName OptionalServiceNameID, data manifest.Data, client api.Interface, li fsterr.LogInterface) (serviceID string, source manifest.Source, flag string, err error) {
 	flag = "--service-id"
 	serviceID, source = data.ServiceID()
 
-	if source == manifest.SourceUndefined {
-		if !serviceName.WasSet {
-			err = fsterr.ErrNoServiceID
+	if serviceName.WasSet {
+		if source == manifest.SourceFlag {
+			err = fmt.Errorf("cannot specify both %s and %s", FlagServiceIDName, FlagServiceName)
 			if li != nil {
 				li.Add(err)
 			}
@@ -174,9 +174,13 @@ func ServiceID(serviceName OptionalServiceNameID, data manifest.Data, client api
 			if li != nil {
 				li.Add(err)
 			}
-		} else {
-			source = manifest.SourceFlag
+			return serviceID, source, flag, err
 		}
+		source = manifest.SourceFlag
+	}
+
+	if source == manifest.SourceUndefined {
+		err = fsterr.ErrNoServiceID
 	}
 
 	return serviceID, source, flag, err

--- a/pkg/argparser/common.go
+++ b/pkg/argparser/common.go
@@ -15,8 +15,8 @@ var (
 	FlagServiceIDDesc = "Service ID (falls back to FASTLY_SERVICE_ID, then fastly.toml)"
 	// FlagServiceName is the flag name.
 	FlagServiceName = "service-name"
-	// FlagServiceDesc is the flag description.
-	FlagServiceDesc = "The name of the service"
+	// FlagServiceNameDesc is the flag description.
+	FlagServiceNameDesc = "The name of the service"
 	// FlagVersionName is the flag name.
 	FlagVersionName = "version"
 	// FlagVersionDesc is the flag description.

--- a/pkg/commands/acl/create.go
+++ b/pkg/commands/acl/create.go
@@ -44,7 +44,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/acl/delete.go
+++ b/pkg/commands/acl/delete.go
@@ -43,7 +43,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/acl/describe.go
+++ b/pkg/commands/acl/describe.go
@@ -40,7 +40,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/acl/list.go
+++ b/pkg/commands/acl/list.go
@@ -40,7 +40,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/acl/update.go
+++ b/pkg/commands/acl/update.go
@@ -44,7 +44,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/aclentry/create.go
+++ b/pkg/commands/aclentry/create.go
@@ -35,7 +35,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("subnet", "Number of bits for the subnet mask applied to the IP address").Action(c.subnet.Set).IntVar(&c.subnet.Value)

--- a/pkg/commands/aclentry/delete.go
+++ b/pkg/commands/aclentry/delete.go
@@ -33,7 +33,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/aclentry/describe.go
+++ b/pkg/commands/aclentry/describe.go
@@ -35,7 +35,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/aclentry/list.go
+++ b/pkg/commands/aclentry/list.go
@@ -35,7 +35,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/aclentry/update.go
+++ b/pkg/commands/aclentry/update.go
@@ -40,7 +40,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("subnet", "Number of bits for the subnet mask applied to the IP address").Action(c.subnet.Set).IntVar(&c.subnet.Value)

--- a/pkg/commands/backend/create.go
+++ b/pkg/commands/backend/create.go
@@ -96,7 +96,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("shield", "The shield POP designated to reduce inbound load on this origin by serving the cached data to the rest of the network").Action(c.shield.Set).StringVar(&c.shield.Value)

--- a/pkg/commands/backend/delete.go
+++ b/pkg/commands/backend/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/backend/describe.go
+++ b/pkg/commands/backend/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/backend/list.go
+++ b/pkg/commands/backend/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/backend/update.go
+++ b/pkg/commands/backend/update.go
@@ -94,7 +94,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("shield", "The shield POP designated to reduce inbound load on this origin by serving the cached data to the rest of the network").Action(c.Shield.Set).StringVar(&c.Shield.Value)

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -77,7 +77,7 @@ func NewDeployCommand(parent argparser.Registerer, g *global.Data) *DeployComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -70,7 +70,7 @@ func NewPublishCommand(parent argparser.Registerer, g *global.Data, build *Build
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("status-check-code", "Set the expected status response for the service availability check to the root path").IntVar(&c.statusCheckCode)

--- a/pkg/commands/compute/update.go
+++ b/pkg/commands/compute/update.go
@@ -41,7 +41,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/dictionary/create.go
+++ b/pkg/commands/dictionary/create.go
@@ -57,7 +57,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("write-only", "Whether to mark this dictionary as write-only").Action(c.writeOnly.Set).BoolVar(&c.writeOnly.Value)

--- a/pkg/commands/dictionary/delete.go
+++ b/pkg/commands/dictionary/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/dictionary/describe.go
+++ b/pkg/commands/dictionary/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/dictionary/list.go
+++ b/pkg/commands/dictionary/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/dictionary/update.go
+++ b/pkg/commands/dictionary/update.go
@@ -60,7 +60,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("write-only", "Whether to mark this dictionary as write-only. Can be true or false (defaults to false)").Action(c.writeOnly.Set).StringVar(&c.writeOnly.Value)

--- a/pkg/commands/dictionaryentry/create.go
+++ b/pkg/commands/dictionaryentry/create.go
@@ -42,7 +42,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/dictionaryentry/delete.go
+++ b/pkg/commands/dictionaryentry/delete.go
@@ -40,7 +40,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/dictionaryentry/describe.go
+++ b/pkg/commands/dictionaryentry/describe.go
@@ -45,7 +45,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/dictionaryentry/list.go
+++ b/pkg/commands/dictionaryentry/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("sort", "Field on which to sort").Default("created").StringVar(&c.sort)

--- a/pkg/commands/dictionaryentry/update.go
+++ b/pkg/commands/dictionaryentry/update.go
@@ -47,7 +47,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("value", "Dictionary item value").StringVar(&c.Input.ItemValue)

--- a/pkg/commands/domain/create.go
+++ b/pkg/commands/domain/create.go
@@ -58,7 +58,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/domain/delete.go
+++ b/pkg/commands/domain/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/domain/describe.go
+++ b/pkg/commands/domain/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/domain/list.go
+++ b/pkg/commands/domain/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/domain/update.go
+++ b/pkg/commands/domain/update.go
@@ -58,7 +58,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/domain/validate.go
+++ b/pkg/commands/domain/validate.go
@@ -37,7 +37,7 @@ func NewValidateCommand(parent argparser.Registerer, g *global.Data) *ValidateCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/healthcheck/create.go
+++ b/pkg/commands/healthcheck/create.go
@@ -75,7 +75,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("threshold", "How many healthchecks must succeed to be considered healthy").Action(c.threshold.Set).IntVar(&c.threshold.Value)

--- a/pkg/commands/healthcheck/delete.go
+++ b/pkg/commands/healthcheck/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/healthcheck/describe.go
+++ b/pkg/commands/healthcheck/describe.go
@@ -51,7 +51,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/healthcheck/list.go
+++ b/pkg/commands/healthcheck/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/healthcheck/update.go
+++ b/pkg/commands/healthcheck/update.go
@@ -74,7 +74,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("threshold", "How many healthchecks must succeed to be considered healthy").Action(c.Threshold.Set).IntVar(&c.Threshold.Value)

--- a/pkg/commands/logging/azureblob/create.go
+++ b/pkg/commands/logging/azureblob/create.go
@@ -89,7 +89,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/azureblob/delete.go
+++ b/pkg/commands/logging/azureblob/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/azureblob/describe.go
+++ b/pkg/commands/logging/azureblob/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/azureblob/list.go
+++ b/pkg/commands/logging/azureblob/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/azureblob/update.go
+++ b/pkg/commands/logging/azureblob/update.go
@@ -92,7 +92,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/bigquery/create.go
+++ b/pkg/commands/logging/bigquery/create.go
@@ -78,7 +78,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("table", "Your BigQuery table").Action(c.Table.Set).StringVar(&c.Table.Value)

--- a/pkg/commands/logging/bigquery/delete.go
+++ b/pkg/commands/logging/bigquery/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/bigquery/describe.go
+++ b/pkg/commands/logging/bigquery/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/bigquery/list.go
+++ b/pkg/commands/logging/bigquery/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/bigquery/update.go
+++ b/pkg/commands/logging/bigquery/update.go
@@ -80,7 +80,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("table", "Your BigQuery table").Action(c.Table.Set).StringVar(&c.Table.Value)

--- a/pkg/commands/logging/cloudfiles/create.go
+++ b/pkg/commands/logging/cloudfiles/create.go
@@ -89,7 +89,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/cloudfiles/delete.go
+++ b/pkg/commands/logging/cloudfiles/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/cloudfiles/describe.go
+++ b/pkg/commands/logging/cloudfiles/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/cloudfiles/list.go
+++ b/pkg/commands/logging/cloudfiles/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/cloudfiles/update.go
+++ b/pkg/commands/logging/cloudfiles/update.go
@@ -90,7 +90,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/datadog/create.go
+++ b/pkg/commands/logging/datadog/create.go
@@ -71,7 +71,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/datadog/delete.go
+++ b/pkg/commands/logging/datadog/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/datadog/describe.go
+++ b/pkg/commands/logging/datadog/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/datadog/list.go
+++ b/pkg/commands/logging/datadog/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/datadog/update.go
+++ b/pkg/commands/logging/datadog/update.go
@@ -73,7 +73,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/digitalocean/create.go
+++ b/pkg/commands/logging/digitalocean/create.go
@@ -89,7 +89,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/digitalocean/delete.go
+++ b/pkg/commands/logging/digitalocean/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/digitalocean/describe.go
+++ b/pkg/commands/logging/digitalocean/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/digitalocean/list.go
+++ b/pkg/commands/logging/digitalocean/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/digitalocean/update.go
+++ b/pkg/commands/logging/digitalocean/update.go
@@ -90,7 +90,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/elasticsearch/create.go
+++ b/pkg/commands/logging/elasticsearch/create.go
@@ -82,7 +82,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/elasticsearch/delete.go
+++ b/pkg/commands/logging/elasticsearch/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/elasticsearch/describe.go
+++ b/pkg/commands/logging/elasticsearch/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/elasticsearch/list.go
+++ b/pkg/commands/logging/elasticsearch/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/elasticsearch/update.go
+++ b/pkg/commands/logging/elasticsearch/update.go
@@ -84,7 +84,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/ftp/create.go
+++ b/pkg/commands/logging/ftp/create.go
@@ -85,7 +85,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("user", "The username for the server (can be anonymous)").Action(c.Username.Set).StringVar(&c.Username.Value)

--- a/pkg/commands/logging/ftp/delete.go
+++ b/pkg/commands/logging/ftp/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/ftp/describe.go
+++ b/pkg/commands/logging/ftp/describe.go
@@ -39,7 +39,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/logging/ftp/list.go
+++ b/pkg/commands/logging/ftp/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/ftp/update.go
+++ b/pkg/commands/logging/ftp/update.go
@@ -87,7 +87,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/gcs/create.go
+++ b/pkg/commands/logging/gcs/create.go
@@ -88,7 +88,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/gcs/delete.go
+++ b/pkg/commands/logging/gcs/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/gcs/describe.go
+++ b/pkg/commands/logging/gcs/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/gcs/list.go
+++ b/pkg/commands/logging/gcs/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/gcs/update.go
+++ b/pkg/commands/logging/gcs/update.go
@@ -89,7 +89,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("user", "Your GCS service account email address. The client_email field in your service account authentication JSON").Action(c.User.Set).StringVar(&c.User.Value)

--- a/pkg/commands/logging/googlepubsub/create.go
+++ b/pkg/commands/logging/googlepubsub/create.go
@@ -75,7 +75,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("topic", "The Google Cloud Pub/Sub topic to which logs will be published").Action(c.Topic.Set).StringVar(&c.Topic.Value)

--- a/pkg/commands/logging/googlepubsub/delete.go
+++ b/pkg/commands/logging/googlepubsub/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/googlepubsub/describe.go
+++ b/pkg/commands/logging/googlepubsub/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/googlepubsub/list.go
+++ b/pkg/commands/logging/googlepubsub/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/googlepubsub/update.go
+++ b/pkg/commands/logging/googlepubsub/update.go
@@ -77,7 +77,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("topic", "The Google Cloud Pub/Sub topic to which logs will be published").Action(c.Topic.Set).StringVar(&c.Topic.Value)

--- a/pkg/commands/logging/heroku/create.go
+++ b/pkg/commands/logging/heroku/create.go
@@ -70,7 +70,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("url", "The url to stream logs to").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/commands/logging/heroku/delete.go
+++ b/pkg/commands/logging/heroku/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/heroku/describe.go
+++ b/pkg/commands/logging/heroku/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/heroku/list.go
+++ b/pkg/commands/logging/heroku/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/heroku/update.go
+++ b/pkg/commands/logging/heroku/update.go
@@ -72,7 +72,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("url", "The url to stream logs to").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/commands/logging/honeycomb/create.go
+++ b/pkg/commands/logging/honeycomb/create.go
@@ -71,7 +71,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/honeycomb/delete.go
+++ b/pkg/commands/logging/honeycomb/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/honeycomb/describe.go
+++ b/pkg/commands/logging/honeycomb/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/honeycomb/list.go
+++ b/pkg/commands/logging/honeycomb/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/honeycomb/update.go
+++ b/pkg/commands/logging/honeycomb/update.go
@@ -73,7 +73,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/https/create.go
+++ b/pkg/commands/logging/https/create.go
@@ -88,7 +88,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/https/delete.go
+++ b/pkg/commands/logging/https/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/https/describe.go
+++ b/pkg/commands/logging/https/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/https/list.go
+++ b/pkg/commands/logging/https/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/https/update.go
+++ b/pkg/commands/logging/https/update.go
@@ -90,7 +90,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/kafka/create.go
+++ b/pkg/commands/logging/kafka/create.go
@@ -90,7 +90,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/kafka/delete.go
+++ b/pkg/commands/logging/kafka/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/kafka/describe.go
+++ b/pkg/commands/logging/kafka/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/kafka/list.go
+++ b/pkg/commands/logging/kafka/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/kafka/update.go
+++ b/pkg/commands/logging/kafka/update.go
@@ -93,7 +93,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/kinesis/create.go
+++ b/pkg/commands/logging/kinesis/create.go
@@ -83,7 +83,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 

--- a/pkg/commands/logging/kinesis/delete.go
+++ b/pkg/commands/logging/kinesis/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/kinesis/describe.go
+++ b/pkg/commands/logging/kinesis/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/kinesis/list.go
+++ b/pkg/commands/logging/kinesis/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/kinesis/update.go
+++ b/pkg/commands/logging/kinesis/update.go
@@ -78,7 +78,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("stream-name", "Your Kinesis stream name").Action(c.StreamName.Set).StringVar(&c.StreamName.Value)

--- a/pkg/commands/logging/loggly/create.go
+++ b/pkg/commands/logging/loggly/create.go
@@ -69,7 +69,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/loggly/delete.go
+++ b/pkg/commands/logging/loggly/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/loggly/describe.go
+++ b/pkg/commands/logging/loggly/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/loggly/list.go
+++ b/pkg/commands/logging/loggly/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/loggly/update.go
+++ b/pkg/commands/logging/loggly/update.go
@@ -71,7 +71,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/logshuttle/create.go
+++ b/pkg/commands/logging/logshuttle/create.go
@@ -70,7 +70,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("url", "Your Log Shuttle endpoint url").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/commands/logging/logshuttle/delete.go
+++ b/pkg/commands/logging/logshuttle/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/logshuttle/describe.go
+++ b/pkg/commands/logging/logshuttle/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/logshuttle/list.go
+++ b/pkg/commands/logging/logshuttle/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/logshuttle/update.go
+++ b/pkg/commands/logging/logshuttle/update.go
@@ -72,7 +72,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("url", "Your Log Shuttle endpoint url").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/commands/logging/newrelic/create.go
+++ b/pkg/commands/logging/newrelic/create.go
@@ -69,7 +69,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelic/delete.go
+++ b/pkg/commands/logging/newrelic/delete.go
@@ -43,7 +43,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelic/describe.go
+++ b/pkg/commands/logging/newrelic/describe.go
@@ -40,7 +40,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelic/list.go
+++ b/pkg/commands/logging/newrelic/list.go
@@ -40,7 +40,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelic/update.go
+++ b/pkg/commands/logging/newrelic/update.go
@@ -70,7 +70,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelicotlp/create.go
+++ b/pkg/commands/logging/newrelicotlp/create.go
@@ -71,7 +71,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelicotlp/delete.go
+++ b/pkg/commands/logging/newrelicotlp/delete.go
@@ -43,7 +43,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelicotlp/describe.go
+++ b/pkg/commands/logging/newrelicotlp/describe.go
@@ -40,7 +40,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelicotlp/list.go
+++ b/pkg/commands/logging/newrelicotlp/list.go
@@ -40,7 +40,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/newrelicotlp/update.go
+++ b/pkg/commands/logging/newrelicotlp/update.go
@@ -72,7 +72,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/logging/openstack/create.go
+++ b/pkg/commands/logging/openstack/create.go
@@ -88,7 +88,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("url", "Your OpenStack auth url").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/commands/logging/openstack/delete.go
+++ b/pkg/commands/logging/openstack/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/openstack/describe.go
+++ b/pkg/commands/logging/openstack/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/openstack/list.go
+++ b/pkg/commands/logging/openstack/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/openstack/update.go
+++ b/pkg/commands/logging/openstack/update.go
@@ -88,7 +88,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/papertrail/create.go
+++ b/pkg/commands/logging/papertrail/create.go
@@ -71,7 +71,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/papertrail/delete.go
+++ b/pkg/commands/logging/papertrail/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/papertrail/describe.go
+++ b/pkg/commands/logging/papertrail/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/papertrail/list.go
+++ b/pkg/commands/logging/papertrail/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/papertrail/update.go
+++ b/pkg/commands/logging/papertrail/update.go
@@ -73,7 +73,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/s3/create.go
+++ b/pkg/commands/logging/s3/create.go
@@ -102,7 +102,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/s3/delete.go
+++ b/pkg/commands/logging/s3/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/s3/describe.go
+++ b/pkg/commands/logging/s3/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/s3/list.go
+++ b/pkg/commands/logging/s3/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/s3/update.go
+++ b/pkg/commands/logging/s3/update.go
@@ -101,7 +101,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TimestampFormat(c.CmdClause, &c.TimestampFormat)

--- a/pkg/commands/logging/scalyr/create.go
+++ b/pkg/commands/logging/scalyr/create.go
@@ -73,7 +73,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/scalyr/delete.go
+++ b/pkg/commands/logging/scalyr/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/scalyr/describe.go
+++ b/pkg/commands/logging/scalyr/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/scalyr/list.go
+++ b/pkg/commands/logging/scalyr/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/scalyr/update.go
+++ b/pkg/commands/logging/scalyr/update.go
@@ -75,7 +75,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/sftp/create.go
+++ b/pkg/commands/logging/sftp/create.go
@@ -91,7 +91,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("ssh-known-hosts", "A list of host keys for all hosts we can connect to over SFTP").Action(c.SSHKnownHosts.Set).StringVar(&c.SSHKnownHosts.Value)

--- a/pkg/commands/logging/sftp/delete.go
+++ b/pkg/commands/logging/sftp/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/sftp/describe.go
+++ b/pkg/commands/logging/sftp/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/sftp/list.go
+++ b/pkg/commands/logging/sftp/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/sftp/update.go
+++ b/pkg/commands/logging/sftp/update.go
@@ -92,7 +92,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("ssh-known-hosts", "A list of host keys for all hosts we can connect to over SFTP").Action(c.SSHKnownHosts.Set).StringVar(&c.SSHKnownHosts.Value)

--- a/pkg/commands/logging/splunk/create.go
+++ b/pkg/commands/logging/splunk/create.go
@@ -75,7 +75,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/splunk/delete.go
+++ b/pkg/commands/logging/splunk/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/splunk/describe.go
+++ b/pkg/commands/logging/splunk/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/splunk/list.go
+++ b/pkg/commands/logging/splunk/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/splunk/update.go
+++ b/pkg/commands/logging/splunk/update.go
@@ -76,7 +76,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/sumologic/create.go
+++ b/pkg/commands/logging/sumologic/create.go
@@ -70,7 +70,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("url", "The URL to POST to").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/commands/logging/sumologic/delete.go
+++ b/pkg/commands/logging/sumologic/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/sumologic/describe.go
+++ b/pkg/commands/logging/sumologic/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/sumologic/list.go
+++ b/pkg/commands/logging/sumologic/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/sumologic/update.go
+++ b/pkg/commands/logging/sumologic/update.go
@@ -72,7 +72,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	c.CmdClause.Flag("url", "The URL to POST to").Action(c.URL.Set).StringVar(&c.URL.Value)

--- a/pkg/commands/logging/syslog/create.go
+++ b/pkg/commands/logging/syslog/create.go
@@ -80,7 +80,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.TLSCACert(c.CmdClause, &c.TLSCACert)

--- a/pkg/commands/logging/syslog/delete.go
+++ b/pkg/commands/logging/syslog/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/syslog/describe.go
+++ b/pkg/commands/logging/syslog/describe.go
@@ -50,7 +50,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/syslog/list.go
+++ b/pkg/commands/logging/syslog/list.go
@@ -50,7 +50,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/logging/syslog/update.go
+++ b/pkg/commands/logging/syslog/update.go
@@ -81,7 +81,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.ServiceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.ServiceName.Value,
 	})
 	common.ResponseCondition(c.CmdClause, &c.ResponseCondition)

--- a/pkg/commands/logtail/root.go
+++ b/pkg/commands/logtail/root.go
@@ -58,7 +58,7 @@ func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("from", "From time, in Unix seconds").Int64Var(&c.cfg.from)

--- a/pkg/commands/products/root.go
+++ b/pkg/commands/products/root.go
@@ -56,7 +56,7 @@ func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/purge/root.go
+++ b/pkg/commands/purge/root.go
@@ -39,7 +39,7 @@ func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("soft", "A 'soft' purge marks affected objects as stale rather than making them inaccessible").BoolVar(&c.soft)

--- a/pkg/commands/ratelimit/create.go
+++ b/pkg/commands/ratelimit/create.go
@@ -86,7 +86,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("uri-dict-name", "The name of an Edge Dictionary containing URIs as keys").StringVar(&c.uriDictName)

--- a/pkg/commands/ratelimit/list.go
+++ b/pkg/commands/ratelimit/list.go
@@ -37,7 +37,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/resourcelink/create.go
+++ b/pkg/commands/resourcelink/create.go
@@ -61,7 +61,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagServiceName,
 		Action:      c.serviceName.Set,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/resourcelink/delete.go
+++ b/pkg/commands/resourcelink/delete.go
@@ -55,7 +55,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagServiceName,
 		Action:      c.serviceName.Set,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/resourcelink/describe.go
+++ b/pkg/commands/resourcelink/describe.go
@@ -54,7 +54,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagServiceName,
 		Action:      c.serviceName.Set,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/resourcelink/list.go
+++ b/pkg/commands/resourcelink/list.go
@@ -49,7 +49,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagServiceName,
 		Action:      c.serviceName.Set,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/resourcelink/update.go
+++ b/pkg/commands/resourcelink/update.go
@@ -66,7 +66,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagServiceName,
 		Action:      c.serviceName.Set,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/service/delete.go
+++ b/pkg/commands/service/delete.go
@@ -41,7 +41,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/service/describe.go
+++ b/pkg/commands/service/describe.go
@@ -43,7 +43,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/service/update.go
+++ b/pkg/commands/service/update.go
@@ -42,7 +42,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/serviceauth/create.go
+++ b/pkg/commands/serviceauth/create.go
@@ -47,7 +47,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/serviceversion/activate.go
+++ b/pkg/commands/serviceversion/activate.go
@@ -34,7 +34,7 @@ func NewActivateCommand(parent argparser.Registerer, g *global.Data) *ActivateCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/serviceversion/clone.go
+++ b/pkg/commands/serviceversion/clone.go
@@ -33,7 +33,7 @@ func NewCloneCommand(parent argparser.Registerer, g *global.Data) *CloneCommand 
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/serviceversion/deactivate.go
+++ b/pkg/commands/serviceversion/deactivate.go
@@ -33,7 +33,7 @@ func NewDeactivateCommand(parent argparser.Registerer, g *global.Data) *Deactiva
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/serviceversion/list.go
+++ b/pkg/commands/serviceversion/list.go
@@ -41,7 +41,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	return &c

--- a/pkg/commands/serviceversion/lock.go
+++ b/pkg/commands/serviceversion/lock.go
@@ -33,7 +33,7 @@ func NewLockCommand(parent argparser.Registerer, g *global.Data) *LockCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/serviceversion/update.go
+++ b/pkg/commands/serviceversion/update.go
@@ -40,7 +40,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{

--- a/pkg/commands/stats/historical.go
+++ b/pkg/commands/stats/historical.go
@@ -40,7 +40,7 @@ func NewHistoricalCommand(parent argparser.Registerer, g *global.Data) *Historic
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/stats/realtime.go
+++ b/pkg/commands/stats/realtime.go
@@ -36,7 +36,7 @@ func NewRealtimeCommand(parent argparser.Registerer, g *global.Data) *RealtimeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/condition/create.go
+++ b/pkg/commands/vcl/condition/create.go
@@ -66,7 +66,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/condition/delete.go
+++ b/pkg/commands/vcl/condition/delete.go
@@ -52,7 +52,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/condition/describe.go
+++ b/pkg/commands/vcl/condition/describe.go
@@ -47,7 +47,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/condition/list.go
+++ b/pkg/commands/vcl/condition/list.go
@@ -45,7 +45,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/condition/update.go
+++ b/pkg/commands/vcl/condition/update.go
@@ -62,7 +62,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/custom/create.go
+++ b/pkg/commands/vcl/custom/create.go
@@ -45,7 +45,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/custom/delete.go
+++ b/pkg/commands/vcl/custom/delete.go
@@ -43,7 +43,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/custom/describe.go
+++ b/pkg/commands/vcl/custom/describe.go
@@ -40,7 +40,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/custom/list.go
+++ b/pkg/commands/vcl/custom/list.go
@@ -40,7 +40,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/custom/update.go
+++ b/pkg/commands/vcl/custom/update.go
@@ -46,7 +46,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/snippet/create.go
+++ b/pkg/commands/vcl/snippet/create.go
@@ -50,7 +50,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("type", "The location in generated VCL where the snippet should be placed").Action(c.location.Set).HintOptions(Locations...).EnumVar(&c.location.Value, Locations...)

--- a/pkg/commands/vcl/snippet/delete.go
+++ b/pkg/commands/vcl/snippet/delete.go
@@ -43,7 +43,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/snippet/describe.go
+++ b/pkg/commands/vcl/snippet/describe.go
@@ -41,7 +41,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").StringVar(&c.snippetID)

--- a/pkg/commands/vcl/snippet/list.go
+++ b/pkg/commands/vcl/snippet/list.go
@@ -40,7 +40,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -48,7 +48,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Action:      c.serviceName.Set,
 		Name:        argparser.FlagServiceName,
-		Description: argparser.FlagServiceDesc,
+		Description: argparser.FlagServiceNameDesc,
 		Dst:         &c.serviceName.Value,
 	})
 	c.CmdClause.Flag("snippet-id", "Alphanumeric string identifying a VCL Snippet").StringVar(&c.snippetID)


### PR DESCRIPTION
When the --service-name flag was added it was given the lowest
priority for obtaining a service ID. If a user supplied this flag but
also supplied --service-id, or had a fastly.toml with a service ID in
it, or had the FASTLY_SERVICE_ID environment variable set, the
--service-name flag would be ignored. This resulted in a user
accidentally deleting a service because the flag was ignored.

This commit changes the priority so that --service-name and
--service-id have equal (top) priority, and also ensures that
supplying both will result in an error. It also adds a unit test for
the argparser.ServiceID() function which implements this logic.

Closes #1261.