### PR TITLE
feat(products): Add support for Log Explorer & Insights.

### DIFF
--- a/pkg/commands/products/products_test.go
+++ b/pkg/commands/products/products_test.go
@@ -29,14 +29,15 @@ func TestProductEnablement(t *testing.T) {
 				},
 			},
 			Args: "--service-id 123",
-			WantOutput: `PRODUCT             ENABLED
-bot_management      false
-brotli_compression  false
-domain_inspector    false
-fanout              false
-image_optimizer     false
-origin_inspector    false
-websockets          false
+			WantOutput: `PRODUCT                ENABLED
+bot_management         false
+brotli_compression     false
+domain_inspector       false
+fanout                 false
+image_optimizer        false
+log_explorer_insights  false
+origin_inspector       false
+websockets             false
 `,
 		},
 		{
@@ -47,25 +48,26 @@ websockets          false
 				},
 			},
 			Args: "--service-id 123",
-			WantOutput: `PRODUCT             ENABLED
-bot_management      true
-brotli_compression  true
-domain_inspector    true
-fanout              true
-image_optimizer     true
-origin_inspector    true
-websockets          true
+			WantOutput: `PRODUCT                ENABLED
+bot_management         true
+brotli_compression     true
+domain_inspector       true
+fanout                 true
+image_optimizer        true
+log_explorer_insights  true
+origin_inspector       true
+websockets             true
 `,
 		},
 		{
 			Name:      "validate flag parsing error for enabling product",
 			Args:      "--service-id 123 --enable foo",
-			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,origin_inspector,websockets, got 'foo'",
+			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
 		},
 		{
 			Name:      "validate flag parsing error for disabling product",
 			Args:      "--service-id 123 --disable foo",
-			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,origin_inspector,websockets, got 'foo'",
+			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
 		},
 		{
 			Name: "validate success for enabling product",
@@ -106,6 +108,7 @@ websockets          true
   "domain_inspector": false,
   "fanout": false,
   "image_optimizer": false,
+  "log_explorer_insights": false,
   "origin_inspector": false,
   "websockets": false
 }`,
@@ -124,6 +127,7 @@ websockets          true
   "domain_inspector": true,
   "fanout": true,
   "image_optimizer": true,
+  "log_explorer_insights": true,
   "origin_inspector": true,
   "websockets": true
 }`,

--- a/pkg/commands/products/root.go
+++ b/pkg/commands/products/root.go
@@ -31,6 +31,7 @@ var ProductEnablementOptions = []string{
 	"domain_inspector",
 	"fanout",
 	"image_optimizer",
+	"log_explorer_insights",
 	"origin_inspector",
 	"websockets",
 }
@@ -143,6 +144,12 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 		ps.ImageOptimizer = true
 	}
 	if _, err = ac.GetProduct(&fastly.ProductEnablementInput{
+		ProductID: fastly.ProductLogExplorerInsights,
+		ServiceID: serviceID,
+	}); err == nil {
+		ps.LogExplorerInsights = true
+	}
+	if _, err = ac.GetProduct(&fastly.ProductEnablementInput{
 		ProductID: fastly.ProductOriginInspector,
 		ServiceID: serviceID,
 	}); err == nil {
@@ -166,6 +173,7 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 	t.AddLine(fastly.ProductDomainInspector, ps.DomainInspector)
 	t.AddLine(fastly.ProductFanout, ps.Fanout)
 	t.AddLine(fastly.ProductImageOptimizer, ps.ImageOptimizer)
+	t.AddLine(fastly.ProductLogExplorerInsights, ps.LogExplorerInsights)
 	t.AddLine(fastly.ProductOriginInspector, ps.OriginInspector)
 	t.AddLine(fastly.ProductWebSockets, ps.WebSockets)
 	t.Print()
@@ -184,6 +192,8 @@ func identifyProduct(product string) fastly.Product {
 		return fastly.ProductFanout
 	case "image_optimizer":
 		return fastly.ProductImageOptimizer
+	case "log_explorer_insights":
+		return fastly.ProductLogExplorerInsights
 	case "origin_inspector":
 		return fastly.ProductOriginInspector
 	case "websockets":
@@ -195,11 +205,12 @@ func identifyProduct(product string) fastly.Product {
 
 // ProductStatus indicates the status for each product.
 type ProductStatus struct {
-	BotManagement     bool `json:"bot_management"`
-	BrotliCompression bool `json:"brotli_compression"`
-	DomainInspector   bool `json:"domain_inspector"`
-	Fanout            bool `json:"fanout"`
-	ImageOptimizer    bool `json:"image_optimizer"`
-	OriginInspector   bool `json:"origin_inspector"`
-	WebSockets        bool `json:"websockets"`
+	BotManagement       bool `json:"bot_management"`
+	BrotliCompression   bool `json:"brotli_compression"`
+	DomainInspector     bool `json:"domain_inspector"`
+	Fanout              bool `json:"fanout"`
+	ImageOptimizer      bool `json:"image_optimizer"`
+	LogExplorerInsights bool `json:"log_explorer_insights"`
+	OriginInspector     bool `json:"origin_inspector"`
+	WebSockets          bool `json:"websockets"`
 }


### PR DESCRIPTION
The `fastly products` command can now enable, disable, and obtain the enablement status of the Log Explorer & Insights product.