### PR TITLE
Publish to GitHub packages in addition to npmjs

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -12,17 +12,39 @@ jobs:
         uses: actions/checkout@v4
       - name: "Fetch unshallow repo"
         run: git fetch --prune --unshallow
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Set up auth for GitHub packages
+        run: |
+          npm config set "//npm.pkg.github.com/:_authToken" "\${NODE_AUTH_TOKEN}"
       - name: Update npm packages to latest version
         working-directory: ./npm/@fastly/cli
         run: npm install && npm version "${{ github.ref_name }}" --allow-same-version
-      - name: Publish npm packages
+      - name: Publish packages to npmjs.org
         working-directory: ./npm/@fastly
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for dir in *; do
             (
               echo $dir
               cd $dir
-              npm config set "//registry.npmjs.org/:_authToken" "${{ secrets.NPM_TOKEN }}"
+              npm publish --access=public
+            )
+          done
+      - name: Publish packages to GitHub packages
+        working-directory: ./npm/@fastly
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm config set "@fastly:registry" "https://npm.pkg.github.com/"
+          for dir in *; do
+            (
+              echo $dir
+              cd $dir
               npm publish --access=public
             )
           done


### PR DESCRIPTION
This PR updates the NPM package publish workflow to publish to GitHub packages in addition to npmjs.

There are a few changes here:

* The proposed change now uses the workflow described in https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages to use the [setup-node action](https://github.com/actions/setup-node) to set up the node environment. As a result of this action, the following is added to `.npmrc` in the runner (including the variable placeholder):

   ```
   //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
   registry=https://registry.npmjs.org/
   always-auth=true
   ```

* After this we add the following line to `.npmrc` by invoking `npm config set`:

   ```
   //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
   ```

* Now, when publishing to npmjs, we set the environment value `NODE_AUTH_TOKEN` to the NPM publish token, which is resolved as `npm publish` reads `.npmrc`.

* After that, there is a new step that publishes to GitHub packages, which sets the registry for the `@fastly` scope to `npm.pkg.github.com`. For this step we set the environment value `NODE_AUTH_TOKEN` to the GitHub token, which is resolved as `npm publish` reads `.npmrc`.