### PR TITLE
Additional checking for wasm32-wasi output from Rust projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bug fixes:
 
+- fix(language/rust): Check for wasm32-wasi output from build process and inform user how to reconfigure their project. [#1458](https://github.com/fastly/cli/pull/1458)
+
 ### Dependencies:
 - dep(go.mod): upgrade go-fastly from v9 to v10 [#1448](https://github.com/fastly/cli/pull/1448)
 - build(deps): `golang.org/x/oauth2` from 0.28.0 to 0.29.0 ([#1451](https://github.com/fastly/cli/pull/1451))


### PR DESCRIPTION
In version 11.0.0 a test was added to ensure that the CLI's global configuration file was not configured for 'wasm32-wasi' output from Rust projects. That was insufficient to avoid build errors in existing projects configured for that target, so this commit adds an additional check. Specifically, if the WASM binary is not found in the expected location after a successful build, a check is made to see if the binary is found in the 'old' location. If it is found there, an error is emitted which includes a link to the instructions for how to reconfigure the project.

NOTE: The URL in this PR is not yet live; it will be once a PR to our documentation site has been merged.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

* [X] What is the user impact of this change? - a new error will be generated for Rust projects which have not been upgraded

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->