### PR TITLE
breaking(products): Remove support for NGWAF product.

### DIFF
--- a/pkg/commands/products/products_test.go
+++ b/pkg/commands/products/products_test.go
@@ -35,7 +35,6 @@ brotli_compression  false
 domain_inspector    false
 fanout              false
 image_optimizer     false
-ngwaf               false
 origin_inspector    false
 websockets          false
 `,
@@ -54,7 +53,6 @@ brotli_compression  true
 domain_inspector    true
 fanout              true
 image_optimizer     true
-ngwaf               true
 origin_inspector    true
 websockets          true
 `,
@@ -62,12 +60,12 @@ websockets          true
 		{
 			Name:      "validate flag parsing error for enabling product",
 			Args:      "--service-id 123 --enable foo",
-			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,ngwaf,origin_inspector,websockets, got 'foo'",
+			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,origin_inspector,websockets, got 'foo'",
 		},
 		{
 			Name:      "validate flag parsing error for disabling product",
 			Args:      "--service-id 123 --disable foo",
-			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,ngwaf,origin_inspector,websockets, got 'foo'",
+			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,origin_inspector,websockets, got 'foo'",
 		},
 		{
 			Name: "validate success for enabling product",
@@ -108,7 +106,6 @@ websockets          true
   "domain_inspector": false,
   "fanout": false,
   "image_optimizer": false,
-  "ngwaf": false,
   "origin_inspector": false,
   "websockets": false
 }`,
@@ -127,7 +124,6 @@ websockets          true
   "domain_inspector": true,
   "fanout": true,
   "image_optimizer": true,
-  "ngwaf": true,
   "origin_inspector": true,
   "websockets": true
 }`,

--- a/pkg/commands/products/root.go
+++ b/pkg/commands/products/root.go
@@ -31,7 +31,6 @@ var ProductEnablementOptions = []string{
 	"domain_inspector",
 	"fanout",
 	"image_optimizer",
-	"ngwaf",
 	"origin_inspector",
 	"websockets",
 }
@@ -144,12 +143,6 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 		ps.ImageOptimizer = true
 	}
 	if _, err = ac.GetProduct(&fastly.ProductEnablementInput{
-		ProductID: fastly.ProductNGWAF,
-		ServiceID: serviceID,
-	}); err == nil {
-		ps.NGWAF = true
-	}
-	if _, err = ac.GetProduct(&fastly.ProductEnablementInput{
 		ProductID: fastly.ProductOriginInspector,
 		ServiceID: serviceID,
 	}); err == nil {
@@ -173,7 +166,6 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	t.AddLine(fastly.ProductDomainInspector, ps.DomainInspector)
 	t.AddLine(fastly.ProductFanout, ps.Fanout)
 	t.AddLine(fastly.ProductImageOptimizer, ps.ImageOptimizer)
-	t.AddLine(fastly.ProductNGWAF, ps.NGWAF)
 	t.AddLine(fastly.ProductOriginInspector, ps.OriginInspector)
 	t.AddLine(fastly.ProductWebSockets, ps.WebSockets)
 	t.Print()
@@ -192,8 +184,6 @@ func identifyProduct(product string) fastly.Product {
 		return fastly.ProductFanout
 	case "image_optimizer":
 		return fastly.ProductImageOptimizer
-	case "ngwaf":
-		return fastly.ProductNGWAF
 	case "origin_inspector":
 		return fastly.ProductOriginInspector
 	case "websockets":
@@ -210,7 +200,6 @@ type ProductStatus struct {
 	DomainInspector   bool `json:"domain_inspector"`
 	Fanout            bool `json:"fanout"`
 	ImageOptimizer    bool `json:"image_optimizer"`
-	NGWAF             bool `json:"ngwaf"`
 	OriginInspector   bool `json:"origin_inspector"`
 	WebSockets        bool `json:"websockets"`
 }


### PR DESCRIPTION
The support added for the NGWAF product in version 10.15.0 did not work, and is being removed so that it can be redesigned. Since the feature was non-operational, no users of the CLI could have relied on it, so the major version number is not being incremented in spite of the breaking nature of the change.