### PR TITLE
Add the ability to show generated VCL for a service version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking:
 
 ### Enhancements:
+- feat(vcl): Allow showing of generated VCL for a service version [#1498](https://github.com/fastly/cli/pull/1498)
 
 ### Bug fixes:
 

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -239,6 +239,8 @@ type Interface interface {
 
 	CreateManagedLogging(*fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
 
+	GetGeneratedVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
+
 	CreateVCL(*fastly.CreateVCLInput) (*fastly.VCL, error)
 	ListVCLs(*fastly.ListVCLsInput) ([]*fastly.VCL, error)
 	GetVCL(*fastly.GetVCLInput) (*fastly.VCL, error)

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -500,6 +500,7 @@ func Define( // nolint:revive // function-length
 	userList := user.NewListCommand(userCmdRoot.CmdClause, data)
 	userUpdate := user.NewUpdateCommand(userCmdRoot.CmdClause, data)
 	vclCmdRoot := vcl.NewRootCommand(app, data)
+	vclDescribe := vcl.NewDescribeCommand(vclCmdRoot.CmdClause, data)
 	vclConditionCmdRoot := condition.NewRootCommand(vclCmdRoot.CmdClause, data)
 	vclConditionCreate := condition.NewCreateCommand(vclConditionCmdRoot.CmdClause, data)
 	vclConditionDelete := condition.NewDeleteCommand(vclConditionCmdRoot.CmdClause, data)
@@ -913,6 +914,7 @@ func Define( // nolint:revive // function-length
 		userList,
 		userUpdate,
 		vclCmdRoot,
+		vclDescribe,
 		vclConditionCmdRoot,
 		vclConditionCreate,
 		vclConditionDelete,

--- a/pkg/commands/vcl/describe.go
+++ b/pkg/commands/vcl/describe.go
@@ -1,0 +1,142 @@
+package vcl
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/go-fastly/v10/fastly"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+)
+
+// NewDescribeCommand returns a usable command registered under the parent.
+func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCommand {
+	c := DescribeCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+	c.CmdClause = parent.Command("describe", "Get the generated VCL for a particular service and version").Alias("get")
+
+	// Required.
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagVersionName,
+		Description: argparser.FlagVersionDesc,
+		Dst:         &c.serviceVersion.Value,
+		Required:    true,
+	})
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag()) // --json
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagServiceIDName,
+		Description: argparser.FlagServiceIDDesc,
+		Dst:         &g.Manifest.Flag.ServiceID,
+		Short:       's',
+	})
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Action:      c.serviceName.Set,
+		Name:        argparser.FlagServiceName,
+		Description: argparser.FlagServiceNameDesc,
+		Dst:         &c.serviceName.Value,
+	})
+
+	return &c
+}
+
+// DescribeCommand calls the Fastly API to list appropriate resources.
+type DescribeCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	serviceName    argparser.OptionalServiceNameID
+	serviceVersion argparser.OptionalServiceVersion
+}
+
+// Exec invokes the application logic for the command.
+func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	serviceID, serviceVersion, err := argparser.ServiceDetails(argparser.ServiceDetailsOpts{
+		APIClient:          c.Globals.APIClient,
+		Manifest:           *c.Globals.Manifest,
+		Out:                out,
+		ServiceNameFlag:    c.serviceName,
+		ServiceVersionFlag: c.serviceVersion,
+		VerboseMode:        c.Globals.Flags.Verbose,
+	})
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": fsterr.ServiceVersion(serviceVersion),
+		})
+		return err
+	}
+
+	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
+
+	o, err := c.Globals.APIClient.GetGeneratedVCL(input)
+	if err != nil {
+		c.Globals.ErrLog.AddWithContext(err, map[string]any{
+			"Service ID":      serviceID,
+			"Service Version": fastly.ToValue(serviceVersion.Number),
+		})
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, o); ok {
+		return err
+	}
+
+	if c.Globals.Verbose() {
+		c.printVerbose(out, fastly.ToValue(serviceVersion.Number), o)
+	} else {
+		err = c.print(out, o)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// constructInput transforms values parsed from CLI flags into an object to be used by the API client library.
+func (c *DescribeCommand) constructInput(serviceID string, serviceVersion int) *fastly.GetGeneratedVCLInput {
+	var input fastly.GetGeneratedVCLInput
+
+	input.ServiceID = serviceID
+	input.ServiceVersion = serviceVersion
+
+	return &input
+}
+
+// printVerbose displays the information returned from the API in a verbose
+// format.
+func (c *DescribeCommand) printVerbose(out io.Writer, serviceVersion int, v *fastly.VCL) {
+	fmt.Fprintf(out, "Service Version: %d\n", serviceVersion)
+
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "Name: %s\n", fastly.ToValue(v.Name))
+	fmt.Fprintf(out, "Main: %t\n", fastly.ToValue(v.Main))
+
+	if v.CreatedAt != nil {
+		fmt.Fprintf(out, "Created at: %s\n", v.CreatedAt)
+	}
+	if v.UpdatedAt != nil {
+		fmt.Fprintf(out, "Updated at: %s\n", v.UpdatedAt)
+	}
+	if v.DeletedAt != nil {
+		fmt.Fprintf(out, "Deleted at: %s\n", v.DeletedAt)
+	}
+
+	fmt.Fprintf(out, "Content: \n%s\n", fastly.ToValue(v.Content))
+}
+
+// print the generated VCL.
+func (c *DescribeCommand) print(out io.Writer, v *fastly.VCL) error {
+	fmt.Fprintf(out, "%s\n", fastly.ToValue(v.Content))
+	return nil
+}

--- a/pkg/commands/vcl/vcl_test.go
+++ b/pkg/commands/vcl/vcl_test.go
@@ -1,0 +1,71 @@
+package vcl_test
+
+import (
+	"testing"
+
+	"github.com/fastly/go-fastly/v10/fastly"
+
+	root "github.com/fastly/cli/pkg/commands/vcl"
+	"github.com/fastly/cli/pkg/mock"
+	"github.com/fastly/cli/pkg/testutil"
+)
+
+func TestVCLDescribe(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --version flag",
+			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:      "validate missing --service-id flag",
+			Args:      "--version 3",
+			WantError: "error reading service: no service ID found",
+		},
+		{
+			Name: "validate DescribeVCL API error",
+			API: mock.API{
+				ListVersionsFn: testutil.ListVersions,
+				GetGeneratedVCLFn: func(_ *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+					return nil, testutil.Err
+				},
+			},
+			Args:      "--service-id 123 --version 3",
+			WantError: testutil.Err.Error(),
+		},
+		{
+			Name: "validate DescribeVCL API success",
+			API: mock.API{
+				ListVersionsFn:    testutil.ListVersions,
+				GetGeneratedVCLFn: getVCL,
+			},
+			Args:       "--service-id 123 --version 3",
+			WantOutput: "# some vcl content\n",
+		},
+		{
+			Name: "validate missing --verbose flag",
+			API: mock.API{
+				ListVersionsFn:    testutil.ListVersions,
+				GetGeneratedVCLFn: getVCL,
+			},
+			Args:       "--service-id 123 --verbose --version 1",
+			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (profile: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nMain: false\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nContent: \n# some vcl content\n",
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
+}
+
+func getVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+	t := testutil.Date
+
+	return &fastly.VCL{
+		Content:        fastly.ToPointer("# some vcl content"),
+		Main:           fastly.ToPointer(false),
+		Name:           fastly.ToPointer("foo"),
+		ServiceID:      fastly.ToPointer(i.ServiceID),
+		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+		CreatedAt:      &t,
+		DeletedAt:      &t,
+		UpdatedAt:      &t,
+	}, nil
+}

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -231,6 +231,8 @@ type API struct {
 
 	CreateManagedLoggingFn func(*fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
 
+	GetGeneratedVCLFn func(*fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
+
 	CreateVCLFn func(*fastly.CreateVCLInput) (*fastly.VCL, error)
 	ListVCLsFn  func(*fastly.ListVCLsInput) ([]*fastly.VCL, error)
 	GetVCLFn    func(*fastly.GetVCLInput) (*fastly.VCL, error)
@@ -1319,6 +1321,11 @@ func (m API) GetStatsJSON(i *fastly.GetStatsInput, dst any) error {
 // CreateManagedLogging implements Interface.
 func (m API) CreateManagedLogging(i *fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error) {
 	return m.CreateManagedLoggingFn(i)
+}
+
+// GetGeneratedVCL implements Interface.
+func (m API) GetGeneratedVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+	return m.GetGeneratedVCLFn(i)
 }
 
 // CreateVCL implements Interface.


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

* [x] What is the user impact of this change? - _Adds a new command to show the generated VCL for a service-version_



### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->