### PR TITLE
feat(npm): Properly handle error from npm-invoked cli

### DIFF
--- a/npm/@fastly/cli/fastly.js
+++ b/npm/@fastly/cli/fastly.js
@@ -19,4 +19,14 @@ try {
     If your platform is not supported, you can open an issue at https://github.com/fastly/cli/issues`);
 }
 
-execFileSync(location, process.argv.slice(2), { stdio: "inherit" });
+try {
+  execFileSync(location, process.argv.slice(2), { stdio: "inherit" });
+} catch(err) {
+  if (err.code) {
+    // Spawning child process failed
+    throw err;
+  }
+  if (err.status != null) {
+    process.exitCode = err.status;
+  }
+}


### PR DESCRIPTION
This PR corrects the case when the `fastly` command exits with a non-zero exit code when called through the npm wrapper.
Before this fix, the script doesn't run to completion, a stack trace leaks, and the real exit code is not available to the caller.

Example error output when called with non-existent `--asdf` flag:
```
ERROR: error parsing arguments: unknown long flag '--asdf'.

node:internal/errors:865
  const err = new Error(message);
              ^

Error: Command failed: /Users/komuro/Library/Application Support/fnm/node-versions/v18.19.1/installation/lib/node_modules/@fastly/cli/node_modules/@fastly/cli-darwin-arm64/fastly --asdf
    at checkExecSyncError (node:child_process:890:11)
    at execFileSync (node:child_process:926:15)
    at file:///Users/komuro/Library/Application%20Support/fnm/node-versions/v18.19.1/installation/lib/node_modules/@fastly/cli/fastly.js:22:1 {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 22519,
  stdout: null,
  stderr: null
}

Node.js v18.19.1
```

This happens because the exit code is 1. The wrapper invokes `fastly` using the [`child_process.execFileSync()` function](https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options):

> If the process times out or has a non-zero exit code, this method will throw an [Error](https://nodejs.org/api/errors.html#class-error) that will include the full result of the underlying [child_process.spawnSync()](https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options).

This PR fixes this by:

* Wrapping the call to `execFileSync()` with a `try` / `catch`.
* Checking the thrown `err` object for `code`. If this is set then it means `execFileSync()` itself failed (couldn't launch, timeout, etc.), so we rethrow the error.
* Checking the thrown `err` object for `status`. If this is set then it means the child process has set an exit code, so we set the current process's exit code to the value.

New output:
```
ERROR: error parsing arguments: unknown long flag '--asdf'.
```
