### PR TITLE
refactor: Rename various parts of testutil package.

### DIFF
--- a/.tmpl/test.go
+++ b/.tmpl/test.go
@@ -14,7 +14,7 @@ const (
 )
 
 func TestCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
@@ -81,11 +81,11 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{baseCommand, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{baseCommand, "create"}, scenarios)
 }
 
 func TestDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
@@ -147,11 +147,11 @@ func TestDelete(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{baseCommand, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{baseCommand, "delete"}, scenarios)
 }
 
 func TestDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
@@ -183,11 +183,11 @@ func TestDescribe(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{baseCommand, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{baseCommand, "describe"}, scenarios)
 }
 
 func TestList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
@@ -228,11 +228,11 @@ func TestList(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{baseCommand, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{baseCommand, "list"}, scenarios)
 }
 
 func TestUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
 			Args:      "--version 3",
@@ -292,7 +292,7 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{baseCommand, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{baseCommand, "update"}, scenarios)
 }
 
 func get${CLI_API}(i *fastly.Get${CLI_API}Input) (*fastly.${CLI_API}, error) {

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func TestShellCompletion(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "bash shell complete",
-			Arg:  "--completion-script-bash",
+			Args: "--completion-script-bash",
 			WantOutput: `
 _fastly_bash_autocomplete() {
     local cur prev opts base
@@ -34,7 +34,7 @@ complete -F _fastly_bash_autocomplete fastly
 		},
 		{
 			Name: "zsh shell complete",
-			Arg:  "--completion-script-zsh",
+			Args: "--completion-script-zsh",
 			WantOutput: `
 #compdef fastly
 autoload -U compinit && compinit
@@ -56,7 +56,7 @@ complete -F _fastly_bash_autocomplete fastly
 		// FIXME: Put back `sso` GA.
 		{
 			Name: "shell evaluate completion options",
-			Arg:  "--completion-bash",
+			Args: "--completion-bash",
 			WantOutput: `help
 sso
 acl
@@ -126,9 +126,9 @@ whoami
 			}()
 
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {
-				return testutil.MockGlobalData(testutil.Args(testcase.Arg), &stdout), nil
+				return testutil.MockGlobalData(testutil.SplitArgs(testcase.Args), &stdout), nil
 			}
-			err := app.Run(testutil.Args(testcase.Arg), nil)
+			err := app.Run(testutil.SplitArgs(testcase.Args), nil)
 			if err != nil {
 				errors.Deduce(err).Print(&stderr)
 			}

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -11,20 +11,20 @@ import (
 )
 
 func TestACLCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foo",
+			Args:      "--name foo",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foo --version 3",
+			Args:      "--name foo --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -32,7 +32,7 @@ func TestACLCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foo --service-id 123 --version 1",
+			Args:      "--name foo --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -40,7 +40,7 @@ func TestACLCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foo --service-id 123 --version 2",
+			Args:      "--name foo --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -51,7 +51,7 @@ func TestACLCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foo --service-id 123 --version 3",
+			Args:      "--name foo --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -67,7 +67,7 @@ func TestACLCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--name foo --service-id 123 --version 3",
+			Args:       "--name foo --service-id 123 --version 3",
 			WantOutput: "Created ACL 'foo' (id: 456, service: 123, version: 3)",
 		},
 		{
@@ -84,29 +84,29 @@ func TestACLCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--autoclone --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --name foo --service-id 123 --version 1",
 			WantOutput: "Created ACL 'foo' (id: 456, service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestACLDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -114,7 +114,7 @@ func TestACLDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -122,7 +122,7 @@ func TestACLDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foo --service-id 123 --version 2",
+			Args:      "--name foo --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -133,7 +133,7 @@ func TestACLDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -144,7 +144,7 @@ func TestACLDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "Deleted ACL 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -156,29 +156,29 @@ func TestACLDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--autoclone --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --name foo --service-id 123 --version 1",
 			WantOutput: "Deleted ACL 'foo' (service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestACLDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -189,7 +189,7 @@ func TestACLDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -198,7 +198,7 @@ func TestACLDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetACLFn:       getACL,
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -207,23 +207,23 @@ func TestACLDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetACLFn:       getACL,
 			},
-			Arg:        "--name foobar --service-id 123 --version 1",
+			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestACLList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -234,7 +234,7 @@ func TestACLList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -243,7 +243,7 @@ func TestACLList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListACLsFn:     listACLs,
 			},
-			Arg:        "--service-id 123 --version 3",
+			Args:       "--service-id 123 --version 3",
 			WantOutput: "SERVICE ID  VERSION  NAME  ID\n123         3        foo   456\n123         3        bar   789\n",
 		},
 		{
@@ -252,7 +252,7 @@ func TestACLList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListACLsFn:     listACLs,
 			},
-			Arg:        "--service-id 123 --version 1",
+			Args:       "--service-id 123 --version 1",
 			WantOutput: "SERVICE ID  VERSION  NAME  ID\n123         1        foo   456\n123         1        bar   789\n",
 		},
 		{
@@ -261,34 +261,34 @@ func TestACLList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListACLsFn:     listACLs,
 			},
-			Arg:        "--service-id 123 --verbose --version 1",
+			Args:       "--service-id 123 --verbose --version 1",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (profile: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nID: 789\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestACLUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--new-name beepboop --version 3",
+			Args:      "--new-name beepboop --version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --new-name flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error parsing arguments: required flag --new-name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar --new-name beepboop",
+			Args:      "--name foobar --new-name beepboop",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --new-name beepboop --version 3",
+			Args:      "--name foobar --new-name beepboop --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -296,7 +296,7 @@ func TestACLUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foo --new-name beepboop --service-id 123 --version 1",
+			Args:      "--name foo --new-name beepboop --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -304,7 +304,7 @@ func TestACLUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foo --new-name beepboop --service-id 123 --version 2",
+			Args:      "--name foo --new-name beepboop --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -315,7 +315,7 @@ func TestACLUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -331,7 +331,7 @@ func TestACLUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:       "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 3)",
 		},
 		{
@@ -348,12 +348,12 @@ func TestACLUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
 			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func getACL(i *fastly.GetACLInput) (*fastly.ACL, error) {

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -14,20 +14,20 @@ import (
 )
 
 func TestACLEntryCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Arg:       "--ip 127.0.0.1",
+			Args:      "--ip 127.0.0.1",
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --ip flag",
-			Arg:       "--acl-id 123",
+			Args:      "--acl-id 123",
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--acl-id 123 --ip 127.0.0.1",
+			Args:      "--acl-id 123 --ip 127.0.0.1",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -37,7 +37,7 @@ func TestACLEntryCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--acl-id 123 --ip 127.0.0.1 --service-id 123",
+			Args:      "--acl-id 123 --ip 127.0.0.1 --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -52,7 +52,7 @@ func TestACLEntryCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--acl-id 123 --ip 127.0.0.1 --service-id 123",
+			Args:       "--acl-id 123 --ip 127.0.0.1 --service-id 123",
 			WantOutput: "Created ACL entry '456' (ip: 127.0.0.1, negated: false, service: 123)",
 		},
 		{
@@ -68,29 +68,29 @@ func TestACLEntryCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--acl-id 123 --ip 127.0.0.1 --negated --service-id 123",
+			Args:       "--acl-id 123 --ip 127.0.0.1 --negated --service-id 123",
 			WantOutput: "Created ACL entry '456' (ip: 127.0.0.1, negated: true, service: 123)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestACLEntryDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Arg:       "--id 456",
+			Args:      "--id 456",
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --id flag",
-			Arg:       "--acl-id 123",
+			Args:      "--acl-id 123",
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--acl-id 123 --id 456",
+			Args:      "--acl-id 123 --id 456",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -100,7 +100,7 @@ func TestACLEntryDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--acl-id 123 --id 456 --service-id 123",
+			Args:      "--acl-id 123 --id 456 --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -110,29 +110,29 @@ func TestACLEntryDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--acl-id 123 --id 456 --service-id 123",
+			Args:       "--acl-id 123 --id 456 --service-id 123",
 			WantOutput: "Deleted ACL entry '456' (service: 123)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestACLEntryDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --acl-id flag",
-			Arg:       "--id 456",
+			Args:      "--id 456",
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --id flag",
-			Arg:       "--acl-id 123",
+			Args:      "--acl-id 123",
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--acl-id 123 --id 456",
+			Args:      "--acl-id 123 --id 456",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -142,7 +142,7 @@ func TestACLEntryDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--acl-id 123 --id 456 --service-id 123",
+			Args:      "--acl-id 123 --id 456 --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -150,23 +150,23 @@ func TestACLEntryDescribe(t *testing.T) {
 			API: mock.API{
 				GetACLEntryFn: getACLEntry,
 			},
-			Arg:        "--acl-id 123 --id 456 --service-id 123",
+			Args:       "--acl-id 123 --id 456 --service-id 123",
 			WantOutput: "\nService ID: 123\nACL ID: 123\nID: 456\nIP: 127.0.0.1\nSubnet: 0\nNegated: false\nComment: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestACLEntryList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --acl-id flag",
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--acl-id 123",
+			Args:      "--acl-id 123",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -181,7 +181,7 @@ func TestACLEntryList(t *testing.T) {
 					}, fastly.ListOpts{}, "/example")
 				},
 			},
-			Arg:       "--acl-id 123 --service-id 123",
+			Args:      "--acl-id 123 --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -223,7 +223,7 @@ func TestACLEntryList(t *testing.T) {
 					}, fastly.ListOpts{}, "/example")
 				},
 			},
-			Arg:        "--acl-id 123 --service-id 123",
+			Args:       "--acl-id 123 --service-id 123",
 			WantOutput: listACLEntriesOutput,
 		},
 		{
@@ -265,12 +265,12 @@ func TestACLEntryList(t *testing.T) {
 					}, fastly.ListOpts{}, "/example")
 				},
 			},
-			Arg:        "--acl-id 123 --per-page 1 --service-id 123 --verbose",
+			Args:       "--acl-id 123 --per-page 1 --service-id 123 --verbose",
 			WantOutput: listACLEntriesOutputVerbose,
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 var listACLEntriesOutput = `SERVICE ID  ID   IP         SUBNET  NEGATED
@@ -308,19 +308,19 @@ Deleted at: 2021-06-15 23:00:00 +0000 UTC
 `
 
 func TestACLEntryUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --acl-id flag",
 			WantError: "error parsing arguments: required flag --acl-id not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--acl-id 123",
+			Args:      "--acl-id 123",
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate missing --id flag for single entry update",
-			Arg:       "--acl-id 123 --service-id 123",
+			Args:      "--acl-id 123 --service-id 123",
 			WantError: "no ID found",
 		},
 		{
@@ -330,7 +330,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--acl-id 123 --id 456 --service-id 123",
+			Args:      "--acl-id 123 --id 456 --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -340,7 +340,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:       `--acl-id 123 --file {"foo":"bar"} --id 456 --service-id 123`,
+			Args:      `--acl-id 123 --file {"foo":"bar"} --id 456 --service-id 123`,
 			WantError: "missing 'entries'",
 		},
 		{
@@ -350,7 +350,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:       `--acl-id 123 --file {"entries":[]} --id 456 --service-id 123`,
+			Args:      `--acl-id 123 --file {"entries":[]} --id 456 --service-id 123`,
 			WantError: "missing 'entries'",
 		},
 		{
@@ -360,7 +360,7 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--acl-id 123 --file testdata/batch.json --id 456 --service-id 123",
+			Args:       "--acl-id 123 --file testdata/batch.json --id 456 --service-id 123",
 			WantOutput: "Updated 3 ACL entries (service: 123)",
 		},
 		// NOTE: When specifying JSON inline be sure not to have any spaces, and don't
@@ -374,12 +374,12 @@ func TestACLEntryUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        `--acl-id 123 --file {"entries":[{"op":"create","ip":"127.0.0.1","subnet":8},{"op":"update"},{"op":"upsert"}]} --id 456 --service-id 123`,
+			Args:       `--acl-id 123 --file {"entries":[{"op":"create","ip":"127.0.0.1","subnet":8},{"op":"update"},{"op":"upsert"}]} --id 456 --service-id 123`,
 			WantOutput: "Updated 3 ACL entries (service: 123)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func getACLEntry(i *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {

--- a/pkg/commands/alerts/alerts_test.go
+++ b/pkg/commands/alerts/alerts_test.go
@@ -24,65 +24,65 @@ func TestAlertsCreate(t *testing.T) {
 		},
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "ok all required",
-			Arg:  createFlags.String(),
+			Args: createFlags.String(),
 			API:  mock.API{CreateAlertDefinitionFn: CreateAlertDefinitionResponse},
 		},
 		{
 			Name:      "no name",
-			Arg:       createFlags.Remove("--name").String(),
+			Args:      createFlags.Remove("--name").String(),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "no description",
-			Arg:       createFlags.Remove("--description").String(),
+			Args:      createFlags.Remove("--description").String(),
 			WantError: "error parsing arguments: required flag --description not provided",
 		},
 		{
 			Name:      "no metric",
-			Arg:       createFlags.Remove("--metric").String(),
+			Args:      createFlags.Remove("--metric").String(),
 			WantError: "error parsing arguments: required flag --metric not provided",
 		},
 		{
 			Name:      "no source",
-			Arg:       createFlags.Remove("--source").String(),
+			Args:      createFlags.Remove("--source").String(),
 			WantError: "error parsing arguments: required flag --source not provided",
 		},
 		{
 			Name:      "no type",
-			Arg:       createFlags.Remove("--type").String(),
+			Args:      createFlags.Remove("--type").String(),
 			WantError: "error parsing arguments: required flag --type not provided",
 		},
 		{
 			Name:      "no period",
-			Arg:       createFlags.Remove("--period").String(),
+			Args:      createFlags.Remove("--period").String(),
 			WantError: "error parsing arguments: required flag --period not provided",
 		},
 		{
 			Name:      "no threshold",
-			Arg:       createFlags.Remove("--threshold").String(),
+			Args:      createFlags.Remove("--threshold").String(),
 			WantError: "error parsing arguments: required flag --threshold not provided",
 		},
 		{
 			Name: "ok optional json",
-			Arg:  createFlags.Add(flag{Flag: "--json"}).String(),
+			Args: createFlags.Add(flag{Flag: "--json"}).String(),
 			API:  mock.API{CreateAlertDefinitionFn: CreateAlertDefinitionResponse},
 		},
 		{
 			Name: "ok optional ignoreBelow",
-			Arg:  createFlags.Add(flag{Flag: "--ignoreBelow", Value: "5.0"}).String(),
+			Args: createFlags.Add(flag{Flag: "--ignoreBelow", Value: "5.0"}).String(),
 			API:  mock.API{CreateAlertDefinitionFn: CreateAlertDefinitionResponse},
 		},
 		{
 			Name: "ok optional service-id",
-			Arg:  createFlags.Add(flag{Flag: "--service-id", Value: "ABC"}).String(),
+			Args: createFlags.Add(flag{Flag: "--service-id", Value: "ABC"}).String(),
 			API:  mock.API{CreateAlertDefinitionFn: CreateAlertDefinitionResponse},
 		},
 		{
 			Name: "ok optional dimensions",
-			Arg: createFlags.
+			Args: createFlags.
 				Change(flag{Flag: "--source", Value: "origins"}).
 				Add(flag{Flag: "--dimensions", Value: "fastly.com"}).
 				Add(flag{Flag: "--dimensions", Value: "fastly2.com"}).String(),
@@ -90,14 +90,14 @@ func TestAlertsCreate(t *testing.T) {
 		},
 		{
 			Name: "ok optional integrations",
-			Arg: createFlags.
+			Args: createFlags.
 				Add(flag{Flag: "--integrations", Value: "ABC1"}).
 				Add(flag{Flag: "--integrations", Value: "ABC2"}).String(),
 			API: mock.API{CreateAlertDefinitionFn: CreateAlertDefinitionResponse},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestAlertsUpdate(t *testing.T) {
@@ -114,65 +114,65 @@ func TestAlertsUpdate(t *testing.T) {
 		},
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "ok all required",
-			Arg:  updateFlags.String(),
+			Args: updateFlags.String(),
 			API:  mock.API{UpdateAlertDefinitionFn: UpdateAlertDefinitionResponse},
 		},
 		{
 			Name:      "no id",
-			Arg:       updateFlags.Remove("--id").String(),
+			Args:      updateFlags.Remove("--id").String(),
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name:      "no name",
-			Arg:       updateFlags.Remove("--name").String(),
+			Args:      updateFlags.Remove("--name").String(),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "no description",
-			Arg:       updateFlags.Remove("--description").String(),
+			Args:      updateFlags.Remove("--description").String(),
 			WantError: "error parsing arguments: required flag --description not provided",
 		},
 		{
 			Name:      "no metric",
-			Arg:       updateFlags.Remove("--metric").String(),
+			Args:      updateFlags.Remove("--metric").String(),
 			WantError: "error parsing arguments: required flag --metric not provided",
 		},
 		{
 			Name:      "no source",
-			Arg:       updateFlags.Remove("--source").String(),
+			Args:      updateFlags.Remove("--source").String(),
 			WantError: "error parsing arguments: required flag --source not provided",
 		},
 		{
 			Name:      "no type",
-			Arg:       updateFlags.Remove("--type").String(),
+			Args:      updateFlags.Remove("--type").String(),
 			WantError: "error parsing arguments: required flag --type not provided",
 		},
 		{
 			Name:      "no period",
-			Arg:       updateFlags.Remove("--period").String(),
+			Args:      updateFlags.Remove("--period").String(),
 			WantError: "error parsing arguments: required flag --period not provided",
 		},
 		{
 			Name:      "no threshold",
-			Arg:       updateFlags.Remove("--threshold").String(),
+			Args:      updateFlags.Remove("--threshold").String(),
 			WantError: "error parsing arguments: required flag --threshold not provided",
 		},
 		{
 			Name: "ok optional json",
-			Arg:  updateFlags.Add(flag{Flag: "--json"}).String(),
+			Args: updateFlags.Add(flag{Flag: "--json"}).String(),
 			API:  mock.API{UpdateAlertDefinitionFn: UpdateAlertDefinitionResponse},
 		},
 		{
 			Name: "ok optional ignoreBelow",
-			Arg:  updateFlags.Add(flag{Flag: "--ignoreBelow", Value: "5.0"}).String(),
+			Args: updateFlags.Add(flag{Flag: "--ignoreBelow", Value: "5.0"}).String(),
 			API:  mock.API{UpdateAlertDefinitionFn: UpdateAlertDefinitionResponse},
 		},
 		{
 			Name: "ok optional dimensions",
-			Arg: updateFlags.
+			Args: updateFlags.
 				Change(flag{Flag: "--source", Value: "origins"}).
 				Add(flag{Flag: "--dimensions", Value: "fastly.com"}).
 				Add(flag{Flag: "--dimensions", Value: "fastly2.com"}).String(),
@@ -180,23 +180,23 @@ func TestAlertsUpdate(t *testing.T) {
 		},
 		{
 			Name: "ok optional integrations",
-			Arg:  updateFlags.Add(flag{Flag: "--integrations", Value: "ABC1"}).Add(flag{Flag: "--integrations", Value: "ABC2"}).String(),
+			Args: updateFlags.Add(flag{Flag: "--integrations", Value: "ABC1"}).Add(flag{Flag: "--integrations", Value: "ABC2"}).String(),
 			API:  mock.API{UpdateAlertDefinitionFn: UpdateAlertDefinitionResponse},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func TestAlertsDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "no definition id",
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name: "ok",
-			Arg:  "--id ABC",
+			Args: "--id ABC",
 			API: mock.API{
 				DeleteAlertDefinitionFn: func(i *fastly.DeleteAlertDefinitionInput) error {
 					return nil
@@ -205,18 +205,18 @@ func TestAlertsDelete(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestAlertsDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "no definition id",
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name: "ok",
-			Arg:  "--id ABC",
+			Args: "--id ABC",
 			API: mock.API{
 				GetAlertDefinitionFn: func(i *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error) {
 					response := &mockDefinition
@@ -227,11 +227,11 @@ func TestAlertsDescribe(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestAlertsList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:       "ok",
 			API:        mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
@@ -239,52 +239,52 @@ func TestAlertsList(t *testing.T) {
 		},
 		{
 			Name: "ok verbose",
-			Arg:  "-v",
+			Args: "-v",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok json",
-			Arg:  "-j",
+			Args: "-j",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok cursor",
-			Arg:  "--cursor ABC",
+			Args: "--cursor ABC",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok limit",
-			Arg:  "--limit 1",
+			Args: "--limit 1",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok definition name",
-			Arg:  "--name test",
+			Args: "--name test",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok sort name",
-			Arg:  "--sort name",
+			Args: "--sort name",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok sort updated_at",
-			Arg:  "--sort updated_at",
+			Args: "--sort updated_at",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok sort created_at asc",
-			Arg:  "--sort created_at --order asc",
+			Args: "--sort created_at --order asc",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok sort created_at desc",
-			Arg:  "--sort created_at --order desc",
+			Args: "--sort created_at --order desc",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
 			Name: "ok service id",
-			Arg:  "--service-id ABC",
+			Args: "--service-id ABC",
 			API:  mock.API{ListAlertDefinitionsFn: ListAlertDefinitionsEmptyResponse},
 		},
 		{
@@ -307,11 +307,11 @@ func TestAlertsList(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestAlertsHistoryList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:       "ok",
 			API:        mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
@@ -319,52 +319,52 @@ func TestAlertsHistoryList(t *testing.T) {
 		},
 		{
 			Name: "ok verbose",
-			Arg:  "-v",
+			Args: "-v",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok json",
-			Arg:  "--json",
+			Args: "--json",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok cursor",
-			Arg:  "--cursor ABC",
+			Args: "--cursor ABC",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok limit",
-			Arg:  "--limit 1",
+			Args: "--limit 1",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok status",
-			Arg:  "--status active",
+			Args: "--status active",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok sort start",
-			Arg:  "--sort start",
+			Args: "--sort start",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok sort start asc",
-			Arg:  "--sort start --order asc",
+			Args: "--sort start --order asc",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok sort start desc",
-			Arg:  "--sort start --order desc",
+			Args: "--sort start --order desc",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok service id",
-			Arg:  "--service-id ABC",
+			Args: "--service-id ABC",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
 			Name: "ok definition id",
-			Arg:  "--definition-id ABC",
+			Args: "--definition-id ABC",
 			API:  mock.API{ListAlertHistoryFn: ListAlertHistoryEmptyResponse},
 		},
 		{
@@ -387,7 +387,7 @@ func TestAlertsHistoryList(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "history"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "history"}, scenarios)
 }
 
 type flag struct {

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAuthTokenCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --password flag",
 			WantError: "error parsing arguments: required flag --password not provided",
@@ -24,7 +24,7 @@ func TestAuthTokenCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--password secure --token 123",
+			Args:      "--password secure --token 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -40,7 +40,7 @@ func TestAuthTokenCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--password secure --token 123",
+			Args:       "--password secure --token 123",
 			WantOutput: "Created token '123abc' (name: Example, id: 123, scope: foobar, expires: 2021-06-15 23:00:00 +0000 UTC)",
 		},
 		{
@@ -56,19 +56,19 @@ func TestAuthTokenCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--expires 2021-09-15T23:00:00Z --name Testing --password secure --scope purge_all --scope global:read --services a,b,c --token 123",
+			Args:       "--expires 2021-09-15T23:00:00Z --name Testing --password secure --scope purge_all --scope global:read --services a,b,c --token 123",
 			WantOutput: "Created token '123abc' (name: Testing, id: 123, scope: purge_all global:read, expires: 2021-09-15 23:00:00 +0000 UTC)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestAuthTokenDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing optional flags",
-			Arg:       "--token 123",
+			Args:      "--token 123",
 			WantError: "error parsing arguments: must provide either the --current, --file or --id flag",
 		},
 		{
@@ -78,7 +78,7 @@ func TestAuthTokenDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--current --token 123",
+			Args:      "--current --token 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -88,7 +88,7 @@ func TestAuthTokenDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--file ./testdata/tokens --token 123",
+			Args:      "--file ./testdata/tokens --token 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -98,7 +98,7 @@ func TestAuthTokenDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id 123 --token 123",
+			Args:      "--id 123 --token 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -108,7 +108,7 @@ func TestAuthTokenDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--current --token 123",
+			Args:       "--current --token 123",
 			WantOutput: "Deleted current token",
 		},
 		{
@@ -118,7 +118,7 @@ func TestAuthTokenDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--file ./testdata/tokens --token 123",
+			Args:       "--file ./testdata/tokens --token 123",
 			WantOutput: "Deleted tokens",
 		},
 		{
@@ -128,7 +128,7 @@ func TestAuthTokenDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--file ./testdata/tokens --token 123 --verbose",
+			Args:       "--file ./testdata/tokens --token 123 --verbose",
 			WantOutput: fileTokensOutput(),
 		},
 		{
@@ -138,16 +138,16 @@ func TestAuthTokenDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id 123 --token 123",
+			Args:       "--id 123 --token 123",
 			WantOutput: "Deleted token '123'",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestAuthTokenDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate GetTokenSelf API error",
 			API: mock.API{
@@ -155,7 +155,7 @@ func TestAuthTokenDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--token 123",
+			Args:      "--token 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -163,16 +163,16 @@ func TestAuthTokenDescribe(t *testing.T) {
 			API: mock.API{
 				GetTokenSelfFn: getToken,
 			},
-			Arg:        "--token 123",
+			Args:       "--token 123",
 			WantOutput: describeTokenOutput(),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestAuthTokenList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate ListTokens API error",
 			API: mock.API{
@@ -189,7 +189,7 @@ func TestAuthTokenList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--customer-id 123",
+			Args:      "--customer-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -204,7 +204,7 @@ func TestAuthTokenList(t *testing.T) {
 			API: mock.API{
 				ListCustomerTokensFn: listCustomerTokens,
 			},
-			Arg:        "--customer-id 123",
+			Args:       "--customer-id 123",
 			WantOutput: listTokenOutputSummary(false),
 		},
 		{
@@ -220,12 +220,12 @@ func TestAuthTokenList(t *testing.T) {
 			API: mock.API{
 				ListTokensFn: listTokens,
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: listTokenOutputVerbose(),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func getToken() (*fastly.Token, error) {

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func TestBackendCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--version 1",
+			Args:      "--version 1",
 			WantError: "error reading service: no service ID found",
 		},
 		// The following test specifies a service version that's 'active', and
@@ -26,7 +26,7 @@ func TestBackendCreate(t *testing.T) {
 		// --autoclone flag and trying to add a backend to an activated service
 		// should cause an error.
 		{
-			Arg: "--service-id 123 --version 1 --address example.com --name www.test.com",
+			Args: "--service-id 123 --version 1 --address example.com --name www.test.com",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
@@ -37,7 +37,7 @@ func TestBackendCreate(t *testing.T) {
 		// --autoclone flag and trying to add a backend to a locked service
 		// should cause an error.
 		{
-			Arg: "--service-id 123 --version 2 --address example.com --name www.test.com",
+			Args: "--service-id 123 --version 2 --address example.com --name www.test.com",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
@@ -46,7 +46,7 @@ func TestBackendCreate(t *testing.T) {
 		// The following test is the same as the 'active' test above but it appends --autoclone
 		// so we can be sure the backend creation error still occurs.
 		{
-			Arg: "--service-id 123 --version 1 --address example.com --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --address example.com --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -57,7 +57,7 @@ func TestBackendCreate(t *testing.T) {
 		// The following test is the same as the 'locked' test above but it appends --autoclone
 		// so we can be sure the backend creation error still occurs.
 		{
-			Arg: "--service-id 123 --version 1 --address example.com --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --address example.com --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -68,7 +68,7 @@ func TestBackendCreate(t *testing.T) {
 		// The following test is the same as above but with an IP address for the
 		// --address flag instead of a hostname.
 		{
-			Arg: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -82,7 +82,7 @@ func TestBackendCreate(t *testing.T) {
 		// NOTE: Added --port flag to validate that a nil pointer dereference is
 		// not triggered at runtime when parsing the arguments.
 		{
-			Arg: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --port 8080",
+			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --port 8080",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -92,7 +92,7 @@ func TestBackendCreate(t *testing.T) {
 		},
 		// We test that setting an invalid host override does not result in an error
 		{
-			Arg: "--service-id 123 --version 1 --address 127.0.0.1 --override-host invalid-host-override --name www.test.com --autoclone --port 8080",
+			Args: "--service-id 123 --version 1 --address 127.0.0.1 --override-host invalid-host-override --name www.test.com --autoclone --port 8080",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -102,7 +102,7 @@ func TestBackendCreate(t *testing.T) {
 		},
 		// The following test validates that --service-name can replace --service-id
 		{
-			Arg: "--service-name test-service --version 1 --address 127.0.0.1 --name www.test.com --autoclone",
+			Args: "--service-name test-service --version 1 --address 127.0.0.1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetServicesFn: func(i *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
@@ -124,7 +124,7 @@ func TestBackendCreate(t *testing.T) {
 		// --verbose so we may validate the expected output message regarding a
 		// missing port is displayed.
 		{
-			Arg: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --use-ssl --verbose",
+			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --use-ssl --verbose",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -136,7 +136,7 @@ func TestBackendCreate(t *testing.T) {
 		// --verbose so we may validate a successful backend creation.
 		//
 		{
-			Arg: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --port 8443 --use-ssl --verbose",
+			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --port 8443 --use-ssl --verbose",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -147,7 +147,7 @@ func TestBackendCreate(t *testing.T) {
 		// The following test specifies a service version that's 'inactive' and not 'locked',
 		// and subsequently we expect it to be the same editable version.
 		{
-			Arg: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com",
+			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CreateBackendFn: createBackendOK,
@@ -156,7 +156,7 @@ func TestBackendCreate(t *testing.T) {
 		},
 		// The following tests verify parsing of the --tcp-ka-enable flag.
 		{
-			Arg: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=true",
+			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=true",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CreateBackendFn: createBackendOK,
@@ -164,7 +164,7 @@ func TestBackendCreate(t *testing.T) {
 			WantOutput: "Created backend www.test.com (service 123 version 3)",
 		},
 		{
-			Arg: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=false",
+			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=false",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CreateBackendFn: createBackendOK,
@@ -172,7 +172,7 @@ func TestBackendCreate(t *testing.T) {
 			WantOutput: "Created backend www.test.com (service 123 version 3)",
 		},
 		{
-			Arg: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=invalid",
+			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=invalid",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CreateBackendFn: createBackendOK,
@@ -180,13 +180,13 @@ func TestBackendCreate(t *testing.T) {
 			WantError: "'tcp-ka-enable' flag must be one of the following [true, false]",
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestBackendList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg: "--service-id 123 --version 1 --json",
+			Args: "--service-id 123 --version 1 --json",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
@@ -194,7 +194,7 @@ func TestBackendList(t *testing.T) {
 			WantOutput: listBackendsJSONOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --json --verbose",
+			Args: "--service-id 123 --version 1 --json --verbose",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
@@ -202,7 +202,7 @@ func TestBackendList(t *testing.T) {
 			WantError: fsterr.ErrInvalidVerboseJSONCombo.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
@@ -210,7 +210,7 @@ func TestBackendList(t *testing.T) {
 			WantOutput: listBackendsShortOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --verbose",
+			Args: "--service-id 123 --version 1 --verbose",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
@@ -218,7 +218,7 @@ func TestBackendList(t *testing.T) {
 			WantOutput: listBackendsVerboseOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 -v",
+			Args: "--service-id 123 --version 1 -v",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
@@ -226,7 +226,7 @@ func TestBackendList(t *testing.T) {
 			WantOutput: listBackendsVerboseOutput,
 		},
 		{
-			Arg: "--verbose --service-id 123 --version 1",
+			Args: "--verbose --service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
@@ -234,7 +234,7 @@ func TestBackendList(t *testing.T) {
 			WantOutput: listBackendsVerboseOutput,
 		},
 		{
-			Arg: "-v --service-id 123 --version 1",
+			Args: "-v --service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsOK,
@@ -242,7 +242,7 @@ func TestBackendList(t *testing.T) {
 			WantOutput: listBackendsVerboseOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListBackendsFn: listBackendsError,
@@ -250,17 +250,17 @@ func TestBackendList(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestBackendDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com",
+			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetBackendFn:   getBackendError,
@@ -268,7 +268,7 @@ func TestBackendDescribe(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com",
+			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetBackendFn:   getBackendOK,
@@ -276,17 +276,17 @@ func TestBackendDescribe(t *testing.T) {
 			WantOutput: describeBackendOutput,
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestBackendUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 2 --new-name www.test.com --comment ",
+			Args:      "--service-id 123 --version 2 --new-name www.test.com --comment ",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -296,7 +296,7 @@ func TestBackendUpdate(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --comment  --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --comment  --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -307,7 +307,7 @@ func TestBackendUpdate(t *testing.T) {
 		},
 		// The following tests verify parsing of the --tcp-ka-enable flag.
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=true --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=true --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -317,7 +317,7 @@ func TestBackendUpdate(t *testing.T) {
 			WantOutput: "Updated backend  (service 123 version 4)",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=false --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=false --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -327,7 +327,7 @@ func TestBackendUpdate(t *testing.T) {
 			WantOutput: "Updated backend  (service 123 version 4)",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=invalid --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=invalid --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -337,17 +337,17 @@ func TestBackendUpdate(t *testing.T) {
 			WantError: "'tcp-ka-enable' flag must be one of the following [true, false]",
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func TestBackendDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -356,7 +356,7 @@ func TestBackendDelete(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -365,7 +365,7 @@ func TestBackendDelete(t *testing.T) {
 			WantOutput: "Deleted backend www.test.com (service 123 version 4)",
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 var errTest = errors.New("fixture error")

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -25,7 +25,7 @@ func TestBuildRust(t *testing.T) {
 		t.Skip("Set TEST_COMPUTE_BUILD to run this test")
 	}
 
-	args := testutil.Args
+	args := testutil.SplitArgs
 
 	scenarios := []struct {
 		name                 string
@@ -258,7 +258,7 @@ func TestBuildGo(t *testing.T) {
 		t.Skip("Set TEST_COMPUTE_BUILD to run this test")
 	}
 
-	args := testutil.Args
+	args := testutil.SplitArgs
 
 	scenarios := []struct {
 		name                 string
@@ -451,7 +451,7 @@ func TestBuildJavaScript(t *testing.T) {
 		t.Skip("Set TEST_COMPUTE_BUILD to run this test")
 	}
 
-	args := testutil.Args
+	args := testutil.SplitArgs
 
 	scenarios := []struct {
 		name                 string
@@ -646,7 +646,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 		t.Skip("Set TEST_COMPUTE_BUILD to run this test")
 	}
 
-	args := testutil.Args
+	args := testutil.SplitArgs
 
 	scenarios := []struct {
 		name                 string
@@ -837,7 +837,7 @@ func TestBuildAssemblyScript(t *testing.T) {
 
 // NOTE: TestBuildOther also validates the post_build settings.
 func TestBuildOther(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	if os.Getenv("TEST_COMPUTE_BUILD") == "" {
 		t.Log("skipping test")
 		t.Skip("Set TEST_COMPUTE_BUILD to run this test")

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -88,7 +88,7 @@ func TestDeploy(t *testing.T) {
 	}()
 
 	originalPackageSizeLimit := compute.MaxPackageSize
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		api            mock.API
 		args           []string
@@ -2213,7 +2213,7 @@ func TestDeploy_ActivateBeacon(t *testing.T) {
 	}()
 
 	stdout := threadsafe.Buffer{}
-	args := testutil.Args("compute deploy --auto-yes --non-interactive")
+	args := testutil.SplitArgs("compute deploy --auto-yes --non-interactive")
 	recordingHTTP := &mock.HTTPClient{
 		Responses: []*http.Response{
 			// the body is closed by beacon.Notify

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	if os.Getenv("TEST_COMPUTE_INIT") == "" {
 		t.Log("skipping test")
 		t.Skip("Set TEST_COMPUTE_INIT to run this test")
@@ -437,7 +437,7 @@ func TestInit_ExistingService(t *testing.T) {
 	}{
 		{
 			name: "when the service exists",
-			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			args: testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
 			getServiceDetails: func(gsi *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 				if gsi.ServiceID != *serviceID {
 					return nil, &fastly.HTTPError{
@@ -486,7 +486,7 @@ func TestInit_ExistingService(t *testing.T) {
 		},
 		{
 			name: "when the service doesn't exist",
-			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			args: testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
 			getServiceDetails: func(_ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 				return nil, &fastly.HTTPError{
 					StatusCode: http.StatusNotFound,
@@ -500,7 +500,7 @@ func TestInit_ExistingService(t *testing.T) {
 		},
 		{
 			name: "service has no versions that include package metadata",
-			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			args: testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
 			getServiceDetails: func(_ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 				return &fastly.ServiceDetail{
 					ServiceID:     serviceID,
@@ -527,7 +527,7 @@ func TestInit_ExistingService(t *testing.T) {
 		},
 		{
 			name: "service is vcl",
-			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			args: testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
 			getServiceDetails: func(*fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 				return &fastly.ServiceDetail{
 					ServiceID: serviceID,
@@ -539,14 +539,14 @@ func TestInit_ExistingService(t *testing.T) {
 		},
 		{
 			name:          "service id does not look like a Fastly ID",
-			args:          testutil.Args("compute init --from LsyQ2UXDGk6d4EN"),
+			args:          testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4EN"),
 			expectInError: "--from url seems invalid",
 			// Not a valid URL OR Service ID
 			suppresBeacon: true,
 		},
 		{
 			name: "service has a cloned_from value",
-			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			args: testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
 			getServiceDetails: func(*fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 				return &fastly.ServiceDetail{
 					ServiceID: serviceID,
@@ -572,7 +572,7 @@ func TestInit_ExistingService(t *testing.T) {
 		},
 		{
 			name: "service has an unreachable cloned_from value",
-			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			args: testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
 			getServiceDetails: func(*fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 				return &fastly.ServiceDetail{
 					ServiceID: serviceID,
@@ -598,7 +598,7 @@ func TestInit_ExistingService(t *testing.T) {
 		},
 		{
 			name: "service has active version greater than 1",
-			args: testutil.Args("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
+			args: testutil.SplitArgs("compute init --from LsyQ2UXDGk6d4ENjvgqTN4"),
 			getServiceDetails: func(*fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 				return &fastly.ServiceDetail{
 					ServiceID: serviceID,

--- a/pkg/commands/compute/metadata_test.go
+++ b/pkg/commands/compute/metadata_test.go
@@ -24,9 +24,9 @@ func TestMetadata(t *testing.T) {
 		t.Error(err)
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg: "--enable",
+			Args: "--enable",
 			ConfigFile: &config.File{
 				ConfigVersion: staticConfig.ConfigVersion,
 				CLI: config.CLI{
@@ -42,12 +42,12 @@ func TestMetadata(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
 			WantOutput: "SUCCESS: configuration updated",
-			Validator: func(t *testing.T, _ *testutil.TestScenario, opts *global.Data, _ *threadsafe.Buffer) {
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
 				data, err := os.ReadFile(opts.ConfigPath)
 				if err != nil {
 					t.Error(err)
@@ -65,7 +65,7 @@ func TestMetadata(t *testing.T) {
 			},
 		},
 		{
-			Arg: "--disable",
+			Args: "--disable",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -75,12 +75,12 @@ func TestMetadata(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
 			WantOutput: "SUCCESS: configuration updated",
-			Validator: func(t *testing.T, _ *testutil.TestScenario, opts *global.Data, _ *threadsafe.Buffer) {
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
 				data, err := os.ReadFile(opts.ConfigPath)
 				if err != nil {
 					t.Error(err)
@@ -98,7 +98,7 @@ func TestMetadata(t *testing.T) {
 			},
 		},
 		{
-			Arg: "--enable --disable-build",
+			Args: "--enable --disable-build",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -108,7 +108,7 @@ func TestMetadata(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -116,7 +116,7 @@ func TestMetadata(t *testing.T) {
 				"INFO: We will enable all metadata except for the specified `--disable-*` flags",
 				"SUCCESS: configuration updated",
 			},
-			Validator: func(t *testing.T, _ *testutil.TestScenario, opts *global.Data, _ *threadsafe.Buffer) {
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
 				data, err := os.ReadFile(opts.ConfigPath)
 				if err != nil {
 					t.Error(err)
@@ -134,7 +134,7 @@ func TestMetadata(t *testing.T) {
 			},
 		},
 		{
-			Arg: "--disable --enable-machine",
+			Args: "--disable --enable-machine",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -144,7 +144,7 @@ func TestMetadata(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -152,7 +152,7 @@ func TestMetadata(t *testing.T) {
 				"INFO: We will disable all metadata except for the specified `--enable-*` flags",
 				"SUCCESS: configuration updated",
 			},
-			Validator: func(t *testing.T, _ *testutil.TestScenario, opts *global.Data, _ *threadsafe.Buffer) {
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
 				data, err := os.ReadFile(opts.ConfigPath)
 				if err != nil {
 					t.Error(err)
@@ -171,5 +171,5 @@ func TestMetadata(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "metadata"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "metadata"}, scenarios)
 }

--- a/pkg/commands/compute/pack_test.go
+++ b/pkg/commands/compute/pack_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPack(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	for _, testcase := range []struct {
 		name          string
 		args          []string

--- a/pkg/commands/compute/update_test.go
+++ b/pkg/commands/compute/update_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func TestUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "package API error",
-			Arg:  "-s 123 --version 1 --package pkg/package.tar.gz --autoclone",
+			Args: "-s 123 --version 1 --package pkg/package.tar.gz --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -37,7 +37,7 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			Name: "success",
-			Arg:  "-s 123 --version 2 --package pkg/package.tar.gz --autoclone",
+			Args: "-s 123 --version 2 --package pkg/package.tar.gz --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -60,5 +60,5 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/compute/validate_test.go
+++ b/pkg/commands/compute/validate_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "success",
-			Arg:  "--package pkg/package.tar.gz",
+			Args: "--package pkg/package.tar.gz",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -28,5 +28,5 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "validate"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "validate"}, scenarios)
 }

--- a/pkg/commands/config/config_test.go
+++ b/pkg/commands/config/config_test.go
@@ -22,7 +22,7 @@ func TestConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate config file content is displayed",
 			Env: &testutil.EnvConfig{
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 						{Src: string(data), Dst: "config.toml"},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -39,14 +39,14 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			Name: "validate config location is displayed",
-			Arg:  "--location",
+			Args: "--location",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Write: []testutil.FileIO{
 						{Src: string(data), Dst: "config.toml"},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 					scenario.WantOutput = scenario.ConfigPath
 				},
@@ -54,5 +54,5 @@ func TestConfig(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName}, scenarios)
 }

--- a/pkg/commands/configstore/configstore_test.go
+++ b/pkg/commands/configstore/configstore_test.go
@@ -21,12 +21,12 @@ func TestCreateStoreCommand(t *testing.T) {
 	)
 	now := time.Now()
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--name %s", storeName),
+			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
 				CreateConfigStoreFn: func(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return nil, errors.New("invalid request")
@@ -35,7 +35,7 @@ func TestCreateStoreCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--name %s", storeName),
+			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
 				CreateConfigStoreFn: func(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
@@ -47,7 +47,7 @@ func TestCreateStoreCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Created Config Store '%s' (%s)", storeName, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--name %s --json", storeName),
+			Args: fmt.Sprintf("--name %s --json", storeName),
 			API: mock.API{
 				CreateConfigStoreFn: func(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
@@ -67,19 +67,19 @@ func TestCreateStoreCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestDeleteStoreCommand(t *testing.T) {
 	const storeID = "test123"
 	errStoreNotFound := errors.New("store not found")
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: "--store-id DOES-NOT-EXIST",
+			Args: "--store-id DOES-NOT-EXIST",
 			API: mock.API{
 				DeleteConfigStoreFn: func(i *fastly.DeleteConfigStoreInput) error {
 					if i.StoreID != storeID {
@@ -91,7 +91,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 			WantError: errStoreNotFound.Error(),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				DeleteConfigStoreFn: func(i *fastly.DeleteConfigStoreInput) error {
 					if i.StoreID != storeID {
@@ -103,7 +103,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Deleted Config Store '%s'\n", storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --json", storeID),
+			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				DeleteConfigStoreFn: func(i *fastly.DeleteConfigStoreInput) error {
 					if i.StoreID != storeID {
@@ -116,7 +116,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestGetStoreCommand(t *testing.T) {
@@ -127,12 +127,12 @@ func TestGetStoreCommand(t *testing.T) {
 
 	now := time.Now()
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				GetConfigStoreFn: func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return nil, errors.New("invalid request")
@@ -141,7 +141,7 @@ func TestGetStoreCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				GetConfigStoreFn: func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
@@ -161,7 +161,7 @@ func TestGetStoreCommand(t *testing.T) {
 			),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --metadata", storeID),
+			Args: fmt.Sprintf("--store-id %s --metadata", storeID),
 			API: mock.API{
 				GetConfigStoreFn: func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
@@ -188,7 +188,7 @@ func TestGetStoreCommand(t *testing.T) {
 			),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --json", storeID),
+			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				GetConfigStoreFn: func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
@@ -206,7 +206,7 @@ func TestGetStoreCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "get"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "get"}, scenarios)
 }
 
 func TestListStoresCommand(t *testing.T) {
@@ -222,7 +222,7 @@ func TestListStoresCommand(t *testing.T) {
 		{StoreID: storeID + "+1", Name: storeName + "+1", CreatedAt: &now},
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			API: mock.API{
 				ListConfigStoresFn: func(i *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
@@ -248,7 +248,7 @@ func TestListStoresCommand(t *testing.T) {
 			WantOutput: fmtStores(stores),
 		},
 		{
-			Arg: "--json",
+			Args: "--json",
 			API: mock.API{
 				ListConfigStoresFn: func(i *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
 					return stores, nil
@@ -258,7 +258,7 @@ func TestListStoresCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestListStoreServicesCommand(t *testing.T) {
@@ -272,9 +272,9 @@ func TestListStoreServicesCommand(t *testing.T) {
 		{ServiceID: fastly.ToPointer("abc2"), Name: fastly.ToPointer("test2"), Type: fastly.ToPointer("vcl")},
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				ListConfigStoreServicesFn: func(i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return nil, nil
@@ -283,7 +283,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 			WantOutput: fmtServices(nil),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				ListConfigStoreServicesFn: func(i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return nil, errors.New("unknown error")
@@ -292,7 +292,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 			WantError: "unknown error",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				ListConfigStoreServicesFn: func(i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return services, nil
@@ -301,7 +301,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 			WantOutput: fmtServices(services),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --json", storeID),
+			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				ListConfigStoreServicesFn: func(i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return services, nil
@@ -311,7 +311,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list-services"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list-services"}, scenarios)
 }
 
 func TestUpdateStoreCommand(t *testing.T) {
@@ -321,13 +321,13 @@ func TestUpdateStoreCommand(t *testing.T) {
 	)
 	now := time.Now()
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       fmt.Sprintf("--store-id %s", storeID),
+			Args:      fmt.Sprintf("--store-id %s", storeID),
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --name %s", storeID, storeName),
+			Args: fmt.Sprintf("--store-id %s --name %s", storeID, storeName),
 			API: mock.API{
 				UpdateConfigStoreFn: func(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return nil, errors.New("invalid request")
@@ -336,7 +336,7 @@ func TestUpdateStoreCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --name %s", storeID, storeName),
+			Args: fmt.Sprintf("--store-id %s --name %s", storeID, storeName),
 			API: mock.API{
 				UpdateConfigStoreFn: func(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
@@ -349,7 +349,7 @@ func TestUpdateStoreCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Updated Config Store '%s' (%s)", storeName, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --name %s --json", storeID, storeName),
+			Args: fmt.Sprintf("--store-id %s --name %s --json", storeID, storeName),
 			API: mock.API{
 				UpdateConfigStoreFn: func(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
@@ -369,5 +369,5 @@ func TestUpdateStoreCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/configstoreentry/configstoreentry_test.go
+++ b/pkg/commands/configstoreentry/configstoreentry_test.go
@@ -24,13 +24,13 @@ func TestCreateEntryCommand(t *testing.T) {
 	)
 	now := time.Now()
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--key a-key --value a-value",
+			Args:      "--key a-key --value a-value",
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
 				CreateConfigStoreItemFn: func(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
@@ -39,7 +39,7 @@ func TestCreateEntryCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
 				CreateConfigStoreItemFn: func(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
@@ -52,7 +52,7 @@ func TestCreateEntryCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Created key '%s' in Config Store '%s'", itemKey, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue),
 			API: mock.API{
 				CreateConfigStoreItemFn: func(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
@@ -74,7 +74,7 @@ func TestCreateEntryCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestDeleteEntryCommand(t *testing.T) {
@@ -96,25 +96,25 @@ func TestDeleteEntryCommand(t *testing.T) {
 		}
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--key a-key",
+			Args:      "--key a-key",
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg:       "--store-id " + storeID,
+			Args:      "--store-id " + storeID,
 			WantError: "invalid command, neither --all or --key provided",
 		},
 		{
-			Arg:       "--json --all --store-id " + storeID,
+			Args:      "--json --all --store-id " + storeID,
 			WantError: "invalid flag combination, --all and --json",
 		},
 		{
-			Arg:       "--key a-key --all --store-id " + storeID,
+			Args:      "--key a-key --all --store-id " + storeID,
 			WantError: "invalid flag combination, --all and --key",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				DeleteConfigStoreItemFn: func(i *fastly.DeleteConfigStoreItemInput) error {
 					return errors.New("invalid request")
@@ -123,7 +123,7 @@ func TestDeleteEntryCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				DeleteConfigStoreItemFn: func(i *fastly.DeleteConfigStoreItemInput) error {
 					return nil
@@ -132,7 +132,7 @@ func TestDeleteEntryCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Deleted key '%s' from Config Store '%s'", itemKey, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
 				DeleteConfigStoreItemFn: func(i *fastly.DeleteConfigStoreItemInput) error {
 					return nil
@@ -149,7 +149,7 @@ func TestDeleteEntryCommand(t *testing.T) {
 			}),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
+			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
 				ListConfigStoreItemsFn: func(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
@@ -166,7 +166,7 @@ SUCCESS: Deleted all keys from Config Store '%s'
 `, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
+			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
 				ListConfigStoreItemsFn: func(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
@@ -179,7 +179,7 @@ SUCCESS: Deleted all keys from Config Store '%s'
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestDescribeEntryCommand(t *testing.T) {
@@ -197,13 +197,13 @@ func TestDescribeEntryCommand(t *testing.T) {
 		UpdatedAt: &now,
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--key a-key",
+			Args:      "--key a-key",
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				GetConfigStoreItemFn: func(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
@@ -212,7 +212,7 @@ func TestDescribeEntryCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				GetConfigStoreItemFn: func(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
@@ -227,7 +227,7 @@ func TestDescribeEntryCommand(t *testing.T) {
 			WantOutput: printConfigStoreItem(testItem),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
 				GetConfigStoreItemFn: func(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
@@ -243,7 +243,7 @@ func TestDescribeEntryCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestListEntriesCommand(t *testing.T) {
@@ -262,12 +262,12 @@ func TestListEntriesCommand(t *testing.T) {
 		}
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				ListConfigStoreItemsFn: func(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
@@ -276,7 +276,7 @@ func TestListEntriesCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				ListConfigStoreItemsFn: func(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
@@ -285,7 +285,7 @@ func TestListEntriesCommand(t *testing.T) {
 			WantOutput: printConfigStoreItemsTbl(testItems),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --json", storeID),
+			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				ListConfigStoreItemsFn: func(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
@@ -295,7 +295,7 @@ func TestListEntriesCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestUpdateEntryCommand(t *testing.T) {
@@ -306,13 +306,13 @@ func TestUpdateEntryCommand(t *testing.T) {
 	)
 	now := time.Now()
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--key a-key --value a-value",
+			Args:      "--key a-key --value a-value",
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
 				UpdateConfigStoreItemFn: func(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
@@ -321,7 +321,7 @@ func TestUpdateEntryCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
 				UpdateConfigStoreItemFn: func(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
@@ -334,7 +334,7 @@ func TestUpdateEntryCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Updated config store item %s in store %s", itemKey, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue+"updated"),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue+"updated"),
 			API: mock.API{
 				UpdateConfigStoreItemFn: func(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
@@ -356,7 +356,7 @@ func TestUpdateEntryCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func printConfigStoreItem(i *fastly.ConfigStoreItem) string {

--- a/pkg/commands/dictionary/dictionary_test.go
+++ b/pkg/commands/dictionary/dictionary_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 func TestDictionaryDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--version 1 --service-id 123",
+			Args:      "--version 1 --service-id 123",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--version 1 --service-id 123 --name dict-1",
+			Args: "--version 1 --service-id 123 --name dict-1",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetDictionaryFn: describeDictionaryOK,
@@ -27,7 +27,7 @@ func TestDictionaryDescribe(t *testing.T) {
 			WantOutput: describeDictionaryOutput,
 		},
 		{
-			Arg: "--version 1 --service-id 123 --name dict-1",
+			Args: "--version 1 --service-id 123 --name dict-1",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				GetDictionaryFn: describeDictionaryOKDeleted,
@@ -35,7 +35,7 @@ func TestDictionaryDescribe(t *testing.T) {
 			WantOutput: describeDictionaryOutputDeleted,
 		},
 		{
-			Arg: "--version 1 --service-id 123 --name dict-1 --verbose",
+			Args: "--version 1 --service-id 123 --name dict-1 --verbose",
 			API: mock.API{
 				ListVersionsFn:        testutil.ListVersions,
 				GetDictionaryFn:       describeDictionaryOK,
@@ -45,17 +45,17 @@ func TestDictionaryDescribe(t *testing.T) {
 			WantOutput: describeDictionaryOutputVerbose,
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestDictionaryCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--version 1",
+			Args:      "--version 1",
 			WantError: "error reading service: no service ID found",
 		},
 		{
-			Arg: "--version 1 --service-id 123 --name denylist --autoclone",
+			Args: "--version 1 --service-id 123 --name denylist --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -64,7 +64,7 @@ func TestDictionaryCreate(t *testing.T) {
 			WantOutput: createDictionaryOutput,
 		},
 		{
-			Arg: "--version 1 --service-id 123 --name denylist --write-only --autoclone",
+			Args: "--version 1 --service-id 123 --name denylist --write-only --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -73,7 +73,7 @@ func TestDictionaryCreate(t *testing.T) {
 			WantOutput: createDictionaryOutputWriteOnly,
 		},
 		{
-			Arg: "--version 1 --service-id 123 --name denylist --write-only fish --autoclone",
+			Args: "--version 1 --service-id 123 --name denylist --write-only fish --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -81,7 +81,7 @@ func TestDictionaryCreate(t *testing.T) {
 			WantError: "error parsing arguments: unexpected 'fish'",
 		},
 		{
-			Arg: "--version 1 --service-id 123 --name denylist --autoclone",
+			Args: "--version 1 --service-id 123 --name denylist --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -90,17 +90,17 @@ func TestDictionaryCreate(t *testing.T) {
 			WantError: "Duplicate record",
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestDeleteDictionary(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name allowlist --autoclone",
+			Args: "--service-id 123 --version 1 --name allowlist --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -109,7 +109,7 @@ func TestDeleteDictionary(t *testing.T) {
 			WantOutput: deleteDictionaryOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name allowlist --autoclone",
+			Args: "--service-id 123 --version 1 --name allowlist --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -118,13 +118,13 @@ func TestDeleteDictionary(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestListDictionary(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg: "--version 1",
+			Args: "--version 1",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListDictionariesFn: listDictionariesOk,
@@ -132,11 +132,11 @@ func TestListDictionary(t *testing.T) {
 			WantError: "error reading service: no service ID found",
 		},
 		{
-			Arg:       "--service-id 123",
+			Args:      "--service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			Arg: "--version 1 --service-id 123",
+			Args: "--version 1 --service-id 123",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				ListDictionariesFn: listDictionariesOk,
@@ -144,25 +144,25 @@ func TestListDictionary(t *testing.T) {
 			WantOutput: listDictionariesOutput,
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestUpdateDictionary(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--version 1 --name oldname --new-name newname",
+			Args:      "--version 1 --name oldname --new-name newname",
 			WantError: "error reading service: no service ID found",
 		},
 		{
-			Arg:       "--service-id 123 --name oldname --new-name newname",
+			Args:      "--service-id 123 --name oldname --new-name newname",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			Arg:       "--service-id 123 --version 1 --new-name newname",
+			Args:      "--service-id 123 --version 1 --new-name newname",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name oldname --autoclone",
+			Args: "--service-id 123 --version 1 --name oldname --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -170,7 +170,7 @@ func TestUpdateDictionary(t *testing.T) {
 			WantError: "error parsing arguments: required flag --new-name or --write-only not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
+			Args: "--service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -179,7 +179,7 @@ func TestUpdateDictionary(t *testing.T) {
 			WantOutput: updateDictionaryNameOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name oldname --new-name dict-1 --write-only true --autoclone",
+			Args: "--service-id 123 --version 1 --name oldname --new-name dict-1 --write-only true --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -188,7 +188,7 @@ func TestUpdateDictionary(t *testing.T) {
 			WantOutput: updateDictionaryNameOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name oldname --write-only true --autoclone",
+			Args: "--service-id 123 --version 1 --name oldname --write-only true --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -197,7 +197,7 @@ func TestUpdateDictionary(t *testing.T) {
 			WantOutput: updateDictionaryOutput,
 		},
 		{
-			Arg: "-v --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
+			Args: "-v --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -206,7 +206,7 @@ func TestUpdateDictionary(t *testing.T) {
 			WantOutput: updateDictionaryOutputVerbose,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
+			Args: "--service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
 			API: mock.API{
 				ListVersionsFn:     testutil.ListVersions,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
@@ -215,7 +215,7 @@ func TestUpdateDictionary(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func describeDictionaryOK(i *fastly.GetDictionaryInput) (*fastly.Dictionary, error) {

--- a/pkg/commands/dictionaryentry/dictionaryitem_test.go
+++ b/pkg/commands/dictionaryentry/dictionaryitem_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDictionaryItemDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -63,7 +63,7 @@ func TestDictionaryItemDescribe(t *testing.T) {
 }
 
 func TestDictionaryItemsList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -142,7 +142,7 @@ func TestDictionaryItemsList(t *testing.T) {
 }
 
 func TestDictionaryItemCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -182,7 +182,7 @@ func TestDictionaryItemCreate(t *testing.T) {
 }
 
 func TestDictionaryItemUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -261,7 +261,7 @@ func TestDictionaryItemUpdate(t *testing.T) {
 }
 
 func TestDictionaryItemDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/domain/domain_test.go
+++ b/pkg/commands/domain/domain_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func TestDomainCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--version 1",
+			Args:      "--version 1",
 			WantError: "error reading service: no service ID found",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -29,7 +29,7 @@ func TestDomainCreate(t *testing.T) {
 			WantOutput: "Created domain www.test.com (service 123 version 4)",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -38,13 +38,13 @@ func TestDomainCreate(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestDomainList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -52,7 +52,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsShortOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --verbose",
+			Args: "--service-id 123 --version 1 --verbose",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -60,7 +60,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 -v",
+			Args: "--service-id 123 --version 1 -v",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -68,7 +68,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Arg: "--verbose --service-id 123 --version 1",
+			Args: "--verbose --service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -76,7 +76,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Arg: "-v --service-id 123 --version 1",
+			Args: "-v --service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsOK,
@@ -84,7 +84,7 @@ func TestDomainList(t *testing.T) {
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				ListDomainsFn:  listDomainsError,
@@ -92,17 +92,17 @@ func TestDomainList(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestDomainDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com",
+			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetDomainFn:    getDomainError,
@@ -110,7 +110,7 @@ func TestDomainDescribe(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com",
+			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetDomainFn:    getDomainOK,
@@ -118,17 +118,17 @@ func TestDomainDescribe(t *testing.T) {
 			WantOutput: describeDomainOutput,
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestDomainUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1 --new-name www.test.com --comment ",
+			Args:      "--service-id 123 --version 1 --new-name www.test.com --comment ",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -137,7 +137,7 @@ func TestDomainUpdate(t *testing.T) {
 			WantError: "error parsing arguments: must provide either --new-name or --comment to update domain",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -146,7 +146,7 @@ func TestDomainUpdate(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -155,17 +155,17 @@ func TestDomainUpdate(t *testing.T) {
 			WantOutput: "Updated domain www.example.com (service 123 version 4)",
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func TestDomainDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -174,7 +174,7 @@ func TestDomainDelete(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name www.test.com --autoclone",
+			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -183,18 +183,18 @@ func TestDomainDelete(t *testing.T) {
 			WantOutput: "Deleted domain www.test.com (service 123 version 4)",
 		},
 	}
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestDomainValidate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -202,7 +202,7 @@ func TestDomainValidate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --name flag",
 		},
 		{
@@ -213,7 +213,7 @@ func TestDomainValidate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foo.example.com --service-id 123 --version 3",
+			Args:      "--name foo.example.com --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -224,7 +224,7 @@ func TestDomainValidate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--all --service-id 123 --version 3",
+			Args:      "--all --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -233,7 +233,7 @@ func TestDomainValidate(t *testing.T) {
 				ListVersionsFn:   testutil.ListVersions,
 				ValidateDomainFn: validateDomain,
 			},
-			Arg:        "--name foo.example.com --service-id 123 --version 3",
+			Args:       "--name foo.example.com --service-id 123 --version 3",
 			WantOutput: validateAPISuccess(3),
 		},
 		{
@@ -242,7 +242,7 @@ func TestDomainValidate(t *testing.T) {
 				ListVersionsFn:       testutil.ListVersions,
 				ValidateAllDomainsFn: validateAllDomains,
 			},
-			Arg:        "--all --service-id 123 --version 3",
+			Args:       "--all --service-id 123 --version 3",
 			WantOutput: validateAllAPISuccess(),
 		},
 		{
@@ -251,12 +251,12 @@ func TestDomainValidate(t *testing.T) {
 				ListVersionsFn:   testutil.ListVersions,
 				ValidateDomainFn: validateDomain,
 			},
-			Arg:        "--name foo.example.com --service-id 123 --version 1",
+			Args:       "--name foo.example.com --service-id 123 --version 1",
 			WantOutput: validateAPISuccess(1),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "validate"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "validate"}, scenarios)
 }
 
 var errTest = errors.New("fixture error")

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestHealthCheckCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -65,7 +65,7 @@ func TestHealthCheckCreate(t *testing.T) {
 }
 
 func TestHealthCheckList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -138,7 +138,7 @@ func TestHealthCheckList(t *testing.T) {
 }
 
 func TestHealthCheckDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -183,7 +183,7 @@ func TestHealthCheckDescribe(t *testing.T) {
 }
 
 func TestHealthCheckUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -238,7 +238,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 }
 
 func TestHealthCheckDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/ip/ip_test.go
+++ b/pkg/commands/ip/ip_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAllIPs(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate listing IP addresses",
 			API: mock.API{
@@ -27,5 +27,5 @@ func TestAllIPs(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName}, scenarios)
 }

--- a/pkg/commands/kvstore/kvstore_test.go
+++ b/pkg/commands/kvstore/kvstore_test.go
@@ -24,12 +24,12 @@ func TestCreateStoreCommand(t *testing.T) {
 	)
 	now := time.Now()
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--name %s", storeName),
+			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return nil, errors.New("invalid request")
@@ -38,7 +38,7 @@ func TestCreateStoreCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--name %s", storeName),
+			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
@@ -50,7 +50,7 @@ func TestCreateStoreCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Created KV Store '%s' (%s)", storeName, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--name %s --json", storeName),
+			Args: fmt.Sprintf("--name %s --json", storeName),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
@@ -71,7 +71,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			// NOTE: The following tests only validate support for the --location flag.
 			// Location/region indicators are not exposed for us to validate.
-			Arg: fmt.Sprintf("--name %s --location %s", storeName, storeLocation),
+			Args: fmt.Sprintf("--name %s --location %s", storeName, storeLocation),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
@@ -85,7 +85,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			// NOTE: The following tests only validate support for the --location flag.
 			// Location/region indicators are not exposed for us to validate.
-			Arg: fmt.Sprintf("--name %s --location %s --json", storeName, storeLocation),
+			Args: fmt.Sprintf("--name %s --location %s --json", storeName, storeLocation),
 			API: mock.API{
 				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
@@ -105,19 +105,19 @@ func TestCreateStoreCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestDeleteStoreCommand(t *testing.T) {
 	const storeID = "test123"
 	errStoreNotFound := errors.New("store not found")
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: "--store-id DOES-NOT-EXIST",
+			Args: "--store-id DOES-NOT-EXIST",
 			API: mock.API{
 				DeleteKVStoreFn: func(i *fastly.DeleteKVStoreInput) error {
 					if i.StoreID != storeID {
@@ -129,7 +129,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 			WantError: errStoreNotFound.Error(),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				DeleteKVStoreFn: func(i *fastly.DeleteKVStoreInput) error {
 					if i.StoreID != storeID {
@@ -141,7 +141,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Deleted KV Store '%s'\n", storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --json", storeID),
+			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				DeleteKVStoreFn: func(i *fastly.DeleteKVStoreInput) error {
 					if i.StoreID != storeID {
@@ -154,7 +154,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestGetStoreCommand(t *testing.T) {
@@ -165,12 +165,12 @@ func TestGetStoreCommand(t *testing.T) {
 
 	now := time.Now()
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				GetKVStoreFn: func(i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
 					return nil, errors.New("invalid request")
@@ -179,7 +179,7 @@ func TestGetStoreCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				GetKVStoreFn: func(i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
@@ -200,7 +200,7 @@ func TestGetStoreCommand(t *testing.T) {
 			),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --json", storeID),
+			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				GetKVStoreFn: func(i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
@@ -218,7 +218,7 @@ func TestGetStoreCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "get"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "get"}, scenarios)
 }
 
 func TestListStoresCommand(t *testing.T) {
@@ -236,7 +236,7 @@ func TestListStoresCommand(t *testing.T) {
 		},
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			API: mock.API{
 				ListKVStoresFn: func(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
@@ -261,7 +261,7 @@ func TestListStoresCommand(t *testing.T) {
 			WantOutput: fmtStores(stores),
 		},
 		{
-			Arg: "--json",
+			Args: "--json",
 			API: mock.API{
 				ListKVStoresFn: func(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
 					return stores, nil
@@ -271,7 +271,7 @@ func TestListStoresCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func fmtStore(ks *fastly.KVStore) string {

--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -22,13 +22,13 @@ func TestCreateCommand(t *testing.T) {
 		itemValue = "the-value"
 	)
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--key a-key --value a-value",
+			Args:      "--key a-key --value a-value",
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
 				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 					return errors.New("invalid request")
@@ -37,7 +37,7 @@ func TestCreateCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
 				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 					return nil
@@ -46,7 +46,7 @@ func TestCreateCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Created key '%s' in KV Store '%s'", itemKey, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue),
+			Args: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue),
 			API: mock.API{
 				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
 					return nil
@@ -55,7 +55,7 @@ func TestCreateCommand(t *testing.T) {
 			WantOutput: fstfmt.JSON(`{"id": %q, "key": %q}`, storeID, itemKey),
 		},
 		{
-			Arg:   fmt.Sprintf("--store-id %s --stdin", storeID),
+			Args:  fmt.Sprintf("--store-id %s --stdin", storeID),
 			Stdin: []string{`{"key":"example","value":"VkFMVUU="}`},
 			API: mock.API{
 				BatchModifyKVStoreKeyFn: func(_ *fastly.BatchModifyKVStoreKeyInput) error {
@@ -65,7 +65,7 @@ func TestCreateCommand(t *testing.T) {
 			WantOutput: "SUCCESS: Inserted keys into KV Store\n",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --file %s", storeID, filepath.Join("testdata", "data.json")),
+			Args: fmt.Sprintf("--store-id %s --file %s", storeID, filepath.Join("testdata", "data.json")),
 			API: mock.API{
 				BatchModifyKVStoreKeyFn: func(_ *fastly.BatchModifyKVStoreKeyInput) error {
 					return nil
@@ -74,7 +74,7 @@ func TestCreateCommand(t *testing.T) {
 			WantOutput: "SUCCESS: Inserted keys into KV Store\n",
 		},
 		{
-			Arg:   fmt.Sprintf("--store-id %s --dir %s", storeID, filepath.Join("testdata", "example")),
+			Args:  fmt.Sprintf("--store-id %s --dir %s", storeID, filepath.Join("testdata", "example")),
 			Stdin: []string{"y"},
 			API: mock.API{
 				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
@@ -84,7 +84,7 @@ func TestCreateCommand(t *testing.T) {
 			WantOutput: "SUCCESS: Inserted 1 keys into KV Store",
 		},
 		{
-			Arg:   fmt.Sprintf("--store-id %s --dir %s --dir-allow-hidden", storeID, filepath.Join("testdata", "example")),
+			Args:  fmt.Sprintf("--store-id %s --dir %s --dir-allow-hidden", storeID, filepath.Join("testdata", "example")),
 			Stdin: []string{"y"},
 			API: mock.API{
 				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
@@ -95,7 +95,7 @@ func TestCreateCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestDeleteCommand(t *testing.T) {
@@ -104,25 +104,25 @@ func TestDeleteCommand(t *testing.T) {
 		itemKey = "foo"
 	)
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--key a-key",
+			Args:      "--key a-key",
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg:       "--store-id " + storeID,
+			Args:      "--store-id " + storeID,
 			WantError: "invalid command, neither --all or --key provided",
 		},
 		{
-			Arg:       "--json --all --store-id " + storeID,
+			Args:      "--json --all --store-id " + storeID,
 			WantError: "invalid flag combination, --all and --json",
 		},
 		{
-			Arg:       "--key a-key --all --store-id " + storeID,
+			Args:      "--key a-key --all --store-id " + storeID,
 			WantError: "invalid flag combination, --all and --key",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return errors.New("invalid request")
@@ -131,7 +131,7 @@ func TestDeleteCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
@@ -140,7 +140,7 @@ func TestDeleteCommand(t *testing.T) {
 			WantOutput: fstfmt.Success("Deleted key '%s' from KV Store '%s'", itemKey, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
 				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
@@ -149,7 +149,7 @@ func TestDeleteCommand(t *testing.T) {
 			WantOutput: fstfmt.JSON(`{"key": "%s", "store_id": "%s", "deleted": true}`, itemKey, storeID),
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
+			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
 				NewListKVStoreKeysPaginatorFn: func(_ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
 					return &mockKVStoresEntriesPaginator{
@@ -164,7 +164,7 @@ func TestDeleteCommand(t *testing.T) {
 			WantOutput: "Deleting keys...",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
+			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
 				NewListKVStoreKeysPaginatorFn: func(_ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
 					return &mockKVStoresEntriesPaginator{
@@ -180,7 +180,7 @@ func TestDeleteCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestGetCommand(t *testing.T) {
@@ -190,13 +190,13 @@ func TestGetCommand(t *testing.T) {
 		itemValue = "a value"
 	)
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--key a-key",
+			Args:      "--key a-key",
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
 					return "", errors.New("invalid request")
@@ -205,7 +205,7 @@ func TestGetCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
 				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
 					return itemValue, nil
@@ -214,7 +214,7 @@ func TestGetCommand(t *testing.T) {
 			WantOutput: itemValue,
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
+			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
 				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
 					return itemValue, nil
@@ -224,7 +224,7 @@ func TestGetCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "get"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "get"}, scenarios)
 }
 
 func TestListCommand(t *testing.T) {
@@ -235,12 +235,12 @@ func TestListCommand(t *testing.T) {
 		testItems[i] = fmt.Sprintf("key-%02d", i)
 	}
 
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			WantError: "error parsing arguments: required flag --store-id not provided",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return nil, errors.New("invalid request")
@@ -249,7 +249,7 @@ func TestListCommand(t *testing.T) {
 			WantError: "invalid request",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s", storeID),
+			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
 				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return &fastly.ListKVStoreKeysResponse{Data: testItems}, nil
@@ -258,7 +258,7 @@ func TestListCommand(t *testing.T) {
 			WantOutput: strings.Join(testItems, "\n") + "\n",
 		},
 		{
-			Arg: fmt.Sprintf("--store-id %s --json", storeID),
+			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return &fastly.ListKVStoreKeysResponse{Data: testItems}, nil
@@ -268,7 +268,7 @@ func TestListCommand(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 type mockKVStoresEntriesPaginator struct {

--- a/pkg/commands/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBlobStorageCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -68,7 +68,7 @@ func TestBlobStorageCreate(t *testing.T) {
 }
 
 func TestBlobStorageList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -141,7 +141,7 @@ func TestBlobStorageList(t *testing.T) {
 }
 
 func TestBlobStorageDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -186,7 +186,7 @@ func TestBlobStorageDescribe(t *testing.T) {
 }
 
 func TestBlobStorageUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -233,7 +233,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 }
 
 func TestBlobStorageDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBigQueryCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestBigQueryCreate(t *testing.T) {
 }
 
 func TestBigQueryList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestBigQueryList(t *testing.T) {
 }
 
 func TestBigQueryDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestBigQueryDescribe(t *testing.T) {
 }
 
 func TestBigQueryUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestBigQueryUpdate(t *testing.T) {
 }
 
 func TestBigQueryDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestCloudfilesCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -67,7 +67,7 @@ func TestCloudfilesCreate(t *testing.T) {
 }
 
 func TestCloudfilesList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -140,7 +140,7 @@ func TestCloudfilesList(t *testing.T) {
 }
 
 func TestCloudfilesDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -185,7 +185,7 @@ func TestCloudfilesDescribe(t *testing.T) {
 }
 
 func TestCloudfilesUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -232,7 +232,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 }
 
 func TestCloudfilesDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/logging/datadog/datadog_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDatadogCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestDatadogCreate(t *testing.T) {
 }
 
 func TestDatadogList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestDatadogList(t *testing.T) {
 }
 
 func TestDatadogDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestDatadogDescribe(t *testing.T) {
 }
 
 func TestDatadogUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestDatadogUpdate(t *testing.T) {
 }
 
 func TestDatadogDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDigitalOceanCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -67,7 +67,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 }
 
 func TestDigitalOceanList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -140,7 +140,7 @@ func TestDigitalOceanList(t *testing.T) {
 }
 
 func TestDigitalOceanDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -185,7 +185,7 @@ func TestDigitalOceanDescribe(t *testing.T) {
 }
 
 func TestDigitalOceanUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -232,7 +232,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 }
 
 func TestDigitalOceanDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestElasticsearchCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestElasticsearchCreate(t *testing.T) {
 }
 
 func TestElasticsearchList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestElasticsearchList(t *testing.T) {
 }
 
 func TestElasticsearchDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestElasticsearchDescribe(t *testing.T) {
 }
 
 func TestElasticsearchUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestElasticsearchUpdate(t *testing.T) {
 }
 
 func TestElasticsearchDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/logging/ftp/ftp_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestFTPCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -67,7 +67,7 @@ func TestFTPCreate(t *testing.T) {
 }
 
 func TestFTPList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -140,7 +140,7 @@ func TestFTPList(t *testing.T) {
 }
 
 func TestFTPDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -185,7 +185,7 @@ func TestFTPDescribe(t *testing.T) {
 }
 
 func TestFTPUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -232,7 +232,7 @@ func TestFTPUpdate(t *testing.T) {
 }
 
 func TestFTPDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGCSCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -76,7 +76,7 @@ func TestGCSCreate(t *testing.T) {
 }
 
 func TestGCSList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -149,7 +149,7 @@ func TestGCSList(t *testing.T) {
 }
 
 func TestGCSDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -194,7 +194,7 @@ func TestGCSDescribe(t *testing.T) {
 }
 
 func TestGCSUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -241,7 +241,7 @@ func TestGCSUpdate(t *testing.T) {
 }
 
 func TestGCSDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGooglePubSubCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 }
 
 func TestGooglePubSubList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestGooglePubSubList(t *testing.T) {
 }
 
 func TestGooglePubSubDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestGooglePubSubDescribe(t *testing.T) {
 }
 
 func TestGooglePubSubUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestGooglePubSubUpdate(t *testing.T) {
 }
 
 func TestGooglePubSubDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/logging/heroku/heroku_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestHerokuCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestHerokuCreate(t *testing.T) {
 }
 
 func TestHerokuList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestHerokuList(t *testing.T) {
 }
 
 func TestHerokuDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestHerokuDescribe(t *testing.T) {
 }
 
 func TestHerokuUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestHerokuUpdate(t *testing.T) {
 }
 
 func TestHerokuDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestHoneycombCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestHoneycombCreate(t *testing.T) {
 }
 
 func TestHoneycombList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestHoneycombList(t *testing.T) {
 }
 
 func TestHoneycombDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestHoneycombDescribe(t *testing.T) {
 }
 
 func TestHoneycombUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestHoneycombUpdate(t *testing.T) {
 }
 
 func TestHoneycombDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestHTTPSCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestHTTPSCreate(t *testing.T) {
 }
 
 func TestHTTPSList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestHTTPSList(t *testing.T) {
 }
 
 func TestHTTPSDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestHTTPSDescribe(t *testing.T) {
 }
 
 func TestHTTPSUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestHTTPSUpdate(t *testing.T) {
 }
 
 func TestHTTPSDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/logging/kafka/kafka_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestKafkaCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestKafkaCreate(t *testing.T) {
 }
 
 func TestKafkaList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestKafkaList(t *testing.T) {
 }
 
 func TestKafkaDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestKafkaDescribe(t *testing.T) {
 }
 
 func TestKafkaUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -233,7 +233,7 @@ func TestKafkaUpdate(t *testing.T) {
 }
 
 func TestKafkaDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestKinesisCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -101,7 +101,7 @@ func TestKinesisCreate(t *testing.T) {
 }
 
 func TestKinesisList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -174,7 +174,7 @@ func TestKinesisList(t *testing.T) {
 }
 
 func TestKinesisDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -219,7 +219,7 @@ func TestKinesisDescribe(t *testing.T) {
 }
 
 func TestKinesisUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -266,7 +266,7 @@ func TestKinesisUpdate(t *testing.T) {
 }
 
 func TestKinesisDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/logging/loggly/loggly_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestLogglyCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestLogglyCreate(t *testing.T) {
 }
 
 func TestLogglyList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestLogglyList(t *testing.T) {
 }
 
 func TestLogglyDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestLogglyDescribe(t *testing.T) {
 }
 
 func TestLogglyUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestLogglyUpdate(t *testing.T) {
 }
 
 func TestLogglyDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestLogshuttleCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestLogshuttleCreate(t *testing.T) {
 }
 
 func TestLogshuttleList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestLogshuttleList(t *testing.T) {
 }
 
 func TestLogshuttleDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestLogshuttleDescribe(t *testing.T) {
 }
 
 func TestLogshuttleUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestLogshuttleUpdate(t *testing.T) {
 }
 
 func TestLogshuttleDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/logging/newrelic/newrelic_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestNewRelicCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--key abc --name foo --version 3",
+			Args:      "--key abc --name foo --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -23,7 +23,7 @@ func TestNewRelicCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--key abc --name foo --service-id 123 --version 1",
+			Args:      "--key abc --name foo --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -31,7 +31,7 @@ func TestNewRelicCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--key abc --name foo --service-id 123 --version 2",
+			Args:      "--key abc --name foo --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -42,7 +42,7 @@ func TestNewRelicCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--key abc --name foo --service-id 123 --version 3",
+			Args:      "--key abc --name foo --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -57,7 +57,7 @@ func TestNewRelicCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--key abc --name foo --service-id 123 --version 3",
+			Args:       "--key abc --name foo --service-id 123 --version 3",
 			WantOutput: "Created New Relic logging endpoint 'foo' (service: 123, version: 3)",
 		},
 		{
@@ -73,29 +73,29 @@ func TestNewRelicCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--autoclone --key abc --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --key abc --name foo --service-id 123 --version 1",
 			WantOutput: "Created New Relic logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
 }
 
 func TestNewRelicDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -103,7 +103,7 @@ func TestNewRelicDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -111,7 +111,7 @@ func TestNewRelicDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 2",
+			Args:      "--name foobar --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -122,7 +122,7 @@ func TestNewRelicDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -133,7 +133,7 @@ func TestNewRelicDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "Deleted New Relic logging endpoint 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -145,29 +145,29 @@ func TestNewRelicDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--autoclone --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --name foo --service-id 123 --version 1",
 			WantOutput: "Deleted New Relic logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
 }
 
 func TestNewRelicDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -178,7 +178,7 @@ func TestNewRelicDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -187,7 +187,7 @@ func TestNewRelicDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetNewRelicFn:  getNewRelic,
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nFormat: \nFormat Version: 0\nName: foobar\nPlacement: \nRegion: \nResponse Condition: \nService ID: 123\nService Version: 3\nToken: abc\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -196,23 +196,23 @@ func TestNewRelicDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetNewRelicFn:  getNewRelic,
 			},
-			Arg:        "--name foobar --service-id 123 --version 1",
+			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nFormat: \nFormat Version: 0\nName: foobar\nPlacement: \nRegion: \nResponse Condition: \nService ID: 123\nService Version: 1\nToken: abc\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestNewRelicList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -223,7 +223,7 @@ func TestNewRelicList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -232,7 +232,7 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListNewRelicFn: listNewRelic,
 			},
-			Arg:        "--service-id 123 --version 3",
+			Args:       "--service-id 123 --version 3",
 			WantOutput: "SERVICE ID  VERSION  NAME\n123         3        foo\n123         3        bar\n",
 		},
 		{
@@ -241,7 +241,7 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListNewRelicFn: listNewRelic,
 			},
-			Arg:        "--service-id 123 --version 1",
+			Args:       "--service-id 123 --version 1",
 			WantOutput: "SERVICE ID  VERSION  NAME\n123         1        foo\n123         1        bar\n",
 		},
 		{
@@ -250,29 +250,29 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListNewRelicFn: listNewRelic,
 			},
-			Arg:        "--service-id 123 --verbose --version 1",
+			Args:       "--service-id 123 --verbose --version 1",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (profile: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }
 
 func TestNewRelicUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar --service-id 123",
+			Args:      "--name foobar --service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -280,7 +280,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -288,7 +288,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 2",
+			Args:      "--name foobar --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -299,7 +299,7 @@ func TestNewRelicUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -314,7 +314,7 @@ func TestNewRelicUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:       "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 3)",
 		},
 		{
@@ -330,12 +330,12 @@ func TestNewRelicUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
 			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
 func getNewRelic(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {

--- a/pkg/commands/logging/newrelicotlp/newrelicotlp_test.go
+++ b/pkg/commands/logging/newrelicotlp/newrelicotlp_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestNewRelicOTLPCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--key abc --name foo --version 3",
+			Args:      "--key abc --name foo --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -23,7 +23,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--key abc --name foo --service-id 123 --version 1",
+			Args:      "--key abc --name foo --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -31,7 +31,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--key abc --name foo --service-id 123 --version 2",
+			Args:      "--key abc --name foo --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -42,7 +42,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--key abc --name foo --service-id 123 --version 3",
+			Args:      "--key abc --name foo --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -57,7 +57,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--key abc --name foo --service-id 123 --version 3",
+			Args:       "--key abc --name foo --service-id 123 --version 3",
 			WantOutput: "Created New Relic OTLP logging endpoint 'foo' (service: 123, version: 3)",
 		},
 		{
@@ -73,29 +73,29 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--autoclone --key abc --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --key abc --name foo --service-id 123 --version 1",
 			WantOutput: "Created New Relic OTLP logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
 }
 
 func TestNewRelicOTLPDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -103,7 +103,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -111,7 +111,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 2",
+			Args:      "--name foobar --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -122,7 +122,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -133,7 +133,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "Deleted New Relic OTLP logging endpoint 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -145,29 +145,29 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--autoclone --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --name foo --service-id 123 --version 1",
 			WantOutput: "Deleted New Relic OTLP logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
 }
 
 func TestNewRelicDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -178,7 +178,7 @@ func TestNewRelicDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -187,7 +187,7 @@ func TestNewRelicDescribe(t *testing.T) {
 				ListVersionsFn:    testutil.ListVersions,
 				GetNewRelicOTLPFn: getNewRelic,
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nFormat: \nFormat Version: 0\nName: foobar\nPlacement: \nRegion: \nResponse Condition: \nService ID: 123\nService Version: 3\nToken: abc\nURL: \nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -196,23 +196,23 @@ func TestNewRelicDescribe(t *testing.T) {
 				ListVersionsFn:    testutil.ListVersions,
 				GetNewRelicOTLPFn: getNewRelic,
 			},
-			Arg:        "--name foobar --service-id 123 --version 1",
+			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nFormat: \nFormat Version: 0\nName: foobar\nPlacement: \nRegion: \nResponse Condition: \nService ID: 123\nService Version: 1\nToken: abc\nURL: \nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestNewRelicList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -223,7 +223,7 @@ func TestNewRelicList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -232,7 +232,7 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn:     testutil.ListVersions,
 				ListNewRelicOTLPFn: listNewRelic,
 			},
-			Arg:        "--service-id 123 --version 3",
+			Args:       "--service-id 123 --version 3",
 			WantOutput: "SERVICE ID  VERSION  NAME\n123         3        foo\n123         3        bar\n",
 		},
 		{
@@ -241,7 +241,7 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn:     testutil.ListVersions,
 				ListNewRelicOTLPFn: listNewRelic,
 			},
-			Arg:        "--service-id 123 --version 1",
+			Args:       "--service-id 123 --version 1",
 			WantOutput: "SERVICE ID  VERSION  NAME\n123         1        foo\n123         1        bar\n",
 		},
 		{
@@ -250,29 +250,29 @@ func TestNewRelicList(t *testing.T) {
 				ListVersionsFn:     testutil.ListVersions,
 				ListNewRelicOTLPFn: listNewRelic,
 			},
-			Arg:        "--service-id 123 --verbose --version 1",
+			Args:       "--service-id 123 --verbose --version 1",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (profile: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\n\nToken: \n\nFormat: \n\nFormat Version: 0\n\nPlacement: \n\nRegion: \n\nResponse Condition: \n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }
 
 func TestNewRelicUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar --service-id 123",
+			Args:      "--name foobar --service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -280,7 +280,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -288,7 +288,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 2",
+			Args:      "--name foobar --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -299,7 +299,7 @@ func TestNewRelicUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -314,7 +314,7 @@ func TestNewRelicUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:       "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantOutput: "Updated New Relic OTLP logging endpoint 'beepboop' (previously: foobar, service: 123, version: 3)",
 		},
 		{
@@ -330,12 +330,12 @@ func TestNewRelicUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
 			WantOutput: "Updated New Relic OTLP logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
 func getNewRelic(i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {

--- a/pkg/commands/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/logging/openstack/openstack_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestOpenstackCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -67,7 +67,7 @@ func TestOpenstackCreate(t *testing.T) {
 }
 
 func TestOpenstackList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -140,7 +140,7 @@ func TestOpenstackList(t *testing.T) {
 }
 
 func TestOpenstackDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -185,7 +185,7 @@ func TestOpenstackDescribe(t *testing.T) {
 }
 
 func TestOpenstackUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -232,7 +232,7 @@ func TestOpenstackUpdate(t *testing.T) {
 }
 
 func TestOpenstackDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestPapertrailCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestPapertrailCreate(t *testing.T) {
 }
 
 func TestPapertrailList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestPapertrailList(t *testing.T) {
 }
 
 func TestPapertrailDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestPapertrailDescribe(t *testing.T) {
 }
 
 func TestPapertrailUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestPapertrailUpdate(t *testing.T) {
 }
 
 func TestPapertrailDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/s3/s3_integration_test.go
+++ b/pkg/commands/logging/s3/s3_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestS3Create(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -117,7 +117,7 @@ func TestS3Create(t *testing.T) {
 }
 
 func TestS3List(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -190,7 +190,7 @@ func TestS3List(t *testing.T) {
 }
 
 func TestS3Describe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -235,7 +235,7 @@ func TestS3Describe(t *testing.T) {
 }
 
 func TestS3Update(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -291,7 +291,7 @@ func TestS3Update(t *testing.T) {
 }
 
 func TestS3Delete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestScalyrCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -68,7 +68,7 @@ func TestScalyrCreate(t *testing.T) {
 }
 
 func TestScalyrList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -141,7 +141,7 @@ func TestScalyrList(t *testing.T) {
 }
 
 func TestScalyrDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -186,7 +186,7 @@ func TestScalyrDescribe(t *testing.T) {
 }
 
 func TestScalyrUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -233,7 +233,7 @@ func TestScalyrUpdate(t *testing.T) {
 }
 
 func TestScalyrDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/logging/sftp/sftp_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSFTPCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -67,7 +67,7 @@ func TestSFTPCreate(t *testing.T) {
 }
 
 func TestSFTPList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -140,7 +140,7 @@ func TestSFTPList(t *testing.T) {
 }
 
 func TestSFTPDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -185,7 +185,7 @@ func TestSFTPDescribe(t *testing.T) {
 }
 
 func TestSFTPUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -232,7 +232,7 @@ func TestSFTPUpdate(t *testing.T) {
 }
 
 func TestSFTPDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/logging/splunk/splunk_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSplunkCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestSplunkCreate(t *testing.T) {
 }
 
 func TestSplunkList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestSplunkList(t *testing.T) {
 }
 
 func TestSplunkDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestSplunkDescribe(t *testing.T) {
 }
 
 func TestSplunkUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestSplunkUpdate(t *testing.T) {
 }
 
 func TestSplunkDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSumologicCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestSumologicCreate(t *testing.T) {
 }
 
 func TestSumologicList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestSumologicList(t *testing.T) {
 }
 
 func TestSumologicDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestSumologicDescribe(t *testing.T) {
 }
 
 func TestSumologicUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestSumologicUpdate(t *testing.T) {
 }
 
 func TestSumologicDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/logging/syslog/syslog_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSyslogCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -59,7 +59,7 @@ func TestSyslogCreate(t *testing.T) {
 }
 
 func TestSyslogList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -132,7 +132,7 @@ func TestSyslogList(t *testing.T) {
 }
 
 func TestSyslogDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -177,7 +177,7 @@ func TestSyslogDescribe(t *testing.T) {
 }
 
 func TestSyslogUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -224,7 +224,7 @@ func TestSyslogUpdate(t *testing.T) {
 }
 
 func TestSyslogDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/pop/pop_test.go
+++ b/pkg/commands/pop/pop_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAllDatacenters(t *testing.T) {
 	var stdout bytes.Buffer
-	args := testutil.Args("pops")
+	args := testutil.SplitArgs("pops")
 	api := mock.API{
 		AllDatacentersFn: func() ([]fastly.Datacenter, error) {
 			return []fastly.Datacenter{

--- a/pkg/commands/products/products_test.go
+++ b/pkg/commands/products/products_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 func TestProductEnablement(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing Service ID",
 			WantError: "failed to identify Service ID: error reading service: no service ID found",
 		},
 		{
 			Name:      "validate invalid enable/disable flag combo",
-			Arg:       "--enable fanout --disable fanout",
+			Args:      "--enable fanout --disable fanout",
 			WantError: "invalid flag combination: --enable and --disable",
 		},
 		{
@@ -28,7 +28,7 @@ func TestProductEnablement(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg: "--service-id 123",
+			Args: "--service-id 123",
 			WantOutput: `PRODUCT             ENABLED
 brotli_compression  false
 domain_inspector    false
@@ -45,7 +45,7 @@ websockets          false
 					return nil, nil
 				},
 			},
-			Arg: "--service-id 123",
+			Args: "--service-id 123",
 			WantOutput: `PRODUCT             ENABLED
 brotli_compression  true
 domain_inspector    true
@@ -57,12 +57,12 @@ websockets          true
 		},
 		{
 			Name:      "validate flag parsing error for enabling product",
-			Arg:       "--service-id 123 --enable foo",
+			Args:      "--service-id 123 --enable foo",
 			WantError: "error parsing arguments: enum value must be one of brotli_compression,domain_inspector,fanout,image_optimizer,origin_inspector,websockets, got 'foo'",
 		},
 		{
 			Name:      "validate flag parsing error for disabling product",
-			Arg:       "--service-id 123 --disable foo",
+			Args:      "--service-id 123 --disable foo",
 			WantError: "error parsing arguments: enum value must be one of brotli_compression,domain_inspector,fanout,image_optimizer,origin_inspector,websockets, got 'foo'",
 		},
 		{
@@ -72,7 +72,7 @@ websockets          true
 					return nil, nil
 				},
 			},
-			Arg:        "--service-id 123 --enable brotli_compression",
+			Args:       "--service-id 123 --enable brotli_compression",
 			WantOutput: "SUCCESS: Successfully enabled product 'brotli_compression'",
 		},
 		{
@@ -82,12 +82,12 @@ websockets          true
 					return nil
 				},
 			},
-			Arg:        "--service-id 123 --disable brotli_compression",
+			Args:       "--service-id 123 --disable brotli_compression",
 			WantOutput: "SUCCESS: Successfully disabled product 'brotli_compression'",
 		},
 		{
 			Name:      "validate invalid json/verbose flag combo",
-			Arg:       "--service-id 123 --json --verbose",
+			Args:      "--service-id 123 --json --verbose",
 			WantError: "invalid flag combination, --verbose and --json",
 		},
 		{
@@ -97,7 +97,7 @@ websockets          true
 					return nil, testutil.Err
 				},
 			},
-			Arg: "--service-id 123 --json",
+			Args: "--service-id 123 --json",
 			WantOutput: `{
   "brotli_compression": false,
   "domain_inspector": false,
@@ -114,7 +114,7 @@ websockets          true
 					return nil, nil
 				},
 			},
-			Arg: "--service-id 123 --json",
+			Args: "--service-id 123 --json",
 			WantOutput: `{
   "brotli_compression": true,
   "domain_inspector": true,
@@ -126,5 +126,5 @@ websockets          true
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName}, scenarios)
 }

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 func TestProfileCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate profile creation works",
-			Arg:  "foo",
+			Args: "foo",
 			API: mock.API{
 				GetTokenSelfFn: getToken,
 				GetUserFn:      getUser,
@@ -32,7 +32,7 @@ func TestProfileCreate(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -45,7 +45,7 @@ func TestProfileCreate(t *testing.T) {
 		},
 		{
 			Name: "validate profile duplication",
-			Arg:  "foo",
+			Args: "foo",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -55,7 +55,7 @@ func TestProfileCreate(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -72,14 +72,14 @@ func TestProfileCreate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestProfileDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate profile deletion works",
-			Arg:  "foo",
+			Args: "foo",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -89,7 +89,7 @@ func TestProfileDelete(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -106,7 +106,7 @@ func TestProfileDelete(t *testing.T) {
 		},
 		{
 			Name: "validate incorrect profile",
-			Arg:  "unknown",
+			Args: "unknown",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -116,7 +116,7 @@ func TestProfileDelete(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -124,11 +124,11 @@ func TestProfileDelete(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestProfileList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate listing profiles works",
 			Env: &testutil.EnvConfig{
@@ -140,7 +140,7 @@ func TestProfileList(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -175,7 +175,7 @@ func TestProfileList(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -197,7 +197,7 @@ func TestProfileList(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -220,7 +220,7 @@ func TestProfileList(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -246,7 +246,7 @@ func TestProfileList(t *testing.T) {
 		},
 		{
 			Name: "validate listing profiles with --verbose and --json causes an error",
-			Arg:  "--verbose --json",
+			Args: "--verbose --json",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -256,7 +256,7 @@ func TestProfileList(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -278,7 +278,7 @@ func TestProfileList(t *testing.T) {
 		},
 		{
 			Name: "validate listing profiles with --json displays data correctly",
-			Arg:  "--json",
+			Args: "--json",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -288,7 +288,7 @@ func TestProfileList(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -337,14 +337,14 @@ func TestProfileList(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestProfileSwitch(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate switching to unknown profile returns an error",
-			Arg:  "unknown",
+			Args: "unknown",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -354,7 +354,7 @@ func TestProfileSwitch(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -362,7 +362,7 @@ func TestProfileSwitch(t *testing.T) {
 		},
 		{
 			Name: "validate switching profiles works",
-			Arg:  "bar",
+			Args: "bar",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -372,7 +372,7 @@ func TestProfileSwitch(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -394,11 +394,11 @@ func TestProfileSwitch(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "switch"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "switch"}, scenarios)
 }
 
 func TestProfileToken(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate the active profile token is displayed by default",
 			Env: &testutil.EnvConfig{
@@ -410,7 +410,7 @@ func TestProfileToken(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -432,7 +432,7 @@ func TestProfileToken(t *testing.T) {
 		},
 		{
 			Name: "validate token is displayed for the specified profile",
-			Arg:  "bar", // we choose a non-default profile
+			Args: "bar", // we choose a non-default profile
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -442,7 +442,7 @@ func TestProfileToken(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -464,7 +464,7 @@ func TestProfileToken(t *testing.T) {
 		},
 		{
 			Name: "validate token is displayed for the specified profile using global --profile",
-			Arg:  "--profile bar", // we choose a non-default profile
+			Args: "--profile bar", // we choose a non-default profile
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -474,7 +474,7 @@ func TestProfileToken(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -496,7 +496,7 @@ func TestProfileToken(t *testing.T) {
 		},
 		{
 			Name: "validate an unrecognised profile causes an error",
-			Arg:  "unknown",
+			Args: "unknown",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -506,7 +506,7 @@ func TestProfileToken(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -514,14 +514,14 @@ func TestProfileToken(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "token"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "token"}, scenarios)
 }
 
 func TestProfileUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate updating unknown profile returns an error",
-			Arg:  "unknown",
+			Args: "unknown",
 			Env: &testutil.EnvConfig{
 				Opts: &testutil.EnvOpts{
 					Copy: []testutil.FileIO{
@@ -531,7 +531,7 @@ func TestProfileUpdate(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -539,7 +539,7 @@ func TestProfileUpdate(t *testing.T) {
 		},
 		{
 			Name: "validate updating profile works",
-			Arg:  "bar", // we choose a non-default profile
+			Args: "bar", // we choose a non-default profile
 			API: mock.API{
 				GetTokenSelfFn: getToken,
 				GetUserFn:      getUser,
@@ -553,7 +553,7 @@ func TestProfileUpdate(t *testing.T) {
 						},
 					},
 				},
-				EditScenario: func(scenario *testutil.TestScenario, rootdir string) {
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
 					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
 				},
 			},
@@ -580,7 +580,7 @@ func TestProfileUpdate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func getToken() (*fastly.Token, error) {

--- a/pkg/commands/purge/purge_test.go
+++ b/pkg/commands/purge/purge_test.go
@@ -12,15 +12,15 @@ import (
 )
 
 func TestPurgeAll(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--all",
+			Args:      "--all",
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate --soft flag isn't usable",
-			Arg:       "--all --service-id 123 --soft",
+			Args:      "--all --service-id 123 --soft",
 			WantError: "purge-all requests cannot be done in soft mode (--soft) and will always immediately invalidate all cached content associated with the service",
 		},
 		{
@@ -30,7 +30,7 @@ func TestPurgeAll(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--all --service-id 123",
+			Args:      "--all --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -42,20 +42,20 @@ func TestPurgeAll(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--all --service-id 123",
+			Args:       "--all --service-id 123",
 			WantOutput: "Purge all status: ok",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName}, scenarios)
 }
 
 func TestPurgeKeys(t *testing.T) {
 	var keys []string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--file ./testdata/keys",
+			Args:      "--file ./testdata/keys",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -65,7 +65,7 @@ func TestPurgeKeys(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--file ./testdata/keys --service-id 123",
+			Args:      "--file ./testdata/keys --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -82,12 +82,12 @@ func TestPurgeKeys(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--file ./testdata/keys --service-id 123",
+			Args:       "--file ./testdata/keys --service-id 123",
 			WantOutput: "KEY  ID\nbar  456\nbaz  789\nfoo  123\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName}, scenarios)
 	assertKeys(keys, t)
 }
 
@@ -102,10 +102,10 @@ func assertKeys(keys []string, t *testing.T) {
 }
 
 func TestPurgeKey(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--key foobar",
+			Args:      "--key foobar",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -115,7 +115,7 @@ func TestPurgeKey(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--key foobar --service-id 123",
+			Args:      "--key foobar --service-id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -128,7 +128,7 @@ func TestPurgeKey(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--key foobar --service-id 123",
+			Args:       "--key foobar --service-id 123",
 			WantOutput: "Purged key: foobar (soft: false). Status: ok, ID: 123",
 		},
 		{
@@ -141,16 +141,16 @@ func TestPurgeKey(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--key foobar --service-id 123 --soft",
+			Args:       "--key foobar --service-id 123 --soft",
 			WantOutput: "Purged key: foobar (soft: true). Status: ok, ID: 123",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName}, scenarios)
 }
 
 func TestPurgeURL(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate Purge API error",
 			API: mock.API{
@@ -158,7 +158,7 @@ func TestPurgeURL(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--service-id 123 --url https://example.com",
+			Args:      "--service-id 123 --url https://example.com",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -171,7 +171,7 @@ func TestPurgeURL(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--service-id 123 --url https://example.com",
+			Args:       "--service-id 123 --url https://example.com",
 			WantOutput: "Purged URL: https://example.com (soft: false). Status: ok, ID: 123",
 		},
 		{
@@ -184,10 +184,10 @@ func TestPurgeURL(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--service-id 123 --soft --url https://example.com",
+			Args:       "--service-id 123 --soft --url https://example.com",
 			WantOutput: "Purged URL: https://example.com (soft: true). Status: ok, ID: 123",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName}, scenarios)
 }

--- a/pkg/commands/ratelimit/ratelimit_test.go
+++ b/pkg/commands/ratelimit/ratelimit_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRateLimitCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate CreateERL API error",
 			API: mock.API{
@@ -20,7 +20,7 @@ func TestRateLimitCreate(t *testing.T) {
 				},
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name example --service-id 123 --version 3",
+			Args:      "--name example --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -34,16 +34,16 @@ func TestRateLimitCreate(t *testing.T) {
 				},
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:        "--name example --service-id 123 --version 3",
+			Args:       "--name example --service-id 123 --version 3",
 			WantOutput: "Created rate limiter 'example' (123)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestRateLimitDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate DeleteERL API error",
 			API: mock.API{
@@ -51,7 +51,7 @@ func TestRateLimitDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id 123",
+			Args:      "--id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -61,16 +61,16 @@ func TestRateLimitDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id 123",
+			Args:       "--id 123",
 			WantOutput: "SUCCESS: Deleted rate limiter '123'\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestRateLimitDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate GetERL API error",
 			API: mock.API{
@@ -78,7 +78,7 @@ func TestRateLimitDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id 123",
+			Args:      "--id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -95,16 +95,16 @@ func TestRateLimitDescribe(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id 123",
+			Args:       "--id 123",
 			WantOutput: "\nAction: response\nClient Key: []\nFeature Revision: 0\nHTTP Methods: []\nID: 123\nLogger Type: \nName: example\nPenalty Box Duration: 20\nResponse: \nResponse Object Name: \nRPS Limit: 10\nService ID: \nURI Dictionary Name: \nVersion: 0\nWindowSize: 60\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestRateLimitList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate ListERL API error",
 			API: mock.API{
@@ -113,7 +113,7 @@ func TestRateLimitList(t *testing.T) {
 				},
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -133,16 +133,16 @@ func TestRateLimitList(t *testing.T) {
 				},
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:        "--service-id 123 --version 3",
+			Args:       "--service-id 123 --version 3",
 			WantOutput: "ID   NAME     ACTION    RPS LIMIT  WINDOW SIZE  PENALTY BOX DURATION\n123  example  response  10         60           20\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TesRateLimittUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate UpdateERL API error",
 			API: mock.API{
@@ -150,7 +150,7 @@ func TesRateLimittUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id 123 --name example",
+			Args:      "--id 123 --name example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -163,10 +163,10 @@ func TesRateLimittUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id 123 --name example",
+			Args:       "--id 123 --name example",
 			WantOutput: "Updated rate limiter 'example' (123)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/resourcelink/resourcelink_test.go
+++ b/pkg/commands/resourcelink/resourcelink_test.go
@@ -147,7 +147,7 @@ func TestCreateServiceResourceCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(resourcelink.RootName + " " + testcase.args)
+			args := testutil.SplitArgs(resourcelink.RootName + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.CreateResourceFn
@@ -252,7 +252,7 @@ func TestDeleteServiceResourceCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(resourcelink.RootName + " " + testcase.args)
+			args := testutil.SplitArgs(resourcelink.RootName + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.DeleteResourceFn
@@ -349,7 +349,7 @@ Last edited (UTC): 2023-10-15 12:18`,
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(resourcelink.RootName + " " + testcase.args)
+			args := testutil.SplitArgs(resourcelink.RootName + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.GetResourceFn
@@ -464,7 +464,7 @@ Resource Link 3/3
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(resourcelink.RootName + " " + testcase.args)
+			args := testutil.SplitArgs(resourcelink.RootName + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.ListResourcesFn
@@ -602,7 +602,7 @@ func TestUpdateServiceResourceCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(resourcelink.RootName + " " + testcase.args)
+			args := testutil.SplitArgs(resourcelink.RootName + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.UpdateResourceFn

--- a/pkg/commands/secretstore/secretstore_test.go
+++ b/pkg/commands/secretstore/secretstore_test.go
@@ -79,7 +79,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstore.RootNameStore + " " + testcase.args)
+			args := testutil.SplitArgs(secretstore.RootNameStore + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.CreateSecretStoreFn
@@ -164,7 +164,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstore.RootNameStore + " " + testcase.args)
+			args := testutil.SplitArgs(secretstore.RootNameStore + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.DeleteSecretStoreFn
@@ -254,7 +254,7 @@ func TestDescribeStoreCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstore.RootNameStore + " " + testcase.args)
+			args := testutil.SplitArgs(secretstore.RootNameStore + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.GetSecretStoreFn
@@ -346,7 +346,7 @@ func TestListStoresCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstore.RootNameStore + " " + testcase.args)
+			args := testutil.SplitArgs(secretstore.RootNameStore + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.ListSecretStoresFn

--- a/pkg/commands/secretstoreentry/secretstoreentry_test.go
+++ b/pkg/commands/secretstoreentry/secretstoreentry_test.go
@@ -229,7 +229,7 @@ func TestCreateSecretCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstoreentry.RootNameSecret + " " + testcase.args)
+			args := testutil.SplitArgs(secretstoreentry.RootNameSecret + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 			if testcase.stdin != "" {
 				var stdin bytes.Buffer
@@ -330,7 +330,7 @@ func TestDeleteSecretCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstoreentry.RootNameSecret + " " + testcase.args)
+			args := testutil.SplitArgs(secretstoreentry.RootNameSecret + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.DeleteSecretFn
@@ -437,7 +437,7 @@ func TestDescribeSecretCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstoreentry.RootNameSecret + " " + testcase.args)
+			args := testutil.SplitArgs(secretstoreentry.RootNameSecret + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.GetSecretFn
@@ -525,7 +525,7 @@ func TestListSecretsCommand(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.args, func(t *testing.T) {
 			var stdout bytes.Buffer
-			args := testutil.Args(secretstoreentry.RootNameSecret + " " + testcase.args)
+			args := testutil.SplitArgs(secretstoreentry.RootNameSecret + " " + testcase.args)
 			opts := testutil.MockGlobalData(args, &stdout)
 
 			f := testcase.api.ListSecretsFn

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestServiceCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -76,7 +76,7 @@ func TestServiceCreate(t *testing.T) {
 }
 
 func TestServiceList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -219,7 +219,7 @@ func TestServiceList(t *testing.T) {
 }
 
 func TestServiceDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -279,7 +279,7 @@ func TestServiceDescribe(t *testing.T) {
 }
 
 func TestServiceSearch(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -323,7 +323,7 @@ func TestServiceSearch(t *testing.T) {
 }
 
 func TestServiceUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -391,7 +391,7 @@ func TestServiceUpdate(t *testing.T) {
 }
 
 func TestServiceDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	nonEmptyServiceID := regexp.MustCompile(`service_id = "[^"]+"`)
 
 	scenarios := []struct {

--- a/pkg/commands/serviceauth/service_test.go
+++ b/pkg/commands/serviceauth/service_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestServiceAuthCreate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -55,7 +55,7 @@ func TestServiceAuthCreate(t *testing.T) {
 }
 
 func TestServiceAuthList(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -125,7 +125,7 @@ func TestServiceAuthList(t *testing.T) {
 }
 
 func TestServiceAuthDescribe(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -186,7 +186,7 @@ func TestServiceAuthDescribe(t *testing.T) {
 }
 
 func TestServiceAuthUpdate(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API
@@ -229,7 +229,7 @@ func TestServiceAuthUpdate(t *testing.T) {
 }
 
 func TestServiceAuthDelete(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -12,20 +12,20 @@ import (
 )
 
 func TestVersionClone(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 1",
+			Args:      "--version 1",
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--service-id 123",
+			Args:      "--service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name: "validate successful clone",
-			Arg:  "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -34,7 +34,7 @@ func TestVersionClone(t *testing.T) {
 		},
 		{
 			Name: "validate error will be passed through if cloning fails",
-			Arg:  "--service-id 456 --version 1",
+			Args: "--service-id 456 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionError,
@@ -43,50 +43,50 @@ func TestVersionClone(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "clone"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "clone"}, scenarios)
 }
 
 func TestVersionList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:        "--service-id 123",
+			Args:       "--service-id 123",
 			API:        mock.API{ListVersionsFn: testutil.ListVersions},
 			WantOutput: listVersionsShortOutput,
 		},
 		{
-			Arg:        "--service-id 123 --verbose",
+			Args:       "--service-id 123 --verbose",
 			API:        mock.API{ListVersionsFn: testutil.ListVersions},
 			WantOutput: listVersionsVerboseOutput,
 		},
 		{
-			Arg:        "--service-id 123 -v",
+			Args:       "--service-id 123 -v",
 			API:        mock.API{ListVersionsFn: testutil.ListVersions},
 			WantOutput: listVersionsVerboseOutput,
 		},
 		{
-			Arg:        "--verbose --service-id 123",
+			Args:       "--verbose --service-id 123",
 			API:        mock.API{ListVersionsFn: testutil.ListVersions},
 			WantOutput: listVersionsVerboseOutput,
 		},
 		{
-			Arg:        "-v --service-id 123",
+			Args:       "-v --service-id 123",
 			API:        mock.API{ListVersionsFn: testutil.ListVersions},
 			WantOutput: listVersionsVerboseOutput,
 		},
 		{
-			Arg:       "--service-id 123",
+			Args:      "--service-id 123",
 			API:       mock.API{ListVersionsFn: testutil.ListVersionsError},
 			WantError: testutil.Err.Error(),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestVersionUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg: "--service-id 123 --version 1 --comment foo --autoclone",
+			Args: "--service-id 123 --version 1 --comment foo --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -95,7 +95,7 @@ func TestVersionUpdate(t *testing.T) {
 			WantOutput: "Updated service 123 version 4",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --autoclone",
+			Args: "--service-id 123 --version 1 --autoclone",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
@@ -103,7 +103,7 @@ func TestVersionUpdate(t *testing.T) {
 			WantError: "error parsing arguments: required flag --comment not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --comment foo --autoclone",
+			Args: "--service-id 123 --version 1 --comment foo --autoclone",
 			API: mock.API{
 				ListVersionsFn:  testutil.ListVersions,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
@@ -113,24 +113,24 @@ func TestVersionUpdate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func TestVersionActivate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123",
+			Args:      "--service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
 			WantError: "service version 1 is active",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --autoclone",
+			Args: "--service-id 123 --version 1 --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -139,7 +139,7 @@ func TestVersionActivate(t *testing.T) {
 			WantError: testutil.Err.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --autoclone",
+			Args: "--service-id 123 --version 1 --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -148,7 +148,7 @@ func TestVersionActivate(t *testing.T) {
 			WantOutput: "Activated service 123 version 4",
 		},
 		{
-			Arg: "--service-id 123 --version 2 --autoclone",
+			Args: "--service-id 123 --version 2 --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -157,7 +157,7 @@ func TestVersionActivate(t *testing.T) {
 			WantOutput: "Activated service 123 version 4",
 		},
 		{
-			Arg: "--service-id 123 --version 3 --autoclone",
+			Args: "--service-id 123 --version 3 --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				ActivateVersionFn: activateVersionOK,
@@ -166,17 +166,17 @@ func TestVersionActivate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "activate"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "activate"}, scenarios)
 }
 
 func TestVersionDeactivate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123",
+			Args:      "--service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				DeactivateVersionFn: deactivateVersionOK,
@@ -184,7 +184,7 @@ func TestVersionDeactivate(t *testing.T) {
 			WantOutput: "Deactivated service 123 version 1",
 		},
 		{
-			Arg: "--service-id 123 --version 3",
+			Args: "--service-id 123 --version 3",
 			API: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				DeactivateVersionFn: deactivateVersionOK,
@@ -192,7 +192,7 @@ func TestVersionDeactivate(t *testing.T) {
 			WantError: "service version 3 is not active",
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn:      testutil.ListVersions,
 				DeactivateVersionFn: deactivateVersionError,
@@ -201,17 +201,17 @@ func TestVersionDeactivate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "deactivate"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "deactivate"}, scenarios)
 }
 
 func TestVersionLock(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123",
+			Args:      "--service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				LockVersionFn:  lockVersionOK,
@@ -219,7 +219,7 @@ func TestVersionLock(t *testing.T) {
 			WantOutput: "Locked service 123 version 1",
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				LockVersionFn:  lockVersionError,
@@ -228,7 +228,7 @@ func TestVersionLock(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "lock"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "lock"}, scenarios)
 }
 
 var listVersionsShortOutput = strings.TrimSpace(`

--- a/pkg/commands/stats/historical_test.go
+++ b/pkg/commands/stats/historical_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestHistorical(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/stats/regions_test.go
+++ b/pkg/commands/stats/regions_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRegions(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	scenarios := []struct {
 		args       []string
 		api        mock.API

--- a/pkg/commands/tls/config/config_test.go
+++ b/pkg/commands/tls/config/config_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func TestDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --id flag",
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -30,7 +30,7 @@ func TestDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -57,16 +57,16 @@ func TestDescribe(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "\nID: " + mockResponseID + "\nName: Foo\nDNS Record ID: 456\nDNS Record Type: Bar\nDNS Record Region: Baz\nBulk: true\nDefault: true\nHTTP Protocol: 1.1\nTLS Protocol: 1.3\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: validateAPIError,
 			API: mock.API{
@@ -102,24 +102,24 @@ func TestList(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: "\nID: " + mockResponseID + "\nName: Foo\nDNS Record ID: 456\nDNS Record Type: Bar\nDNS Record Region: Baz\nBulk: true\nDefault: true\nHTTP Protocol: 1.1\nTLS Protocol: 1.3\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --id flag",
-			Arg:       "--name example",
+			Args:      "--name example",
 			WantError: "error parsing arguments: required flag --id not provided",
 		},
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--id 123",
+			Args:      "--id 123",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
@@ -129,7 +129,7 @@ func TestUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example --name example",
+			Args:      "--id example --name example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -141,10 +141,10 @@ func TestUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example --name example",
+			Args:       "--id example --name example",
 			WantOutput: fmt.Sprintf("Updated TLS Configuration '%s'", mockResponseID),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/tls/custom/activation/activation_test.go
+++ b/pkg/commands/tls/custom/activation/activation_test.go
@@ -21,15 +21,15 @@ const (
 )
 
 func TestTLSCustomActivationEnable(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
-			Arg:       "--cert-id example",
+			Args:      "--cert-id example",
 			WantError: "required flag --id not provided",
 		},
 		{
 			Name:      validateMissingIDFlag,
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: "required flag --cert-id not provided",
 		},
 		{
@@ -39,7 +39,7 @@ func TestTLSCustomActivationEnable(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--cert-id example --id example",
+			Args:      "--cert-id example --id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -54,16 +54,16 @@ func TestTLSCustomActivationEnable(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--cert-id example --id example",
+			Args:       "--cert-id example --id example",
 			WantOutput: fmt.Sprintf("Enabled TLS Activation '%s' (Certificate '%s')", mockResponseID, mockResponseCertID),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "enable"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "enable"}, scenarios)
 }
 
 func TestTLSCustomActivationDisable(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -75,7 +75,7 @@ func TestTLSCustomActivationDisable(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -85,16 +85,16 @@ func TestTLSCustomActivationDisable(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "Disabled TLS Activation 'example'",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "disable"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "disable"}, scenarios)
 }
 
 func TestTLSCustomActivationDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -106,7 +106,7 @@ func TestTLSCustomActivationDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -120,16 +120,16 @@ func TestTLSCustomActivationDescribe(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "\nID: " + mockResponseID + "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestTLSCustomActivationList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: validateAPIError,
 			API: mock.API{
@@ -152,24 +152,24 @@ func TestTLSCustomActivationList(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: "\nID: " + mockResponseID + "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }
 
 func TestTLSCustomActivationUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
-			Arg:       "--cert-id example",
+			Args:      "--cert-id example",
 			WantError: "required flag --id not provided",
 		},
 		{
 			Name:      validateMissingIDFlag,
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: "required flag --cert-id not provided",
 		},
 		{
@@ -179,7 +179,7 @@ func TestTLSCustomActivationUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--cert-id example --id example",
+			Args:      "--cert-id example --id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -194,10 +194,10 @@ func TestTLSCustomActivationUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--cert-id example --id example",
+			Args:       "--cert-id example --id example",
 			WantOutput: fmt.Sprintf("Updated TLS Activation Certificate '%s' (previously: 'example')", mockResponseCertID),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/tls/custom/certificate/certificate_test.go
+++ b/pkg/commands/tls/custom/certificate/certificate_test.go
@@ -22,19 +22,19 @@ const (
 
 func TestTLSCustomCertCreate(t *testing.T) {
 	var content string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --cert-blob and --cert-path flags",
 			WantError: "neither --cert-path or --cert-blob provided, one must be provided",
 		},
 		{
 			Name:      "validate specifying both --cert-blob and --cert-path flags",
-			Arg:       "--cert-blob foo --cert-path bar",
+			Args:      "--cert-blob foo --cert-path bar",
 			WantError: "cert-path and cert-blob provided, only one can be specified",
 		},
 		{
 			Name:      "validate invalid --cert-path arg",
-			Arg:       "--cert-path ............",
+			Args:      "--cert-path ............",
 			WantError: "error reading cert-path",
 		},
 		{
@@ -47,7 +47,7 @@ func TestTLSCustomCertCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--cert-path ./testdata/certificate.crt",
+			Args:            "--cert-path ./testdata/certificate.crt",
 			WantOutput:      fmt.Sprintf("Created TLS Certificate '%s'", mockResponseID),
 			PathContentFlag: &testutil.PathContentFlag{Flag: "cert-path", Fixture: "certificate.crt", Content: func() string { return content }},
 		},
@@ -59,7 +59,7 @@ func TestTLSCustomCertCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:             "--cert-blob example",
+			Args:            "--cert-blob example",
 			WantError:       testutil.Err.Error(),
 			PathContentFlag: &testutil.PathContentFlag{Flag: "cert-path", Fixture: "certificate.crt", Content: func() string { return content }},
 		},
@@ -73,17 +73,17 @@ func TestTLSCustomCertCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--cert-blob example",
+			Args:            "--cert-blob example",
 			WantOutput:      fmt.Sprintf("Created TLS Certificate '%s'", mockResponseID),
 			PathContentFlag: &testutil.PathContentFlag{Flag: "cert-path", Fixture: "certificate.crt", Content: func() string { return content }},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
 }
 
 func TestTLSCustomCertDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -95,7 +95,7 @@ func TestTLSCustomCertDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -105,16 +105,16 @@ func TestTLSCustomCertDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "Deleted TLS Certificate 'example'",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
 }
 
 func TestTLSCustomCertDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -126,7 +126,7 @@ func TestTLSCustomCertDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -147,16 +147,16 @@ func TestTLSCustomCertDescribe(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "\nID: " + mockResponseID + "\nIssued to: " + mockFieldValue + "\nIssuer: " + mockFieldValue + "\nName: " + mockFieldValue + "\nReplace: true\nSerial number: " + mockFieldValue + "\nSignature algorithm: " + mockFieldValue + "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestTLSCustomCertList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: validateAPIError,
 			API: mock.API{
@@ -186,35 +186,35 @@ func TestTLSCustomCertList(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (profile: user)\n\nID: " + mockResponseID + "\nIssued to: " + mockFieldValue + "\nIssuer: " + mockFieldValue + "\nName: " + mockFieldValue + "\nReplace: true\nSerial number: " + mockFieldValue + "\nSignature algorithm: " + mockFieldValue + "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }
 
 func TestTLSCustomCertUpdate(t *testing.T) {
 	var content string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
-			Arg:       "--cert-blob example",
+			Args:      "--cert-blob example",
 			WantError: "required flag --id not provided",
 		},
 		{
 			Name:      "validate missing --cert-blob and --cert-path flags",
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: "neither --cert-path or --cert-blob provided, one must be provided",
 		},
 		{
 			Name:      "validate specifying both --cert-blob and --cert-path flags",
-			Arg:       "--id example --cert-blob foo --cert-path bar",
+			Args:      "--id example --cert-blob foo --cert-path bar",
 			WantError: "cert-path and cert-blob provided, only one can be specified",
 		},
 		{
 			Name:      "validate invalid --cert-path arg",
-			Arg:       "--id example --cert-path ............",
+			Args:      "--id example --cert-path ............",
 			WantError: "error reading cert-path",
 		},
 		{
@@ -225,7 +225,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:             "--cert-blob example --id example",
+			Args:            "--cert-blob example --id example",
 			WantError:       testutil.Err.Error(),
 			PathContentFlag: &testutil.PathContentFlag{Flag: "cert-path", Fixture: "certificate.crt", Content: func() string { return content }},
 		},
@@ -239,7 +239,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--cert-blob example --id example",
+			Args:            "--cert-blob example --id example",
 			WantOutput:      fmt.Sprintf("Updated TLS Certificate '%s'", mockResponseID),
 			PathContentFlag: &testutil.PathContentFlag{Flag: "cert-path", Fixture: "certificate.crt", Content: func() string { return content }},
 		},
@@ -254,7 +254,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--cert-blob example --id example --name example",
+			Args:            "--cert-blob example --id example --name example",
 			WantOutput:      "Updated TLS Certificate 'Updated' (previously: 'example')",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "cert-path", Fixture: "certificate.crt", Content: func() string { return content }},
 		},
@@ -268,11 +268,11 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--id example --cert-path ./testdata/certificate.crt",
+			Args:            "--id example --cert-path ./testdata/certificate.crt",
 			WantOutput:      "SUCCESS: Updated TLS Certificate '123'",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "cert-path", Fixture: "certificate.crt", Content: func() string { return content }},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/tls/custom/domain/domain_test.go
+++ b/pkg/commands/tls/custom/domain/domain_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func TestList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: validateAPIError,
 			API: mock.API{
@@ -40,10 +40,10 @@ func TestList(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: "\nID: " + mockResponseID + "\nType: example\n\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }

--- a/pkg/commands/tls/custom/privatekey/privatekey_test.go
+++ b/pkg/commands/tls/custom/privatekey/privatekey_test.go
@@ -22,20 +22,20 @@ const (
 
 func TestTLSCustomPrivateKeyCreate(t *testing.T) {
 	var content string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --key and --key-path flags",
-			Arg:       "--name example",
+			Args:      "--name example",
 			WantError: "neither --key-path or --key provided, one must be provided",
 		},
 		{
 			Name:      "validate using both --key and --key-path flags",
-			Arg:       "--name example --key example --key-path foobar",
+			Args:      "--name example --key example --key-path foobar",
 			WantError: "--key-path and --key provided, only one can be specified",
 		},
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--key example",
+			Args:      "--key example",
 			WantError: "required flag --name not provided",
 		},
 		{
@@ -46,7 +46,7 @@ func TestTLSCustomPrivateKeyCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:             "--key example --name example",
+			Args:            "--key example --name example",
 			WantError:       testutil.Err.Error(),
 			PathContentFlag: &testutil.PathContentFlag{Flag: "key-path", Fixture: "testkey.pem", Content: func() string { return content }},
 		},
@@ -61,7 +61,7 @@ func TestTLSCustomPrivateKeyCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--key example --name example",
+			Args:            "--key example --name example",
 			WantOutput:      "Created TLS Private Key 'example'",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "key-path", Fixture: "testkey.pem", Content: func() string { return content }},
 		},
@@ -76,22 +76,22 @@ func TestTLSCustomPrivateKeyCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--name example --key-path ./testdata/testkey.pem",
+			Args:            "--name example --key-path ./testdata/testkey.pem",
 			WantOutput:      "Created TLS Private Key 'example'",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "key-path", Fixture: "testkey.pem", Content: func() string { return content }},
 		},
 		{
 			Name:      "validate invalid --key-path arg",
-			Arg:       "--name example --key-path ............",
+			Args:      "--name example --key-path ............",
 			WantError: "error reading key-path",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
 }
 
 func TestTLSCustomPrivateKeyDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -103,7 +103,7 @@ func TestTLSCustomPrivateKeyDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -113,16 +113,16 @@ func TestTLSCustomPrivateKeyDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "Deleted TLS Private Key 'example'",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
 }
 
 func TestTLSCustomPrivateKeyDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -134,7 +134,7 @@ func TestTLSCustomPrivateKeyDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -152,16 +152,16 @@ func TestTLSCustomPrivateKeyDescribe(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "\nID: " + mockResponseID + "\nName: example\nKey Length: 123\nKey Type: example\nPublic Key SHA1: example\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nReplace: false\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestTLSCustomPrivateKeyList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: validateAPIError,
 			API: mock.API{
@@ -188,10 +188,10 @@ func TestTLSCustomPrivateKeyList(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: "\nID: " + mockResponseID + "\nName: example\nKey Length: 123\nKey Type: example\nPublic Key SHA1: example\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nReplace: false\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }

--- a/pkg/commands/tls/platform/platform_test.go
+++ b/pkg/commands/tls/platform/platform_test.go
@@ -19,15 +19,15 @@ const (
 )
 
 func TestTLSPlatformUpload(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --cert-blob flag",
-			Arg:       "--intermediates-blob example",
+			Args:      "--intermediates-blob example",
 			WantError: "required flag --cert-blob not provided",
 		},
 		{
 			Name:      "validate missing --intermediates-blob flag",
-			Arg:       "--cert-blob example",
+			Args:      "--cert-blob example",
 			WantError: "required flag --intermediates-blob not provided",
 		},
 		{
@@ -37,7 +37,7 @@ func TestTLSPlatformUpload(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--cert-blob example --intermediates-blob example",
+			Args:      "--cert-blob example --intermediates-blob example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -49,16 +49,16 @@ func TestTLSPlatformUpload(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--cert-blob example --intermediates-blob example",
+			Args:       "--cert-blob example --intermediates-blob example",
 			WantOutput: fmt.Sprintf("Uploaded TLS Bulk Certificate '%s'", mockResponseID),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "upload"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "upload"}, scenarios)
 }
 
 func TestTLSPlatformDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -70,7 +70,7 @@ func TestTLSPlatformDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -80,16 +80,16 @@ func TestTLSPlatformDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "Deleted TLS Bulk Certificate 'example'",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestTLSPlatformDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -101,7 +101,7 @@ func TestTLSPlatformDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -117,16 +117,16 @@ func TestTLSPlatformDescribe(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "\nID: 123\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nReplace: true\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestTLSPlatformList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: validateAPIError,
 			API: mock.API{
@@ -151,29 +151,29 @@ func TestTLSPlatformList(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: "\nID: " + mockResponseID + "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nReplace: true\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestTLSPlatformUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
-			Arg:       "--cert-blob example --intermediates-blob example",
+			Args:      "--cert-blob example --intermediates-blob example",
 			WantError: "required flag --id not provided",
 		},
 		{
 			Name:      "validate missing --cert-blob flag",
-			Arg:       "--id example --intermediates-blob example",
+			Args:      "--id example --intermediates-blob example",
 			WantError: "required flag --cert-blob not provided",
 		},
 		{
 			Name:      "validate missing --intermediates-blob flag",
-			Arg:       "--id example --cert-blob example",
+			Args:      "--id example --cert-blob example",
 			WantError: "required flag --intermediates-blob not provided",
 		},
 		{
@@ -183,7 +183,7 @@ func TestTLSPlatformUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example --cert-blob example --intermediates-blob example",
+			Args:      "--id example --cert-blob example --intermediates-blob example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -195,10 +195,10 @@ func TestTLSPlatformUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example --cert-blob example --intermediates-blob example",
+			Args:       "--id example --cert-blob example --intermediates-blob example",
 			WantOutput: "Updated TLS Bulk Certificate '123'",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/tls/subscription/subscription_test.go
+++ b/pkg/commands/tls/subscription/subscription_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 func TestTLSSubscriptionCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --domain flag",
 			WantError: "required flag --domain not provided",
@@ -32,7 +32,7 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--domain example.com",
+			Args:      "--domain example.com",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -48,16 +48,16 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--domain example.com",
+			Args:       "--domain example.com",
 			WantOutput: fmt.Sprintf("Created TLS Subscription '%s' (Authority: %s, Common Name: example.com)", mockResponseID, certificateAuthority),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestTLSSubscriptionDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -69,7 +69,7 @@ func TestTLSSubscriptionDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -79,16 +79,16 @@ func TestTLSSubscriptionDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "Deleted TLS Subscription 'example' (force: false)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestTLSSubscriptionDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -100,7 +100,7 @@ func TestTLSSubscriptionDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -117,16 +117,16 @@ func TestTLSSubscriptionDescribe(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: "\nID: " + mockResponseID + "\nCertificate Authority: " + certificateAuthority + "\nState: pending\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestTLSSubscriptionList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: validateAPIError,
 			API: mock.API{
@@ -152,16 +152,16 @@ func TestTLSSubscriptionList(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--verbose",
+			Args:       "--verbose",
 			WantOutput: "\nID: " + mockResponseID + "\nCertificate Authority: " + certificateAuthority + "\nState: pending\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestTLSSubscriptionUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      validateMissingIDFlag,
 			WantError: "required flag --id not provided",
@@ -173,7 +173,7 @@ func TestTLSSubscriptionUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id example",
+			Args:      "--id example",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -189,10 +189,10 @@ func TestTLSSubscriptionUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id example",
+			Args:       "--id example",
 			WantOutput: fmt.Sprintf("Updated TLS Subscription '%s' (Authority: %s, Common Name: example.com)", mockResponseID, certificateAuthority),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }

--- a/pkg/commands/user/user_test.go
+++ b/pkg/commands/user/user_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestUserCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate CreateUser API error",
 			API: mock.API{
@@ -20,7 +20,7 @@ func TestUserCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--login foo@example.com --name foobar",
+			Args:      "--login foo@example.com --name foobar",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -33,16 +33,16 @@ func TestUserCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--login foo@example.com --name foobar",
+			Args:       "--login foo@example.com --name foobar",
 			WantOutput: "Created user 'foobar' (role: user)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "create"}, scenarios)
 }
 
 func TestUserDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --id flag",
 			WantError: "error parsing arguments: required flag --id not provided",
@@ -54,7 +54,7 @@ func TestUserDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id foo123",
+			Args:      "--id foo123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -64,16 +64,16 @@ func TestUserDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id foo123",
+			Args:       "--id foo123",
 			WantOutput: "Deleted user (id: foo123)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "delete"}, scenarios)
 }
 
 func TestUserDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --id flag",
 			WantError: "error parsing arguments: must provide --id flag",
@@ -85,7 +85,7 @@ func TestUserDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id 123",
+			Args:      "--id 123",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -95,7 +95,7 @@ func TestUserDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--current",
+			Args:      "--current",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -103,7 +103,7 @@ func TestUserDescribe(t *testing.T) {
 			API: mock.API{
 				GetUserFn: getUser,
 			},
-			Arg:        "--id 123",
+			Args:       "--id 123",
 			WantOutput: describeUserOutput(),
 		},
 		{
@@ -111,16 +111,16 @@ func TestUserDescribe(t *testing.T) {
 			API: mock.API{
 				GetCurrentUserFn: getCurrentUser,
 			},
-			Arg:        "--current",
+			Args:       "--current",
 			WantOutput: describeCurrentUserOutput(),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
 func TestUserList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --customer-id flag",
 			WantError: "error reading customer ID: no customer ID found",
@@ -132,7 +132,7 @@ func TestUserList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--customer-id abc",
+			Args:      "--customer-id abc",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -140,7 +140,7 @@ func TestUserList(t *testing.T) {
 			API: mock.API{
 				ListCustomerUsersFn: listUsers,
 			},
-			Arg:        "--customer-id abc",
+			Args:       "--customer-id abc",
 			WantOutput: listOutput(),
 		},
 		{
@@ -148,33 +148,33 @@ func TestUserList(t *testing.T) {
 			API: mock.API{
 				ListCustomerUsersFn: listUsers,
 			},
-			Arg:        "--customer-id abc --verbose",
+			Args:       "--customer-id abc --verbose",
 			WantOutput: listVerboseOutput(),
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
 func TestUserUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --id flag",
 			WantError: "error parsing arguments: must provide --id flag",
 		},
 		{
 			Name:      "validate missing --name and --role flags",
-			Arg:       "--id 123",
+			Args:      "--id 123",
 			WantError: "error parsing arguments: must provide either the --name or --role with the --id flag",
 		},
 		{
 			Name:      "validate missing --login flag with --password-reset",
-			Arg:       "--password-reset",
+			Args:      "--password-reset",
 			WantError: "error parsing arguments: must provide --login when requesting a password reset",
 		},
 		{
 			Name:      "validate invalid --role value",
-			Arg:       "--id 123 --role foobar",
+			Args:      "--id 123 --role foobar",
 			WantError: "error parsing arguments: enum value must be one of user,billing,engineer,superuser, got 'foobar'",
 		},
 		{
@@ -184,7 +184,7 @@ func TestUserUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--id 123 --name foo",
+			Args:      "--id 123 --name foo",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -194,7 +194,7 @@ func TestUserUpdate(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--id 123 --login foo@example.com --password-reset",
+			Args:      "--id 123 --login foo@example.com --password-reset",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -208,7 +208,7 @@ func TestUserUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--id 123 --name foo --role engineer",
+			Args:       "--id 123 --name foo --role engineer",
 			WantOutput: "Updated user 'foo' (role: engineer)",
 		},
 		{
@@ -218,12 +218,12 @@ func TestUserUpdate(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--id 123 --login foo@example.com --password-reset",
+			Args:       "--id 123 --login foo@example.com --password-reset",
 			WantOutput: "Reset user password (login: foo@example.com)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
 func getUser(i *fastly.GetUserInput) (*fastly.User, error) {

--- a/pkg/commands/vcl/condition/condition_test.go
+++ b/pkg/commands/vcl/condition/condition_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func TestConditionCreate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--version 1",
+			Args:      "--version 1",
 			WantError: "error reading service: no service ID found",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false --statement false --type REQUEST --autoclone",
+			Args: "--service-id 123 --version 1 --name always_false --statement false --type REQUEST --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -29,7 +29,7 @@ func TestConditionCreate(t *testing.T) {
 			WantOutput: "Created condition always_false (service 123 version 4)",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false --statement false --type REQUEST --priority 10 --autoclone",
+			Args: "--service-id 123 --version 1 --name always_false --statement false --type REQUEST --priority 10 --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -39,17 +39,17 @@ func TestConditionCreate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
 }
 
 func TestConditionDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false --autoclone",
+			Args: "--service-id 123 --version 1 --name always_false --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -58,7 +58,7 @@ func TestConditionDelete(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false --autoclone",
+			Args: "--service-id 123 --version 1 --name always_false --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -68,17 +68,17 @@ func TestConditionDelete(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
 }
 
 func TestConditionUpdate(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1 --new-name false_always --comment ",
+			Args:      "--service-id 123 --version 1 --new-name false_always --comment ",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false --autoclone",
+			Args: "--service-id 123 --version 1 --name always_false --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -87,7 +87,7 @@ func TestConditionUpdate(t *testing.T) {
 			WantError: "error parsing arguments: must provide either --new-name, --statement, --type or --priority to update condition",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false --new-name false_always --autoclone",
+			Args: "--service-id 123 --version 1 --name always_false --new-name false_always --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -96,7 +96,7 @@ func TestConditionUpdate(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false --new-name false_always --autoclone",
+			Args: "--service-id 123 --version 1 --name always_false --new-name false_always --autoclone",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
@@ -106,17 +106,17 @@ func TestConditionUpdate(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
 func TestConditionDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false",
+			Args: "--service-id 123 --version 1 --name always_false",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetConditionFn: getConditionError,
@@ -124,7 +124,7 @@ func TestConditionDescribe(t *testing.T) {
 			WantError: errTest.Error(),
 		},
 		{
-			Arg: "--service-id 123 --version 1 --name always_false",
+			Args: "--service-id 123 --version 1 --name always_false",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				GetConditionFn: getConditionOK,
@@ -133,13 +133,13 @@ func TestConditionDescribe(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestConditionList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListConditionsFn: listConditionsOK,
@@ -147,7 +147,7 @@ func TestConditionList(t *testing.T) {
 			WantOutput: listConditionsShortOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 --verbose",
+			Args: "--service-id 123 --version 1 --verbose",
 			API: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListConditionsFn: listConditionsOK,
@@ -155,7 +155,7 @@ func TestConditionList(t *testing.T) {
 			WantOutput: listConditionsVerboseOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1 -v",
+			Args: "--service-id 123 --version 1 -v",
 			API: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListConditionsFn: listConditionsOK,
@@ -163,7 +163,7 @@ func TestConditionList(t *testing.T) {
 			WantOutput: listConditionsVerboseOutput,
 		},
 		{
-			Arg: "--verbose --service-id 123 --version 1",
+			Args: "--verbose --service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListConditionsFn: listConditionsOK,
@@ -171,7 +171,7 @@ func TestConditionList(t *testing.T) {
 			WantOutput: listConditionsVerboseOutput,
 		},
 		{
-			Arg: "-v --service-id 123 --version 1",
+			Args: "-v --service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListConditionsFn: listConditionsOK,
@@ -179,7 +179,7 @@ func TestConditionList(t *testing.T) {
 			WantOutput: listConditionsVerboseOutput,
 		},
 		{
-			Arg: "--service-id 123 --version 1",
+			Args: "--service-id 123 --version 1",
 			API: mock.API{
 				ListVersionsFn:   testutil.ListVersions,
 				ListConditionsFn: listConditionsError,
@@ -188,7 +188,7 @@ func TestConditionList(t *testing.T) {
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }
 
 var describeConditionOutput = "\n" + strings.TrimSpace(`

--- a/pkg/commands/vcl/custom/custom_test.go
+++ b/pkg/commands/vcl/custom/custom_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestVCLCustomCreate(t *testing.T) {
 	var content string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name: "validate missing --autoclone flag with 'active' service",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content ./testdata/example.vcl --name foo --service-id 123 --version 1",
+			Args:      "--content ./testdata/example.vcl --name foo --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -27,7 +27,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content ./testdata/example.vcl --name foo --service-id 123 --version 2",
+			Args:      "--content ./testdata/example.vcl --name foo --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -38,7 +38,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--content ./testdata/example.vcl --name foo --service-id 123 --version 3",
+			Args:      "--content ./testdata/example.vcl --name foo --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -67,7 +67,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content ./testdata/example.vcl --name foo --service-id 123 --version 3",
+			Args:            "--content ./testdata/example.vcl --name foo --service-id 123 --version 3",
 			WantOutput:      "Created custom VCL 'foo' (service: 123, version: 3, main: false)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},
@@ -98,7 +98,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content ./testdata/example.vcl --main --name foo --service-id 123 --version 3",
+			Args:            "--content ./testdata/example.vcl --main --name foo --service-id 123 --version 3",
 			WantOutput:      "Created custom VCL 'foo' (service: 123, version: 3, main: true)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},
@@ -129,7 +129,7 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1",
+			Args:            "--autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1",
 			WantOutput:      "Created custom VCL 'foo' (service: 123, version: 4, main: false)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},
@@ -159,30 +159,30 @@ func TestVCLCustomCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content inline_vcl --name foo --service-id 123 --version 3",
+			Args:            "--content inline_vcl --name foo --service-id 123 --version 3",
 			WantOutput:      "Created custom VCL 'foo' (service: 123, version: 3, main: false)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
 }
 
 func TestVCLCustomDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -190,7 +190,7 @@ func TestVCLCustomDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -198,7 +198,7 @@ func TestVCLCustomDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 2",
+			Args:      "--name foobar --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -209,7 +209,7 @@ func TestVCLCustomDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -220,7 +220,7 @@ func TestVCLCustomDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "Deleted custom VCL 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -232,29 +232,29 @@ func TestVCLCustomDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--autoclone --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --name foo --service-id 123 --version 1",
 			WantOutput: "Deleted custom VCL 'foo' (service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
 }
 
 func TestVCLCustomDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -265,7 +265,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -274,7 +274,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetVCLFn:       getVCL,
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -283,23 +283,23 @@ func TestVCLCustomDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetVCLFn:       getVCL,
 			},
-			Arg:        "--name foobar --service-id 123 --version 1",
+			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestVCLCustomList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -310,7 +310,7 @@ func TestVCLCustomList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -319,7 +319,7 @@ func TestVCLCustomList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListVCLsFn:     listVCLs,
 			},
-			Arg:        "--service-id 123 --version 3",
+			Args:       "--service-id 123 --version 3",
 			WantOutput: "SERVICE ID  VERSION  NAME  MAIN\n123         3        foo   true\n123         3        bar   false\n",
 		},
 		{
@@ -328,7 +328,7 @@ func TestVCLCustomList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListVCLsFn:     listVCLs,
 			},
-			Arg:        "--service-id 123 --version 1",
+			Args:       "--service-id 123 --version 1",
 			WantOutput: "SERVICE ID  VERSION  NAME  MAIN\n123         1        foo   true\n123         1        bar   false\n",
 		},
 		{
@@ -337,30 +337,30 @@ func TestVCLCustomList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListVCLsFn:     listVCLs,
 			},
-			Arg:        "--service-id 123 --verbose --version 1",
+			Args:       "--service-id 123 --verbose --version 1",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (profile: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nMain: false\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }
 
 func TestVCLCustomUpdate(t *testing.T) {
 	var content string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -368,7 +368,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -376,7 +376,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 2",
+			Args:      "--name foobar --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -387,7 +387,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -404,7 +404,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:        "--name foobar --new-name beepboop --service-id 123 --version 3",
+			Args:       "--name foobar --new-name beepboop --service-id 123 --version 3",
 			WantOutput: "Updated custom VCL 'beepboop' (previously: 'foobar', service: 123, version: 3)",
 		},
 		{
@@ -424,7 +424,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content updated --name foobar --service-id 123 --version 3",
+			Args:            "--content updated --name foobar --service-id 123 --version 3",
 			WantOutput:      "Updated custom VCL 'foobar' (service: 123, version: 3)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},
@@ -446,13 +446,13 @@ func TestVCLCustomUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1",
+			Args:            "--autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1",
 			WantOutput:      "Updated custom VCL 'foo' (service: 123, version: 4)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
 func getVCL(i *fastly.GetVCLInput) (*fastly.VCL, error) {

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestVCLSnippetCreate(t *testing.T) {
 	var content string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--content /path/to/snippet.vcl --name foo --type recv --version 3",
+			Args:      "--content /path/to/snippet.vcl --name foo --type recv --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -24,7 +24,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 1",
+			Args:      "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -32,7 +32,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 2",
+			Args:      "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -43,7 +43,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 3",
+			Args:      "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -72,7 +72,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 3",
+			Args:            "--content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 3",
 			WantOutput:      "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
@@ -102,7 +102,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content ./testdata/snippet.vcl --dynamic --name foo --service-id 123 --type recv --version 3",
+			Args:            "--content ./testdata/snippet.vcl --dynamic --name foo --service-id 123 --type recv --version 3",
 			WantOutput:      "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: true, snippet id: 123, type: recv, priority: 0)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
@@ -133,7 +133,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content ./testdata/snippet.vcl --name foo --priority 1 --service-id 123 --type recv --version 3",
+			Args:            "--content ./testdata/snippet.vcl --name foo --priority 1 --service-id 123 --type recv --version 3",
 			WantOutput:      "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 1)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
@@ -164,7 +164,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--autoclone --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 1",
+			Args:            "--autoclone --content ./testdata/snippet.vcl --name foo --service-id 123 --type recv --version 1",
 			WantOutput:      "Created VCL snippet 'foo' (service: 123, version: 4, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
@@ -194,30 +194,30 @@ func TestVCLSnippetCreate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content inline_vcl --name foo --service-id 123 --type recv --version 3",
+			Args:            "--content inline_vcl --name foo --service-id 123 --type recv --version 3",
 			WantOutput:      "Created VCL snippet 'foo' (service: 123, version: 3, dynamic: false, snippet id: 123, type: recv, priority: 0)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
 }
 
 func TestVCLSnippetDelete(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --name flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
 			Name:      "validate missing --version flag",
-			Arg:       "--name foobar",
+			Args:      "--name foobar",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--name foobar --version 3",
+			Args:      "--name foobar --version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -225,7 +225,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 1",
+			Args:      "--name foobar --service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -233,7 +233,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--name foobar --service-id 123 --version 2",
+			Args:      "--name foobar --service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -244,7 +244,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 					return testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -255,7 +255,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "Deleted VCL snippet 'foobar' (service: 123, version: 3)",
 		},
 		{
@@ -267,23 +267,23 @@ func TestVCLSnippetDelete(t *testing.T) {
 					return nil
 				},
 			},
-			Arg:        "--autoclone --name foo --service-id 123 --version 1",
+			Args:       "--autoclone --name foo --service-id 123 --version 1",
 			WantOutput: "Deleted VCL snippet 'foo' (service: 123, version: 4)",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
 }
 
 func TestVCLSnippetDescribe(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -291,7 +291,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --name with a versioned VCL snippet",
 		},
 		{
@@ -299,7 +299,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--dynamic --service-id 123 --version 3",
+			Args:      "--dynamic --service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --snippet-id with a dynamic VCL snippet",
 		},
 		{
@@ -310,7 +310,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--name foobar --service-id 123 --version 3",
+			Args:      "--name foobar --service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -319,7 +319,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetSnippetFn:   getSnippet,
 			},
-			Arg:        "--name foobar --service-id 123 --version 3",
+			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -328,7 +328,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				GetSnippetFn:   getSnippet,
 			},
-			Arg:        "--name foobar --service-id 123 --version 1",
+			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 		{
@@ -337,23 +337,23 @@ func TestVCLSnippetDescribe(t *testing.T) {
 				ListVersionsFn:      testutil.ListVersions,
 				GetDynamicSnippetFn: getDynamicSnippet,
 			},
-			Arg:        "--dynamic --service-id 123 --snippet-id 456 --version 3",
+			Args:       "--dynamic --service-id 123 --snippet-id 456 --version 3",
 			WantOutput: "\nService ID: 123\nID: 456\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "describe"}, scenarios)
 }
 
 func TestVCLSnippetList(t *testing.T) {
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -364,7 +364,7 @@ func TestVCLSnippetList(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--service-id 123 --version 3",
+			Args:      "--service-id 123 --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -373,7 +373,7 @@ func TestVCLSnippetList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListSnippetsFn: listSnippets,
 			},
-			Arg:        "--service-id 123 --version 3",
+			Args:       "--service-id 123 --version 3",
 			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC  SNIPPET ID\n123         3        foo   true     abc\n123         3        bar   false    abc\n",
 		},
 		{
@@ -382,7 +382,7 @@ func TestVCLSnippetList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListSnippetsFn: listSnippets,
 			},
-			Arg:        "--service-id 123 --version 1",
+			Args:       "--service-id 123 --version 1",
 			WantOutput: "SERVICE ID  VERSION  NAME  DYNAMIC  SNIPPET ID\n123         1        foo   true     abc\n123         1        bar   false    abc\n",
 		},
 		{
@@ -391,24 +391,24 @@ func TestVCLSnippetList(t *testing.T) {
 				ListVersionsFn: testutil.ListVersions,
 				ListSnippetsFn: listSnippets,
 			},
-			Arg:        "--service-id 123 --verbose --version 1",
+			Args:       "--service-id 123 --verbose --version 1",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (profile: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nID: abc\nPriority: 0\nDynamic: true\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nID: abc\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
 }
 
 func TestVCLSnippetUpdate(t *testing.T) {
 	var content string
-	scenarios := []testutil.TestScenario{
+	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing --version flag",
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Name:      "validate missing --service-id flag",
-			Arg:       "--version 3",
+			Args:      "--version 3",
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -416,7 +416,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--service-id 123 --version 1",
+			Args:      "--service-id 123 --version 1",
 			WantError: "service version 1 is active",
 		},
 		{
@@ -424,7 +424,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--service-id 123 --version 2",
+			Args:      "--service-id 123 --version 2",
 			WantError: "service version 2 is locked",
 		},
 		{
@@ -432,7 +432,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content inline_vcl --new-name bar --service-id 123 --type recv --version 3",
+			Args:      "--content inline_vcl --new-name bar --service-id 123 --type recv --version 3",
 			WantError: "error parsing arguments: must provide --name to update a versioned VCL snippet",
 		},
 		{
@@ -440,7 +440,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content inline_vcl --dynamic --service-id 123 --version 3",
+			Args:      "--content inline_vcl --dynamic --service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet",
 		},
 		{
@@ -448,7 +448,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content inline_vcl --new-name foobar --service-id 123 --snippet-id 456 --version 3",
+			Args:      "--content inline_vcl --new-name foobar --service-id 123 --snippet-id 456 --version 3",
 			WantError: "error parsing arguments: --snippet-id is not supported when updating a versioned VCL snippet",
 		},
 		{
@@ -456,7 +456,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 			},
-			Arg:       "--content inline_vcl --dynamic --new-name foobar --service-id 123 --snippet-id 456 --version 3",
+			Args:      "--content inline_vcl --dynamic --new-name foobar --service-id 123 --snippet-id 456 --version 3",
 			WantError: "error parsing arguments: --new-name is not supported when updating a dynamic VCL snippet",
 		},
 		{
@@ -467,7 +467,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					return nil, testutil.Err
 				},
 			},
-			Arg:       "--content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3",
+			Args:      "--content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3",
 			WantError: testutil.Err.Error(),
 		},
 		{
@@ -488,7 +488,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3",
+			Args:            "--content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3",
 			WantOutput:      "Updated VCL snippet 'bar' (previously: 'foo', service: 123, version: 3, type: recv, priority: 100)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
@@ -507,7 +507,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--content inline_vcl --dynamic --service-id 123 --snippet-id 456 --version 3",
+			Args:            "--content inline_vcl --dynamic --service-id 123 --snippet-id 456 --version 3",
 			WantOutput:      "Updated dynamic VCL snippet '456' (service: 123)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
@@ -530,13 +530,13 @@ func TestVCLSnippetUpdate(t *testing.T) {
 					}, nil
 				},
 			},
-			Arg:             "--autoclone --content inline_vcl --name foo --new-name bar --priority 1 --service-id 123 --type recv --version 1",
+			Args:            "--autoclone --content inline_vcl --name foo --new-name bar --priority 1 --service-id 123 --type recv --version 1",
 			WantOutput:      "Updated VCL snippet 'bar' (previously: 'foo', service: 123, version: 4, type: recv, priority: 1)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
 	}
 
-	testutil.RunScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
 func getSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error) {

--- a/pkg/commands/version/version_test.go
+++ b/pkg/commands/version/version_test.go
@@ -74,7 +74,7 @@ func TestVersion(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	args := testutil.Args("version")
+	args := testutil.SplitArgs("version")
 	opts := testutil.MockGlobalData(args, &stdout)
 	opts.Versioners = global.Versioners{
 		Viceroy: github.New(github.Opts{

--- a/pkg/commands/whoami/whoami_test.go
+++ b/pkg/commands/whoami/whoami_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestWhoami(t *testing.T) {
-	args := testutil.Args
+	args := testutil.SplitArgs
 	for _, testcase := range []struct {
 		name       string
 		args       []string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -265,7 +265,7 @@ token = "foobar"`) {
 }
 
 type testInvalidConfigScenario struct {
-	testutil.TestScenario
+	testutil.CLIScenario
 
 	invalid      bool
 	staticConfig []byte

--- a/pkg/internal/beacon/beacon_test.go
+++ b/pkg/internal/beacon/beacon_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNotify(t *testing.T) {
-	args := testutil.Args("compute deploy")
+	args := testutil.SplitArgs("compute deploy")
 	out := bytes.NewBuffer(nil)
 	g := testutil.MockGlobalData(args, out)
 	m := &mockHTTPClient{

--- a/pkg/testutil/args.go
+++ b/pkg/testutil/args.go
@@ -19,7 +19,7 @@ import (
 
 var argsPattern = regexp.MustCompile("`.+`")
 
-// Args is a simple wrapper function designed to accept a CLI command
+// SplitArgs is a simple wrapper function designed to accept a CLI command
 // (including flags) and return it as a slice for consumption by app.Run().
 //
 // NOTE: One test file (TestBigQueryCreate) passes RSA content inline into the
@@ -35,7 +35,7 @@ var argsPattern = regexp.MustCompile("`.+`")
 // surrounded by backticks with --- and then splits the resulting string by
 // spaces. Afterwards if there was a backtick matched, then we re-insert the
 // backticked content into the slice where --- is found.
-func Args(args string) []string {
+func SplitArgs(args string) []string {
 	var backtickMatch []string
 
 	if strings.Contains(args, "`") {


### PR DESCRIPTION
* Restore 'Args' name in scenario struct.

* Rename TestScenario to CLIScenario to clarify that it is only applicable to CLI-style tests.

* Rename RunScenarios and RunScenario for the same reason.

* Rename Args function to SplitArgs to better describe its purpose.