### PR TITLE
fix(sso): Ensure that only one authentication cycle is started.

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -639,7 +639,7 @@ func commandCollectsData(command string) bool {
 // requires just the authentication server to be running.
 func commandRequiresAuthServer(command string) bool {
 	switch command {
-	case "profile create", "profile switch", "profile update":
+	case "profile create", "profile switch", "profile update", "sso":
 		return true
 	}
 	return false
@@ -660,7 +660,7 @@ func commandRequiresToken(command argparser.Command) bool {
 	}
 	commandName = strings.Split(commandName, " ")[0]
 	switch commandName {
-	case "config", "profile", "update", "version":
+	case "config", "profile", "sso", "update", "version":
 		return false
 	}
 	return true


### PR DESCRIPTION
The 'sso' command, when run against a profile with an expired refresh token, would cause two authentication cycles to be started: one by the CLI core before the 'sso' command itself was executed, and then another by the 'sso' command. The second cycle would fail and result in an 'extra' browser tab/window with an error message of "ERROR: no authorization code returned". While the authentication was successful and the new refresh/access/session tokens were stored, this confused the user of the CLI.