### PR TITLE
build: read os/arch at runtime

### DIFF
--- a/.github/workflows/tag_to_draft_release.yml
+++ b/.github/workflows/tag_to_draft_release.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22.x'
-      - name: "Set GOHOSTOS and GOHOSTARCH"
-        run: echo "GOHOSTOS=$(go env GOHOSTOS)" >> $GITHUB_ENV && echo "GOHOSTARCH=$(go env GOHOSTARCH)" >> $GITHUB_ENV
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@1.83.0
       - name: "Generate static app config"
@@ -43,6 +41,4 @@ jobs:
           args: release --clean
         env:
           AUR_KEY: '${{ github.workspace }}/aur_key'
-          GOHOSTOS: ${{ env.GOHOSTOS }}
-          GOHOSTARCH: ${{ env.GOHOSTARCH }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,8 +22,6 @@ builds:
       ldflags:
         - -s -w -X "github.com/fastly/cli/pkg/revision.AppVersion=v{{ .Version }}"
         - -X "github.com/fastly/cli/pkg/revision.GitCommit={{ .ShortCommit }}"
-        - -X "github.com/fastly/cli/pkg/revision.GoHostOS={{ .Env.GOHOSTOS }}"
-        - -X "github.com/fastly/cli/pkg/revision.GoHostArch={{ .Env.GOHOSTARCH }}"
         - -X "github.com/fastly/cli/pkg/revision.Environment=release"
     env:
       - CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ GO_BIN ?= go ## Allows overriding go executable.
 TEST_COMMAND ?= $(GO_BIN) test ## Enables support for tools such as https://github.com/rakyll/gotest
 TEST_ARGS ?= -v -timeout 15m ./... ## The compute tests can sometimes exceed the default 10m limit
 
-GOHOSTOS ?= $(shell go env GOHOSTOS || echo unknown)
-GOHOSTARCH ?= $(shell go env GOHOSTARCH || echo unknown)
-
 ifeq ($(OS), Windows_NT)
 	SHELL = cmd.exe
 	.SHELLFLAGS = /c
@@ -42,7 +39,7 @@ endif
 # EXAMPLE:
 # make release GORELEASER_ARGS="--clean --skip=post-hooks --skip=validate"
 release: dependencies $(GO_FILES) ## Build executables using goreleaser
-	@GOHOSTOS="${GOHOSTOS}" GOHOSTARCH="${GOHOSTARCH}" goreleaser build ${GORELEASER_ARGS}
+	goreleaser build ${GORELEASER_ARGS}
 
 # Useful for attaching a debugger such as https://github.com/go-delve/delve
 debug:

--- a/pkg/commands/version/version_test.go
+++ b/pkg/commands/version/version_test.go
@@ -94,7 +94,7 @@ func TestVersion(t *testing.T) {
 	testutil.AssertNoError(t, err)
 	testutil.AssertString(t, strings.Join([]string{
 		"Fastly CLI version v0.0.0-unknown (unknown)",
-		fmt.Sprintf("Built with go version %s unknown/unknown (%s)", runtime.Version(), mockTime.Format("2006-01-02")),
+		fmt.Sprintf("Built with go version %s %s/%s (%s)", runtime.Version(), runtime.GOOS, runtime.GOARCH, mockTime.Format("2006-01-02")),
 		"Viceroy version: viceroy 0.0.0",
 		"",
 	}, "\n"), stdout.String())

--- a/pkg/revision/revision.go
+++ b/pkg/revision/revision.go
@@ -24,12 +24,10 @@ var (
 	// GoHostArc instead. It can be set to the build host's `go version` output.
 	GoVersion string
 
-	// GoHostOS is the output of `go env GOHOSTOS` Passed to goreleaser by
-	// `make fastly` or the GHA workflow.
+	// GoHostOS is the value from `runtime.GOOS`
 	GoHostOS string
 
-	// GoHostArch is the output of `go env GOHOSTARCH` Passed to goreleaser by
-	// `make fastly` or the GHA workflow.
+	// GoHostArch is the value from `runtime.GOARCH`
 	GoHostArch string
 
 	// Environment is set to either "development" (when working locally) or
@@ -48,16 +46,10 @@ func init() {
 	if GitCommit == "" {
 		GitCommit = "unknown"
 	}
-	if GoHostOS == "" {
-		GoHostOS = "unknown"
-	}
-	if GoHostArch == "" {
-		GoHostArch = "unknown"
-	}
+	GoHostOS = runtime.GOOS
+	GoHostArch = runtime.GOARCH
 	if GoVersion == "" {
 		// runtime.Version() provides the Go tree's version string at build time
-		// the other values like OS and Arch aren't accessible and are passed in
-		// separately
 		GoVersion = fmt.Sprintf("go version %s %s/%s", runtime.Version(), GoHostOS, GoHostArch)
 	}
 	if Environment == "" {


### PR DESCRIPTION
All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

- [ ] Does your submission pass tests?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

### User Impact

- [ ] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

Hey :wave:, we're packaging this over at Homebrew and I just noticed these ldflags can be read at runtime instead (simplifying the build): https://pkg.go.dev/runtime#pkg-constants
