### PR TITLE
refactor: Use constants from net/http for HTTP methods instead of hardcoded strings.

### DIFF
--- a/pkg/api/undocumented/undocumented.go
+++ b/pkg/api/undocumented/undocumented.go
@@ -103,7 +103,7 @@ func Call(opts CallOptions) (data []byte, err error) {
 		return []byte{}, NewError(err, res.StatusCode)
 	}
 
-	if res.StatusCode >= 400 {
+	if res.StatusCode >= http.StatusBadRequest {
 		return data, NewError(fmt.Errorf("error response: %q", data), res.StatusCode)
 	}
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -138,7 +138,7 @@ func (s Server) GetJWT(authorizationCode string) (JWT, error) {
 		"http://localhost:8080/callback", // NOTE: not redirected to, just a security check.
 	)
 
-	req, err := http.NewRequest("POST", s.WellKnownEndpoints.Token, strings.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, s.WellKnownEndpoints.Token, strings.NewReader(payload))
 	if err != nil {
 		return JWT{}, err
 	}
@@ -352,7 +352,7 @@ func (s *Server) RefreshAccessToken(refreshToken string) (JWT, error) {
 		refreshToken,
 	)
 
-	req, err := http.NewRequest("POST", s.WellKnownEndpoints.Token, strings.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, s.WellKnownEndpoints.Token, strings.NewReader(payload))
 	if err != nil {
 		return JWT{}, err
 	}

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -1157,7 +1157,7 @@ func generateTimeout(d time.Duration) string {
 // whatever the user defined with --status-check-code), which should help
 // signify if the service is generally available.
 func pingServiceURL(serviceURL string, httpClient api.HTTPClient, expectedStatusCode int, debugMode bool) (ok bool, status int, err error) {
-	req, err := http.NewRequest("GET", serviceURL, nil)
+	req, err := http.NewRequest(http.MethodGet, serviceURL, nil)
 	if err != nil {
 		return false, 0, err
 	}

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -877,7 +877,7 @@ func (c *InitCommand) FetchPackageTemplate(branch, tag string, archives []file.A
 		return fmt.Errorf("--from url seems invalid: %s", c.CloneFrom)
 	}
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		err = fmt.Errorf("failed to construct package request URL: %w", err)
 		c.Globals.ErrLog.Add(err)

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -307,7 +308,7 @@ func listHealthChecksOK(i *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck,
 			ServiceVersion: fastly.ToPointer(i.ServiceVersion),
 			Name:           fastly.ToPointer("test"),
 			Comment:        fastly.ToPointer("test"),
-			Method:         fastly.ToPointer("HEAD"),
+			Method:         fastly.ToPointer(http.MethodHead),
 			Host:           fastly.ToPointer("www.test.com"),
 			Path:           fastly.ToPointer("/health"),
 		},
@@ -316,7 +317,7 @@ func listHealthChecksOK(i *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck,
 			ServiceVersion: fastly.ToPointer(i.ServiceVersion),
 			Name:           fastly.ToPointer("example"),
 			Comment:        fastly.ToPointer("example"),
-			Method:         fastly.ToPointer("HEAD"),
+			Method:         fastly.ToPointer(http.MethodHead),
 			Host:           fastly.ToPointer("www.example.com"),
 			Path:           fastly.ToPointer("/health"),
 		},
@@ -373,7 +374,7 @@ func getHealthCheckOK(i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
 		Name:           fastly.ToPointer("test"),
-		Method:         fastly.ToPointer("HEAD"),
+		Method:         fastly.ToPointer(http.MethodHead),
 		Host:           fastly.ToPointer("www.test.com"),
 		Path:           fastly.ToPointer("/healthcheck"),
 		Comment:        fastly.ToPointer("test"),

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -285,7 +286,7 @@ func createHTTPSOK(i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
 		ContentType:       fastly.ToPointer("application/json"),
 		HeaderName:        fastly.ToPointer("name"),
 		HeaderValue:       fastly.ToPointer("value"),
-		Method:            fastly.ToPointer("GET"),
+		Method:            fastly.ToPointer(http.MethodGet),
 		JSONFormat:        fastly.ToPointer("1"),
 		Placement:         fastly.ToPointer("none"),
 		TLSCACert:         fastly.ToPointer("-----BEGIN CERTIFICATE-----foo"),
@@ -315,7 +316,7 @@ func listHTTPSsOK(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
 			ContentType:       fastly.ToPointer("application/json"),
 			HeaderName:        fastly.ToPointer("name"),
 			HeaderValue:       fastly.ToPointer("value"),
-			Method:            fastly.ToPointer("GET"),
+			Method:            fastly.ToPointer(http.MethodGet),
 			JSONFormat:        fastly.ToPointer("1"),
 			Placement:         fastly.ToPointer("none"),
 			TLSCACert:         fastly.ToPointer("-----BEGIN CERTIFICATE-----foo"),
@@ -337,7 +338,7 @@ func listHTTPSsOK(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
 			ContentType:       fastly.ToPointer("application/json"),
 			HeaderName:        fastly.ToPointer("name"),
 			HeaderValue:       fastly.ToPointer("value"),
-			Method:            fastly.ToPointer("GET"),
+			Method:            fastly.ToPointer(http.MethodGet),
 			JSONFormat:        fastly.ToPointer("1"),
 			Placement:         fastly.ToPointer("none"),
 			TLSCACert:         fastly.ToPointer("-----BEGIN CERTIFICATE-----foo"),
@@ -424,7 +425,7 @@ func getHTTPSOK(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
 		ContentType:       fastly.ToPointer("application/json"),
 		HeaderName:        fastly.ToPointer("name"),
 		HeaderValue:       fastly.ToPointer("value"),
-		Method:            fastly.ToPointer("GET"),
+		Method:            fastly.ToPointer(http.MethodGet),
 		JSONFormat:        fastly.ToPointer("1"),
 		Placement:         fastly.ToPointer("none"),
 		TLSCACert:         fastly.ToPointer("-----BEGIN CERTIFICATE-----foo"),
@@ -476,7 +477,7 @@ func updateHTTPSOK(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
 		ContentType:       fastly.ToPointer("application/json"),
 		HeaderName:        fastly.ToPointer("name"),
 		HeaderValue:       fastly.ToPointer("value"),
-		Method:            fastly.ToPointer("GET"),
+		Method:            fastly.ToPointer(http.MethodGet),
 		JSONFormat:        fastly.ToPointer("1"),
 		Placement:         fastly.ToPointer("none"),
 		TLSCACert:         fastly.ToPointer("-----BEGIN CERTIFICATE-----foo"),

--- a/pkg/commands/logging/https/https_test.go
+++ b/pkg/commands/logging/https/https_test.go
@@ -2,6 +2,7 @@ package https_test
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 
 	"github.com/fastly/go-fastly/v9/fastly"
@@ -48,7 +49,7 @@ func TestCreateHTTPSInput(t *testing.T) {
 				ContentType:       fastly.ToPointer("application/json"),
 				HeaderName:        fastly.ToPointer("name"),
 				HeaderValue:       fastly.ToPointer("value"),
-				Method:            fastly.ToPointer("GET"),
+				Method:            fastly.ToPointer(http.MethodGet),
 				JSONFormat:        fastly.ToPointer("1"),
 				Placement:         fastly.ToPointer("none"),
 				TLSCACert:         fastly.ToPointer("-----BEGIN CERTIFICATE-----foo"),
@@ -271,7 +272,7 @@ func createCommandAll() *https.CreateCommand {
 		ContentType:       argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "application/json"},
 		HeaderName:        argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "name"},
 		HeaderValue:       argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "value"},
-		Method:            argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "GET"},
+		Method:            argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: http.MethodGet},
 		JSONFormat:        argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "1"},
 		MessageType:       argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "classic"},
 		RequestMaxEntries: argparser.OptionalInt{Optional: argparser.Optional{WasSet: true}, Value: 2},

--- a/pkg/commands/logtail/root.go
+++ b/pkg/commands/logtail/root.go
@@ -155,10 +155,10 @@ func (c *RootCommand) tail(out io.Writer) error {
 			break
 		}
 
-		req, err := http.NewRequest("GET", path, nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
-				"GET": path,
+				http.MethodGet: path,
 			})
 			return fmt.Errorf("unable to create new request: %w", err)
 		}
@@ -196,7 +196,7 @@ func (c *RootCommand) tail(out io.Writer) error {
 
 			// Try the response again after a 1 second wait.
 			if resp.StatusCode/100 == 5 && resp.StatusCode != 501 ||
-				resp.StatusCode == 429 {
+				resp.StatusCode == http.StatusTooManyRequests {
 				time.Sleep(1 * time.Second)
 				continue
 			}


### PR DESCRIPTION
This PR introduces the following changes:

Updated occurrences of HTTP methods (e.g., "GET", "POST") with their corresponding constants from the net/http package (e.g., http.MethodGet, http.MethodPost).
Ensures consistency, improves maintainability, and reduces the risk of typos.

Using constants improves code readability and reduces the risk of errors from hardcoded values.


executed `make all` and the output is same as as `main` branch