### PR TITLE
fix(compute/init): Init no longer fails if directory of same name as starter kit exists in current directory

### DIFF
--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -944,13 +944,11 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		return err
 	}
 
-	tempdir, err := tempDir("package-init-download")
-	if err != nil {
+	if tempdir, err := tempDir("package-init-download"); err != nil {
 		err = fmt.Errorf("error creating temporary path for package template download: %w", err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -476,8 +476,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 				}
 				spinner.Message(msg + "...")
 				spinner.StopFailMessage(msg)
-				spinErr = spinner.StopFail()
-				if spinErr != nil {
+				if spinErr := spinner.StopFail(); spinErr != nil {
 					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 			}
@@ -848,8 +847,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 	if fi, err := os.Stat(c.CloneFrom); err == nil && fi.IsDir() {
 		if err := cp.Copy(c.CloneFrom, c.dir); err != nil {
 			spinner.StopFailMessage(msg)
-			spinErr := spinner.StopFail()
-			if spinErr != nil {
+			if spinErr := spinner.StopFail(); spinErr != nil {
 				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
@@ -863,8 +861,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 	u, err := url.Parse(c.CloneFrom)
 	if err != nil {
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return fmt.Errorf("could not read --from URL: %w", err)
@@ -874,8 +871,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 	// empty and the string ends up in u.Path.
 	if u.Host == "" && u.Scheme == "" {
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return fmt.Errorf("--from url seems invalid: %s", c.CloneFrom)
@@ -889,8 +885,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		if gitRepositoryRegEx.MatchString(c.CloneFrom) {
 			if err := c.ClonePackageFromEndpoint(c.CloneFrom, branch, tag); err != nil {
 				spinner.StopFailMessage(msg)
-				spinErr := spinner.StopFail()
-				if spinErr != nil {
+				if spinErr := spinner.StopFail(); spinErr != nil {
 					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return err
@@ -900,8 +895,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		}
 
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
@@ -925,8 +919,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		err = fmt.Errorf("failed to get package '%s': %w", req.URL.String(), err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
@@ -937,8 +930,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		err := fmt.Errorf("failed to get package '%s': %s", req.URL.String(), res.Status)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
@@ -972,8 +964,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		err = fmt.Errorf("failed to create local %s archive: %w", filename, err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
@@ -984,8 +975,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		err = fmt.Errorf("failed to write %s archive to disk: %w", filename, err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err
@@ -1033,8 +1023,7 @@ mimes:
 			if err != nil {
 				c.Globals.ErrLog.Add(err)
 				spinner.StopFailMessage(msg)
-				spinErr := spinner.StopFail()
-				if spinErr != nil {
+				if spinErr := spinner.StopFail(); spinErr != nil {
 					return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 				}
 				return err
@@ -1050,8 +1039,7 @@ mimes:
 			err = fmt.Errorf("failed to extract %s archive content: %w", filename, err)
 			c.Globals.ErrLog.Add(err)
 			spinner.StopFailMessage(msg)
-			spinErr := spinner.StopFail()
-			if spinErr != nil {
+			if spinErr := spinner.StopFail(); spinErr != nil {
 				return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 			}
 			return err
@@ -1063,8 +1051,7 @@ mimes:
 
 	if err := c.ClonePackageFromEndpoint(c.CloneFrom, branch, tag); err != nil {
 		spinner.StopFailMessage(msg)
-		spinErr := spinner.StopFail()
-		if spinErr != nil {
+		if spinErr := spinner.StopFail(); spinErr != nil {
 			return fmt.Errorf(text.SpinnerErrWrapper, spinErr, err)
 		}
 		return err

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -944,7 +944,8 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		return err
 	}
 
-	if tempdir, err := tempDir("package-init-download"); err != nil {
+	tempdir, err := tempDir("package-init-download")
+	if err != nil {
 		err = fmt.Errorf("error creating temporary path for package template download: %w", err)
 		c.Globals.ErrLog.Add(err)
 		spinner.StopFailMessage(msg)

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -251,8 +251,7 @@ func TestInit(t *testing.T) {
 				"SUCCESS: Initialized package",
 			},
 			setupSteps: func() error {
-				file, err := os.Create("main.zip")
-				if file != nil {
+				if file, err := os.Create("main.zip"); file != nil {
 					defer file.Close()
 				}
 				return err
@@ -448,9 +447,8 @@ func TestInit(t *testing.T) {
 
 			// Before running the test, run some steps to initialize the environment.
 			if testcase.setupSteps != nil {
-				err := testcase.setupSteps()
-				if err != nil {
-					panic(err)
+				if err := testcase.setupSteps(); err != nil {
+					t.Fatal(err)
 				}
 			}
 

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -57,6 +57,7 @@ func TestInit(t *testing.T) {
 		manifestIncludes string
 		manifestPath     string
 		stdin            string
+		setupSteps       func() error
 	}{
 		{
 			name:      "broken endpoint",
@@ -374,6 +375,14 @@ func TestInit(t *testing.T) {
 			defer func() {
 				_ = os.Chdir(pwd)
 			}()
+
+			// Before running the test, run some steps to initialize the environment.
+			if testcase.setupSteps != nil {
+				err := testcase.setupSteps()
+				if err != nil {
+					panic(err)
+				}
+			}
 
 			var stdout bytes.Buffer
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -251,7 +251,8 @@ func TestInit(t *testing.T) {
 				"SUCCESS: Initialized package",
 			},
 			setupSteps: func() error {
-				if file, err := os.Create("main.zip"); file != nil {
+				file, err := os.Create("main.zip")
+				if file != nil {
 					defer file.Close()
 				}
 				return err

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -151,6 +151,28 @@ func TestInit(t *testing.T) {
 			},
 		},
 		{
+			name: "with --from set to starter kit repository when dir with same name exists in pwd",
+			args: args("compute init --auto-yes --from https://github.com/fastly/compute-starter-kit-rust-default"),
+			configFile: config.File{
+				StarterKits: config.StarterKitLanguages{
+					Rust: []config.StarterKit{
+						{
+							Name: "Default",
+							Path: "https://github.com/fastly/compute-starter-kit-rust-default.git",
+						},
+					},
+				},
+			},
+			wantOutput: []string{
+				"Fetching package template",
+				"Reading fastly.toml",
+				"SUCCESS: Initialized package",
+			},
+			setupSteps: func() error {
+				return os.MkdirAll("compute-starter-kit-rust-default", 0755)
+			},
+		},
+		{
 			name: "with --from set to starter kit repository with .git extension and branch",
 			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default.git --branch main"),
 			configFile: config.File{
@@ -170,6 +192,28 @@ func TestInit(t *testing.T) {
 			},
 		},
 		{
+			name: "with --from set to starter kit repository with .git extension and branch when dir with same name exists in pwd",
+			args: args("compute init --auto-yes --from https://github.com/fastly/compute-starter-kit-rust-default.git --branch main"),
+			configFile: config.File{
+				StarterKits: config.StarterKitLanguages{
+					Rust: []config.StarterKit{
+						{
+							Name: "Default",
+							Path: "https://github.com/fastly/compute-starter-kit-rust-default.git",
+						},
+					},
+				},
+			},
+			wantOutput: []string{
+				"Fetching package template",
+				"Reading fastly.toml",
+				"SUCCESS: Initialized package",
+			},
+			setupSteps: func() error {
+				return os.MkdirAll("compute-starter-kit-rust-default.git", 0755)
+			},
+		},
+		{
 			name: "with --from set to zip archive",
 			args: args("compute init --from https://github.com/fastly/compute-starter-kit-rust-default/archive/refs/heads/main.zip"),
 			configFile: config.File{
@@ -186,6 +230,32 @@ func TestInit(t *testing.T) {
 				"Fetching package template",
 				"Reading fastly.toml",
 				"SUCCESS: Initialized package",
+			},
+		},
+		{
+			name: "with --from set to zip archive when file with same name exists in pwd",
+			args: args("compute init --auto-yes --from https://github.com/fastly/compute-starter-kit-rust-default/archive/refs/heads/main.zip"),
+			configFile: config.File{
+				StarterKits: config.StarterKitLanguages{
+					Rust: []config.StarterKit{
+						{
+							Name: "Default",
+							Path: "https://github.com/fastly/compute-starter-kit-rust-default.git",
+						},
+					},
+				},
+			},
+			wantOutput: []string{
+				"Fetching package template",
+				"Reading fastly.toml",
+				"SUCCESS: Initialized package",
+			},
+			setupSteps: func() error {
+				file, err := os.Create("main.zip")
+				if file != nil {
+					defer file.Close()
+				}
+				return err
 			},
 		},
 		{


### PR DESCRIPTION
Resolves #1255.

This PR resolves the issue by placing the temporary file created during the download performed by `fastly compute init --from` in a temporary directory rather than the current directory.

Notes:

* This PR adds a `setupSteps` member to the test table in _init_test_, and runs those steps as part of the initialization of each test.

* This PR adds a few new test cases to _init_test_ that uses the above `setupSteps` mechanism to create a directory with the same name as the starter kit before calling `fastly compute init`.

* The existing `defer` cleanup done to remove the temporary file has been removed, because the cleanup code for the temporary directory will clean it up.