### PR TITLE
feat(npm): Add TypeScript types to @fastly/cli

### DIFF
--- a/npm/@fastly/cli/index.d.ts
+++ b/npm/@fastly/cli/index.d.ts
@@ -1,0 +1,4 @@
+declare module '@fastly/cli' {
+  const location: string;
+  export default location;
+}

--- a/npm/@fastly/cli/package.json
+++ b/npm/@fastly/cli/package.json
@@ -11,6 +11,7 @@
         "decompress-targz": "^4.1.1"
     },
     "main": "index.js",
+    "types": "index.d.ts",
     "engines": {
         "node": ">=16"
     },


### PR DESCRIPTION
This PR adds TypeScript types to the `@fastly/cli` package so that it can be imported into TypeScript programs.

```typescript
import cli from '@fastly/cli';

const result = spawnSync(
  cli,
  [
    "version",
  ],
  {
    shell: true,
    encoding: "utf-8",
  }
);
```

Without these types, TypeScript will complain:

```
TS2306: File
/path/to/node_modules/@fastly/cli/index.d.ts
is not a module.
```