### PR TITLE
feat(service-version): Add 'stage' and 'unstage' commands.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v9 v9.9.0
+	github.com/fastly/go-fastly/v9 v9.10.0
 	github.com/hashicorp/cap v0.7.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/otiai10/copy v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2 h1:S6Dco8FtAhEI/qkg/00H6RdEGC+MCy5GPiQ+xweNRFE=
 github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v9 v9.9.0 h1:VDCyORoWi608l/LBp+tY+qic3M5/5ZFw+rtAfV6VR9E=
-github.com/fastly/go-fastly/v9 v9.9.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
+github.com/fastly/go-fastly/v9 v9.10.0 h1:Emg9foA2+o7ERs7NVit18Wih8TEEOC+XEeb8Kcyehtw=
+github.com/fastly/go-fastly/v9 v9.10.0/go.mod h1:5w2jgJBZqQEebOwM/rRg7wutAcpDTziiMYWb/6qdM7U=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/argparser/cmd.go
+++ b/pkg/argparser/cmd.go
@@ -109,14 +109,18 @@ type OptionalFloat64 struct {
 // ServiceDetailsOpts provides data and behaviours required by the
 // ServiceDetails function.
 type ServiceDetailsOpts struct {
-	// Active controls whether active serviceversions will be included in the result;
+	// Active controls whether active service-versions will be included in the result;
 	// if this is Empty, then the 'active' state of the version is ignored;
 	// otherwise, the 'active' state must match the value
 	Active optional.Optional[bool]
-	// Locked controls whether locked serviceversions will be included in the result;
+	// Locked controls whether locked service-versions will be included in the result;
 	// if this is Empty, then the 'locked' state of the version is ignored;
 	// otherwise, the 'locked' state must match the value
-	Locked             optional.Optional[bool]
+	Locked optional.Optional[bool]
+	// Staging controls whether staging service-versions will be included in the result;
+	// if this is Empty, then the 'staging' state of the version is ignored;
+	// otherwise, the 'staging' state must match the value
+	Staging            optional.Optional[bool]
 	AutoCloneFlag      OptionalAutoClone
 	APIClient          api.Interface
 	Manifest           manifest.Data
@@ -173,6 +177,17 @@ func ServiceDetails(opts ServiceDetailsOpts) (serviceID string, serviceVersion *
 		if !locked && fastly.ToValue(v.Locked) {
 			failure = true
 			failureState = "locked"
+		}
+	}
+
+	if staging, present := opts.Staging.Get(); present {
+		if staging && !fastly.ToValue(v.Staging) {
+			failure = true
+			failureState = "not staged"
+		}
+		if !staging && fastly.ToValue(v.Staging) {
+			failure = true
+			failureState = "staged"
 		}
 	}
 

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -27,7 +27,7 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 	}{
 		"latest": {
 			flagValue:   "latest",
-			wantVersion: 3,
+			wantVersion: 4,
 		},
 		"active": {
 			flagValue:   "active",
@@ -48,8 +48,8 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 			wantVersion: 2,
 		},
 		"specific version ERR": {
-			flagValue:   "4",
-			errExpected: true, // there is no version 4
+			flagValue:   "5",
+			errExpected: true, // there is no version 5
 		},
 	}
 
@@ -89,7 +89,8 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 
 // listVersions returns a list of service versions in different states.
 //
-// The first element is active, the second is locked, the third is editable.
+// The first element is active, the second is locked, the third is
+// editable, the fourth is staged.
 func listVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
 		{
@@ -101,15 +102,19 @@ func listVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
 			Number:    fastly.ToPointer(2),
-			Active:    fastly.ToPointer(false),
 			Locked:    fastly.ToPointer(true),
 			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
 		},
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
 			Number:    fastly.ToPointer(3),
-			Active:    fastly.ToPointer(false),
 			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
+		},
+		{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(4),
+			Staging:   fastly.ToPointer(true),
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
 		},
 	}, nil
 }

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -399,6 +399,8 @@ func Define(
 	serviceVersionDeactivate := serviceversion.NewDeactivateCommand(serviceVersionCmdRoot.CmdClause, data)
 	serviceVersionList := serviceversion.NewListCommand(serviceVersionCmdRoot.CmdClause, data)
 	serviceVersionLock := serviceversion.NewLockCommand(serviceVersionCmdRoot.CmdClause, data)
+	serviceVersionStage := serviceversion.NewStageCommand(serviceVersionCmdRoot.CmdClause, data)
+	serviceVersionUnstage := serviceversion.NewUnstageCommand(serviceVersionCmdRoot.CmdClause, data)
 	serviceVersionUpdate := serviceversion.NewUpdateCommand(serviceVersionCmdRoot.CmdClause, data)
 	statsCmdRoot := stats.NewRootCommand(app, data)
 	statsHistorical := stats.NewHistoricalCommand(statsCmdRoot.CmdClause, data)
@@ -768,6 +770,8 @@ func Define(
 		serviceVersionDeactivate,
 		serviceVersionList,
 		serviceVersionLock,
+		serviceVersionStage,
+		serviceVersionUnstage,
 		serviceVersionUpdate,
 		ssoCmdRoot,
 		statsCmdRoot,

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -525,7 +525,7 @@ func TestDeploy(t *testing.T) {
 		},
 		{
 			name: "success with path",
-			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version latest"),
+			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version 3"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
 				GetPackageFn:        getPackageOk,
@@ -559,7 +559,7 @@ func TestDeploy(t *testing.T) {
 		// inside the given package tar.gz archive.
 		{
 			name: "success with path called from non project directory",
-			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version latest --verbose"),
+			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version 3 --verbose"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
 				GetPackageFn:        getPackageOk,
@@ -591,7 +591,7 @@ func TestDeploy(t *testing.T) {
 		},
 		{
 			name: "success with inactive version",
-			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version latest"),
+			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version 3"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
 				GetPackageFn:        getPackageOk,

--- a/pkg/commands/serviceversion/list.go
+++ b/pkg/commands/serviceversion/list.go
@@ -77,11 +77,12 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
-		tw.AddHeader("NUMBER", "ACTIVE", "LAST EDITED (UTC)")
+		tw.AddHeader("NUMBER", "ACTIVE", "STAGING", "LAST EDITED (UTC)")
 		for _, version := range o {
 			tw.AddLine(
 				fastly.ToValue(version.Number),
 				fastly.ToValue(version.Active),
+				fastly.ToValue(version.Staging),
 				parseTime(version.UpdatedAt),
 			)
 		}

--- a/pkg/commands/serviceversion/stage.go
+++ b/pkg/commands/serviceversion/stage.go
@@ -24,7 +24,8 @@ type StageCommand struct {
 func NewStageCommand(parent argparser.Registerer, g *global.Data) *StageCommand {
 	var c StageCommand
 	c.Globals = g
-	c.CmdClause = parent.Command("stage", "Stage a Fastly service version")
+	// FIXME: unhide this command when appropriate
+	c.CmdClause = parent.Command("stage", "Stage a Fastly service version").Hidden()
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagServiceIDName,
 		Description: argparser.FlagServiceIDDesc,

--- a/pkg/commands/serviceversion/stage.go
+++ b/pkg/commands/serviceversion/stage.go
@@ -1,0 +1,83 @@
+package serviceversion
+
+import (
+	"io"
+
+	"github.com/fastly/go-fastly/v9/fastly"
+
+	"4d63.com/optional"
+	"github.com/fastly/cli/pkg/argparser"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// StageCommand calls the Fastly API to stage a service version.
+type StageCommand struct {
+	argparser.Base
+	Input          fastly.ActivateVersionInput
+	serviceName    argparser.OptionalServiceNameID
+	serviceVersion argparser.OptionalServiceVersion
+}
+
+// NewStageCommand returns a usable command registered under the parent.
+func NewStageCommand(parent argparser.Registerer, g *global.Data) *StageCommand {
+	var c StageCommand
+	c.Globals = g
+	c.CmdClause = parent.Command("stage", "Stage a Fastly service version")
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagServiceIDName,
+		Description: argparser.FlagServiceIDDesc,
+		Dst:         &g.Manifest.Flag.ServiceID,
+		Short:       's',
+	})
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Action:      c.serviceName.Set,
+		Name:        argparser.FlagServiceName,
+		Description: argparser.FlagServiceNameDesc,
+		Dst:         &c.serviceName.Value,
+	})
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagVersionName,
+		Description: argparser.FlagVersionDesc,
+		Dst:         &c.serviceVersion.Value,
+		Required:    true,
+	})
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *StageCommand) Exec(_ io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := argparser.ServiceDetails(argparser.ServiceDetailsOpts{
+		Active:             optional.Of(false),
+		APIClient:          c.Globals.APIClient,
+		Manifest:           *c.Globals.Manifest,
+		Out:                out,
+		ServiceNameFlag:    c.serviceName,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flags.Verbose,
+	})
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": errors.ServiceVersion(serviceVersion),
+		})
+		return err
+	}
+
+	c.Input.ServiceID = serviceID
+	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
+	c.Input.Environment = "staging"
+
+	ver, err := c.Globals.APIClient.ActivateVersion(&c.Input)
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": serviceVersion.Number,
+		})
+		return err
+	}
+
+	text.Success(out, "Staged service %s version %d", fastly.ToValue(ver.ServiceID), c.Input.ServiceVersion)
+	return nil
+}

--- a/pkg/commands/serviceversion/unstage.go
+++ b/pkg/commands/serviceversion/unstage.go
@@ -24,7 +24,8 @@ type UnstageCommand struct {
 func NewUnstageCommand(parent argparser.Registerer, g *global.Data) *UnstageCommand {
 	var c UnstageCommand
 	c.Globals = g
-	c.CmdClause = parent.Command("unstage", "Unstage a Fastly service version")
+	// FIXME: unhide this command when appropriate
+	c.CmdClause = parent.Command("unstage", "Unstage a Fastly service version").Hidden()
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagServiceIDName,
 		Description: argparser.FlagServiceIDDesc,

--- a/pkg/commands/serviceversion/unstage.go
+++ b/pkg/commands/serviceversion/unstage.go
@@ -1,0 +1,83 @@
+package serviceversion
+
+import (
+	"io"
+
+	"github.com/fastly/go-fastly/v9/fastly"
+
+	"4d63.com/optional"
+	"github.com/fastly/cli/pkg/argparser"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// UnstageCommand calls the Fastly API to unstage a service version.
+type UnstageCommand struct {
+	argparser.Base
+	Input          fastly.DeactivateVersionInput
+	serviceName    argparser.OptionalServiceNameID
+	serviceVersion argparser.OptionalServiceVersion
+}
+
+// NewUnstageCommand returns a usable command registered under the parent.
+func NewUnstageCommand(parent argparser.Registerer, g *global.Data) *UnstageCommand {
+	var c UnstageCommand
+	c.Globals = g
+	c.CmdClause = parent.Command("unstage", "Unstage a Fastly service version")
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagServiceIDName,
+		Description: argparser.FlagServiceIDDesc,
+		Dst:         &g.Manifest.Flag.ServiceID,
+		Short:       's',
+	})
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Action:      c.serviceName.Set,
+		Name:        argparser.FlagServiceName,
+		Description: argparser.FlagServiceNameDesc,
+		Dst:         &c.serviceName.Value,
+	})
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagVersionName,
+		Description: argparser.FlagVersionDesc,
+		Dst:         &c.serviceVersion.Value,
+		Required:    true,
+	})
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UnstageCommand) Exec(_ io.Reader, out io.Writer) error {
+	serviceID, serviceVersion, err := argparser.ServiceDetails(argparser.ServiceDetailsOpts{
+		Staging:            optional.Of(true),
+		APIClient:          c.Globals.APIClient,
+		Manifest:           *c.Globals.Manifest,
+		Out:                out,
+		ServiceNameFlag:    c.serviceName,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flags.Verbose,
+	})
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": errors.ServiceVersion(serviceVersion),
+		})
+		return err
+	}
+
+	c.Input.ServiceID = serviceID
+	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
+	c.Input.Environment = "staging"
+
+	ver, err := c.Globals.APIClient.DeactivateVersion(&c.Input)
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": fastly.ToValue(serviceVersion.Number),
+		})
+		return err
+	}
+
+	text.Success(out, "Unstaged service %s version %d", fastly.ToValue(ver.ServiceID), c.Input.ServiceVersion)
+	return nil
+}

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -17,7 +17,8 @@ var Err = errors.New("test error")
 
 // ListVersions returns a list of service versions in different states.
 //
-// The first element is active, the second is locked, the third is editable.
+// The first element is active, the second is locked, the third is
+// editable, the fourth is staged.
 //
 // NOTE: consult the entire test suite before adding any new entries to the
 // returned type as the tests currently use testutil.CloneVersionResult() as a
@@ -33,15 +34,19 @@ func ListVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
 			Number:    fastly.ToPointer(2),
-			Active:    fastly.ToPointer(false),
 			Locked:    fastly.ToPointer(true),
 			UpdatedAt: MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
 		},
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
 			Number:    fastly.ToPointer(3),
-			Active:    fastly.ToPointer(false),
 			UpdatedAt: MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
+		},
+		{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(4),
+			Staging:   fastly.ToPointer(true),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
 		},
 	}, nil
 }


### PR DESCRIPTION
Some notes

1. The tests fail because it gets the wrong error message - I think  misunderstand the test system
2. Instead of the `Stage` and `Unstage` methods in `go-fastly` maybe these commands should use `Activate` and `Deactivate`  with an `Environment` parameter set
3. This does not add the ability to pass an optional `Enviroment` param to the `activate` and `deactivate` commands.