### PR TITLE
fix(compute/publish): Don't change directory twice during execution when --dir/-C are used.

### DIFF
--- a/pkg/commands/compute/publish.go
+++ b/pkg/commands/compute/publish.go
@@ -200,5 +200,8 @@ func (c *PublishCommand) Deploy(in io.Reader, out io.Writer) error {
 		c.deploy.StatusCheckTimeout = c.statusCheckTimeout
 	}
 	c.deploy.StatusCheckPath = c.statusCheckPath
+	if c.projectDir != "" {
+		c.build.SkipChangeDir = true // we've already changed directory
+	}
 	return c.deploy.Exec(in, out)
 }


### PR DESCRIPTION
The 'deploy' command now has the same "skip changing directory" logic that the 'build' command has, so that it won't attempt to change the working directory when invoked by 'publish'.

Closes #1049.