### PR TITLE
[CDTOOL-1085] fix(sso): Don't display the token after authentication.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat(tools/domain): add `suggest` and `status` domain tools endpoints ([#1482](https://github.com/fastly/cli/pull/1482))
 
 ### Bug fixes:
+- fix(sso): Don't display the token after authentication. ([#1490](https://github.com/fastly/cli/pull/1490))
 
 ### Dependencies:
 - build(deps): `github.com/fastly/go-fastly/v10` from 10.0.1 to 10.1.0 ([#1476](https://github.com/fastly/cli/pull/1476))

--- a/pkg/commands/sso/root.go
+++ b/pkg/commands/sso/root.go
@@ -198,7 +198,7 @@ func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	if c.InvokedFromProfileCreate || c.InvokedFromProfileUpdate || c.InvokedFromProfileSwitch {
 		textFn = text.Info
 	}
-	textFn(out, "Session token (persisted to your local configuration): %s", ar.SessionToken)
+	textFn(out, "Session token has been stored, use 'fastly profile token %s' to display it.", profileName)
 	return nil
 }
 

--- a/pkg/commands/sso/sso_test.go
+++ b/pkg/commands/sso/sso_test.go
@@ -97,7 +97,7 @@ func TestSSO(t *testing.T) {
 			WantOutputs: []string{
 				"We're going to authenticate the 'user' profile",
 				"We need to open your browser to authenticate you.",
-				"Session token (persisted to your local configuration): 123",
+				"Session token has been stored, use 'fastly profile token user' to display it.",
 			},
 			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
 				const expectedToken = "123"
@@ -137,7 +137,7 @@ func TestSSO(t *testing.T) {
 			WantOutputs: []string{
 				"We're going to authenticate the 'test_user' profile",
 				"We need to open your browser to authenticate you.",
-				"Session token (persisted to your local configuration): 123",
+				"Session token has been stored, use 'fastly profile token test_user' to display it.",
 			},
 			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
 				const expectedToken = "123"
@@ -280,7 +280,7 @@ func TestSSO(t *testing.T) {
 			WantOutputs: []string{
 				"Your access token has expired and so has your refresh token.",
 				"Starting a local server to handle the authentication flow.",
-				"Session token (persisted to your local configuration): 123",
+				"Session token has been stored, use 'fastly profile token user' to display it.",
 				"{Latitude:1 Longitude:2 X:3 Y:4}",
 			},
 			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {


### PR DESCRIPTION
The token should not be displayed except when the user specifically requests it; instead of displaying it automatically, tell the user which command they can run to display it if they need to.

New output:
```
kpfleming@kpfleming:~/src/fastly/cli$ ./fastly --profile testing sso
IMPORTANT: We're going to authenticate the 'testing' profile and make it the default. We need to open your browser to authenticate you.

Do you want to continue? [y/N]: y

INFO: Starting a local server to handle the authentication flow.

We're opening the following URL in your default web browser so you may authenticate with Fastly:
	https://accounts.fastly.com/realms/fastly/protocol/openid-connect/auth?REDACTED

SUCCESS: Session token has been stored, use 'fastly profile token testing' to display it.
```

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [X] Does your submission pass tests?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

* [ ] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->