### PR TITLE
Clarifying documentation on npm publishing process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,20 +12,23 @@
 1. Copy/paste CHANGELOG into the [draft release](https://github.com/fastly/cli/releases).
 1. Publish draft release.
 
-## Creation of npm modules
+## Creation of npm packages
 
-Each release of the Fastly CLI will trigger the creation of a new version of the `@fastly/cli` npm module, as well as multiple per-platform modules (e.g. `@fastly/cli-darwin-arm64`). The root module (`@fastly/cli`) depends on the platform-specific modules as `optionalDependencies` so that npm will only install the compatible platform-specific package.
+Each release of the Fastly CLI triggers a workflow in `.github/workflows/publish_release.yml` that results in the creation of a new version of the `@fastly/cli` npm package, as well as multiple packages each representing a supported platform/arch combo (e.g. `@fastly/cli-darwin-arm64`). These packages are given the same version number as the Fastly CLI release. The workflow then publishes the `@fastly/cli` package and the per-platform/arch packages to npm using the `NPM_TOKEN` secret in this repository. The per-platform/arch packages are generated on each release and not committed to source control.
 
-To see an example of the module layout, run...
+> [!NOTE]
+> The workflow step that performs `npm version` in the directory of the `@fastly/cli` package triggers the execution of the `version` script listed in its `package.json`. In turn, this script creates the per-platform/arch packages.
+
+The `@fastly/cli` package is set up to declare the platform/arch-specific packages as `optionalDependencies`. When a package installs `@fastly/cli` as one of its `dependencies`, npm will additionally install just the platform/arch-specific package compatible with the environment.
+
+> [!NOTE]
+> The `optionalDependencies` list only restricts the packages that are actually installed into the `node_modules` directory in an environment, and does not affect what is saved to the lockfile (`package-lock.json`). All the platform/arch-specific packages will be listed in the lockfile, so a single lockfile is safe to use in environments that may represent a different platform/arch combo.
+
+To see an example of the module layout, run:
 
 ```sh
-$ npm install @fastly/cli-darwin-arm64 --verbose
-```
-
-Next, run...
-
-```sh
-$ ls node_modules/@fastly/cli-darwin-arm64
+npm install @fastly/cli-darwin-arm64 --verbose
+ls node_modules/@fastly/cli-darwin-arm64
 ```
 
 You should see a `fastly` executable binary as well as an `index.js` shim which allows the package to be imported as a module by other JavaScript projects.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@
 
 ## Creation of npm packages
 
-Each release of the Fastly CLI triggers a workflow in `.github/workflows/publish_release.yml` that results in the creation of a new version of the `@fastly/cli` npm package, as well as multiple packages each representing a supported platform/arch combo (e.g. `@fastly/cli-darwin-arm64`). These packages are given the same version number as the Fastly CLI release. The workflow then publishes the `@fastly/cli` package and the per-platform/arch packages to npm using the `NPM_TOKEN` secret in this repository. The per-platform/arch packages are generated on each release and not committed to source control.
+Each release of the Fastly CLI triggers a workflow in `.github/workflows/publish_release.yml` that results in the creation of a new version of the `@fastly/cli` npm package, as well as multiple packages each representing a supported platform/arch combo (e.g. `@fastly/cli-darwin-arm64`). These packages are given the same version number as the Fastly CLI release. The workflow then publishes the `@fastly/cli` package and the per-platform/arch packages to npmjs.com using the `NPM_TOKEN` secret in this repository. The per-platform/arch packages are generated on each release and not committed to source control.
 
 > [!NOTE]
 > The workflow step that performs `npm version` in the directory of the `@fastly/cli` package triggers the execution of the `version` script listed in its `package.json`. In turn, this script creates the per-platform/arch packages.


### PR DESCRIPTION
This PR adds a few sentences to the releases doc to clarify how some of the steps work.