### PR TITLE
Updates for renamed typescript default starter kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Unreleased
+
+**Enhancements:**
+
+- fix(compute/init): Updates for renamed TypeScript default starter kit
+
+**Bug fixes:**
+
+**Dependencies:**
+
 ## [v10.19.0](https://github.com/fastly/cli/releases/tag/v10.19.0) (2025-02-18)
 
 **Enhancements:**

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -19,7 +19,7 @@ kits=(
   compute-starter-kit-rust-empty
   compute-starter-kit-rust-static-content
   compute-starter-kit-rust-websockets
-  compute-starter-kit-typescript
+  compute-starter-kit-typescript-default
 )
 
 function parse() {


### PR DESCRIPTION
The GitHub URL for the TypeScript default starter kit has recently been renamed from https://github.com/fastly/compute-starter-kit-typescript to https://github.com/fastly/compute-starter-kit-typescript-default to make starter kit names consistent between languages.

GitHub automatically provides 301 redirects so breakages will not occur (notably, I have seen that the CLI is able to initialize a new project following the redirect), but this PR updates these references.
