### PR TITLE
fix(compute build): Emit warning if Rust 1.82.0 (or higher) are used for the build.

### DIFF
--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -1,4 +1,4 @@
-config_version = 6
+config_version = 7
 
 [fastly]
 account_endpoint = "https://accounts.fastly.com"

--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -18,7 +18,7 @@ toolchain_constraint = ">= 1.21"           # Go toolchain constraint for use wit
 toolchain_constraint_tinygo = ">= 1.18"    # Go toolchain constraint for use with TinyGo.
 
 [language.rust]
-toolchain_constraint = ">= 1.56.1"
+toolchain_constraint = ">= 1.56.1 < 1.82.0"
 wasm_wasi_target = "wasm32-wasi"
 
 [wasm-tools]


### PR DESCRIPTION
Rust 1.82.0 introduced a change to how 'reference types' are handled in WebAssembly and the Compute platform is not yet compatible with that change.