### PR TITLE
Farhansajid1/domain tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v10 v10.1.0
+	github.com/fastly/go-fastly/v10 v10.2.0
 	github.com/hashicorp/cap v0.9.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/otiai10/copy v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fastly/go-fastly/v10 v10.1.0 h1:dg2FRXybWJsLjqzA2y7xb97P+RlpiNqj/QeiNNKJzQs=
 github.com/fastly/go-fastly/v10 v10.1.0/go.mod h1:r2+2hR6uZBAR6P72MCfVSzUWfpInZSnHPt9gyqtes2k=
+github.com/fastly/go-fastly/v10 v10.2.0 h1:EICGnjskzXBgz4aUpK6mioCURMz5PUt1YoZySj3bzD0=
+github.com/fastly/go-fastly/v10 v10.2.0/go.mod h1:UcROjNqDweQhC1f0N0qSeTIHJBZ/eCNTSZ/ZJe7rjCk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/fastly/cli/pkg/commands/domainv1/tools"
 	"github.com/fastly/kingpin"
 
 	"github.com/fastly/cli/pkg/argparser"
@@ -204,6 +205,9 @@ func Define( // nolint:revive // function-length
 	domainv1Describe := domainv1.NewDescribeCommand(domainv1CmdRoot.CmdClause, data)
 	domainv1List := domainv1.NewListCommand(domainv1CmdRoot.CmdClause, data)
 	domainv1Update := domainv1.NewUpdateCommand(domainv1CmdRoot.CmdClause, data)
+	domainv1ToolsCmdRoot := tools.NewRootCommand(domainv1CmdRoot.CmdClause, data)
+	domainv1ToolsStatus := tools.NewDomainStatusCommand(domainv1ToolsCmdRoot.CmdClause, data)
+	domainv1ToolsSuggestion := tools.NewDomainSuggestionsCommand(domainv1ToolsCmdRoot.CmdClause, data)
 	healthcheckCmdRoot := healthcheck.NewRootCommand(app, data)
 	healthcheckCreate := healthcheck.NewCreateCommand(healthcheckCmdRoot.CmdClause, data)
 	healthcheckDelete := healthcheck.NewDeleteCommand(healthcheckCmdRoot.CmdClause, data)
@@ -615,7 +619,10 @@ func Define( // nolint:revive // function-length
 		domainv1Delete,
 		domainv1Describe,
 		domainv1List,
+		domainv1ToolsCmdRoot,
 		domainv1Update,
+		domainv1ToolsStatus,
+		domainv1ToolsSuggestion,
 		healthcheckCmdRoot,
 		healthcheckCreate,
 		healthcheckDelete,

--- a/pkg/commands/domainv1/tools/doc.go
+++ b/pkg/commands/domainv1/tools/doc.go
@@ -1,0 +1,2 @@
+// Package tools contains commands for interacting with domains.
+package tools

--- a/pkg/commands/domainv1/tools/doc.go
+++ b/pkg/commands/domainv1/tools/doc.go
@@ -1,2 +1,2 @@
-// Package tools contains commands for interacting with domains.
+// Package tools contains commands for interacting with tools for domains.
 package tools

--- a/pkg/commands/domainv1/tools/root.go
+++ b/pkg/commands/domainv1/tools/root.go
@@ -1,0 +1,31 @@
+package tools
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/argparser"
+	"github.com/fastly/cli/pkg/global"
+)
+
+// RootCommand is the parent command for all tool subcommands in this package.
+// It should be installed under the primary `domainv1` root command.
+type RootCommand struct {
+	argparser.Base
+	// no flags
+}
+
+// CommandName is the string to be used to invoke this command
+const CommandName = "tools"
+
+// NewRootCommand returns a new tools command registered in the parent.
+func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = g
+	c.CmdClause = parent.Command(CommandName, "Tools for interacting with Domains")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(_ io.Reader, _ io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/commands/domainv1/tools/status.go
+++ b/pkg/commands/domainv1/tools/status.go
@@ -31,7 +31,6 @@ func NewDomainStatusCommand(parent argparser.Registerer, g *global.Data) *GetDom
 	}
 
 	cmd.CmdClause = parent.Command("status", "Check the availability status of a single domain name.")
-
 	// Required.
 	cmd.CmdClause.Flag("domain", "Domain being checked for availability").Required().StringVar(&cmd.domain)
 	// Optional.
@@ -70,11 +69,12 @@ func (g *GetDomainStatusCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	writeStatusSummary(out, st)
+	printStatusSummary(out, st)
 	return nil
 }
 
-func writeStatusSummary(w io.Writer, st *status.Status) {
+// printStatusSummary displays the information returned from the API in a summarized format.
+func printStatusSummary(w io.Writer, st *status.Status) {
 	fmt.Fprintf(w, "Domain: %s\n", st.Domain)
 	fmt.Fprintf(w, "Zone: %s\n", st.Zone)
 	fmt.Fprintf(w, "Status: %s\n", st.Status)

--- a/pkg/commands/domainv1/tools/status.go
+++ b/pkg/commands/domainv1/tools/status.go
@@ -1,0 +1,95 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/status"
+)
+
+// GetDomainStatusCommand calls the Fastly API to check the availability status of a domain.
+type GetDomainStatusCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+	// Required.
+	domain string
+	// Optional.
+	scope argparser.OptionalString
+}
+
+// NewDomainStatusCommand returns a usable DomainStatusCommand registered under the parent.
+func NewDomainStatusCommand(parent argparser.Registerer, g *global.Data) *GetDomainStatusCommand {
+	cmd := GetDomainStatusCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	cmd.CmdClause = parent.Command("status", "Check the availability status of a single domain name.")
+
+	// Required.
+	cmd.CmdClause.Flag("domain", "Domain being checked for availability").Required().StringVar(&cmd.domain)
+	// Optional.
+	cmd.CmdClause.Flag("scope", "Scope determines the availability check to perform, specify `estimate` for an estimated check").Action(cmd.scope.Set).StringVar(&cmd.scope.Value)
+	cmd.RegisterFlagBool(cmd.JSONFlag())
+
+	return &cmd
+}
+
+// Exec invokes the application logic for the command.
+func (g *GetDomainStatusCommand) Exec(_ io.Reader, out io.Writer) error {
+	if g.Globals.Verbose() && g.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := g.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	input := &status.GetInput{
+		Domain: g.domain,
+	}
+
+	if g.scope.WasSet {
+		input.Scope = fastly.ToPointer(status.Scope(g.scope.Value))
+	}
+
+	st, err := status.Get(fc, input)
+	if err != nil {
+		g.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := g.WriteJSON(out, st); ok {
+		return err
+	}
+
+	writeStatusSummary(out, st)
+	return nil
+}
+
+func writeStatusSummary(w io.Writer, st *status.Status) {
+	fmt.Fprintf(w, "Domain: %s\n", st.Domain)
+	fmt.Fprintf(w, "Zone: %s\n", st.Zone)
+	fmt.Fprintf(w, "Status: %s\n", st.Status)
+	fmt.Fprintf(w, "Tags: %s\n", st.Tags)
+
+	if st.Scope != nil {
+		fmt.Fprintf(w, "Scope: %s\n", *st.Scope)
+	}
+
+	if len(st.Offers) > 0 {
+		fmt.Fprintf(w, "Offers:\n")
+		for _, o := range st.Offers {
+			fmt.Fprintf(w, "  - Vendor: %s\n", o.Vendor)
+			fmt.Fprintf(w, "    Currency: %s\n", o.Currency)
+			fmt.Fprintf(w, "    Price: %s\n", o.Price)
+		}
+	}
+}

--- a/pkg/commands/domainv1/tools/status_test.go
+++ b/pkg/commands/domainv1/tools/status_test.go
@@ -1,0 +1,129 @@
+package tools_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	root "github.com/fastly/cli/pkg/commands/domainv1"
+	"github.com/fastly/cli/pkg/commands/domainv1/tools"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/status"
+)
+
+func TestNewDomainsV1ToolsStatusCommand(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Args:      "",
+			WantError: "error parsing arguments: required flag --domain not provided",
+		},
+		{
+			Args: "--domain domainr-testing.com",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(status.Status{
+							Domain: "domainr-testing.com",
+							Zone:   "com",
+							Status: "undelegated inactive",
+							Tags:   "generic",
+						}))),
+					},
+				},
+			},
+			WantOutput: `Domain: domainr-testing.com
+Zone: com
+Status: undelegated inactive
+Tags: generic
+`,
+		},
+		{
+			Args: "--domain domainr-testing.org --scope estimate",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(status.Status{
+							Domain: "domainr-testing.org",
+							Zone:   "org",
+							Status: "marketed priced transferable active",
+							Tags:   "generic",
+							Scope:  fastly.ToPointer(status.ScopeEstimate),
+							Offers: []status.Offer{
+								{
+									Vendor:   "am.godaddy.com",
+									Currency: "USD",
+									Price:    "25000.00",
+								},
+								{
+									Vendor:   "example.com",
+									Currency: "USD",
+									Price:    "20000.00",
+								},
+							},
+						}))),
+					},
+				},
+			},
+			WantOutput: `Domain: domainr-testing.org
+Zone: org
+Status: marketed priced transferable active
+Tags: generic
+Scope: estimate
+Offers:
+  - Vendor: am.godaddy.com
+    Currency: USD
+    Price: 25000.00
+  - Vendor: example.com
+    Currency: USD
+    Price: 20000.00
+`,
+		},
+		{
+			Args: "-j --domain domainr-testing.org --scope estimate",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(status.Status{
+							Domain: "domainr-testing.org",
+							Zone:   "org",
+							Status: "marketed priced transferable active",
+							Tags:   "generic",
+							Scope:  fastly.ToPointer(status.ScopeEstimate),
+							Offers: []status.Offer{
+								{
+									Vendor:   "am.godaddy.com",
+									Currency: "USD",
+									Price:    "25000.00",
+								},
+							},
+						}))),
+					},
+				},
+			},
+			WantOutput: `{
+  "domain": "domainr-testing.org",
+  "zone": "org",
+  "status": "marketed priced transferable active",
+  "scope": "estimate",
+  "tags": "generic",
+  "offers": [
+    {
+      "vendor": "am.godaddy.com",
+      "price": "25000.00",
+      "currency": "USD"
+    }
+  ]
+}
+`,
+		},
+	}
+	testutil.RunCLIScenarios(t, []string{root.CommandName, tools.CommandName, "status"}, scenarios)
+}

--- a/pkg/commands/domainv1/tools/suggest.go
+++ b/pkg/commands/domainv1/tools/suggest.go
@@ -1,0 +1,127 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/suggest"
+)
+
+// GetDomainSuggestionsCommand calls the Fastly API to perform a real-time query of the search term(s) against the
+// know zones database.
+type GetDomainSuggestionsCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+	// Required.
+	query string
+	// Optional.
+	defaults argparser.OptionalString
+	keywords argparser.OptionalString
+	location argparser.OptionalString
+	vendor   argparser.OptionalString
+}
+
+// NewDomainSuggestionsCommand returns a usable DomainSuggestionCommand registered under the parent.
+func NewDomainSuggestionsCommand(parent argparser.Registerer, g *global.Data) *GetDomainSuggestionsCommand {
+	cmd := GetDomainSuggestionsCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	cmd.CmdClause = parent.Command("suggest", "Performs real-time queries against the known zones database")
+
+	// Required.
+	cmd.CmdClause.Flag("query", "The term(s) to search against.").Required().StringVar(&cmd.query)
+	// Optional.
+	cmd.CmdClause.Flag("defaults", "Comma-separated list of default zones to include in the search results response").Action(cmd.defaults.Set).StringVar(&cmd.defaults.Value)
+	cmd.CmdClause.Flag("keywords", "Comma-separated list of keywords for seeding the results").Action(cmd.keywords.Set).StringVar(&cmd.keywords.Value)
+	cmd.CmdClause.Flag("location", "Overrides the IP location detection for country-code zones, with a two-character country code").Action(cmd.location.Set).StringVar(&cmd.location.Value)
+	cmd.CmdClause.Flag("vendor", "The domain name of a specific registrar or vendor ").Action(cmd.vendor.Set).StringVar(&cmd.vendor.Value)
+	cmd.RegisterFlagBool(cmd.JSONFlag())
+
+	return &cmd
+}
+
+// Exec invokes the application logic for the command.
+func (g *GetDomainSuggestionsCommand) Exec(_ io.Reader, out io.Writer) error {
+	if g.Globals.Verbose() && g.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := g.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	input := &suggest.GetInput{
+		Query: g.query,
+	}
+
+	if g.defaults.WasSet {
+		input.Defaults = fastly.ToPointer(g.defaults.Value)
+	}
+
+	if g.keywords.WasSet {
+		input.Keywords = fastly.ToPointer(g.keywords.Value)
+	}
+
+	if g.location.WasSet {
+		input.Location = fastly.ToPointer(g.location.Value)
+	}
+
+	if g.vendor.WasSet {
+		input.Vendor = fastly.ToPointer(g.vendor.Value)
+	}
+
+	suggestions, err := suggest.Get(fc, input)
+	if err != nil {
+		g.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := g.WriteJSON(out, suggestions); ok {
+		return err
+	}
+
+	if g.Globals.Verbose() {
+		writeSearchVerbose(out, suggestions)
+	} else {
+		writeSearchSummary(out, suggestions)
+	}
+
+	return nil
+}
+
+func writeSearchSummary(out io.Writer, suggestions *suggest.Suggestions) {
+	t := text.NewTable(out)
+	t.AddHeader("Domain", "Subdomain", "Zone", "Path")
+	for _, suggestion := range suggestions.Results {
+		var path string
+		if suggestion.Path != nil {
+			path = *suggestion.Path
+		}
+		t.AddLine(suggestion.Domain, suggestion.Subdomain, suggestion.Zone, path)
+	}
+
+	t.Print()
+}
+
+func writeSearchVerbose(out io.Writer, suggestions *suggest.Suggestions) {
+	for _, suggestion := range suggestions.Results {
+		fmt.Fprintf(out, "Domain: %s\n", suggestion.Domain)
+		fmt.Fprintf(out, "Subdomain: %s\n", suggestion.Subdomain)
+		fmt.Fprintf(out, "Zone: %s\n", suggestion.Zone)
+
+		if suggestion.Path != nil {
+			fmt.Fprintf(out, "Path: %s\n", *suggestion.Path)
+		}
+		fmt.Fprintf(out, "\n")
+	}
+}

--- a/pkg/commands/domainv1/tools/suggest.go
+++ b/pkg/commands/domainv1/tools/suggest.go
@@ -36,7 +36,6 @@ func NewDomainSuggestionsCommand(parent argparser.Registerer, g *global.Data) *G
 	}
 
 	cmd.CmdClause = parent.Command("suggest", "Performs real-time queries against the known zones database")
-
 	// Required.
 	cmd.CmdClause.Flag("query", "The term(s) to search against.").Required().StringVar(&cmd.query)
 	// Optional.
@@ -91,15 +90,17 @@ func (g *GetDomainSuggestionsCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	if g.Globals.Verbose() {
-		writeSearchVerbose(out, suggestions)
+		printSearchVerbose(out, suggestions)
 	} else {
-		writeSearchSummary(out, suggestions)
+		printSearchSummary(out, suggestions)
 	}
 
 	return nil
 }
 
-func writeSearchSummary(out io.Writer, suggestions *suggest.Suggestions) {
+// printSearchSummary displays the information returned from the API in a summarized
+// format.
+func printSearchSummary(out io.Writer, suggestions *suggest.Suggestions) {
 	t := text.NewTable(out)
 	t.AddHeader("Domain", "Subdomain", "Zone", "Path")
 	for _, suggestion := range suggestions.Results {
@@ -113,7 +114,9 @@ func writeSearchSummary(out io.Writer, suggestions *suggest.Suggestions) {
 	t.Print()
 }
 
-func writeSearchVerbose(out io.Writer, suggestions *suggest.Suggestions) {
+// printSearchVerbose displays the information returned from the API in a verbose
+// format.
+func printSearchVerbose(out io.Writer, suggestions *suggest.Suggestions) {
 	for _, suggestion := range suggestions.Results {
 		fmt.Fprintf(out, "Domain: %s\n", suggestion.Domain)
 		fmt.Fprintf(out, "Subdomain: %s\n", suggestion.Subdomain)

--- a/pkg/commands/domainv1/tools/suggest_test.go
+++ b/pkg/commands/domainv1/tools/suggest_test.go
@@ -1,0 +1,199 @@
+package tools_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	root "github.com/fastly/cli/pkg/commands/domainv1"
+	"github.com/fastly/cli/pkg/commands/domainv1/tools"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/suggest"
+)
+
+func TestNewDomainsV1ToolsSuggestCommand(t *testing.T) {
+	testSuggestions := suggest.Suggestions{
+		Results: []suggest.Suggestion{
+			{
+				Domain:    "domainrtest.ing",
+				Subdomain: "domainrtest.",
+				Zone:      "ing",
+			},
+			{
+				Domain:    "domainrtesti.ng",
+				Subdomain: "domainrtesti.",
+				Zone:      "ng",
+			},
+			{
+				Domain:    "domainrtesting.com",
+				Subdomain: "domainrtesting.",
+				Zone:      "com",
+			},
+			{
+				Domain:    "domainrtesting.net",
+				Subdomain: "domainrtesting.",
+				Zone:      "net",
+			},
+			{
+				Domain:    "domainrtest.in",
+				Subdomain: "domainrtest.",
+				Zone:      "in",
+				Path:      fastly.ToPointer("/g"),
+			},
+		},
+	}
+	scenarios := []testutil.CLIScenario{
+		{
+			Args:      "",
+			WantError: "error parsing arguments: required flag --query not provided",
+		},
+		{
+			Args: "--query `domainr testing`",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(testSuggestions))),
+					},
+				},
+			},
+			WantOutput: `Domain              Subdomain        Zone  Path
+domainrtest.ing     domainrtest.     ing   
+domainrtesti.ng     domainrtesti.    ng    
+domainrtesting.com  domainrtesting.  com   
+domainrtesting.net  domainrtesting.  net   
+domainrtest.in      domainrtest.     in    /g
+`,
+		},
+		{
+			Args: "--query foo --keywords=food,kitchen --defaults=club",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(suggest.Suggestions{
+							Results: []suggest.Suggestion{
+								{
+									Domain:    "foo.eat",
+									Subdomain: "foo.",
+									Zone:      "eat",
+								},
+								{
+									Domain:    "foo.cafe",
+									Subdomain: "foo.",
+									Zone:      "cafe",
+								},
+								{
+									Domain:    "foo.menu",
+									Subdomain: "foo.",
+									Zone:      "menu",
+								},
+								{
+									Domain:    "foo.kitchen",
+									Subdomain: "foo.",
+									Zone:      "kitchen",
+								},
+								{
+									Domain:    "foo.club",
+									Subdomain: "foo.",
+									Zone:      "club",
+								},
+							},
+						}))),
+					},
+				},
+			},
+			WantOutput: `Domain       Subdomain  Zone     Path
+foo.eat      foo.       eat      
+foo.cafe     foo.       cafe     
+foo.menu     foo.       menu     
+foo.kitchen  foo.       kitchen  
+foo.club     foo.       club     
+`,
+		},
+		{
+			Args: "-j --query `domainr testing`",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(testSuggestions))),
+					},
+				},
+			},
+			WantOutput: `{
+  "results": [
+    {
+      "domain": "domainrtest.ing",
+      "subdomain": "domainrtest.",
+      "zone": "ing"
+    },
+    {
+      "domain": "domainrtesti.ng",
+      "subdomain": "domainrtesti.",
+      "zone": "ng"
+    },
+    {
+      "domain": "domainrtesting.com",
+      "subdomain": "domainrtesting.",
+      "zone": "com"
+    },
+    {
+      "domain": "domainrtesting.net",
+      "subdomain": "domainrtesting.",
+      "zone": "net"
+    },
+    {
+      "domain": "domainrtest.in",
+      "subdomain": "domainrtest.",
+      "zone": "in",
+      "path": "/g"
+    }
+  ]
+}
+`,
+		},
+		{
+			Args: "-v --query `domainr testing`",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(testSuggestions))),
+					},
+				},
+			},
+			WantOutput: `Fastly API endpoint: https://api.fastly.com
+Fastly API token provided via config file (profile: user)
+
+Domain: domainrtest.ing
+Subdomain: domainrtest.
+Zone: ing
+
+Domain: domainrtesti.ng
+Subdomain: domainrtesti.
+Zone: ng
+
+Domain: domainrtesting.com
+Subdomain: domainrtesting.
+Zone: com
+
+Domain: domainrtesting.net
+Subdomain: domainrtesting.
+Zone: net
+
+Domain: domainrtest.in
+Subdomain: domainrtest.
+Zone: in
+Path: /g
+`,
+		},
+	}
+	testutil.RunCLIScenarios(t, []string{root.CommandName, tools.CommandName, "suggest"}, scenarios)
+}


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

This PR adds commands for the domain tools. Once a user has enabled Domain Discovery on their accounts, they should have access to the endpoints that enable this.

The commands make use of the `status` and `suggest` implementation which were added in https://github.com/fastly/go-fastly/pull/672.

The core changes:
* Add a root command for tools, which can be reused
* Add `suggest` and `status` subcommands under tools
* Tests for `suggest` and `status` subcommands 

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

* [ ] What is the user impact of this change?

Users that have enabled domain discovery on their accounts can use the `suggest` and `status` commands.

### Are there any considerations that need to be addressed for release?

No breaking changes