### PR TITLE
build(go.mod): upgrade the minimum version of go to 1.23.0 and the max to 1.23.6

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: "Install dependencies"
         run: make dependencies
         shell: bash

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: "Install dependencies"
         run: make dependencies
         shell: bash
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         tinygo-version: [0.31.2]
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         node-version: [18]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/tag_to_draft_release.yml
+++ b/.github/workflows/tag_to_draft_release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Go"
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@1.83.0
       - name: "Generate static app config"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 **Dependencies:**
 
+- build(deps): upgrade Go from 1.22 to 1.23 ([#624](https://github.com/fastly/cli/pull/1414))
+
 ## [v10.19.0](https://github.com/fastly/cli/releases/tag/v10.19.0) (2025-02-18)
 
 **Enhancements:**

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/fastly/cli
 
-go 1.22.0
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### Are there any considerations that need to be addressed for release?
 many new dependabot updates require 1.23 ([1412](https://github.com/fastly/cli/pull/1412), [1411](https://github.com/fastly/cli/pull/1411), [1410](https://github.com/fastly/cli/pull/1410), [1409](https://github.com/fastly/cli/pull/1409), [1408](https://github.com/fastly/cli/pull/1408))