### PR TITLE
Revert "breaking(language.rust): switch Rust builds to wasm32-wasip1 from wasm32-wasi (#1382)"

### DIFF
--- a/.fastly/config.toml
+++ b/.fastly/config.toml
@@ -18,8 +18,8 @@ toolchain_constraint = ">= 1.21"           # Go toolchain constraint for use wit
 toolchain_constraint_tinygo = ">= 1.18"    # Go toolchain constraint for use with TinyGo.
 
 [language.rust]
-toolchain_constraint = ">= 1.78.0"
-wasm_wasi_target = "wasm32-wasip1"
+toolchain_constraint = ">= 1.56.1, <1.84.0"
+wasm_wasi_target = "wasm32-wasi"
 
 [wasm-tools]
 ttl = "24h"

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.83.0 # to install tq via `make config`
       - name: "Generate static app config"
         run: make config
       - name: "Config Artifact"
@@ -31,7 +31,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.83.0 # to install tq via `make config`
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -83,11 +83,11 @@ jobs:
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@stable
-      - name: "Add wasm32-wasip1 Rust target"
-        run: rustup target add wasm32-wasip1 --toolchain stable
+        uses: dtolnay/rust-toolchain@1.83.0
+      - name: "Add wasm32-wasi Rust target"
+        run: rustup target add wasm32-wasi --toolchain 1.83.0
       - name: "Validate Rust toolchain"
-        run: rustup show && rustup target list --installed --toolchain stable
+        run: rustup show && rustup target list --installed --toolchain 1.83.0
         shell: bash
       - name: "Install Node"
         uses: actions/setup-node@v4

--- a/.github/workflows/tag_to_draft_release.yml
+++ b/.github/workflows/tag_to_draft_release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Set GOHOSTOS and GOHOSTARCH"
         run: echo "GOHOSTOS=$(go env GOHOSTOS)" >> $GITHUB_ENV && echo "GOHOSTARCH=$(go env GOHOSTARCH)" >> $GITHUB_ENV
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.83.0
       - name: "Generate static app config"
         run: make config
       # Passing the raw SSH private key causes an error:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 **Enhancements:**
 
-- breaking(language.rust): Switch Rust builds to wasm32-wasip1 instead of wasm32-wasi [#1382](https://github.com/fastly/cli/pull/1382)
 - build(.github/): tune up build process and add changelog enforcement
 
 **Bug fixes:**

--- a/Dockerfile-rust
+++ b/Dockerfile-rust
@@ -1,9 +1,9 @@
 FROM rust:latest
 LABEL maintainer="Fastly OSS <oss@fastly.com>"
 
-ENV RUST_TOOLCHAIN=stable
+ENV RUST_TOOLCHAIN=1.83.0
 RUN rustup toolchain install ${RUST_TOOLCHAIN} \
-  && rustup target add wasm32-wasip1 --toolchain ${RUST_TOOLCHAIN} \
+  && rustup target add wasm32-wasi --toolchain ${RUST_TOOLCHAIN} \
   && apt-get update && apt-get install -y curl jq && apt-get -y clean && rm -rf /var/lib/apt/lists/* \
   && export FASTLY_CLI_VERSION=$(curl -s https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \
             GOARCH=$(dpkg --print-architecture) \

--- a/TESTING.md
+++ b/TESTING.md
@@ -43,7 +43,7 @@ TEST_COMPUTE_BUILD_RUST=1 make test TEST_ARGS="-run TestBuildRust/fastly_crate_p
 
 When running the tests locally, if you don't have the relevant language ecosystems set-up properly then the tests will fail to run and you'll need to review the code to see what the remediation steps are, as that output doesn't get shown when running the test suite.
 
-> **NOTE**: you might notice a discrepancy between CI and your local environment which is caused by the difference in Rust toolchain versions as defined in .github/workflows/pr_test.yml which specifies the version required to be tested for in CI. Running `rustup toolchain install <version>` and `rustup target add wasm32-wasip1 --toolchain <version>` will resolve any failing integration tests you may be running locally.
+> **NOTE**: you might notice a discrepancy between CI and your local environment which is caused by the difference in Rust toolchain versions as defined in .github/workflows/pr_test.yml which specifies the version required to be tested for in CI. Running `rustup toolchain install <version>` and `rustup target add wasm32-wasi --toolchain <version>` will resolve any failing integration tests you may be running locally.
 
 To the run the full test suite:
 

--- a/pkg/commands/compute/build_test.go
+++ b/pkg/commands/compute/build_test.go
@@ -73,8 +73,8 @@ func TestBuildRust(t *testing.T) {
 				Profiles: testutil.TokenProfile(),
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainConstraint: ">= 1.78.0",
-						WasmWasiTarget:      "wasm32-wasip1",
+						ToolchainConstraint: ">= 1.54.0",
+						WasmWasiTarget:      "wasm32-wasi",
 					},
 				},
 			},
@@ -102,8 +102,8 @@ func TestBuildRust(t *testing.T) {
 				Profiles: testutil.TokenProfile(),
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainConstraint: ">= 1.78.0",
-						WasmWasiTarget:      "wasm32-wasip1",
+						ToolchainConstraint: ">= 1.54.0",
+						WasmWasiTarget:      "wasm32-wasi",
 					},
 				},
 			},
@@ -123,14 +123,15 @@ func TestBuildRust(t *testing.T) {
 		    build = "echo no compilation happening"`,
 			wantRemediationError: compute.DefaultBuildErrorRemediation,
 		},
+		// NOTE: This test passes --verbose so we can validate specific outputs.
 		{
-			name: "wasmwasi target error",
+			name: "successful build",
 			args: args("compute build --verbose"),
 			applicationConfig: &config.File{
 				Profiles: testutil.TokenProfile(),
 				Language: config.Language{
 					Rust: config.Rust{
-						ToolchainConstraint: ">= 1.78.0",
+						ToolchainConstraint: ">= 1.54.0",
 						WasmWasiTarget:      "wasm32-wasi",
 					},
 				},
@@ -148,36 +149,7 @@ func TestBuildRust(t *testing.T) {
 			language = "rust"
 
 		    [scripts]
-		    build = "%s"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustDefaultPackageName, compute.RustDefaultWasmWasiTarget)),
-			wantError: "the default build in .fastly/config.toml should produce a wasm32-wasip1 binary, but was instead set to produce a wasm32-wasi binary",
-		},
-		// NOTE: This test passes --verbose so we can validate specific outputs.
-		{
-			name: "successful build",
-			args: args("compute build --verbose"),
-			applicationConfig: &config.File{
-				Profiles: testutil.TokenProfile(),
-				Language: config.Language{
-					Rust: config.Rust{
-						ToolchainConstraint: ">= 1.78.0",
-						WasmWasiTarget:      "wasm32-wasip1",
-					},
-				},
-			},
-			cargoManifest: `
-			[package]
-			name = "fastly-compute-project"
-			version = "0.1.0"
-
-			[dependencies]
-			fastly = "=0.6.0"`,
-			fastlyManifest: fmt.Sprintf(`
-			manifest_version = 2
-			name = "test"
-			language = "rust"
-
-		    [scripts]
-		    build = "%s"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustDefaultPackageName, compute.RustDefaultWasmWasiTarget)),
+		    build = "%s"`, fmt.Sprintf(compute.RustDefaultBuildCommand, compute.RustDefaultPackageName)),
 			wantOutput: []string{
 				"Creating ./bin directory (for Wasm binary)",
 				"Built package",

--- a/pkg/commands/compute/language_rust.go
+++ b/pkg/commands/compute/language_rust.go
@@ -30,10 +30,7 @@ import (
 // NOTE: In the 5.x CLI releases we persisted the default to the fastly.toml
 // We no longer do that. In 6.x we use the default and just inform the user.
 // This makes the experience less confusing as users didn't expect file changes.
-const RustDefaultBuildCommand = "cargo build --bin %s --release --target %s --color always"
-
-// RustDefaultWasmWasiTarget is the expected Rust WasmWasi build target
-const RustDefaultWasmWasiTarget = "wasm32-wasip1"
+const RustDefaultBuildCommand = "cargo build --bin %s --release --target wasm32-wasi --color always"
 
 // RustManifest is the manifest file for defining project configuration.
 const RustManifest = "Cargo.toml"
@@ -148,7 +145,7 @@ func (r *Rust) Dependencies() map[string]string {
 // Build compiles the user's source code into a Wasm binary.
 func (r *Rust) Build() error {
 	if r.build == "" {
-		r.build = fmt.Sprintf(RustDefaultBuildCommand, RustDefaultPackageName, RustDefaultWasmWasiTarget)
+		r.build = fmt.Sprintf(RustDefaultBuildCommand, RustDefaultPackageName)
 		r.defaultBuild = true
 	}
 
@@ -171,11 +168,6 @@ func (r *Rust) Build() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	var wasmWasiTarget = r.config.WasmWasiTarget
-	if wasmWasiTarget != RustDefaultWasmWasiTarget {
-		return fmt.Errorf("the default build in .fastly/config.toml should produce a %s binary, but was instead set to produce a %s binary", RustDefaultWasmWasiTarget, wasmWasiTarget)
 	}
 
 	bt := BuildToolchain{
@@ -212,7 +204,7 @@ type RustToolchain struct {
 // modifyCargoPackageName validates whether the --bin flag matches the
 // Cargo.toml package name. If it doesn't match, update the default build script
 // to match.
-func (r *Rust) modifyCargoPackageName(defaultBuild bool) error {
+func (r *Rust) modifyCargoPackageName(noBuildScript bool) error {
 	s := "cargo locate-project --quiet"
 	args := strings.Split(s, " ")
 
@@ -252,16 +244,18 @@ func (r *Rust) modifyCargoPackageName(defaultBuild bool) error {
 		return fmt.Errorf("error reading %s manifest: %w", RustManifest, err)
 	}
 
+	hasCustomBuildScript := !noBuildScript
+
 	switch {
 	case m.Package.Name != "":
 		// If using standard project structure.
 		// Cargo.toml won't be a Workspace, so it will contain a package name.
 		r.packageName = m.Package.Name
-	case len(m.Workspace.Members) > 0 && defaultBuild:
+	case len(m.Workspace.Members) > 0 && noBuildScript:
 		// If user has a Cargo Workspace AND no custom script.
 		// We need to identify which Workspace package is their application.
 		// Then extract the package name from its Cargo.toml manifest.
-		// We do this by checking for a rust-toolchain.toml containing the proper target.
+		// We do this by checking for a rust-toolchain.toml containing a wasm32-wasi target.
 		//
 		// NOTE: This logic will need to change in the future.
 		// Specifically, when we support linking multiple Wasm binaries.
@@ -276,20 +270,16 @@ func (r *Rust) modifyCargoPackageName(defaultBuild bool) error {
 			if err != nil {
 				return fmt.Errorf("failed to unmarshal '%s' data: %w", rustToolchainFile, err)
 			}
-			if len(rtm.Toolchain.Targets) > 0 {
-				if rtm.Toolchain.Targets[0] == RustDefaultWasmWasiTarget {
-					var cm CargoManifest
-					err := cm.Read(filepath.Join(m, "Cargo.toml"))
-					if err != nil {
-						return err
-					}
-					r.packageName = cm.Package.Name
-				} else {
-					return fmt.Errorf("please consult https://www.fastly.com/documentation/guides/compute/#install-language-tooling to configure your toolchain correctly")
+			if len(rtm.Toolchain.Targets) > 0 && rtm.Toolchain.Targets[0] == "wasm32-wasi" {
+				var cm CargoManifest
+				err := cm.Read(filepath.Join(m, "Cargo.toml"))
+				if err != nil {
+					return err
 				}
+				r.packageName = cm.Package.Name
 			}
 		}
-	case len(m.Workspace.Members) > 0 && !defaultBuild:
+	case len(m.Workspace.Members) > 0 && hasCustomBuildScript:
 		// If user has a Cargo Workspace AND a custom script.
 		// Trust their custom script aligns with the relevant Workspace package name.
 		// i.e. we parse the package name specified in their custom script.
@@ -303,8 +293,8 @@ func (r *Rust) modifyCargoPackageName(defaultBuild bool) error {
 	}
 
 	// Ensure the default build script matches the Cargo.toml package name.
-	if defaultBuild && r.packageName != "" && r.packageName != RustDefaultPackageName {
-		r.build = fmt.Sprintf(RustDefaultBuildCommand, r.packageName, RustDefaultWasmWasiTarget)
+	if noBuildScript && r.packageName != "" && r.packageName != RustDefaultPackageName {
+		r.build = fmt.Sprintf(RustDefaultBuildCommand, r.packageName)
 	}
 
 	return nil

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -11,8 +11,8 @@ version = "0.0.1"
 
 [language]
   [language.rust]
-  toolchain_constraint = ">= 1.78.0"
-  wasm_wasi_target = "wasm32-wasip1"
+  toolchain_constraint = ">= 1.49.0 < 2.0.0"
+  wasm_wasi_target = "wasm32-wasi"
 
 [starter-kits]
 [[starter-kits.assemblyscript]]


### PR DESCRIPTION

This reverts commit 44ac1d6d3524be3064befdbb9efd92b511a226b8.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?