### PR TITLE
fix(profile/token): 'profile token' command must check the validity of the stored token.

### DIFF
--- a/pkg/commands/profile/token.go
+++ b/pkg/commands/profile/token.go
@@ -3,12 +3,15 @@ package profile
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/fastly/cli/pkg/argparser"
+	"github.com/fastly/cli/pkg/config"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/profile"
 	"github.com/fastly/cli/pkg/text"
+	fsttime "github.com/fastly/cli/pkg/time"
 )
 
 // TokenCommand represents a Kingpin command.
@@ -26,24 +29,31 @@ func NewTokenCommand(parent argparser.Registerer, g *global.Data) *TokenCommand 
 	return &c
 }
 
+// By default tokens must be valid for at least 5 minutes to be
+// considered valid.
+const defaultTokenTTL int64 = 5 * 60
+
 // Exec implements the command interface.
 func (c *TokenCommand) Exec(_ io.Reader, out io.Writer) (err error) {
-	var p string
+	var name string
 	if c.profile != "" {
-		p = c.profile
+		name = c.profile
 	}
 	if c.Globals.Flags.Profile != "" {
-		p = c.Globals.Flags.Profile
+		name = c.Globals.Flags.Profile
 		// NOTE: If global --profile is set, it take precedence over 'profile' arg.
 		// It's unlikely someone will provide both, but we'll code defensively.
 	}
 
-	if p != "" {
-		if p := profile.Get(p, c.Globals.Config.Profiles); p != nil {
+	if name != "" {
+		if p := profile.Get(name, c.Globals.Config.Profiles); p != nil {
+			if err = checkTokenValidity(name, p, defaultTokenTTL); err != nil {
+				return err
+			}
 			text.Output(out, p.Token)
 			return nil
 		}
-		msg := fmt.Sprintf(profile.DoesNotExist, p)
+		msg := fmt.Sprintf(profile.DoesNotExist, name)
 		return fsterr.RemediationError{
 			Inner:       fmt.Errorf(msg),
 			Remediation: fsterr.ProfileRemediation,
@@ -51,12 +61,33 @@ func (c *TokenCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	}
 
 	// If no 'profile' arg or global --profile, then we'll use 'active' profile.
-	if _, p := profile.Default(c.Globals.Config.Profiles); p != nil {
+	if name, p := profile.Default(c.Globals.Config.Profiles); p != nil {
+		if err = checkTokenValidity(name, p, defaultTokenTTL); err != nil {
+			return err
+		}
 		text.Output(out, p.Token)
 		return nil
 	}
 	return fsterr.RemediationError{
 		Inner:       fmt.Errorf("no profiles available"),
 		Remediation: fsterr.ProfileRemediation,
+	}
+}
+
+func checkTokenValidity(profileName string, p *config.Profile, ttl int64) (err error) {
+	var msg string
+	expiry := time.Unix(p.RefreshTokenCreated, 0).Add(time.Duration(p.RefreshTokenTTL) * time.Second)
+
+	if expiry.After(time.Now().Add(time.Duration(ttl) * time.Second)) {
+		return nil
+	} else if expiry.Before(time.Now()) {
+		msg = fmt.Sprintf(profile.TokenExpired, profileName, expiry.UTC().Format(fsttime.Format))
+	} else {
+		msg = fmt.Sprintf(profile.TokenWillExpire, profileName, expiry.UTC().Format(fsttime.Format))
+	}
+
+	return fsterr.RemediationError{
+		Inner:       fmt.Errorf(msg),
+		Remediation: fsterr.TokenExpirationRemediation,
 	}
 }

--- a/pkg/commands/profile/token.go
+++ b/pkg/commands/profile/token.go
@@ -31,7 +31,7 @@ func NewTokenCommand(parent argparser.Registerer, g *global.Data) *TokenCommand 
 
 // By default tokens must be valid for at least 5 minutes to be
 // considered valid.
-const defaultTokenTTL int64 = 5 * 60
+const defaultTokenTTL time.Duration = 5 * time.Minute
 
 // Exec implements the command interface.
 func (c *TokenCommand) Exec(_ io.Reader, out io.Writer) (err error) {
@@ -74,11 +74,11 @@ func (c *TokenCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	}
 }
 
-func checkTokenValidity(profileName string, p *config.Profile, ttl int64) (err error) {
+func checkTokenValidity(profileName string, p *config.Profile, ttl time.Duration) (err error) {
 	var msg string
 	expiry := time.Unix(p.RefreshTokenCreated, 0).Add(time.Duration(p.RefreshTokenTTL) * time.Second)
 
-	if expiry.After(time.Now().Add(time.Duration(ttl) * time.Second)) {
+	if expiry.After(time.Now().Add(ttl)) {
 		return nil
 	} else if expiry.Before(time.Now()) {
 		msg = fmt.Sprintf(profile.TokenExpired, profileName, expiry.UTC().Format(fsttime.Format))

--- a/pkg/errors/remediation_error.go
+++ b/pkg/errors/remediation_error.go
@@ -165,3 +165,8 @@ var InvalidStaticConfigRemediation = strings.Join([]string{
 	"If this does not resolve the issue, then please file an issue:",
 	"https://github.com/fastly/cli/issues/new?labels=bug&template=bug_report.md",
 }, " ")
+
+// TokenExpirationRemediation indicates that a stored token has expired.
+var TokenExpirationRemediation = strings.Join([]string{
+	"Run 'fastly --profile <NAME> update' to refresh the token.",
+}, " ")

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -13,6 +13,12 @@ const DoesNotExist = "the profile '%s' does not exist"
 // NoDefaults describes an output warning message.
 const NoDefaults = "At least one account profile should be set as the 'default'. Run `fastly profile update <NAME>` and ensure the profile is set to be the default."
 
+// TokenExpired is a token expiration error message.
+const TokenExpired = "the token in profile '%s' expired at '%s'"
+
+// TokenWillExpire is a token expiration error message.
+const TokenWillExpire = "the token in profile '%s' will expire at '%s'"
+
 // Exist reports whether the given profile exists.
 func Exist(name string, p config.Profiles) bool {
 	for k := range p {


### PR DESCRIPTION
The 'fastly profile token' command did not check the validity (expiration) of the stored token, which meant that it would emit an invalid token if the stored session token (and refresh token) had expired. This PR changes the behavior so that the validity of the token is checked as it is for all commands which actually make use of the token.

Because this command is most often used in a non-interactive situation (in a script or some other automation), expired and soon-to-expire tokens just return errors, they don't prompt for re-authentication.