### PR TITLE
feat(object-storage): improve access-keys list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements:
 - feat(vcl): Allow showing of generated VCL for a service version [#1498](https://github.com/fastly/cli/pull/1498)
 - Add experimental "enable Pushpin" mode ([#1509](https://github.com/fastly/cli/pull/1509))
+- feat(object-storage): improve access-keys list output ([#1513](https://github.com/fastly/cli/pull/1513))
 
 ### Bug fixes:
 

--- a/pkg/commands/objectstorage/accesskeys/accesskeys_test.go
+++ b/pkg/commands/objectstorage/accesskeys/accesskeys_test.go
@@ -223,6 +223,7 @@ func TestAccessKeysList(t *testing.T) {
 				SecretKey:   "baz",
 				Description: "bizz",
 				Permission:  akPermission,
+				Buckets:     []string{"b1", "b2"},
 			},
 		},
 		Meta: accesskeys.MetaAccessKeys{},
@@ -303,8 +304,8 @@ Created (UTC): 2021-06-15 23:00
 
 var listAccessKeysString = strings.TrimSpace(`
 ID      Secret  Description  Permssion          Buckets  Created At
-foo     bar     bat          read-only-objects  []       0001-01-01 00:00:00 +0000 UTC
-foobar  baz     bizz         read-only-objects  []       0001-01-01 00:00:00 +0000 UTC
+foo     bar     bat          read-only-objects  all      0001-01-01 00:00:00 +0000 UTC
+foobar  baz     bizz         read-only-objects  [b1 b2]  0001-01-01 00:00:00 +0000 UTC
 `) + "\n"
 
 var zeroListAccessKeysString = strings.TrimSpace(`

--- a/pkg/commands/objectstorage/accesskeys/list.go
+++ b/pkg/commands/objectstorage/accesskeys/list.go
@@ -26,7 +26,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 		},
 	}
 
-	c.CmdClause = parent.Command("list-access-keys", "List all access keys")
+	c.CmdClause = parent.Command("list", "List all access keys").Alias("list-access-keys")
 
 	// Optional.
 	c.RegisterFlagBool(c.JSONFlag())

--- a/pkg/text/accesskey.go
+++ b/pkg/text/accesskey.go
@@ -31,7 +31,15 @@ func PrintAccessKeyTbl(out io.Writer, accessKeys []accesskeys.AccessKey) {
 	for _, accessKey := range accessKeys {
 		// avoid gosec loop aliasing check :/
 		accessKey := accessKey
-		tbl.AddLine(accessKey.AccessKeyID, accessKey.SecretKey, accessKey.Description, accessKey.Permission, accessKey.Buckets, accessKey.CreatedAt)
+		var buckets string
+		if len(accessKey.Buckets) == 0 {
+			// No limitations on buckets
+			buckets = "all"
+		} else {
+			buckets = fmt.Sprintf("%v", accessKey.Buckets)
+		}
+
+		tbl.AddLine(accessKey.AccessKeyID, accessKey.SecretKey, accessKey.Description, accessKey.Permission, buckets, accessKey.CreatedAt)
 	}
 	tbl.Print()
 }


### PR DESCRIPTION
First, rename the `list-access-keys` command to just `list` (while
maintaining an alias for compatibility) to match convention and
eliminate stuttering.

If there are no bucket limitations, print "all" instead of "[]",
which could be misleading.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
