### PR TITLE
fix(service, service-version): stage terminology

### DIFF
--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -541,7 +541,7 @@ Service 1/3
 			Active: false
 			Locked: false
 			Deployed: false
-			Staging: false
+			Staged: false
 			Testing: false
 			Created (UTC): 2021-06-15 23:00
 			Last edited (UTC): 2021-06-15 23:00
@@ -553,7 +553,7 @@ Service 1/3
 			Active: true
 			Locked: false
 			Deployed: true
-			Staging: false
+			Staged: false
 			Testing: false
 			Created (UTC): 2021-06-15 23:00
 			Last edited (UTC): 2021-06-15 23:00

--- a/pkg/commands/serviceversion/list.go
+++ b/pkg/commands/serviceversion/list.go
@@ -77,7 +77,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	if !c.Globals.Verbose() {
 		tw := text.NewTable(out)
-		tw.AddHeader("NUMBER", "ACTIVE", "STAGING", "LAST EDITED (UTC)")
+		tw.AddHeader("NUMBER", "ACTIVE", "STAGED", "LAST EDITED (UTC)")
 		for _, version := range o {
 			tw.AddLine(
 				fastly.ToValue(version.Number),

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -249,17 +249,17 @@ func TestVersionStage(t *testing.T) {
 			Args: "--service-id 123 --version 2",
 			API: mock.API{
 				ListVersionsFn:    testutil.ListVersions,
+				ActivateVersionFn: stageVersionOK,
+			},
+			WantError: "service version 2 is locked",
+		},
+		{
+			Args: "--service-id 123 --version 3",
+			API: mock.API{
+				ListVersionsFn:    testutil.ListVersions,
 				ActivateVersionFn: stageVersionError,
 			},
 			WantError: testutil.Err.Error(),
-		},
-		{
-			Args: "--service-id 123 --version 2",
-			API: mock.API{
-				ListVersionsFn:    testutil.ListVersions,
-				ActivateVersionFn: stageVersionOK,
-			},
-			WantOutput: "Staged service 123 version 2",
 		},
 		{
 			Args: "--service-id 123 --version 3",

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -326,11 +326,11 @@ func TestVersionUnstage(t *testing.T) {
 }
 
 var listVersionsShortOutput = strings.TrimSpace(`
-NUMBER  ACTIVE  STAGING  LAST EDITED (UTC)
-1       true    false    2000-01-01 01:00
-2       false   false    2000-01-02 01:00
-3       false   false    2000-01-03 01:00
-4       false   true     2000-01-04 01:00
+NUMBER  ACTIVE  STAGED  LAST EDITED (UTC)
+1       true    false   2000-01-01 01:00
+2       false   false   2000-01-02 01:00
+3       false   false   2000-01-03 01:00
+4       false   true    2000-01-04 01:00
 `) + "\n"
 
 var listVersionsVerboseOutput = strings.TrimSpace(`
@@ -357,7 +357,7 @@ Versions: 4
 	Version 4/4
 		Number: 4
 		Service ID: 123
-		Staging: true
+		Staged: true
 		Last edited (UTC): 2000-01-04 01:00
 `) + "\n\n"
 

--- a/pkg/commands/serviceversion/stage.go
+++ b/pkg/commands/serviceversion/stage.go
@@ -51,6 +51,7 @@ func NewStageCommand(parent argparser.Registerer, g *global.Data) *StageCommand 
 func (c *StageCommand) Exec(_ io.Reader, out io.Writer) error {
 	serviceID, serviceVersion, err := argparser.ServiceDetails(argparser.ServiceDetailsOpts{
 		Active:             optional.Of(false),
+		Locked:             optional.Of(false),
 		APIClient:          c.Globals.APIClient,
 		Manifest:           *c.Globals.Manifest,
 		Out:                out,

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -76,7 +76,7 @@ func PrintVersion(out io.Writer, indent string, v *fastly.Version) {
 		fmt.Fprintf(out, "Deployed: %v\n", fastly.ToValue(v.Deployed))
 	}
 	if v.Staging != nil {
-		fmt.Fprintf(out, "Staging: %v\n", fastly.ToValue(v.Staging))
+		fmt.Fprintf(out, "Staged: %v\n", fastly.ToValue(v.Staging))
 	}
 	if v.Testing != nil {
 		fmt.Fprintf(out, "Testing: %v\n", fastly.ToValue(v.Testing))

--- a/pkg/text/service_test.go
+++ b/pkg/text/service_test.go
@@ -69,7 +69,7 @@ func TestPrintVersion(t *testing.T) {
 				Staging:   fastly.ToPointer(true),
 				Testing:   fastly.ToPointer(false),
 			},
-			wantOutput: "Number: 1\nService ID: example\nActive: true\nLocked: true\nDeployed: true\nStaging: true\nTesting: false\n",
+			wantOutput: "Number: 1\nService ID: example\nActive: true\nLocked: true\nDeployed: true\nStaged: true\nTesting: false\n",
 		},
 		{
 			name:   "with",
@@ -83,7 +83,7 @@ func TestPrintVersion(t *testing.T) {
 				Staging:   fastly.ToPointer(true),
 				Testing:   fastly.ToPointer(false),
 			},
-			wantOutput: "\tNumber: 1\n\tService ID: example\n\tActive: true\n\tLocked: true\n\tDeployed: true\n\tStaging: true\n\tTesting: false\n",
+			wantOutput: "\tNumber: 1\n\tService ID: example\n\tActive: true\n\tLocked: true\n\tDeployed: true\n\tStaged: true\n\tTesting: false\n",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {


### PR DESCRIPTION
'stage' can only be used on draft versions; use 'staged' instead of 'staging' in user-friendly output.