### PR TITLE
Support new file/format model shape for local_server.kv_store and secret_store (as well as metadata in kv_store)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Enhancements:
 
+- feat(config): Support file/format for kv_store and secret_store in fastly.toml
+
 ### Bug fixes:
 
 ### Dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements:
 
 - feat(config): Support file/format for kv_store and secret_store in fastly.toml
+- feat(config): Support metadata for kv_store in fastly.toml
 
 ### Bug fixes:
 

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -81,6 +81,9 @@ func (f *File) MarshalTOML() ([]byte, error) {
 					if e.Data != "" {
 						obj["data"] = e.Data
 					}
+					if e.Metadata != "" {
+						obj["metadata"] = e.Metadata
+					}
 					items = append(items, obj)
 				}
 				kvStores[key] = items

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -53,7 +53,7 @@ type File struct {
 
 // MarshalTOML performs custom marshalling to TOML for objects of File type.
 func (f *File) MarshalTOML() ([]byte, error) {
-	localServer := make(map[string]interface{})
+	localServer := make(map[string]any)
 
 	if f.LocalServer.Backends != nil {
 		localServer["backends"] = f.LocalServer.Backends
@@ -64,17 +64,17 @@ func (f *File) MarshalTOML() ([]byte, error) {
 	}
 
 	if f.LocalServer.KVStores != nil {
-		kvStores := make(map[string]interface{})
+		kvStores := make(map[string]any)
 		for key, entry := range f.LocalServer.KVStores {
 			if entry.External != nil {
-				kvStores[key] = map[string]interface{}{
+				kvStores[key] = map[string]any{
 					"file":   entry.External.File,
 					"format": entry.External.Format,
 				}
 			} else {
-				items := make([]map[string]interface{}, 0, len(entry.Array))
+				items := make([]map[string]any, 0, len(entry.Array))
 				for _, e := range entry.Array {
-					obj := map[string]interface{}{"key": e.Key}
+					obj := map[string]any{"key": e.Key}
 					if e.File != "" {
 						obj["file"] = e.File
 					}
@@ -90,17 +90,17 @@ func (f *File) MarshalTOML() ([]byte, error) {
 	}
 
 	if f.LocalServer.SecretStores != nil {
-		secretStores := make(map[string]interface{})
+		secretStores := make(map[string]any)
 		for key, entry := range f.LocalServer.SecretStores {
 			if entry.External != nil {
-				secretStores[key] = map[string]interface{}{
+				secretStores[key] = map[string]any{
 					"file":   entry.External.File,
 					"format": entry.External.Format,
 				}
 			} else {
-				items := make([]map[string]interface{}, 0, len(entry.Array))
+				items := make([]map[string]any, 0, len(entry.Array))
 				for _, e := range entry.Array {
-					obj := map[string]interface{}{"key": e.Key}
+					obj := map[string]any{"key": e.Key}
 					if e.File != "" {
 						obj["file"] = e.File
 					}
@@ -119,21 +119,19 @@ func (f *File) MarshalTOML() ([]byte, error) {
 		localServer["viceroy_version"] = f.LocalServer.ViceroyVersion
 	}
 
-	type outputFile struct {
-		Authors         []string    `toml:"authors"`
-		ClonedFrom      string      `toml:"cloned_from,omitempty"`
-		Description     string      `toml:"description"`
-		Language        string      `toml:"language"`
-		Profile         string      `toml:"profile,omitempty"`
-		LocalServer     interface{} `toml:"local_server"` // override this field
-		ManifestVersion Version     `toml:"manifest_version"`
-		Name            string      `toml:"name"`
-		Scripts         Scripts     `toml:"scripts,omitempty"`
-		ServiceID       string      `toml:"service_id"`
-		Setup           Setup       `toml:"setup,omitempty"`
-	}
-
-	out := outputFile{
+	out := struct {
+		Authors         []string `toml:"authors"`
+		ClonedFrom      string   `toml:"cloned_from,omitempty"`
+		Description     string   `toml:"description"`
+		Language        string   `toml:"language"`
+		Profile         string   `toml:"profile,omitempty"`
+		LocalServer     any      `toml:"local_server"` // override this field
+		ManifestVersion Version  `toml:"manifest_version"`
+		Name            string   `toml:"name"`
+		Scripts         Scripts  `toml:"scripts,omitempty"`
+		ServiceID       string   `toml:"service_id"`
+		Setup           Setup    `toml:"setup,omitempty"`
+	}{
 		Authors:         f.Authors,
 		ClonedFrom:      f.ClonedFrom,
 		Description:     f.Description,

--- a/pkg/manifest/local_server.go
+++ b/pkg/manifest/local_server.go
@@ -34,9 +34,10 @@ type LocalConfigStore struct {
 // KVStoreArrayEntry represents an array-based key/value store entries.
 // It expects a key plus either a data or file field.
 type KVStoreArrayEntry struct {
-	Key  string `toml:"key"`
-	File string `toml:"file,omitempty"`
-	Data string `toml:"data,omitempty"`
+	Key      string `toml:"key"`
+	File     string `toml:"file,omitempty"`
+	Data     string `toml:"data,omitempty"`
+	Metadata string `toml:"metadata,omitempty"`
 }
 
 // KVStoreExternalFile represents the external key/value store,

--- a/pkg/manifest/local_server.go
+++ b/pkg/manifest/local_server.go
@@ -1,12 +1,19 @@
 package manifest
 
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/pelletier/go-toml"
+)
+
 // LocalServer represents a list of mocked Viceroy resources.
 type LocalServer struct {
-	Backends       map[string]LocalBackend       `toml:"backends"`
-	ConfigStores   map[string]LocalConfigStore   `toml:"config_stores,omitempty"`
-	KVStores       map[string][]LocalKVStore     `toml:"kv_stores,omitempty"`
-	SecretStores   map[string][]LocalSecretStore `toml:"secret_stores,omitempty"`
-	ViceroyVersion string                        `toml:"viceroy_version,omitempty"`
+	Backends       map[string]LocalBackend     `toml:"backends"`
+	ConfigStores   map[string]LocalConfigStore `toml:"config_stores,omitempty"`
+	KVStores       LocalKVStoreMap             `toml:"kv_stores,omitempty"`
+	SecretStores   LocalSecretStoreMap         `toml:"secret_stores,omitempty"`
+	ViceroyVersion string                      `toml:"viceroy_version,omitempty"`
 }
 
 // LocalBackend represents a backend to be mocked by the local testing server.
@@ -24,16 +31,171 @@ type LocalConfigStore struct {
 	Contents map[string]string `toml:"contents,omitempty"`
 }
 
-// LocalKVStore represents an kv_store to be mocked by the local testing server.
-type LocalKVStore struct {
+// KVStoreArrayEntry represents an array-based key/value store entries.
+// It expects a key plus either a data or file field.
+type KVStoreArrayEntry struct {
 	Key  string `toml:"key"`
 	File string `toml:"file,omitempty"`
 	Data string `toml:"data,omitempty"`
 }
 
-// LocalSecretStore represents a secret_store to be mocked by the local testing server.
-type LocalSecretStore struct {
+// KVStoreExternalFile represents the external key/value store,
+// which must have both a file and a format.
+type KVStoreExternalFile struct {
+	File   string `toml:"file"`
+	Format string `toml:"format"`
+}
+
+// LocalKVStore represents a kv_store to be mocked by the local testing server.
+// It is a union type and can either be an array of KVStoreArrayEntry or a single KVStoreExternalFile.
+// The IsArray flag is used to preserve the original input style.
+type LocalKVStore struct {
+	IsArray  bool                 `toml:"-"`
+	Array    []KVStoreArrayEntry  `toml:"-"`
+	External *KVStoreExternalFile `toml:"-"`
+}
+
+// LocalKVStoreMap is a map of kv_store names to the local kv_store representation.
+type LocalKVStoreMap map[string]LocalKVStore
+
+// UnmarshalTOML performs custom unmarshalling of TOML data for LocalKVStoreMap.
+func (m *LocalKVStoreMap) UnmarshalTOML(v interface{}) error {
+	raw, ok := v.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("expected kv_stores to be a TOML table")
+	}
+
+	result := make(LocalKVStoreMap)
+
+	for key, val := range raw {
+		switch typed := val.(type) {
+		case []interface{}:
+			var entries []KVStoreArrayEntry
+			for _, item := range typed {
+				obj, ok := item.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("invalid item in array for key %q", key)
+				}
+				var arrayEntry KVStoreArrayEntry
+				if err := decodeTOMLMap(obj, &arrayEntry); err != nil {
+					return fmt.Errorf("decode failed for array item in key %q: %w", key, err)
+				}
+				entries = append(entries, arrayEntry)
+			}
+			result[key] = LocalKVStore{
+				IsArray: true,
+				Array:   entries,
+			}
+
+		case map[string]interface{}:
+			file, hasFile := typed["file"].(string)
+			format, hasFormat := typed["format"].(string)
+
+			if !hasFile || !hasFormat {
+				return fmt.Errorf("key %q must have both file and format", key)
+			}
+			result[key] = LocalKVStore{
+				IsArray: false,
+				External: &KVStoreExternalFile{
+					File:   file,
+					Format: format,
+				},
+			}
+
+		default:
+			return fmt.Errorf("unsupported value type for key %q: %T", key, typed)
+		}
+	}
+
+	*m = result
+	return nil
+}
+
+// SecretStoreArrayEntry represents an array-based key/value store entries.
+// It expects a key plus either a data or file field.
+type SecretStoreArrayEntry struct {
 	Key  string `toml:"key"`
 	File string `toml:"file,omitempty"`
 	Data string `toml:"data,omitempty"`
+}
+
+// SecretStoreExternalFile represents the external key/value store,
+// which must have both a file and a format.
+type SecretStoreExternalFile struct {
+	File   string `toml:"file"`
+	Format string `toml:"format"`
+}
+
+// LocalSecretStore represents a secret_store to be mocked by the local testing server.
+// It is a union type and can either be an array of SecretStoreArrayEntry or a single SecretStoreExternalFile.
+// The IsArray flag is used to preserve the original input style.
+type LocalSecretStore struct {
+	IsArray  bool                     `toml:"-"`
+	Array    []SecretStoreArrayEntry  `toml:"-"`
+	External *SecretStoreExternalFile `toml:"-"`
+}
+
+// LocalSecretStoreMap is a map of secret_store names to the local secret_store representation.
+type LocalSecretStoreMap map[string]LocalSecretStore
+
+// UnmarshalTOML performs custom unmarshalling of TOML data for LocalSecretStoreMap.
+func (m *LocalSecretStoreMap) UnmarshalTOML(v interface{}) error {
+	raw, ok := v.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("expected secret_stores to be a TOML table")
+	}
+
+	result := make(LocalSecretStoreMap)
+
+	for key, val := range raw {
+		switch typed := val.(type) {
+		case []interface{}:
+			var entries []SecretStoreArrayEntry
+			for _, item := range typed {
+				obj, ok := item.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("invalid item in array for key %q", key)
+				}
+				var arrayEntry SecretStoreArrayEntry
+				if err := decodeTOMLMap(obj, &arrayEntry); err != nil {
+					return fmt.Errorf("decode failed for array item in key %q: %w", key, err)
+				}
+				entries = append(entries, arrayEntry)
+			}
+			result[key] = LocalSecretStore{
+				IsArray: true,
+				Array:   entries,
+			}
+
+		case map[string]interface{}:
+			file, hasFile := typed["file"].(string)
+			format, hasFormat := typed["format"].(string)
+
+			if !hasFile || !hasFormat {
+				return fmt.Errorf("key %q must have both file and format", key)
+			}
+			result[key] = LocalSecretStore{
+				IsArray: false,
+				External: &SecretStoreExternalFile{
+					File:   file,
+					Format: format,
+				},
+			}
+
+		default:
+			return fmt.Errorf("unsupported value type for key %q: %T", key, typed)
+		}
+	}
+
+	*m = result
+	return nil
+}
+
+func decodeTOMLMap(m map[string]interface{}, out interface{}) error {
+	buf := new(bytes.Buffer)
+	enc := toml.NewEncoder(buf)
+	if err := enc.Encode(m); err != nil {
+		return err
+	}
+	return toml.NewDecoder(buf).Decode(out)
 }

--- a/pkg/manifest/local_server.go
+++ b/pkg/manifest/local_server.go
@@ -59,8 +59,8 @@ type LocalKVStore struct {
 type LocalKVStoreMap map[string]LocalKVStore
 
 // UnmarshalTOML performs custom unmarshalling of TOML data for LocalKVStoreMap.
-func (m *LocalKVStoreMap) UnmarshalTOML(v interface{}) error {
-	raw, ok := v.(map[string]interface{})
+func (m *LocalKVStoreMap) UnmarshalTOML(v any) error {
+	raw, ok := v.(map[string]any)
 	if !ok {
 		return fmt.Errorf("expected kv_stores to be a TOML table")
 	}
@@ -69,10 +69,10 @@ func (m *LocalKVStoreMap) UnmarshalTOML(v interface{}) error {
 
 	for key, val := range raw {
 		switch typed := val.(type) {
-		case []interface{}:
+		case []any:
 			var entries []KVStoreArrayEntry
 			for _, item := range typed {
-				obj, ok := item.(map[string]interface{})
+				obj, ok := item.(map[string]any)
 				if !ok {
 					return fmt.Errorf("invalid item in array for key %q", key)
 				}
@@ -87,7 +87,7 @@ func (m *LocalKVStoreMap) UnmarshalTOML(v interface{}) error {
 				Array:   entries,
 			}
 
-		case map[string]interface{}:
+		case map[string]any:
 			file, hasFile := typed["file"].(string)
 			format, hasFormat := typed["format"].(string)
 
@@ -139,8 +139,8 @@ type LocalSecretStore struct {
 type LocalSecretStoreMap map[string]LocalSecretStore
 
 // UnmarshalTOML performs custom unmarshalling of TOML data for LocalSecretStoreMap.
-func (m *LocalSecretStoreMap) UnmarshalTOML(v interface{}) error {
-	raw, ok := v.(map[string]interface{})
+func (m *LocalSecretStoreMap) UnmarshalTOML(v any) error {
+	raw, ok := v.(map[string]any)
 	if !ok {
 		return fmt.Errorf("expected secret_stores to be a TOML table")
 	}
@@ -149,10 +149,10 @@ func (m *LocalSecretStoreMap) UnmarshalTOML(v interface{}) error {
 
 	for key, val := range raw {
 		switch typed := val.(type) {
-		case []interface{}:
+		case []any:
 			var entries []SecretStoreArrayEntry
 			for _, item := range typed {
-				obj, ok := item.(map[string]interface{})
+				obj, ok := item.(map[string]any)
 				if !ok {
 					return fmt.Errorf("invalid item in array for key %q", key)
 				}
@@ -167,7 +167,7 @@ func (m *LocalSecretStoreMap) UnmarshalTOML(v interface{}) error {
 				Array:   entries,
 			}
 
-		case map[string]interface{}:
+		case map[string]any:
 			file, hasFile := typed["file"].(string)
 			format, hasFormat := typed["format"].(string)
 
@@ -191,7 +191,7 @@ func (m *LocalSecretStoreMap) UnmarshalTOML(v interface{}) error {
 	return nil
 }
 
-func decodeTOMLMap(m map[string]interface{}, out interface{}) error {
+func decodeTOMLMap(m map[string]any, out any) error {
 	buf := new(bytes.Buffer)
 	enc := toml.NewEncoder(buf)
 	if err := enc.Encode(m); err != nil {

--- a/pkg/manifest/local_server_test.go
+++ b/pkg/manifest/local_server_test.go
@@ -21,13 +21,15 @@ func TestLocalKVStores_UnmarshalTOML(t *testing.T) {
 [[kv_stores.my-kv]]
 key = "kv"
 file = "kv.json"
+metadata = "metadata"
 `,
 			expected: LocalKVStore{
 				IsArray: true,
 				Array: []KVStoreArrayEntry{
 					{
-						Key:  "kv",
-						File: "kv.json",
+						Key:      "kv",
+						File:     "kv.json",
+						Metadata: "metadata",
 					},
 				},
 			},

--- a/pkg/manifest/local_server_test.go
+++ b/pkg/manifest/local_server_test.go
@@ -1,65 +1,12 @@
 package manifest
 
 import (
-	"bytes"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/pelletier/go-toml"
 )
-
-type KVWrapper struct {
-	KVStores LocalKVStoreMap `toml:"kv_stores"`
-}
-
-func (w KVWrapper) MarshalTOML() ([]byte, error) {
-	obj := make(map[string]any)
-	kv := make(map[string]any)
-
-	for key, entry := range w.KVStores {
-		if entry.External != nil {
-			kv[key] = map[string]any{
-				"file":   entry.External.File,
-				"format": entry.External.Format,
-			}
-		} else {
-			kv[key] = entry.Array
-		}
-	}
-
-	obj["kv_stores"] = kv
-
-	buf := new(bytes.Buffer)
-	err := toml.NewEncoder(buf).Encode(obj)
-	return buf.Bytes(), err
-}
-
-type SecretStoreWrapper struct {
-	SecretStores LocalSecretStoreMap `toml:"secret_stores"`
-}
-
-func (w SecretStoreWrapper) MarshalTOML() ([]byte, error) {
-	obj := make(map[string]any)
-	kv := make(map[string]any)
-
-	for key, entry := range w.SecretStores {
-		if entry.External != nil {
-			kv[key] = map[string]any{
-				"file":   entry.External.File,
-				"format": entry.External.Format,
-			}
-		} else {
-			kv[key] = entry.Array
-		}
-	}
-
-	obj["kv_stores"] = kv
-
-	buf := new(bytes.Buffer)
-	err := toml.NewEncoder(buf).Encode(obj)
-	return buf.Bytes(), err
-}
 
 func TestLocalKVStores_UnmarshalTOML(t *testing.T) {
 	tests := []struct {
@@ -111,7 +58,9 @@ my-kv = "not-a-valid-entry"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var m KVWrapper
+			var m struct {
+				KVStores LocalKVStoreMap `toml:"kv_stores"`
+			}
 
 			decoder := toml.NewDecoder(strings.NewReader(tt.inputTOML))
 			err := decoder.Decode(&m)
@@ -187,7 +136,9 @@ my-secret-store = "not-a-valid-entry"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var m SecretStoreWrapper
+			var m struct {
+				SecretStores LocalSecretStoreMap `toml:"secret_stores"`
+			}
 
 			decoder := toml.NewDecoder(strings.NewReader(tt.inputTOML))
 			err := decoder.Decode(&m)

--- a/pkg/manifest/local_server_test.go
+++ b/pkg/manifest/local_server_test.go
@@ -1,0 +1,246 @@
+package manifest
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml"
+)
+
+type KVWrapper struct {
+	KVStores LocalKVStoreMap `toml:"kv_stores"`
+}
+
+func (w KVWrapper) MarshalTOML() ([]byte, error) {
+	obj := make(map[string]interface{})
+	kv := make(map[string]interface{})
+
+	for key, entry := range w.KVStores {
+		if entry.External != nil {
+			kv[key] = map[string]interface{}{
+				"file":   entry.External.File,
+				"format": entry.External.Format,
+			}
+		} else {
+			kv[key] = entry.Array
+		}
+	}
+
+	obj["kv_stores"] = kv
+
+	buf := new(bytes.Buffer)
+	err := toml.NewEncoder(buf).Encode(obj)
+	return buf.Bytes(), err
+}
+
+type SecretStoreWrapper struct {
+	SecretStores LocalSecretStoreMap `toml:"secret_stores"`
+}
+
+func (w SecretStoreWrapper) MarshalTOML() ([]byte, error) {
+	obj := make(map[string]interface{})
+	kv := make(map[string]interface{})
+
+	for key, entry := range w.SecretStores {
+		if entry.External != nil {
+			kv[key] = map[string]interface{}{
+				"file":   entry.External.File,
+				"format": entry.External.Format,
+			}
+		} else {
+			kv[key] = entry.Array
+		}
+	}
+
+	obj["kv_stores"] = kv
+
+	buf := new(bytes.Buffer)
+	err := toml.NewEncoder(buf).Encode(obj)
+	return buf.Bytes(), err
+}
+
+func TestLocalKVStores_UnmarshalTOML(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputTOML    string
+		expectError  bool
+		expectArray  bool
+		expectLength int
+		wantFile     string
+	}{
+		{
+			name: "legacy array format",
+			inputTOML: `
+[[kv_stores.my-kv]]
+key = "my-kv"
+file = "kv.json"
+`,
+			expectArray:  true,
+			expectLength: 1,
+			wantFile:     "kv.json",
+		},
+		{
+			name: "external file format",
+			inputTOML: `
+[kv_stores]
+my-kv = { file = "kv.json", format = "json" }
+`,
+			expectArray:  false,
+			expectLength: 0,
+			wantFile:     "kv.json",
+		},
+		{
+			name: "invalid format",
+			inputTOML: `
+[kv_stores]
+my-kv = "not-a-valid-entry"
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m KVWrapper
+
+			decoder := toml.NewDecoder(strings.NewReader(tt.inputTOML))
+			err := decoder.Decode(&m)
+
+			buf := new(bytes.Buffer)
+			encoder := toml.NewEncoder(buf)
+
+			encodeErr := encoder.Encode(m)
+			if encodeErr != nil {
+				log.Fatalf("TOML encode failed: %v", encodeErr)
+			}
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("Expected error for invalid format, but got none")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("Failed to parse TOML: %v", err)
+			}
+
+			got, ok := m.KVStores["my-kv"]
+			if !ok {
+				t.Fatalf("Expected key 'my-kv' not found")
+			}
+
+			if got.IsArray != tt.expectArray {
+				t.Fatalf("Expected IsArray=%v, got %v", tt.expectArray, got.IsArray)
+			}
+
+			if tt.expectArray {
+				if len(got.Array) != tt.expectLength {
+					t.Fatalf("Expected %d inline entries, got %d", tt.expectLength, len(got.Array))
+				}
+				if got.Array[0].File != tt.wantFile {
+					t.Errorf("Expected file %q, got %q", tt.wantFile, got.Array[0].File)
+				}
+			} else {
+				if got.External == nil {
+					t.Fatal("Expected KVStoreExternalFile but got nil")
+				}
+				if got.External.File != tt.wantFile {
+					t.Errorf("Expected file %q, got %q", tt.wantFile, got.External.File)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalSecretStores_UnmarshalTOML(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputTOML    string
+		expectError  bool
+		expectArray  bool
+		expectLength int
+		wantFile     string
+	}{
+		{
+			name: "legacy array format",
+			inputTOML: `
+[[secret_stores.my-secret-store]]
+key = "secret"
+file = "secret.json"
+`,
+			expectArray:  true,
+			expectLength: 1,
+			wantFile:     "secret.json",
+		},
+		{
+			name: "external file format",
+			inputTOML: `
+[secret_stores]
+my-secret-store = { file = "kv.json", format = "json" }
+`,
+			expectArray:  false,
+			expectLength: 0,
+			wantFile:     "kv.json",
+		},
+		{
+			name: "invalid format",
+			inputTOML: `
+[secret_stores]
+my-secret-store = "not-a-valid-entry"
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m SecretStoreWrapper
+
+			decoder := toml.NewDecoder(strings.NewReader(tt.inputTOML))
+			err := decoder.Decode(&m)
+
+			buf := new(bytes.Buffer)
+			encoder := toml.NewEncoder(buf)
+
+			encodeErr := encoder.Encode(m)
+			if encodeErr != nil {
+				log.Fatalf("TOML encode failed: %v", encodeErr)
+			}
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("Expected error for invalid format, but got none")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("Failed to parse TOML: %v", err)
+			}
+
+			got, ok := m.SecretStores["my-secret-store"]
+			if !ok {
+				t.Fatalf("Expected key 'my-secret-store' not found")
+			}
+
+			if got.IsArray != tt.expectArray {
+				t.Fatalf("Expected IsArray=%v, got %v", tt.expectArray, got.IsArray)
+			}
+
+			if tt.expectArray {
+				if len(got.Array) != tt.expectLength {
+					t.Fatalf("Expected %d inline entries, got %d", tt.expectLength, len(got.Array))
+				}
+				if got.Array[0].File != tt.wantFile {
+					t.Errorf("Expected file %q, got %q", tt.wantFile, got.Array[0].File)
+				}
+			} else {
+				if got.External == nil {
+					t.Fatal("Expected SecretStoreExternalFile but got nil")
+				}
+				if got.External.File != tt.wantFile {
+					t.Errorf("Expected file %q, got %q", tt.wantFile, got.External.File)
+				}
+			}
+		})
+	}
+}

--- a/pkg/manifest/testdata/fastly-viceroy-update.toml
+++ b/pkg/manifest/testdata/fastly-viceroy-update.toml
@@ -40,6 +40,7 @@ store_one = [
   { key = "first", data = "This is some data" },
   { key = "second", file = "strings.json" },
 ]
+store_three = { file = "path/to/kv.json", format = "json" }
 
 [[local_server.kv_stores.store_two]]
 key = "first"
@@ -54,6 +55,7 @@ store_one = [
   { key = "first", data = "This is some secret data" },
   { key = "second", file = "/path/to/secret.json" },
 ]
+store_three = { file = "path/to/secret.json", format = "json" }
 
 [[local_server.secret_stores.store_two]]
 key = "first"

--- a/pkg/manifest/testdata/fastly-viceroy-update.toml
+++ b/pkg/manifest/testdata/fastly-viceroy-update.toml
@@ -37,7 +37,7 @@ qux"""
 
 [local_server.kv_stores]
 store_one = [
-  { key = "first", data = "This is some data" },
+  { key = "first", data = "This is some data", metadata = "This is some metadata" },
   { key = "second", file = "strings.json" },
 ]
 store_three = { file = "path/to/kv.json", format = "json" }
@@ -45,6 +45,7 @@ store_three = { file = "path/to/kv.json", format = "json" }
 [[local_server.kv_stores.store_two]]
 key = "first"
 data = "This is some data"
+metadata = "This is some metadata"
 
 [[local_server.kv_stores.store_two]]
 key = "second"


### PR DESCRIPTION
Viceroy's KV Store can now be configured using external JSON files specified using fastly.toml (https://github.com/fastly/Viceroy/pull/365 and https://github.com/fastly/Viceroy/pull/428).

However, Fastly CLI's fastly.toml validation would choke and it was not possible to use the new syntax.

```
✗ Verifying fastly.toml

ERROR: (0, 0): Can't convert file = "./foo.json"
format = "json"
(*toml.Tree) to a tree.
```

This PR updates the TOML marshaling/unmarshaling mechanism to enable the new syntax in fastly.toml.

Fixes #1319

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact
### Are there any considerations that need to be addressed for release?

This should be backwards compatible.

