### PR TITLE
chore: Use full Go version in go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fastly/cli
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
As of Go 1.21 this is expected to be a full 1.N.P version string, not just 1.N (and CodeQL is complaining about it).