### PR TITLE
fix: Auth with NPM during publish workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -17,6 +17,12 @@ jobs:
         run: npm install && npm version "${{ github.ref_name }}" --allow-same-version
       - name: Publish npm packages
         working-directory: ./npm/@fastly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: for dir in *; do (echo $dir && cd $dir && npm publish); done
+        run: |
+          for dir in *; do
+            (
+              echo $dir
+              cd $dir
+              npm config set "//registry.npmjs.org/:_authToken" "${{ secrets.NPM_TOKEN }}"
+              npm publish
+            )
+          done


### PR DESCRIPTION
Publishing CLI to NPM [currently fails](https://github.com/fastly/cli/actions/runs/10395667625/job/28788205408#step:5:29) with this:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
npm error need auth You need to authorize this machine using `npm adduser`
```

As far as I can tell, this happens because even though the token is specified in the "Publish npm packages" step as an environment variable, it's having no effect. `NODE_AUTH_TOKEN` is described in the README of the [`actions/setup-node` action](https://github.com/actions/setup-node/?tab=readme-ov-file#usage).

```yaml
    # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, 
    # and set up auth to read in from env.NODE_AUTH_TOKEN.
    # Default: ''
    registry-url: ''
```

As we are not using `actions/setup-node`, this never happens. Moreover, as `actions/setup-node` writes a `.npmrc` at the package level it's not trivially usable for our use case because the `@fastly/cli-*` packages are generated during the workflow.

This PR updates the "Publish npm packages" workflow by calling `npm config` to have the equivalent effect, that is to write a `.npmrc` to the current directory (directory of each package as they are iterated) that uses `secrets.NPM_TOKEN` to auth with the `registry.npmjs.org` package repository.