### PR TITLE
breaking(language.rust): Switch Rust builds to wasm32-wasip1 instead of wasm32-wasi

### DIFF
--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -18,8 +18,8 @@ toolchain_constraint = ">= 1.21"           # Go toolchain constraint for use wit
 toolchain_constraint_tinygo = ">= 1.18"    # Go toolchain constraint for use with TinyGo.
 
 [language.rust]
-toolchain_constraint = ">= 1.56.1, <1.84.0"
-wasm_wasi_target = "wasm32-wasi"
+toolchain_constraint = ">= 1.78.0"
+wasm_wasi_target = "wasm32-wasip1"
 
 [wasm-tools]
 ttl = "24h"

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@1.83.0 # to install tq via `make config`
+        uses: dtolnay/rust-toolchain@stable
       - name: "Generate static app config"
         run: make config
       - name: "Config Artifact"
@@ -25,7 +25,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@1.83.0 # to install tq via `make config`
+        uses: dtolnay/rust-toolchain@stable
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -124,11 +124,11 @@ jobs:
           path: ${{ steps.go-cache-paths.outputs.gomod }}
           key: ${{ runner.os }}-test-go-mod-${{ hashFiles('**/go.sum') }}
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@1.83.0
-      - name: "Add wasm32-wasi Rust target"
-        run: rustup target add wasm32-wasi --toolchain 1.83.0
+        uses: dtolnay/rust-toolchain@stable
+      - name: "Add wasm32-wasip1 Rust target"
+        run: rustup target add wasm32-wasip1 --toolchain stable
       - name: "Validate Rust toolchain"
-        run: rustup show && rustup target list --installed --toolchain 1.83.0
+        run: rustup show && rustup target list --installed --toolchain stable
         shell: bash
       - name: "Install Node"
         uses: actions/setup-node@v4

--- a/.github/workflows/tag_to_draft_release.yml
+++ b/.github/workflows/tag_to_draft_release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Set GOHOSTOS and GOHOSTARCH"
         run: echo "GOHOSTOS=$(go env GOHOSTOS)" >> $GITHUB_ENV && echo "GOHOSTARCH=$(go env GOHOSTARCH)" >> $GITHUB_ENV
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@1.83.0
+        uses: dtolnay/rust-toolchain@stable
       - name: "Generate static app config"
         run: make config
       # Passing the raw SSH private key causes an error:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Unreleased
+
+**Enhancements:**
+
+- breaking(language.rust): Switch Rust builds to wasm32-wasip1 instead of wasm32-wasi [#1382](https://github.com/fastly/cli/pull/1382)
+
+**Bug fixes:**
+
+**Dependencies:**
+
 ## [v10.18.0](https://github.com/fastly/cli/releases/tag/v10.18.0) (2025-01-29)
 
 **Enhancements:**

--- a/Dockerfile-rust
+++ b/Dockerfile-rust
@@ -1,9 +1,9 @@
 FROM rust:latest
 LABEL maintainer="Fastly OSS <oss@fastly.com>"
 
-ENV RUST_TOOLCHAIN=1.83.0
+ENV RUST_TOOLCHAIN=stable
 RUN rustup toolchain install ${RUST_TOOLCHAIN} \
-  && rustup target add wasm32-wasi --toolchain ${RUST_TOOLCHAIN} \
+  && rustup target add wasm32-wasip1 --toolchain ${RUST_TOOLCHAIN} \
   && apt-get update && apt-get install -y curl jq && apt-get -y clean && rm -rf /var/lib/apt/lists/* \
   && export FASTLY_CLI_VERSION=$(curl -s https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \
             GOARCH=$(dpkg --print-architecture) \

--- a/TESTING.md
+++ b/TESTING.md
@@ -43,7 +43,7 @@ TEST_COMPUTE_BUILD_RUST=1 make test TEST_ARGS="-run TestBuildRust/fastly_crate_p
 
 When running the tests locally, if you don't have the relevant language ecosystems set-up properly then the tests will fail to run and you'll need to review the code to see what the remediation steps are, as that output doesn't get shown when running the test suite.
 
-> **NOTE**: you might notice a discrepancy between CI and your local environment which is caused by the difference in Rust toolchain versions as defined in .github/workflows/pr_test.yml which specifies the version required to be tested for in CI. Running `rustup toolchain install <version>` and `rustup target add wasm32-wasi --toolchain <version>` will resolve any failing integration tests you may be running locally.
+> **NOTE**: you might notice a discrepancy between CI and your local environment which is caused by the difference in Rust toolchain versions as defined in .github/workflows/pr_test.yml which specifies the version required to be tested for in CI. Running `rustup toolchain install <version>` and `rustup target add wasm32-wasip1 --toolchain <version>` will resolve any failing integration tests you may be running locally.
 
 To the run the full test suite:
 

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -11,8 +11,8 @@ version = "0.0.1"
 
 [language]
   [language.rust]
-  toolchain_constraint = ">= 1.49.0 < 2.0.0"
-  wasm_wasi_target = "wasm32-wasi"
+  toolchain_constraint = ">= 1.78.0"
+  wasm_wasi_target = "wasm32-wasip1"
 
 [starter-kits]
 [[starter-kits.assemblyscript]]


### PR DESCRIPTION
Breaking change to support Rust 1.84 and newer

BREAKING CHANGE:
Only the wasm32-wasip1 build target is accepted if a non default config is provided

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?
this is a breaking change and will require a major version bump to prevent breakages