### PR TITLE
fix(build): Correct generation of static configuration file.

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -23,7 +23,7 @@ kits=(
 )
 
 function parse() {
-  tq -f "$k.toml" $1
+  tq -r -f "$k.toml" $1
 }
 
 function append() {


### PR DESCRIPTION
The behavior of 'tq' has recently changed, and just like 'jq' it wraps output in double-quotes unless it is told to generate 'raw' output.