### PR TITLE
fix(kvstoreentry/create): rework --dir

### DIFF
--- a/pkg/commands/kvstoreentry/create.go
+++ b/pkg/commands/kvstoreentry/create.go
@@ -206,7 +206,6 @@ func (c *CreateCommand) ProcessDir(in io.Reader, out io.Writer) error {
 	msg := "%s %d of %d files"
 	spinner.Message(fmt.Sprintf(msg, "Processing", 0, filesTotal) + "...")
 
-	base := filepath.Base(path)
 	processed := make(chan struct{}, c.dirConcurrency)
 	sem := make(chan struct{}, c.dirConcurrency)
 	filesVerboseOutput := make(chan string, filesTotal)
@@ -240,14 +239,8 @@ func (c *CreateCommand) ProcessDir(in io.Reader, out io.Writer) error {
 			}()
 			defer wg.Done()
 
-			filePath := filepath.Join(c.dirPath, file.Name())
-			dir, filename := filepath.Split(filePath)
-			index := strings.Index(dir, base)
-			// If the user runs from `--dir .` (current directory)
-			if index == -1 {
-				index = 0
-			}
-			filename = filepath.Join(dir[index:], filename)
+			filename := file.Name()
+			filePath := filepath.Join(path, filename)
 
 			if c.Globals.Verbose() {
 				filesVerboseOutput <- filename

--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -77,8 +77,11 @@ func TestCreateCommand(t *testing.T) {
 			Args:  fmt.Sprintf("--store-id %s --dir %s", storeID, filepath.Join("testdata", "example")),
 			Stdin: []string{"y"},
 			API: mock.API{
-				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
-					return nil
+				InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+					if i.Key == "foo.txt" {
+						return nil
+					}
+					return errors.New("invalid request")
 				},
 			},
 			WantOutput: "SUCCESS: Inserted 1 keys into KV Store",
@@ -87,8 +90,11 @@ func TestCreateCommand(t *testing.T) {
 			Args:  fmt.Sprintf("--store-id %s --dir %s --dir-allow-hidden", storeID, filepath.Join("testdata", "example")),
 			Stdin: []string{"y"},
 			API: mock.API{
-				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
-					return nil
+				InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+					if i.Key == "foo.txt" || i.Key == ".hiddenfile" {
+						return nil
+					}
+					return errors.New("invalid request")
 				},
 			},
 			WantOutput: "SUCCESS: Inserted 2 keys into KV Store",


### PR DESCRIPTION
Simplify code and exclude directory when inserting keys into the KV store. 

Before this change `create --dir=foo`, will create:

```
foo/abc
foo/def
```

After this change:

```
abc
def
```