### PR TITLE
fix(sso): Ensure that OPTIONS requests sent by browsers do not break SSO authentication.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 ### Enhancements:
 
 ### Bug fixes:
+- fix(sso): Ensure that OPTIONS requests sent by browsers do not break SSO authentication. ([#14XX](https://github.com/fastly/cli/pull/14XX))
 
 ### Dependencies:
 
 ## [v11.3.0](https://github.com/fastly/cli/releases/tag/v11.3.0) (2025-06-11)
 
 ### Enhancements:
-- feat(config-store): Allow for dynamic limits on Config Store entry lengths [#1485](https://github.com/fastly/cli/pull/1485)
+- feat(config-store): Allow for dynamic limits on Config Store entry lengths ([#1485](https://github.com/fastly/cli/pull/1485))
 - feat(backend): Add support for 'prefer IPv6' attribute. ([#1487](https://github.com/fastly/cli/pull/1487))
 - feat(tools/domain): add `suggest` and `status` domain tools endpoints ([#1482](https://github.com/fastly/cli/pull/1482))
 - feat(logging): Add support for 'processing region' attribute. ([#1491](https://github.com/fastly/cli/pull/1491))


### PR DESCRIPTION
Browsers may send 'preflight' OPTIONS requests before sending the GET request which contains the authentication result; the internal webserver will now accept this request, respond to it appropriately, and continue waiting for the GET request.

The webserver will also explicitly reject any requests that are not directed at the proper path, or are any method other than GET or OPTIONS.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### User Impact

* [ ] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->