### PR TITLE
docs: improve object-storage access-keys create flag docs

### DIFF
--- a/pkg/commands/objectstorage/accesskeys/create.go
+++ b/pkg/commands/objectstorage/accesskeys/create.go
@@ -38,10 +38,10 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 	// Required.
 	c.CmdClause.Flag("description", "Description of the access key").Required().StringVar(&c.description)
-	c.CmdClause.Flag("permission", "Permissions to be given to the access key").Required().StringVar(&c.permission)
+	c.CmdClause.Flag("permission", "Permissions to be given to the access key (read-write-admin, read-only-admin, read-write-objects, read-only-objects)").Required().StringVar(&c.permission)
 
 	// Optional.
-	c.CmdClause.Flag("bucket", "Bucket to be associated with the access key. Set flag multiple times to include multiple buckets").StringsVar(&c.buckets)
+	c.CmdClause.Flag("bucket", "Bucket to be associated with the access key. Set flag multiple times to include multiple buckets. If omitted, all buckets are associated").StringsVar(&c.buckets)
 	c.RegisterFlagBool(c.JSONFlag())
 
 	return &c


### PR DESCRIPTION
Specify the valid permissions (read-write-admin, read-only-admin,
read-write-objects, read-only-objects) and note that if you don't
provide the `--bucket` flag, all buckets are accessible by the key.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### User Impact

* [x] What is the user impact of this change?

Better help output.
