### PR TITLE
fix(npm): Fix build checks for JavaScript code

### DIFF
--- a/npm/@fastly/cli/update.js
+++ b/npm/@fastly/cli/update.js
@@ -92,7 +92,7 @@ if (!assets.ok) {
     `Response from https://api.github.com/repos/fastly/cli/releases/${id}/assets was not ok`,
     assets
   );
-  console.error(await response.text());
+  console.error(await assets.text());
   process.exit(1);
 }
 assets = await assets.json();

--- a/npm/@fastly/cli/update.js
+++ b/npm/@fastly/cli/update.js
@@ -74,6 +74,7 @@ let response = await fetch(
 );
 if (!response.ok) {
   console.error(
+    '%s %o',
     `Response from https://api.github.com/repos/fastly/cli/releases/tags/${tag} was not ok`,
     response
   );
@@ -87,6 +88,7 @@ let assets = await fetch(
 );
 if (!assets.ok) {
   console.error(
+    '%s %o',
     `Response from https://api.github.com/repos/fastly/cli/releases/${id}/assets was not ok`,
     assets
   );
@@ -120,7 +122,11 @@ for (const info of packages) {
   const browser_download_url = asset.browser_download_url;
   const archive = await fetch(browser_download_url);
   if (!archive.ok) {
-    console.error(`Response from ${browser_download_url} was not ok`, archive);
+    console.error(
+      '%s %o',
+      `Response from ${browser_download_url} was not ok`,
+      archive
+    );
     console.error(await response.text());
     process.exit(1);
   }


### PR DESCRIPTION
When building the project locally I get these errors:

```
┌──────────────────────────┐
│ 3 Blocking Code Findings │
└──────────────────────────┘
                                            
    npm/@fastly/cli/update.js
     ❱ javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring
          Detected string concatenation with a non-literal variable in a util.format / console.log function.
          If an attacker injects a format specifier in the string, it will forge the log message. Try to use
          constant values for the format string.                                                            
          Details: https://sg.run/7Y5R                                                                      
                                                                                                            
           77┆ `Response from https://api.github.com/repos/fastly/cli/releases/tags/${tag} was not ok`,
            ⋮┆----------------------------------------
           90┆ `Response from https://api.github.com/repos/fastly/cli/releases/${id}/assets was not ok`,
            ⋮┆----------------------------------------
          123┆ console.error(`Response from ${browser_download_url} was not ok`, archive);
                            
  BLOCKING CODE RULES FIRED:
    javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring
```

This happens because the first parameter to `console.error()` is a format string that can accept printf-like placeholders like `%s`. Using non-literal values to build this value is unsafe. For example, `tag` is an untrusted value that is obtained from `argv`. If we were to craft a value for `tag` that includes a placeholder such as `%O`, then we could force the program to dump the internals of the other parameters being passed to `console.error()`.

This PR addresses this issue by inserting a _hard-coded literal_ `'%s %o'` for the format string.

This is actually a point of confusion with `console.log()` and friends, because:
* Most of the time they are used without printf-style placeholders at all
* The functions are defined so that if they are passed only one parameter, then they display just that value as is, without formatting
* The functions are defined so that if the first parameter contains no placeholders, then they display a string that is the concatenation of all arguments separated by spaces

See [`util.format()`](https://nodejs.org/api/util.html#utilformatformat-args) for details.