### PR TITLE
Upgrade to go-fastly version 11.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes:
 
 ### Dependencies:
+- build(deps): `github.com/fastly/go-fastly/v11` from 10 to 111 ([#14XX](https://github.com/fastly/cli/pull/14XX))
 - build(deps): `golang.org/x/sys` from 0.33.0 to 0.34.0 ([#1508](https://github.com/fastly/cli/pull/1508))
 - build(deps): `golang.org/x/term` from 0.32.0 to 0.33.0 ([#1508](https://github.com/fastly/cli/pull/1508))
 - build(deps): `golang.org/x/crypto` from 0.39.0 to 0.40.0 ([#1508](https://github.com/fastly/cli/pull/1508))

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v10 v10.5.1
+	github.com/fastly/go-fastly/v11 v11.2.0
 	github.com/hashicorp/cap v0.9.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/otiai10/copy v1.14.1
@@ -43,7 +43,6 @@ require (
 	github.com/dnaeon/go-vcr v1.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
-	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
@@ -81,4 +80,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-require 4d63.com/optional v0.2.0
+require (
+	4d63.com/optional v0.2.0
+	github.com/mitchellh/go-ps v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:aYo8nnk3ojoQkP5iErif5Xxv0Mo0Ga/FR5+ffl/7+Nk=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v10 v10.5.1 h1:mKtR8DQM0yt58J44pzUAoQlsxUFKK07V/Ui3KcuzOCQ=
-github.com/fastly/go-fastly/v10 v10.5.1/go.mod h1:GXFNVyufNV0E/0JdG932WE8YGYSL5/ar+sPnlhqprhQ=
+github.com/fastly/go-fastly/v11 v11.2.0 h1:4gFhs6dZ0HzNGpZ6XiCi1dwESCMD4je3+OENIcD7wJk=
+github.com/fastly/go-fastly/v11 v11.2.0/go.mod h1:yv1Tvz457kNCxyNaPi3J8Z3xUxeU8m1XN7O4a8OFLgc=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -1,10 +1,11 @@
 package api
 
 import (
+	"context"
 	"crypto/ed25519"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // HTTPClient models a concrete http.Client. It's a consumer contract for some
@@ -18,407 +19,403 @@ type HTTPClient interface {
 // Interface models the methods of the Fastly API client that we use.
 // It exists to allow for easier testing, in combination with Mock.
 type Interface interface {
-	AllIPs() (v4, v6 fastly.IPAddrs, err error)
-	AllDatacenters() (datacenters []fastly.Datacenter, err error)
-
-	CreateService(*fastly.CreateServiceInput) (*fastly.Service, error)
-	GetServices(*fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service]
-	ListServices(*fastly.ListServicesInput) ([]*fastly.Service, error)
-	GetService(*fastly.GetServiceInput) (*fastly.Service, error)
-	GetServiceDetails(*fastly.GetServiceInput) (*fastly.ServiceDetail, error)
-	UpdateService(*fastly.UpdateServiceInput) (*fastly.Service, error)
-	DeleteService(*fastly.DeleteServiceInput) error
-	SearchService(*fastly.SearchServiceInput) (*fastly.Service, error)
-
-	CloneVersion(*fastly.CloneVersionInput) (*fastly.Version, error)
-	ListVersions(*fastly.ListVersionsInput) ([]*fastly.Version, error)
-	GetVersion(*fastly.GetVersionInput) (*fastly.Version, error)
-	UpdateVersion(*fastly.UpdateVersionInput) (*fastly.Version, error)
-	ActivateVersion(*fastly.ActivateVersionInput) (*fastly.Version, error)
-	DeactivateVersion(*fastly.DeactivateVersionInput) (*fastly.Version, error)
-	LockVersion(*fastly.LockVersionInput) (*fastly.Version, error)
-	LatestVersion(*fastly.LatestVersionInput) (*fastly.Version, error)
-
-	CreateDomain(*fastly.CreateDomainInput) (*fastly.Domain, error)
-	ListDomains(*fastly.ListDomainsInput) ([]*fastly.Domain, error)
-	GetDomain(*fastly.GetDomainInput) (*fastly.Domain, error)
-	UpdateDomain(*fastly.UpdateDomainInput) (*fastly.Domain, error)
-	DeleteDomain(*fastly.DeleteDomainInput) error
-	ValidateDomain(i *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error)
-	ValidateAllDomains(i *fastly.ValidateAllDomainsInput) (results []*fastly.DomainValidationResult, err error)
-
-	CreateBackend(*fastly.CreateBackendInput) (*fastly.Backend, error)
-	ListBackends(*fastly.ListBackendsInput) ([]*fastly.Backend, error)
-	GetBackend(*fastly.GetBackendInput) (*fastly.Backend, error)
-	UpdateBackend(*fastly.UpdateBackendInput) (*fastly.Backend, error)
-	DeleteBackend(*fastly.DeleteBackendInput) error
-
-	CreateHealthCheck(*fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error)
-	ListHealthChecks(*fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error)
-	GetHealthCheck(*fastly.GetHealthCheckInput) (*fastly.HealthCheck, error)
-	UpdateHealthCheck(*fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
-	DeleteHealthCheck(*fastly.DeleteHealthCheckInput) error
-
-	GetPackage(*fastly.GetPackageInput) (*fastly.Package, error)
-	UpdatePackage(*fastly.UpdatePackageInput) (*fastly.Package, error)
-
-	CreateDictionary(*fastly.CreateDictionaryInput) (*fastly.Dictionary, error)
-	GetDictionary(*fastly.GetDictionaryInput) (*fastly.Dictionary, error)
-	DeleteDictionary(*fastly.DeleteDictionaryInput) error
-	ListDictionaries(*fastly.ListDictionariesInput) ([]*fastly.Dictionary, error)
-	UpdateDictionary(*fastly.UpdateDictionaryInput) (*fastly.Dictionary, error)
-
-	GetDictionaryItems(*fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem]
-	ListDictionaryItems(*fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error)
-	GetDictionaryItem(*fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error)
-	CreateDictionaryItem(*fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error)
-	UpdateDictionaryItem(*fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error)
-	DeleteDictionaryItem(*fastly.DeleteDictionaryItemInput) error
-	BatchModifyDictionaryItems(*fastly.BatchModifyDictionaryItemsInput) error
-
-	GetDictionaryInfo(*fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error)
-
-	CreateBigQuery(*fastly.CreateBigQueryInput) (*fastly.BigQuery, error)
-	ListBigQueries(*fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error)
-	GetBigQuery(*fastly.GetBigQueryInput) (*fastly.BigQuery, error)
-	UpdateBigQuery(*fastly.UpdateBigQueryInput) (*fastly.BigQuery, error)
-	DeleteBigQuery(*fastly.DeleteBigQueryInput) error
-
-	CreateS3(*fastly.CreateS3Input) (*fastly.S3, error)
-	ListS3s(*fastly.ListS3sInput) ([]*fastly.S3, error)
-	GetS3(*fastly.GetS3Input) (*fastly.S3, error)
-	UpdateS3(*fastly.UpdateS3Input) (*fastly.S3, error)
-	DeleteS3(*fastly.DeleteS3Input) error
-
-	CreateKinesis(*fastly.CreateKinesisInput) (*fastly.Kinesis, error)
-	ListKinesis(*fastly.ListKinesisInput) ([]*fastly.Kinesis, error)
-	GetKinesis(*fastly.GetKinesisInput) (*fastly.Kinesis, error)
-	UpdateKinesis(*fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
-	DeleteKinesis(*fastly.DeleteKinesisInput) error
-
-	CreateSyslog(*fastly.CreateSyslogInput) (*fastly.Syslog, error)
-	ListSyslogs(*fastly.ListSyslogsInput) ([]*fastly.Syslog, error)
-	GetSyslog(*fastly.GetSyslogInput) (*fastly.Syslog, error)
-	UpdateSyslog(*fastly.UpdateSyslogInput) (*fastly.Syslog, error)
-	DeleteSyslog(*fastly.DeleteSyslogInput) error
-
-	CreateLogentries(*fastly.CreateLogentriesInput) (*fastly.Logentries, error)
-	ListLogentries(*fastly.ListLogentriesInput) ([]*fastly.Logentries, error)
-	GetLogentries(*fastly.GetLogentriesInput) (*fastly.Logentries, error)
-	UpdateLogentries(*fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
-	DeleteLogentries(*fastly.DeleteLogentriesInput) error
-
-	CreatePapertrail(*fastly.CreatePapertrailInput) (*fastly.Papertrail, error)
-	ListPapertrails(*fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error)
-	GetPapertrail(*fastly.GetPapertrailInput) (*fastly.Papertrail, error)
-	UpdatePapertrail(*fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
-	DeletePapertrail(*fastly.DeletePapertrailInput) error
-
-	CreateSumologic(*fastly.CreateSumologicInput) (*fastly.Sumologic, error)
-	ListSumologics(*fastly.ListSumologicsInput) ([]*fastly.Sumologic, error)
-	GetSumologic(*fastly.GetSumologicInput) (*fastly.Sumologic, error)
-	UpdateSumologic(*fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
-	DeleteSumologic(*fastly.DeleteSumologicInput) error
-
-	CreateGCS(*fastly.CreateGCSInput) (*fastly.GCS, error)
-	ListGCSs(*fastly.ListGCSsInput) ([]*fastly.GCS, error)
-	GetGCS(*fastly.GetGCSInput) (*fastly.GCS, error)
-	UpdateGCS(*fastly.UpdateGCSInput) (*fastly.GCS, error)
-	DeleteGCS(*fastly.DeleteGCSInput) error
-
-	CreateGrafanaCloudLogs(*fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
-	ListGrafanaCloudLogs(*fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error)
-	GetGrafanaCloudLogs(*fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
-	UpdateGrafanaCloudLogs(*fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
-	DeleteGrafanaCloudLogs(*fastly.DeleteGrafanaCloudLogsInput) error
-
-	CreateFTP(*fastly.CreateFTPInput) (*fastly.FTP, error)
-	ListFTPs(*fastly.ListFTPsInput) ([]*fastly.FTP, error)
-	GetFTP(*fastly.GetFTPInput) (*fastly.FTP, error)
-	UpdateFTP(*fastly.UpdateFTPInput) (*fastly.FTP, error)
-	DeleteFTP(*fastly.DeleteFTPInput) error
-
-	CreateSplunk(*fastly.CreateSplunkInput) (*fastly.Splunk, error)
-	ListSplunks(*fastly.ListSplunksInput) ([]*fastly.Splunk, error)
-	GetSplunk(*fastly.GetSplunkInput) (*fastly.Splunk, error)
-	UpdateSplunk(*fastly.UpdateSplunkInput) (*fastly.Splunk, error)
-	DeleteSplunk(*fastly.DeleteSplunkInput) error
-
-	CreateScalyr(*fastly.CreateScalyrInput) (*fastly.Scalyr, error)
-	ListScalyrs(*fastly.ListScalyrsInput) ([]*fastly.Scalyr, error)
-	GetScalyr(*fastly.GetScalyrInput) (*fastly.Scalyr, error)
-	UpdateScalyr(*fastly.UpdateScalyrInput) (*fastly.Scalyr, error)
-	DeleteScalyr(*fastly.DeleteScalyrInput) error
-
-	CreateLoggly(*fastly.CreateLogglyInput) (*fastly.Loggly, error)
-	ListLoggly(*fastly.ListLogglyInput) ([]*fastly.Loggly, error)
-	GetLoggly(*fastly.GetLogglyInput) (*fastly.Loggly, error)
-	UpdateLoggly(*fastly.UpdateLogglyInput) (*fastly.Loggly, error)
-	DeleteLoggly(*fastly.DeleteLogglyInput) error
-
-	CreateHoneycomb(*fastly.CreateHoneycombInput) (*fastly.Honeycomb, error)
-	ListHoneycombs(*fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error)
-	GetHoneycomb(*fastly.GetHoneycombInput) (*fastly.Honeycomb, error)
-	UpdateHoneycomb(*fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error)
-	DeleteHoneycomb(*fastly.DeleteHoneycombInput) error
-
-	CreateHeroku(*fastly.CreateHerokuInput) (*fastly.Heroku, error)
-	ListHerokus(*fastly.ListHerokusInput) ([]*fastly.Heroku, error)
-	GetHeroku(*fastly.GetHerokuInput) (*fastly.Heroku, error)
-	UpdateHeroku(*fastly.UpdateHerokuInput) (*fastly.Heroku, error)
-	DeleteHeroku(*fastly.DeleteHerokuInput) error
-
-	CreateSFTP(*fastly.CreateSFTPInput) (*fastly.SFTP, error)
-	ListSFTPs(*fastly.ListSFTPsInput) ([]*fastly.SFTP, error)
-	GetSFTP(*fastly.GetSFTPInput) (*fastly.SFTP, error)
-	UpdateSFTP(*fastly.UpdateSFTPInput) (*fastly.SFTP, error)
-	DeleteSFTP(*fastly.DeleteSFTPInput) error
-
-	CreateLogshuttle(*fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error)
-	ListLogshuttles(*fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error)
-	GetLogshuttle(*fastly.GetLogshuttleInput) (*fastly.Logshuttle, error)
-	UpdateLogshuttle(*fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
-	DeleteLogshuttle(*fastly.DeleteLogshuttleInput) error
-
-	CreateCloudfiles(*fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error)
-	ListCloudfiles(*fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error)
-	GetCloudfiles(*fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error)
-	UpdateCloudfiles(*fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error)
-	DeleteCloudfiles(*fastly.DeleteCloudfilesInput) error
-
-	CreateDigitalOcean(*fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error)
-	ListDigitalOceans(*fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error)
-	GetDigitalOcean(*fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error)
-	UpdateDigitalOcean(*fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error)
-	DeleteDigitalOcean(*fastly.DeleteDigitalOceanInput) error
-
-	CreateElasticsearch(*fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error)
-	ListElasticsearch(*fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error)
-	GetElasticsearch(*fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error)
-	UpdateElasticsearch(*fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error)
-	DeleteElasticsearch(*fastly.DeleteElasticsearchInput) error
-
-	CreateBlobStorage(*fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error)
-	ListBlobStorages(*fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error)
-	GetBlobStorage(*fastly.GetBlobStorageInput) (*fastly.BlobStorage, error)
-	UpdateBlobStorage(*fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error)
-	DeleteBlobStorage(*fastly.DeleteBlobStorageInput) error
-
-	CreateDatadog(*fastly.CreateDatadogInput) (*fastly.Datadog, error)
-	ListDatadog(*fastly.ListDatadogInput) ([]*fastly.Datadog, error)
-	GetDatadog(*fastly.GetDatadogInput) (*fastly.Datadog, error)
-	UpdateDatadog(*fastly.UpdateDatadogInput) (*fastly.Datadog, error)
-	DeleteDatadog(*fastly.DeleteDatadogInput) error
-
-	CreateHTTPS(*fastly.CreateHTTPSInput) (*fastly.HTTPS, error)
-	ListHTTPS(*fastly.ListHTTPSInput) ([]*fastly.HTTPS, error)
-	GetHTTPS(*fastly.GetHTTPSInput) (*fastly.HTTPS, error)
-	UpdateHTTPS(*fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
-	DeleteHTTPS(*fastly.DeleteHTTPSInput) error
-
-	CreateKafka(*fastly.CreateKafkaInput) (*fastly.Kafka, error)
-	ListKafkas(*fastly.ListKafkasInput) ([]*fastly.Kafka, error)
-	GetKafka(*fastly.GetKafkaInput) (*fastly.Kafka, error)
-	UpdateKafka(*fastly.UpdateKafkaInput) (*fastly.Kafka, error)
-	DeleteKafka(*fastly.DeleteKafkaInput) error
-
-	CreatePubsub(*fastly.CreatePubsubInput) (*fastly.Pubsub, error)
-	ListPubsubs(*fastly.ListPubsubsInput) ([]*fastly.Pubsub, error)
-	GetPubsub(*fastly.GetPubsubInput) (*fastly.Pubsub, error)
-	UpdatePubsub(*fastly.UpdatePubsubInput) (*fastly.Pubsub, error)
-	DeletePubsub(*fastly.DeletePubsubInput) error
-
-	CreateOpenstack(*fastly.CreateOpenstackInput) (*fastly.Openstack, error)
-	ListOpenstack(*fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
-	GetOpenstack(*fastly.GetOpenstackInput) (*fastly.Openstack, error)
-	UpdateOpenstack(*fastly.UpdateOpenstackInput) (*fastly.Openstack, error)
-	DeleteOpenstack(*fastly.DeleteOpenstackInput) error
-
-	GetRegions() (*fastly.RegionsResponse, error)
-	GetStatsJSON(*fastly.GetStatsInput, any) error
-
-	CreateManagedLogging(*fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
-
-	GetGeneratedVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
-
-	CreateVCL(*fastly.CreateVCLInput) (*fastly.VCL, error)
-	ListVCLs(*fastly.ListVCLsInput) ([]*fastly.VCL, error)
-	GetVCL(*fastly.GetVCLInput) (*fastly.VCL, error)
-	UpdateVCL(*fastly.UpdateVCLInput) (*fastly.VCL, error)
-	DeleteVCL(*fastly.DeleteVCLInput) error
-
-	CreateSnippet(i *fastly.CreateSnippetInput) (*fastly.Snippet, error)
-	ListSnippets(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error)
-	GetSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error)
-	GetDynamicSnippet(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error)
-	UpdateSnippet(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error)
-	UpdateDynamicSnippet(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error)
-	DeleteSnippet(i *fastly.DeleteSnippetInput) error
-
-	Purge(i *fastly.PurgeInput) (*fastly.Purge, error)
-	PurgeKey(i *fastly.PurgeKeyInput) (*fastly.Purge, error)
-	PurgeKeys(i *fastly.PurgeKeysInput) (map[string]string, error)
-	PurgeAll(i *fastly.PurgeAllInput) (*fastly.Purge, error)
-
-	CreateACL(i *fastly.CreateACLInput) (*fastly.ACL, error)
-	DeleteACL(i *fastly.DeleteACLInput) error
-	GetACL(i *fastly.GetACLInput) (*fastly.ACL, error)
-	ListACLs(i *fastly.ListACLsInput) ([]*fastly.ACL, error)
-	UpdateACL(i *fastly.UpdateACLInput) (*fastly.ACL, error)
-
-	CreateACLEntry(i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error)
-	DeleteACLEntry(i *fastly.DeleteACLEntryInput) error
-	GetACLEntry(i *fastly.GetACLEntryInput) (*fastly.ACLEntry, error)
-	GetACLEntries(*fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry]
-	ListACLEntries(i *fastly.ListACLEntriesInput) ([]*fastly.ACLEntry, error)
-	UpdateACLEntry(i *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error)
-	BatchModifyACLEntries(i *fastly.BatchModifyACLEntriesInput) error
-
-	CreateNewRelic(i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error)
-	DeleteNewRelic(i *fastly.DeleteNewRelicInput) error
-	GetNewRelic(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error)
-	ListNewRelic(i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error)
-	UpdateNewRelic(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error)
-
-	CreateNewRelicOTLP(i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
-	DeleteNewRelicOTLP(i *fastly.DeleteNewRelicOTLPInput) error
-	GetNewRelicOTLP(i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
-	ListNewRelicOTLP(i *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error)
-	UpdateNewRelicOTLP(i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
-
-	CreateUser(i *fastly.CreateUserInput) (*fastly.User, error)
-	DeleteUser(i *fastly.DeleteUserInput) error
-	GetCurrentUser() (*fastly.User, error)
-	GetUser(i *fastly.GetUserInput) (*fastly.User, error)
-	ListCustomerUsers(i *fastly.ListCustomerUsersInput) ([]*fastly.User, error)
-	UpdateUser(i *fastly.UpdateUserInput) (*fastly.User, error)
-	ResetUserPassword(i *fastly.ResetUserPasswordInput) error
-
-	BatchDeleteTokens(i *fastly.BatchDeleteTokensInput) error
-	CreateToken(i *fastly.CreateTokenInput) (*fastly.Token, error)
-	DeleteToken(i *fastly.DeleteTokenInput) error
-	DeleteTokenSelf() error
-	GetTokenSelf() (*fastly.Token, error)
-	ListCustomerTokens(i *fastly.ListCustomerTokensInput) ([]*fastly.Token, error)
-	ListTokens(i *fastly.ListTokensInput) ([]*fastly.Token, error)
-
-	NewListKVStoreKeysPaginator(i *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries
-
-	GetCustomTLSConfiguration(i *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
-	ListCustomTLSConfigurations(i *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error)
-	UpdateCustomTLSConfiguration(i *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
-	GetTLSActivation(i *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error)
-	ListTLSActivations(i *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error)
-	UpdateTLSActivation(i *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error)
-	CreateTLSActivation(i *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error)
-	DeleteTLSActivation(i *fastly.DeleteTLSActivationInput) error
-
-	CreateCustomTLSCertificate(i *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
-	DeleteCustomTLSCertificate(i *fastly.DeleteCustomTLSCertificateInput) error
-	GetCustomTLSCertificate(i *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
-	ListCustomTLSCertificates(i *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error)
-	UpdateCustomTLSCertificate(i *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
-
-	ListTLSDomains(i *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error)
-
-	CreatePrivateKey(i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error)
-	DeletePrivateKey(i *fastly.DeletePrivateKeyInput) error
-	GetPrivateKey(i *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error)
-	ListPrivateKeys(i *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error)
-
-	CreateBulkCertificate(i *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error)
-	DeleteBulkCertificate(i *fastly.DeleteBulkCertificateInput) error
-	GetBulkCertificate(i *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error)
-	ListBulkCertificates(i *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error)
-	UpdateBulkCertificate(i *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error)
-
-	CreateTLSSubscription(i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
-	DeleteTLSSubscription(i *fastly.DeleteTLSSubscriptionInput) error
-	GetTLSSubscription(i *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error)
-	ListTLSSubscriptions(i *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error)
-	UpdateTLSSubscription(i *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
-
-	ListServiceAuthorizations(i *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error)
-	GetServiceAuthorization(i *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
-	CreateServiceAuthorization(i *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
-	UpdateServiceAuthorization(i *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
-	DeleteServiceAuthorization(i *fastly.DeleteServiceAuthorizationInput) error
-
-	CreateConfigStore(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error)
-	DeleteConfigStore(i *fastly.DeleteConfigStoreInput) error
-	GetConfigStore(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error)
-	GetConfigStoreMetadata(i *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error)
-	ListConfigStores(i *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error)
-	ListConfigStoreServices(i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error)
-	UpdateConfigStore(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error)
-
-	CreateConfigStoreItem(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
-	DeleteConfigStoreItem(i *fastly.DeleteConfigStoreItemInput) error
-	GetConfigStoreItem(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
-	ListConfigStoreItems(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error)
-	UpdateConfigStoreItem(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
-
-	CreateKVStore(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error)
-	ListKVStores(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error)
-	DeleteKVStore(i *fastly.DeleteKVStoreInput) error
-	GetKVStore(i *fastly.GetKVStoreInput) (*fastly.KVStore, error)
-	ListKVStoreKeys(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error)
-	GetKVStoreKey(i *fastly.GetKVStoreKeyInput) (string, error)
-	DeleteKVStoreKey(i *fastly.DeleteKVStoreKeyInput) error
-	InsertKVStoreKey(i *fastly.InsertKVStoreKeyInput) error
-	BatchModifyKVStoreKey(i *fastly.BatchModifyKVStoreKeyInput) error
-
-	CreateSecretStore(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error)
-	GetSecretStore(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error)
-	DeleteSecretStore(i *fastly.DeleteSecretStoreInput) error
-	ListSecretStores(i *fastly.ListSecretStoresInput) (*fastly.SecretStores, error)
-	CreateSecret(i *fastly.CreateSecretInput) (*fastly.Secret, error)
-	GetSecret(i *fastly.GetSecretInput) (*fastly.Secret, error)
-	DeleteSecret(i *fastly.DeleteSecretInput) error
-	ListSecrets(i *fastly.ListSecretsInput) (*fastly.Secrets, error)
-	CreateClientKey() (*fastly.ClientKey, error)
-	GetSigningKey() (ed25519.PublicKey, error)
-
-	CreateResource(i *fastly.CreateResourceInput) (*fastly.Resource, error)
-	DeleteResource(i *fastly.DeleteResourceInput) error
-	GetResource(i *fastly.GetResourceInput) (*fastly.Resource, error)
-	ListResources(i *fastly.ListResourcesInput) ([]*fastly.Resource, error)
-	UpdateResource(i *fastly.UpdateResourceInput) (*fastly.Resource, error)
-
-	CreateERL(i *fastly.CreateERLInput) (*fastly.ERL, error)
-	DeleteERL(i *fastly.DeleteERLInput) error
-	GetERL(i *fastly.GetERLInput) (*fastly.ERL, error)
-	ListERLs(i *fastly.ListERLsInput) ([]*fastly.ERL, error)
-	UpdateERL(i *fastly.UpdateERLInput) (*fastly.ERL, error)
-
-	CreateCondition(i *fastly.CreateConditionInput) (*fastly.Condition, error)
-	DeleteCondition(i *fastly.DeleteConditionInput) error
-	GetCondition(i *fastly.GetConditionInput) (*fastly.Condition, error)
-	ListConditions(i *fastly.ListConditionsInput) ([]*fastly.Condition, error)
-	UpdateCondition(i *fastly.UpdateConditionInput) (*fastly.Condition, error)
-
-	GetProduct(i *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error)
-	EnableProduct(i *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error)
-	DisableProduct(i *fastly.ProductEnablementInput) error
-
-	ListAlertDefinitions(i *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error)
-	CreateAlertDefinition(i *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error)
-	GetAlertDefinition(i *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error)
-	UpdateAlertDefinition(i *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error)
-	DeleteAlertDefinition(i *fastly.DeleteAlertDefinitionInput) error
-	TestAlertDefinition(i *fastly.TestAlertDefinitionInput) error
-	ListAlertHistory(i *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error)
-
-	ListObservabilityCustomDashboards(i *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error)
-	CreateObservabilityCustomDashboard(i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
-	GetObservabilityCustomDashboard(i *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
-	UpdateObservabilityCustomDashboard(i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
-	DeleteObservabilityCustomDashboard(i *fastly.DeleteObservabilityCustomDashboardInput) error
+	AllIPs(context.Context) (v4, v6 fastly.IPAddrs, err error)
+	AllDatacenters(context.Context) (datacenters []fastly.Datacenter, err error)
+
+	CreateService(context.Context, *fastly.CreateServiceInput) (*fastly.Service, error)
+	GetServices(context.Context, *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service]
+	ListServices(context.Context, *fastly.ListServicesInput) ([]*fastly.Service, error)
+	GetService(context.Context, *fastly.GetServiceInput) (*fastly.Service, error)
+	GetServiceDetails(context.Context, *fastly.GetServiceInput) (*fastly.ServiceDetail, error)
+	UpdateService(context.Context, *fastly.UpdateServiceInput) (*fastly.Service, error)
+	DeleteService(context.Context, *fastly.DeleteServiceInput) error
+	SearchService(context.Context, *fastly.SearchServiceInput) (*fastly.Service, error)
+
+	CloneVersion(context.Context, *fastly.CloneVersionInput) (*fastly.Version, error)
+	ListVersions(context.Context, *fastly.ListVersionsInput) ([]*fastly.Version, error)
+	GetVersion(context.Context, *fastly.GetVersionInput) (*fastly.Version, error)
+	UpdateVersion(context.Context, *fastly.UpdateVersionInput) (*fastly.Version, error)
+	ActivateVersion(context.Context, *fastly.ActivateVersionInput) (*fastly.Version, error)
+	DeactivateVersion(context.Context, *fastly.DeactivateVersionInput) (*fastly.Version, error)
+	LockVersion(context.Context, *fastly.LockVersionInput) (*fastly.Version, error)
+	LatestVersion(context.Context, *fastly.LatestVersionInput) (*fastly.Version, error)
+
+	CreateDomain(context.Context, *fastly.CreateDomainInput) (*fastly.Domain, error)
+	ListDomains(context.Context, *fastly.ListDomainsInput) ([]*fastly.Domain, error)
+	GetDomain(context.Context, *fastly.GetDomainInput) (*fastly.Domain, error)
+	UpdateDomain(context.Context, *fastly.UpdateDomainInput) (*fastly.Domain, error)
+	DeleteDomain(context.Context, *fastly.DeleteDomainInput) error
+	ValidateDomain(context.Context, *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error)
+	ValidateAllDomains(context.Context, *fastly.ValidateAllDomainsInput) ([]*fastly.DomainValidationResult, error)
+
+	CreateBackend(context.Context, *fastly.CreateBackendInput) (*fastly.Backend, error)
+	ListBackends(context.Context, *fastly.ListBackendsInput) ([]*fastly.Backend, error)
+	GetBackend(context.Context, *fastly.GetBackendInput) (*fastly.Backend, error)
+	UpdateBackend(context.Context, *fastly.UpdateBackendInput) (*fastly.Backend, error)
+	DeleteBackend(context.Context, *fastly.DeleteBackendInput) error
+
+	CreateHealthCheck(context.Context, *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error)
+	ListHealthChecks(context.Context, *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error)
+	GetHealthCheck(context.Context, *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error)
+	UpdateHealthCheck(context.Context, *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
+	DeleteHealthCheck(context.Context, *fastly.DeleteHealthCheckInput) error
+
+	GetPackage(context.Context, *fastly.GetPackageInput) (*fastly.Package, error)
+	UpdatePackage(context.Context, *fastly.UpdatePackageInput) (*fastly.Package, error)
+
+	CreateDictionary(context.Context, *fastly.CreateDictionaryInput) (*fastly.Dictionary, error)
+	GetDictionary(context.Context, *fastly.GetDictionaryInput) (*fastly.Dictionary, error)
+	DeleteDictionary(context.Context, *fastly.DeleteDictionaryInput) error
+	ListDictionaries(context.Context, *fastly.ListDictionariesInput) ([]*fastly.Dictionary, error)
+	UpdateDictionary(context.Context, *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error)
+
+	GetDictionaryItems(context.Context, *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem]
+	ListDictionaryItems(context.Context, *fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error)
+	GetDictionaryItem(context.Context, *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error)
+	CreateDictionaryItem(context.Context, *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error)
+	UpdateDictionaryItem(context.Context, *fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error)
+	DeleteDictionaryItem(context.Context, *fastly.DeleteDictionaryItemInput) error
+	BatchModifyDictionaryItems(context.Context, *fastly.BatchModifyDictionaryItemsInput) error
+
+	GetDictionaryInfo(context.Context, *fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error)
+
+	CreateBigQuery(context.Context, *fastly.CreateBigQueryInput) (*fastly.BigQuery, error)
+	ListBigQueries(context.Context, *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error)
+	GetBigQuery(context.Context, *fastly.GetBigQueryInput) (*fastly.BigQuery, error)
+	UpdateBigQuery(context.Context, *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error)
+	DeleteBigQuery(context.Context, *fastly.DeleteBigQueryInput) error
+
+	CreateS3(context.Context, *fastly.CreateS3Input) (*fastly.S3, error)
+	ListS3s(context.Context, *fastly.ListS3sInput) ([]*fastly.S3, error)
+	GetS3(context.Context, *fastly.GetS3Input) (*fastly.S3, error)
+	UpdateS3(context.Context, *fastly.UpdateS3Input) (*fastly.S3, error)
+	DeleteS3(context.Context, *fastly.DeleteS3Input) error
+
+	CreateKinesis(context.Context, *fastly.CreateKinesisInput) (*fastly.Kinesis, error)
+	ListKinesis(context.Context, *fastly.ListKinesisInput) ([]*fastly.Kinesis, error)
+	GetKinesis(context.Context, *fastly.GetKinesisInput) (*fastly.Kinesis, error)
+	UpdateKinesis(context.Context, *fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
+	DeleteKinesis(context.Context, *fastly.DeleteKinesisInput) error
+
+	CreateSyslog(context.Context, *fastly.CreateSyslogInput) (*fastly.Syslog, error)
+	ListSyslogs(context.Context, *fastly.ListSyslogsInput) ([]*fastly.Syslog, error)
+	GetSyslog(context.Context, *fastly.GetSyslogInput) (*fastly.Syslog, error)
+	UpdateSyslog(context.Context, *fastly.UpdateSyslogInput) (*fastly.Syslog, error)
+	DeleteSyslog(context.Context, *fastly.DeleteSyslogInput) error
+
+	CreateLogentries(context.Context, *fastly.CreateLogentriesInput) (*fastly.Logentries, error)
+	ListLogentries(context.Context, *fastly.ListLogentriesInput) ([]*fastly.Logentries, error)
+	GetLogentries(context.Context, *fastly.GetLogentriesInput) (*fastly.Logentries, error)
+	UpdateLogentries(context.Context, *fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
+	DeleteLogentries(context.Context, *fastly.DeleteLogentriesInput) error
+
+	CreatePapertrail(context.Context, *fastly.CreatePapertrailInput) (*fastly.Papertrail, error)
+	ListPapertrails(context.Context, *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error)
+	GetPapertrail(context.Context, *fastly.GetPapertrailInput) (*fastly.Papertrail, error)
+	UpdatePapertrail(context.Context, *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
+	DeletePapertrail(context.Context, *fastly.DeletePapertrailInput) error
+
+	CreateSumologic(context.Context, *fastly.CreateSumologicInput) (*fastly.Sumologic, error)
+	ListSumologics(context.Context, *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error)
+	GetSumologic(context.Context, *fastly.GetSumologicInput) (*fastly.Sumologic, error)
+	UpdateSumologic(context.Context, *fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
+	DeleteSumologic(context.Context, *fastly.DeleteSumologicInput) error
+
+	CreateGCS(context.Context, *fastly.CreateGCSInput) (*fastly.GCS, error)
+	ListGCSs(context.Context, *fastly.ListGCSsInput) ([]*fastly.GCS, error)
+	GetGCS(context.Context, *fastly.GetGCSInput) (*fastly.GCS, error)
+	UpdateGCS(context.Context, *fastly.UpdateGCSInput) (*fastly.GCS, error)
+	DeleteGCS(context.Context, *fastly.DeleteGCSInput) error
+
+	CreateGrafanaCloudLogs(context.Context, *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
+	ListGrafanaCloudLogs(context.Context, *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error)
+	GetGrafanaCloudLogs(context.Context, *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
+	UpdateGrafanaCloudLogs(context.Context, *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
+	DeleteGrafanaCloudLogs(context.Context, *fastly.DeleteGrafanaCloudLogsInput) error
+
+	CreateFTP(context.Context, *fastly.CreateFTPInput) (*fastly.FTP, error)
+	ListFTPs(context.Context, *fastly.ListFTPsInput) ([]*fastly.FTP, error)
+	GetFTP(context.Context, *fastly.GetFTPInput) (*fastly.FTP, error)
+	UpdateFTP(context.Context, *fastly.UpdateFTPInput) (*fastly.FTP, error)
+	DeleteFTP(context.Context, *fastly.DeleteFTPInput) error
+
+	CreateSplunk(context.Context, *fastly.CreateSplunkInput) (*fastly.Splunk, error)
+	ListSplunks(context.Context, *fastly.ListSplunksInput) ([]*fastly.Splunk, error)
+	GetSplunk(context.Context, *fastly.GetSplunkInput) (*fastly.Splunk, error)
+	UpdateSplunk(context.Context, *fastly.UpdateSplunkInput) (*fastly.Splunk, error)
+	DeleteSplunk(context.Context, *fastly.DeleteSplunkInput) error
+
+	CreateScalyr(context.Context, *fastly.CreateScalyrInput) (*fastly.Scalyr, error)
+	ListScalyrs(context.Context, *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error)
+	GetScalyr(context.Context, *fastly.GetScalyrInput) (*fastly.Scalyr, error)
+	UpdateScalyr(context.Context, *fastly.UpdateScalyrInput) (*fastly.Scalyr, error)
+	DeleteScalyr(context.Context, *fastly.DeleteScalyrInput) error
+
+	CreateLoggly(context.Context, *fastly.CreateLogglyInput) (*fastly.Loggly, error)
+	ListLoggly(context.Context, *fastly.ListLogglyInput) ([]*fastly.Loggly, error)
+	GetLoggly(context.Context, *fastly.GetLogglyInput) (*fastly.Loggly, error)
+	UpdateLoggly(context.Context, *fastly.UpdateLogglyInput) (*fastly.Loggly, error)
+	DeleteLoggly(context.Context, *fastly.DeleteLogglyInput) error
+
+	CreateHoneycomb(context.Context, *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error)
+	ListHoneycombs(context.Context, *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error)
+	GetHoneycomb(context.Context, *fastly.GetHoneycombInput) (*fastly.Honeycomb, error)
+	UpdateHoneycomb(context.Context, *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error)
+	DeleteHoneycomb(context.Context, *fastly.DeleteHoneycombInput) error
+
+	CreateHeroku(context.Context, *fastly.CreateHerokuInput) (*fastly.Heroku, error)
+	ListHerokus(context.Context, *fastly.ListHerokusInput) ([]*fastly.Heroku, error)
+	GetHeroku(context.Context, *fastly.GetHerokuInput) (*fastly.Heroku, error)
+	UpdateHeroku(context.Context, *fastly.UpdateHerokuInput) (*fastly.Heroku, error)
+	DeleteHeroku(context.Context, *fastly.DeleteHerokuInput) error
+
+	CreateSFTP(context.Context, *fastly.CreateSFTPInput) (*fastly.SFTP, error)
+	ListSFTPs(context.Context, *fastly.ListSFTPsInput) ([]*fastly.SFTP, error)
+	GetSFTP(context.Context, *fastly.GetSFTPInput) (*fastly.SFTP, error)
+	UpdateSFTP(context.Context, *fastly.UpdateSFTPInput) (*fastly.SFTP, error)
+	DeleteSFTP(context.Context, *fastly.DeleteSFTPInput) error
+
+	CreateLogshuttle(context.Context, *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error)
+	ListLogshuttles(context.Context, *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error)
+	GetLogshuttle(context.Context, *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error)
+	UpdateLogshuttle(context.Context, *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
+	DeleteLogshuttle(context.Context, *fastly.DeleteLogshuttleInput) error
+
+	CreateCloudfiles(context.Context, *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error)
+	ListCloudfiles(context.Context, *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error)
+	GetCloudfiles(context.Context, *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error)
+	UpdateCloudfiles(context.Context, *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error)
+	DeleteCloudfiles(context.Context, *fastly.DeleteCloudfilesInput) error
+
+	CreateDigitalOcean(context.Context, *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error)
+	ListDigitalOceans(context.Context, *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error)
+	GetDigitalOcean(context.Context, *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error)
+	UpdateDigitalOcean(context.Context, *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error)
+	DeleteDigitalOcean(context.Context, *fastly.DeleteDigitalOceanInput) error
+
+	CreateElasticsearch(context.Context, *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error)
+	ListElasticsearch(context.Context, *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error)
+	GetElasticsearch(context.Context, *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error)
+	UpdateElasticsearch(context.Context, *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error)
+	DeleteElasticsearch(context.Context, *fastly.DeleteElasticsearchInput) error
+
+	CreateBlobStorage(context.Context, *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error)
+	ListBlobStorages(context.Context, *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error)
+	GetBlobStorage(context.Context, *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error)
+	UpdateBlobStorage(context.Context, *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error)
+	DeleteBlobStorage(context.Context, *fastly.DeleteBlobStorageInput) error
+
+	CreateDatadog(context.Context, *fastly.CreateDatadogInput) (*fastly.Datadog, error)
+	ListDatadog(context.Context, *fastly.ListDatadogInput) ([]*fastly.Datadog, error)
+	GetDatadog(context.Context, *fastly.GetDatadogInput) (*fastly.Datadog, error)
+	UpdateDatadog(context.Context, *fastly.UpdateDatadogInput) (*fastly.Datadog, error)
+	DeleteDatadog(context.Context, *fastly.DeleteDatadogInput) error
+
+	CreateHTTPS(context.Context, *fastly.CreateHTTPSInput) (*fastly.HTTPS, error)
+	ListHTTPS(context.Context, *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error)
+	GetHTTPS(context.Context, *fastly.GetHTTPSInput) (*fastly.HTTPS, error)
+	UpdateHTTPS(context.Context, *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
+	DeleteHTTPS(context.Context, *fastly.DeleteHTTPSInput) error
+
+	CreateKafka(context.Context, *fastly.CreateKafkaInput) (*fastly.Kafka, error)
+	ListKafkas(context.Context, *fastly.ListKafkasInput) ([]*fastly.Kafka, error)
+	GetKafka(context.Context, *fastly.GetKafkaInput) (*fastly.Kafka, error)
+	UpdateKafka(context.Context, *fastly.UpdateKafkaInput) (*fastly.Kafka, error)
+	DeleteKafka(context.Context, *fastly.DeleteKafkaInput) error
+
+	CreatePubsub(context.Context, *fastly.CreatePubsubInput) (*fastly.Pubsub, error)
+	ListPubsubs(context.Context, *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error)
+	GetPubsub(context.Context, *fastly.GetPubsubInput) (*fastly.Pubsub, error)
+	UpdatePubsub(context.Context, *fastly.UpdatePubsubInput) (*fastly.Pubsub, error)
+	DeletePubsub(context.Context, *fastly.DeletePubsubInput) error
+
+	CreateOpenstack(context.Context, *fastly.CreateOpenstackInput) (*fastly.Openstack, error)
+	ListOpenstack(context.Context, *fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
+	GetOpenstack(context.Context, *fastly.GetOpenstackInput) (*fastly.Openstack, error)
+	UpdateOpenstack(context.Context, *fastly.UpdateOpenstackInput) (*fastly.Openstack, error)
+	DeleteOpenstack(context.Context, *fastly.DeleteOpenstackInput) error
+
+	GetRegions(context.Context) (*fastly.RegionsResponse, error)
+	GetStatsJSON(context.Context, *fastly.GetStatsInput, any) error
+
+	CreateManagedLogging(context.Context, *fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
+
+	GetGeneratedVCL(context.Context, *fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
+
+	CreateVCL(context.Context, *fastly.CreateVCLInput) (*fastly.VCL, error)
+	ListVCLs(context.Context, *fastly.ListVCLsInput) ([]*fastly.VCL, error)
+	GetVCL(context.Context, *fastly.GetVCLInput) (*fastly.VCL, error)
+	UpdateVCL(context.Context, *fastly.UpdateVCLInput) (*fastly.VCL, error)
+	DeleteVCL(context.Context, *fastly.DeleteVCLInput) error
+
+	CreateSnippet(context.Context, *fastly.CreateSnippetInput) (*fastly.Snippet, error)
+	ListSnippets(context.Context, *fastly.ListSnippetsInput) ([]*fastly.Snippet, error)
+	GetSnippet(context.Context, *fastly.GetSnippetInput) (*fastly.Snippet, error)
+	GetDynamicSnippet(context.Context, *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	UpdateSnippet(context.Context, *fastly.UpdateSnippetInput) (*fastly.Snippet, error)
+	UpdateDynamicSnippet(context.Context, *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	DeleteSnippet(context.Context, *fastly.DeleteSnippetInput) error
+
+	Purge(context.Context, *fastly.PurgeInput) (*fastly.Purge, error)
+	PurgeKey(context.Context, *fastly.PurgeKeyInput) (*fastly.Purge, error)
+	PurgeKeys(context.Context, *fastly.PurgeKeysInput) (map[string]string, error)
+	PurgeAll(context.Context, *fastly.PurgeAllInput) (*fastly.Purge, error)
+
+	CreateACL(context.Context, *fastly.CreateACLInput) (*fastly.ACL, error)
+	DeleteACL(context.Context, *fastly.DeleteACLInput) error
+	GetACL(context.Context, *fastly.GetACLInput) (*fastly.ACL, error)
+	ListACLs(context.Context, *fastly.ListACLsInput) ([]*fastly.ACL, error)
+	UpdateACL(context.Context, *fastly.UpdateACLInput) (*fastly.ACL, error)
+
+	CreateACLEntry(context.Context, *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error)
+	DeleteACLEntry(context.Context, *fastly.DeleteACLEntryInput) error
+	GetACLEntry(context.Context, *fastly.GetACLEntryInput) (*fastly.ACLEntry, error)
+	GetACLEntries(context.Context, *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry]
+	ListACLEntries(context.Context, *fastly.ListACLEntriesInput) ([]*fastly.ACLEntry, error)
+	UpdateACLEntry(context.Context, *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error)
+	BatchModifyACLEntries(context.Context, *fastly.BatchModifyACLEntriesInput) error
+
+	CreateNewRelic(context.Context, *fastly.CreateNewRelicInput) (*fastly.NewRelic, error)
+	DeleteNewRelic(context.Context, *fastly.DeleteNewRelicInput) error
+	GetNewRelic(context.Context, *fastly.GetNewRelicInput) (*fastly.NewRelic, error)
+	ListNewRelic(context.Context, *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error)
+	UpdateNewRelic(context.Context, *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error)
+
+	CreateNewRelicOTLP(context.Context, *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
+	DeleteNewRelicOTLP(context.Context, *fastly.DeleteNewRelicOTLPInput) error
+	GetNewRelicOTLP(context.Context, *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
+	ListNewRelicOTLP(context.Context, *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error)
+	UpdateNewRelicOTLP(context.Context, *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
+
+	CreateUser(context.Context, *fastly.CreateUserInput) (*fastly.User, error)
+	DeleteUser(context.Context, *fastly.DeleteUserInput) error
+	GetCurrentUser(context.Context) (*fastly.User, error)
+	GetUser(context.Context, *fastly.GetUserInput) (*fastly.User, error)
+	ListCustomerUsers(context.Context, *fastly.ListCustomerUsersInput) ([]*fastly.User, error)
+	UpdateUser(context.Context, *fastly.UpdateUserInput) (*fastly.User, error)
+	ResetUserPassword(context.Context, *fastly.ResetUserPasswordInput) error
+
+	BatchDeleteTokens(context.Context, *fastly.BatchDeleteTokensInput) error
+	CreateToken(context.Context, *fastly.CreateTokenInput) (*fastly.Token, error)
+	DeleteToken(context.Context, *fastly.DeleteTokenInput) error
+	DeleteTokenSelf(context.Context) error
+	GetTokenSelf(context.Context) (*fastly.Token, error)
+	ListCustomerTokens(context.Context, *fastly.ListCustomerTokensInput) ([]*fastly.Token, error)
+	ListTokens(context.Context, *fastly.ListTokensInput) ([]*fastly.Token, error)
+
+	NewListKVStoreKeysPaginator(context.Context, *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries
+
+	GetCustomTLSConfiguration(context.Context, *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
+	ListCustomTLSConfigurations(context.Context, *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error)
+	UpdateCustomTLSConfiguration(context.Context, *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
+	GetTLSActivation(context.Context, *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error)
+	ListTLSActivations(context.Context, *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error)
+	UpdateTLSActivation(context.Context, *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error)
+	CreateTLSActivation(context.Context, *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error)
+	DeleteTLSActivation(context.Context, *fastly.DeleteTLSActivationInput) error
+
+	CreateCustomTLSCertificate(context.Context, *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
+	DeleteCustomTLSCertificate(context.Context, *fastly.DeleteCustomTLSCertificateInput) error
+	GetCustomTLSCertificate(context.Context, *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
+	ListCustomTLSCertificates(context.Context, *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error)
+	UpdateCustomTLSCertificate(context.Context, *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
+
+	ListTLSDomains(context.Context, *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error)
+
+	CreatePrivateKey(context.Context, *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error)
+	DeletePrivateKey(context.Context, *fastly.DeletePrivateKeyInput) error
+	GetPrivateKey(context.Context, *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error)
+	ListPrivateKeys(context.Context, *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error)
+
+	CreateBulkCertificate(context.Context, *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error)
+	DeleteBulkCertificate(context.Context, *fastly.DeleteBulkCertificateInput) error
+	GetBulkCertificate(context.Context, *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error)
+	ListBulkCertificates(context.Context, *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error)
+	UpdateBulkCertificate(context.Context, *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error)
+
+	CreateTLSSubscription(context.Context, *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
+	DeleteTLSSubscription(context.Context, *fastly.DeleteTLSSubscriptionInput) error
+	GetTLSSubscription(context.Context, *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error)
+	ListTLSSubscriptions(context.Context, *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error)
+	UpdateTLSSubscription(context.Context, *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
+
+	ListServiceAuthorizations(context.Context, *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error)
+	GetServiceAuthorization(context.Context, *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
+	CreateServiceAuthorization(context.Context, *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
+	UpdateServiceAuthorization(context.Context, *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
+	DeleteServiceAuthorization(context.Context, *fastly.DeleteServiceAuthorizationInput) error
+
+	CreateConfigStore(context.Context, *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error)
+	DeleteConfigStore(context.Context, *fastly.DeleteConfigStoreInput) error
+	GetConfigStore(context.Context, *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error)
+	GetConfigStoreMetadata(context.Context, *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error)
+	ListConfigStores(context.Context, *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error)
+	ListConfigStoreServices(context.Context, *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error)
+	UpdateConfigStore(context.Context, *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error)
+
+	CreateConfigStoreItem(context.Context, *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
+	DeleteConfigStoreItem(context.Context, *fastly.DeleteConfigStoreItemInput) error
+	GetConfigStoreItem(context.Context, *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
+	ListConfigStoreItems(context.Context, *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error)
+	UpdateConfigStoreItem(context.Context, *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
+
+	CreateKVStore(context.Context, *fastly.CreateKVStoreInput) (*fastly.KVStore, error)
+	ListKVStores(context.Context, *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error)
+	DeleteKVStore(context.Context, *fastly.DeleteKVStoreInput) error
+	GetKVStore(context.Context, *fastly.GetKVStoreInput) (*fastly.KVStore, error)
+	ListKVStoreKeys(context.Context, *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error)
+	GetKVStoreKey(context.Context, *fastly.GetKVStoreKeyInput) (string, error)
+	DeleteKVStoreKey(context.Context, *fastly.DeleteKVStoreKeyInput) error
+	InsertKVStoreKey(context.Context, *fastly.InsertKVStoreKeyInput) error
+	BatchModifyKVStoreKey(context.Context, *fastly.BatchModifyKVStoreKeyInput) error
+
+	CreateSecretStore(context.Context, *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error)
+	GetSecretStore(context.Context, *fastly.GetSecretStoreInput) (*fastly.SecretStore, error)
+	DeleteSecretStore(context.Context, *fastly.DeleteSecretStoreInput) error
+	ListSecretStores(context.Context, *fastly.ListSecretStoresInput) (*fastly.SecretStores, error)
+	CreateSecret(context.Context, *fastly.CreateSecretInput) (*fastly.Secret, error)
+	GetSecret(context.Context, *fastly.GetSecretInput) (*fastly.Secret, error)
+	DeleteSecret(context.Context, *fastly.DeleteSecretInput) error
+	ListSecrets(context.Context, *fastly.ListSecretsInput) (*fastly.Secrets, error)
+	CreateClientKey(context.Context) (*fastly.ClientKey, error)
+	GetSigningKey(context.Context) (ed25519.PublicKey, error)
+
+	CreateResource(context.Context, *fastly.CreateResourceInput) (*fastly.Resource, error)
+	DeleteResource(context.Context, *fastly.DeleteResourceInput) error
+	GetResource(context.Context, *fastly.GetResourceInput) (*fastly.Resource, error)
+	ListResources(context.Context, *fastly.ListResourcesInput) ([]*fastly.Resource, error)
+	UpdateResource(context.Context, *fastly.UpdateResourceInput) (*fastly.Resource, error)
+
+	CreateERL(context.Context, *fastly.CreateERLInput) (*fastly.ERL, error)
+	DeleteERL(context.Context, *fastly.DeleteERLInput) error
+	GetERL(context.Context, *fastly.GetERLInput) (*fastly.ERL, error)
+	ListERLs(context.Context, *fastly.ListERLsInput) ([]*fastly.ERL, error)
+	UpdateERL(context.Context, *fastly.UpdateERLInput) (*fastly.ERL, error)
+
+	CreateCondition(context.Context, *fastly.CreateConditionInput) (*fastly.Condition, error)
+	DeleteCondition(context.Context, *fastly.DeleteConditionInput) error
+	GetCondition(context.Context, *fastly.GetConditionInput) (*fastly.Condition, error)
+	ListConditions(context.Context, *fastly.ListConditionsInput) ([]*fastly.Condition, error)
+	UpdateCondition(context.Context, *fastly.UpdateConditionInput) (*fastly.Condition, error)
+
+	ListAlertDefinitions(context.Context, *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error)
+	CreateAlertDefinition(context.Context, *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error)
+	GetAlertDefinition(context.Context, *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error)
+	UpdateAlertDefinition(context.Context, *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error)
+	DeleteAlertDefinition(context.Context, *fastly.DeleteAlertDefinitionInput) error
+	TestAlertDefinition(context.Context, *fastly.TestAlertDefinitionInput) error
+	ListAlertHistory(context.Context, *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error)
+
+	ListObservabilityCustomDashboards(context.Context, *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error)
+	CreateObservabilityCustomDashboard(context.Context, *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
+	GetObservabilityCustomDashboard(context.Context, *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
+	UpdateObservabilityCustomDashboard(context.Context, *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
+	DeleteObservabilityCustomDashboard(context.Context, *fastly.DeleteObservabilityCustomDashboardInput) error
 }
 
 // RealtimeStatsInterface is the subset of go-fastly's realtime stats API used here.
 type RealtimeStatsInterface interface {
-	GetRealtimeStatsJSON(*fastly.GetRealtimeStatsInput, any) error
+	GetRealtimeStatsJSON(context.Context, *fastly.GetRealtimeStatsInput, any) error
 }
 
 // Ensure that fastly.Client satisfies Interface.

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -16,7 +16,8 @@ import (
 	"github.com/hashicorp/cap/oidc"
 	"github.com/skratchdot/open-golang/open"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
+
 	"github.com/fastly/kingpin"
 
 	"github.com/fastly/cli/pkg/api"

--- a/pkg/argparser/cmd.go
+++ b/pkg/argparser/cmd.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
+
 	"github.com/fastly/kingpin"
 
 	"4d63.com/optional"

--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -1,6 +1,7 @@
 package argparser
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
+
 	"github.com/fastly/kingpin"
 
 	"github.com/fastly/cli/pkg/api"
@@ -114,7 +116,7 @@ type OptionalServiceVersion struct {
 
 // Parse returns a service version based on the given user input.
 func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fastly.Version, error) {
-	vs, err := client.ListVersions(&fastly.ListVersionsInput{
+	vs, err := client.ListVersions(context.TODO(), &fastly.ListVersionsInput{
 		ServiceID: sid,
 	})
 	if err != nil {
@@ -159,7 +161,7 @@ type OptionalServiceNameID struct {
 
 // Parse returns a service ID based off the given service name.
 func (sv *OptionalServiceNameID) Parse(client api.Interface) (serviceID string, err error) {
-	paginator := client.GetServices(&fastly.GetServicesInput{})
+	paginator := client.GetServices(context.TODO(), &fastly.GetServicesInput{})
 	var services []*fastly.Service
 	for paginator.HasNext() {
 		data, err := paginator.GetNext()
@@ -228,7 +230,7 @@ func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, verbose bool, 
 		}
 	}
 	if ac.Value && (v.Active != nil && *v.Active || v.Locked != nil && *v.Locked) {
-		version, err := client.CloneVersion(&fastly.CloneVersionInput{
+		version, err := client.CloneVersion(context.TODO(), &fastly.CloneVersionInput{
 			ServiceID:      sid,
 			ServiceVersion: fastly.ToValue(v.Number),
 		})

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -2,6 +2,7 @@ package argparser_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/manifest"
@@ -91,7 +92,7 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 //
 // The first element is active, the second is locked, the third is
 // editable, the fourth is staged.
-func listVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+func listVersions(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
@@ -364,8 +365,8 @@ func TestServiceID(t *testing.T) {
 				File: manifest.File{ServiceID: "123"},
 			},
 			API: mock.API{
-				GetServicesFn: func(_ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
-					return fastly.NewPaginator[fastly.Service](&mock.HTTPClient{
+				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
+					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
 						Responses: []*http.Response{
 							{
@@ -383,8 +384,8 @@ func TestServiceID(t *testing.T) {
 			ServiceName: argparser.OptionalServiceNameID{argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "bar"}},
 			Data:        manifest.Data{},
 			API: mock.API{
-				GetServicesFn: func(_ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
-					return fastly.NewPaginator[fastly.Service](&mock.HTTPClient{
+				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
+					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
 						Responses: []*http.Response{
 							{
@@ -441,8 +442,8 @@ func TestContent(t *testing.T) {
 }
 
 // cloneVersionResult returns a function which returns a specific cloned version.
-func cloneVersionResult(version int) func(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return func(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+func cloneVersionResult(version int) func(_ context.Context, i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return func(_ context.Context, i *fastly.CloneVersionInput) (*fastly.Version, error) {
 		return &fastly.Version{
 			ServiceID: fastly.ToPointer(i.ServiceID),
 			Number:    fastly.ToPointer(version),

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -1,9 +1,10 @@
 package acl_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/acl"
 	"github.com/fastly/cli/pkg/mock"
@@ -47,7 +48,7 @@ func TestACLCreate(t *testing.T) {
 			Name: "validate CreateACL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateACLFn: func(_ *fastly.CreateACLInput) (*fastly.ACL, error) {
+				CreateACLFn: func(_ context.Context, _ *fastly.CreateACLInput) (*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -58,7 +59,7 @@ func TestACLCreate(t *testing.T) {
 			Name: "validate CreateACL API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateACLFn: func(i *fastly.CreateACLInput) (*fastly.ACL, error) {
+				CreateACLFn: func(_ context.Context, i *fastly.CreateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
 						ACLID:          fastly.ToPointer("456"),
 						Name:           i.Name,
@@ -75,7 +76,7 @@ func TestACLCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				CreateACLFn: func(i *fastly.CreateACLInput) (*fastly.ACL, error) {
+				CreateACLFn: func(_ context.Context, i *fastly.CreateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
 						ACLID:          fastly.ToPointer("456"),
 						Name:           i.Name,
@@ -129,7 +130,7 @@ func TestACLDelete(t *testing.T) {
 			Name: "validate DeleteACL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteACLFn: func(_ *fastly.DeleteACLInput) error {
+				DeleteACLFn: func(_ context.Context, _ *fastly.DeleteACLInput) error {
 					return testutil.Err
 				},
 			},
@@ -140,7 +141,7 @@ func TestACLDelete(t *testing.T) {
 			Name: "validate DeleteACL API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteACLFn: func(_ *fastly.DeleteACLInput) error {
+				DeleteACLFn: func(_ context.Context, _ *fastly.DeleteACLInput) error {
 					return nil
 				},
 			},
@@ -152,7 +153,7 @@ func TestACLDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				DeleteACLFn: func(_ *fastly.DeleteACLInput) error {
+				DeleteACLFn: func(_ context.Context, _ *fastly.DeleteACLInput) error {
 					return nil
 				},
 			},
@@ -185,7 +186,7 @@ func TestACLDescribe(t *testing.T) {
 			Name: "validate GetACL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				GetACLFn: func(_ *fastly.GetACLInput) (*fastly.ACL, error) {
+				GetACLFn: func(_ context.Context, _ *fastly.GetACLInput) (*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -230,7 +231,7 @@ func TestACLList(t *testing.T) {
 			Name: "validate ListACLs API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				ListACLsFn: func(_ *fastly.ListACLsInput) ([]*fastly.ACL, error) {
+				ListACLsFn: func(_ context.Context, _ *fastly.ListACLsInput) ([]*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -311,7 +312,7 @@ func TestACLUpdate(t *testing.T) {
 			Name: "validate UpdateACL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateACLFn: func(_ *fastly.UpdateACLInput) (*fastly.ACL, error) {
+				UpdateACLFn: func(_ context.Context, _ *fastly.UpdateACLInput) (*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -322,7 +323,7 @@ func TestACLUpdate(t *testing.T) {
 			Name: "validate UpdateACL API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateACLFn: func(i *fastly.UpdateACLInput) (*fastly.ACL, error) {
+				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
 						ACLID:          fastly.ToPointer("456"),
 						Name:           i.NewName,
@@ -339,7 +340,7 @@ func TestACLUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				UpdateACLFn: func(i *fastly.UpdateACLInput) (*fastly.ACL, error) {
+				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
 						ACLID:          fastly.ToPointer("456"),
 						Name:           i.NewName,
@@ -356,7 +357,7 @@ func TestACLUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
-func getACL(i *fastly.GetACLInput) (*fastly.ACL, error) {
+func getACL(_ context.Context, i *fastly.GetACLInput) (*fastly.ACL, error) {
 	t := testutil.Date
 
 	return &fastly.ACL{
@@ -371,7 +372,7 @@ func getACL(i *fastly.GetACLInput) (*fastly.ACL, error) {
 	}, nil
 }
 
-func listACLs(i *fastly.ListACLsInput) ([]*fastly.ACL, error) {
+func listACLs(_ context.Context, i *fastly.ListACLsInput) ([]*fastly.ACL, error) {
 	t := testutil.Date
 	vs := []*fastly.ACL{
 		{

--- a/pkg/commands/acl/create.go
+++ b/pkg/commands/acl/create.go
@@ -1,9 +1,10 @@
 package acl
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -86,7 +87,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
-	a, err := c.Globals.APIClient.CreateACL(input)
+	a, err := c.Globals.APIClient.CreateACL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/acl/delete.go
+++ b/pkg/commands/acl/delete.go
@@ -1,9 +1,10 @@
 package acl
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
-	err = c.Globals.APIClient.DeleteACL(input)
+	err = c.Globals.APIClient.DeleteACL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/acl/describe.go
+++ b/pkg/commands/acl/describe.go
@@ -1,10 +1,11 @@
 package acl
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.GetACL(input)
+	o, err := c.Globals.APIClient.GetACL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/acl/list.go
+++ b/pkg/commands/acl/list.go
@@ -1,10 +1,11 @@
 package acl
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -80,7 +81,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.ListACLs(input)
+	o, err := c.Globals.APIClient.ListACLs(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/acl/update.go
+++ b/pkg/commands/acl/update.go
@@ -1,9 +1,10 @@
 package acl
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -87,7 +88,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	a, err := c.Globals.APIClient.UpdateACL(input)
+	a, err := c.Globals.APIClient.UpdateACL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -1,12 +1,13 @@
 package aclentry_test
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/aclentry"
 	"github.com/fastly/cli/pkg/mock"
@@ -33,7 +34,7 @@ func TestACLEntryCreate(t *testing.T) {
 		{
 			Name: "validate CreateACLEntry API error",
 			API: mock.API{
-				CreateACLEntryFn: func(_ *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
+				CreateACLEntryFn: func(_ context.Context, _ *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -43,7 +44,7 @@ func TestACLEntryCreate(t *testing.T) {
 		{
 			Name: "validate CreateACLEntry API success",
 			API: mock.API{
-				CreateACLEntryFn: func(i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
+				CreateACLEntryFn: func(_ context.Context, i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
 					return &fastly.ACLEntry{
 						ACLID:     fastly.ToPointer(i.ACLID),
 						EntryID:   fastly.ToPointer("456"),
@@ -58,7 +59,7 @@ func TestACLEntryCreate(t *testing.T) {
 		{
 			Name: "validate CreateACLEntry API success with negated IP",
 			API: mock.API{
-				CreateACLEntryFn: func(i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
+				CreateACLEntryFn: func(_ context.Context, i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
 					return &fastly.ACLEntry{
 						ACLID:     fastly.ToPointer(i.ACLID),
 						EntryID:   fastly.ToPointer("456"),
@@ -96,7 +97,7 @@ func TestACLEntryDelete(t *testing.T) {
 		{
 			Name: "validate DeleteACL API error",
 			API: mock.API{
-				DeleteACLEntryFn: func(_ *fastly.DeleteACLEntryInput) error {
+				DeleteACLEntryFn: func(_ context.Context, _ *fastly.DeleteACLEntryInput) error {
 					return testutil.Err
 				},
 			},
@@ -106,7 +107,7 @@ func TestACLEntryDelete(t *testing.T) {
 		{
 			Name: "validate DeleteACL API success",
 			API: mock.API{
-				DeleteACLEntryFn: func(_ *fastly.DeleteACLEntryInput) error {
+				DeleteACLEntryFn: func(_ context.Context, _ *fastly.DeleteACLEntryInput) error {
 					return nil
 				},
 			},
@@ -138,7 +139,7 @@ func TestACLEntryDescribe(t *testing.T) {
 		{
 			Name: "validate GetACL API error",
 			API: mock.API{
-				GetACLEntryFn: func(_ *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {
+				GetACLEntryFn: func(_ context.Context, _ *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -172,8 +173,8 @@ func TestACLEntryList(t *testing.T) {
 		{
 			Name: "validate ListACLEntries API error (via GetNext() call)",
 			API: mock.API{
-				GetACLEntriesFn: func(_ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
-					return fastly.NewPaginator[fastly.ACLEntry](&mock.HTTPClient{
+				GetACLEntriesFn: func(ctx context.Context, _ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
+					return fastly.NewPaginator[fastly.ACLEntry](ctx, &mock.HTTPClient{
 						Errors: []error{
 							testutil.Err,
 						},
@@ -187,8 +188,8 @@ func TestACLEntryList(t *testing.T) {
 		{
 			Name: "validate ListACLEntries API success",
 			API: mock.API{
-				GetACLEntriesFn: func(_ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
-					return fastly.NewPaginator[fastly.ACLEntry](&mock.HTTPClient{
+				GetACLEntriesFn: func(ctx context.Context, _ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
+					return fastly.NewPaginator[fastly.ACLEntry](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
 						Responses: []*http.Response{
 							{
@@ -229,8 +230,8 @@ func TestACLEntryList(t *testing.T) {
 		{
 			Name: "validate --verbose flag",
 			API: mock.API{
-				GetACLEntriesFn: func(_ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
-					return fastly.NewPaginator[fastly.ACLEntry](&mock.HTTPClient{
+				GetACLEntriesFn: func(ctx context.Context, _ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
+					return fastly.NewPaginator[fastly.ACLEntry](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
 						Responses: []*http.Response{
 							{
@@ -326,7 +327,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateACL API error",
 			API: mock.API{
-				UpdateACLEntryFn: func(_ *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error) {
+				UpdateACLEntryFn: func(_ context.Context, _ *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -336,7 +337,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate error from --file set with invalid json",
 			API: mock.API{
-				BatchModifyACLEntriesFn: func(_ *fastly.BatchModifyACLEntriesInput) error {
+				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},
 			},
@@ -346,7 +347,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate error from --file set with zero json entries",
 			API: mock.API{
-				BatchModifyACLEntriesFn: func(_ *fastly.BatchModifyACLEntriesInput) error {
+				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},
 			},
@@ -356,7 +357,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate success with --file",
 			API: mock.API{
-				BatchModifyACLEntriesFn: func(_ *fastly.BatchModifyACLEntriesInput) error {
+				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},
 			},
@@ -370,7 +371,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate success with --file as inline json",
 			API: mock.API{
-				BatchModifyACLEntriesFn: func(_ *fastly.BatchModifyACLEntriesInput) error {
+				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},
 			},
@@ -382,7 +383,7 @@ func TestACLEntryUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
-func getACLEntry(i *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {
+func getACLEntry(_ context.Context, i *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {
 	t := testutil.Date
 
 	return &fastly.ACLEntry{

--- a/pkg/commands/aclentry/create.go
+++ b/pkg/commands/aclentry/create.go
@@ -1,9 +1,10 @@
 package aclentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -67,7 +68,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID)
 
-	a, err := c.Globals.APIClient.CreateACLEntry(input)
+	a, err := c.Globals.APIClient.CreateACLEntry(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/aclentry/delete.go
+++ b/pkg/commands/aclentry/delete.go
@@ -1,9 +1,10 @@
 package aclentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -60,7 +61,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput(serviceID)
-	err = c.Globals.APIClient.DeleteACLEntry(input)
+	err = c.Globals.APIClient.DeleteACLEntry(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/aclentry/describe.go
+++ b/pkg/commands/aclentry/describe.go
@@ -1,10 +1,11 @@
 package aclentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -68,7 +69,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID)
 
-	o, err := c.Globals.APIClient.GetACLEntry(input)
+	o, err := c.Globals.APIClient.GetACLEntry(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/aclentry/list.go
+++ b/pkg/commands/aclentry/list.go
@@ -1,10 +1,11 @@
 package aclentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -75,7 +76,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput(serviceID)
-	paginator := c.Globals.APIClient.GetACLEntries(input)
+	paginator := c.Globals.APIClient.GetACLEntries(context.TODO(), input)
 
 	var o []*fastly.ACLEntry
 	for paginator.HasNext() {

--- a/pkg/commands/aclentry/update.go
+++ b/pkg/commands/aclentry/update.go
@@ -1,11 +1,12 @@
 package aclentry
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -78,7 +79,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 			return err
 		}
 
-		err = c.Globals.APIClient.BatchModifyACLEntries(input)
+		err = c.Globals.APIClient.BatchModifyACLEntries(context.TODO(), input)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Service ID": serviceID,
@@ -95,7 +96,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	a, err := c.Globals.APIClient.UpdateACLEntry(input)
+	a, err := c.Globals.APIClient.UpdateACLEntry(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/alerts/alerts_test.go
+++ b/pkg/commands/alerts/alerts_test.go
@@ -1,6 +1,7 @@
 package alerts_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -8,7 +9,7 @@ import (
 	root "github.com/fastly/cli/pkg/commands/alerts"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 func TestAlertsCreate(t *testing.T) {
@@ -198,7 +199,7 @@ func TestAlertsDelete(t *testing.T) {
 			Name: "ok",
 			Args: "--id ABC",
 			API: mock.API{
-				DeleteAlertDefinitionFn: func(_ *fastly.DeleteAlertDefinitionInput) error {
+				DeleteAlertDefinitionFn: func(_ context.Context, _ *fastly.DeleteAlertDefinitionInput) error {
 					return nil
 				},
 			},
@@ -218,7 +219,7 @@ func TestAlertsDescribe(t *testing.T) {
 			Name: "ok",
 			Args: "--id ABC",
 			API: mock.API{
-				GetAlertDefinitionFn: func(_ *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error) {
+				GetAlertDefinitionFn: func(_ context.Context, _ *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error) {
 					response := &mockDefinition
 					return response, nil
 				},
@@ -290,7 +291,7 @@ func TestAlertsList(t *testing.T) {
 		{
 			Name: "validate ListAlerts API success",
 			API: mock.API{
-				ListAlertDefinitionsFn: func(_ *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error) {
+				ListAlertDefinitionsFn: func(_ context.Context, _ *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error) {
 					response := &fastly.AlertDefinitionsResponse{
 						Data: []fastly.AlertDefinition{mockDefinition},
 						Meta: fastly.AlertsMeta{
@@ -370,7 +371,7 @@ func TestAlertsHistoryList(t *testing.T) {
 		{
 			Name: "validate ListAlerts API success",
 			API: mock.API{
-				ListAlertHistoryFn: func(_ *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error) {
+				ListAlertHistoryFn: func(_ context.Context, _ *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error) {
 					response := &fastly.AlertHistoryResponse{
 						Data: []fastly.AlertHistory{mockHistory},
 						Meta: fastly.AlertsMeta{
@@ -445,7 +446,7 @@ func (t *flagList) String() string {
 
 var mockTime = time.Date(2024, 0o5, 0o1, 12, 0o0, 11, 0, time.UTC)
 
-var ListAlertDefinitionsEmptyResponse = func(_ *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error) {
+var ListAlertDefinitionsEmptyResponse = func(_ context.Context, _ *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error) {
 	response := &fastly.AlertDefinitionsResponse{
 		Data: []fastly.AlertDefinition{},
 		Meta: fastly.AlertsMeta{
@@ -458,7 +459,7 @@ var ListAlertDefinitionsEmptyResponse = func(_ *fastly.ListAlertDefinitionsInput
 	return response, nil
 }
 
-var ListAlertHistoryEmptyResponse = func(_ *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error) {
+var ListAlertHistoryEmptyResponse = func(_ context.Context, _ *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error) {
 	response := &fastly.AlertHistoryResponse{
 		Data: []fastly.AlertHistory{},
 		Meta: fastly.AlertsMeta{
@@ -498,12 +499,12 @@ var mockHistory = fastly.AlertHistory{
 	End:          mockTime,
 }
 
-var CreateAlertDefinitionResponse = func(_ *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
+var CreateAlertDefinitionResponse = func(_ context.Context, _ *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
 	response := &mockDefinition
 	return response, nil
 }
 
-var UpdateAlertDefinitionResponse = func(_ *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
+var UpdateAlertDefinitionResponse = func(_ context.Context, _ *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
 	response := &mockDefinition
 	return response, nil
 }

--- a/pkg/commands/alerts/common.go
+++ b/pkg/commands/alerts/common.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // evaluationType is a list of supported evaluation types.

--- a/pkg/commands/alerts/create.go
+++ b/pkg/commands/alerts/create.go
@@ -1,12 +1,13 @@
 package alerts
 
 import (
+	"context"
 	"io"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.
@@ -64,7 +65,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	definition, err := c.Globals.APIClient.CreateAlertDefinition(input)
+	definition, err := c.Globals.APIClient.CreateAlertDefinition(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/alerts/delete.go
+++ b/pkg/commands/alerts/delete.go
@@ -1,10 +1,11 @@
 package alerts
 
 import (
+	"context"
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -45,7 +46,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	err := c.Globals.APIClient.DeleteAlertDefinition(input)
+	err := c.Globals.APIClient.DeleteAlertDefinition(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Definition ID": c.definitionID,

--- a/pkg/commands/alerts/describe.go
+++ b/pkg/commands/alerts/describe.go
@@ -1,9 +1,10 @@
 package alerts
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -44,7 +45,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	definition, err := c.Globals.APIClient.GetAlertDefinition(input)
+	definition, err := c.Globals.APIClient.GetAlertDefinition(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/alerts/list.go
+++ b/pkg/commands/alerts/list.go
@@ -1,11 +1,12 @@
 package alerts
 
 import (
+	"context"
 	"errors"
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -58,7 +59,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	for {
-		definitions, err := c.Globals.APIClient.ListAlertDefinitions(input)
+		definitions, err := c.Globals.APIClient.ListAlertDefinitions(context.TODO(), input)
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/alerts/list_history.go
+++ b/pkg/commands/alerts/list_history.go
@@ -1,11 +1,12 @@
 package alerts
 
 import (
+	"context"
 	"errors"
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -65,7 +66,7 @@ func (c *ListHistoryCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	for {
-		history, err := c.Globals.APIClient.ListAlertHistory(input)
+		history, err := c.Globals.APIClient.ListAlertHistory(context.TODO(), input)
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/alerts/update.go
+++ b/pkg/commands/alerts/update.go
@@ -1,9 +1,10 @@
 package alerts
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -65,7 +66,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	definition, err := c.Globals.APIClient.UpdateAlertDefinition(input)
+	definition, err := c.Globals.APIClient.UpdateAlertDefinition(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -1,10 +1,11 @@
 package authtoken_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/authtoken"
 	"github.com/fastly/cli/pkg/mock"
@@ -20,7 +21,7 @@ func TestAuthTokenCreate(t *testing.T) {
 		{
 			Name: "validate CreateToken API error",
 			API: mock.API{
-				CreateTokenFn: func(_ *fastly.CreateTokenInput) (*fastly.Token, error) {
+				CreateTokenFn: func(_ context.Context, _ *fastly.CreateTokenInput) (*fastly.Token, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -30,7 +31,7 @@ func TestAuthTokenCreate(t *testing.T) {
 		{
 			Name: "validate CreateToken API success with no flags",
 			API: mock.API{
-				CreateTokenFn: func(_ *fastly.CreateTokenInput) (*fastly.Token, error) {
+				CreateTokenFn: func(_ context.Context, _ *fastly.CreateTokenInput) (*fastly.Token, error) {
 					return &fastly.Token{
 						ExpiresAt:   &testutil.Date,
 						TokenID:     fastly.ToPointer("123"),
@@ -46,7 +47,7 @@ func TestAuthTokenCreate(t *testing.T) {
 		{
 			Name: "validate CreateToken API success with all flags",
 			API: mock.API{
-				CreateTokenFn: func(i *fastly.CreateTokenInput) (*fastly.Token, error) {
+				CreateTokenFn: func(_ context.Context, i *fastly.CreateTokenInput) (*fastly.Token, error) {
 					return &fastly.Token{
 						ExpiresAt:   i.ExpiresAt,
 						TokenID:     fastly.ToPointer("123"),
@@ -74,7 +75,7 @@ func TestAuthTokenDelete(t *testing.T) {
 		{
 			Name: "validate DeleteTokenSelf API error with --current",
 			API: mock.API{
-				DeleteTokenSelfFn: func() error {
+				DeleteTokenSelfFn: func(_ context.Context) error {
 					return testutil.Err
 				},
 			},
@@ -84,7 +85,7 @@ func TestAuthTokenDelete(t *testing.T) {
 		{
 			Name: "validate BatchDeleteTokens API error with --file",
 			API: mock.API{
-				BatchDeleteTokensFn: func(_ *fastly.BatchDeleteTokensInput) error {
+				BatchDeleteTokensFn: func(_ context.Context, _ *fastly.BatchDeleteTokensInput) error {
 					return testutil.Err
 				},
 			},
@@ -94,7 +95,7 @@ func TestAuthTokenDelete(t *testing.T) {
 		{
 			Name: "validate DeleteToken API error with --id",
 			API: mock.API{
-				DeleteTokenFn: func(_ *fastly.DeleteTokenInput) error {
+				DeleteTokenFn: func(_ context.Context, _ *fastly.DeleteTokenInput) error {
 					return testutil.Err
 				},
 			},
@@ -104,7 +105,7 @@ func TestAuthTokenDelete(t *testing.T) {
 		{
 			Name: "validate DeleteTokenSelf API success with --current",
 			API: mock.API{
-				DeleteTokenSelfFn: func() error {
+				DeleteTokenSelfFn: func(_ context.Context) error {
 					return nil
 				},
 			},
@@ -114,7 +115,7 @@ func TestAuthTokenDelete(t *testing.T) {
 		{
 			Name: "validate BatchDeleteTokens API success with --file",
 			API: mock.API{
-				BatchDeleteTokensFn: func(_ *fastly.BatchDeleteTokensInput) error {
+				BatchDeleteTokensFn: func(_ context.Context, _ *fastly.BatchDeleteTokensInput) error {
 					return nil
 				},
 			},
@@ -124,7 +125,7 @@ func TestAuthTokenDelete(t *testing.T) {
 		{
 			Name: "validate BatchDeleteTokens API success with --file and --verbose",
 			API: mock.API{
-				BatchDeleteTokensFn: func(_ *fastly.BatchDeleteTokensInput) error {
+				BatchDeleteTokensFn: func(_ context.Context, _ *fastly.BatchDeleteTokensInput) error {
 					return nil
 				},
 			},
@@ -134,7 +135,7 @@ func TestAuthTokenDelete(t *testing.T) {
 		{
 			Name: "validate DeleteToken API success with --id",
 			API: mock.API{
-				DeleteTokenFn: func(_ *fastly.DeleteTokenInput) error {
+				DeleteTokenFn: func(_ context.Context, _ *fastly.DeleteTokenInput) error {
 					return nil
 				},
 			},
@@ -151,7 +152,7 @@ func TestAuthTokenDescribe(t *testing.T) {
 		{
 			Name: "validate GetTokenSelf API error",
 			API: mock.API{
-				GetTokenSelfFn: func() (*fastly.Token, error) {
+				GetTokenSelfFn: func(_ context.Context) (*fastly.Token, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -176,7 +177,7 @@ func TestAuthTokenList(t *testing.T) {
 		{
 			Name: "validate ListTokens API error",
 			API: mock.API{
-				ListTokensFn: func(_ *fastly.ListTokensInput) ([]*fastly.Token, error) {
+				ListTokensFn: func(_ context.Context, _ *fastly.ListTokensInput) ([]*fastly.Token, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -185,7 +186,7 @@ func TestAuthTokenList(t *testing.T) {
 		{
 			Name: "validate ListCustomerTokens API error",
 			API: mock.API{
-				ListCustomerTokensFn: func(_ *fastly.ListCustomerTokensInput) ([]*fastly.Token, error) {
+				ListCustomerTokensFn: func(_ context.Context, _ *fastly.ListCustomerTokensInput) ([]*fastly.Token, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -228,7 +229,7 @@ func TestAuthTokenList(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "list"}, scenarios)
 }
 
-func getToken() (*fastly.Token, error) {
+func getToken(_ context.Context) (*fastly.Token, error) {
 	t := testutil.Date
 
 	return &fastly.Token{
@@ -244,9 +245,9 @@ func getToken() (*fastly.Token, error) {
 	}, nil
 }
 
-func listTokens(_ *fastly.ListTokensInput) ([]*fastly.Token, error) {
+func listTokens(ctx context.Context, _ *fastly.ListTokensInput) ([]*fastly.Token, error) {
 	t := testutil.Date
-	token, _ := getToken()
+	token, _ := getToken(ctx)
 	vs := []*fastly.Token{
 		token,
 		{
@@ -264,8 +265,8 @@ func listTokens(_ *fastly.ListTokensInput) ([]*fastly.Token, error) {
 	return vs, nil
 }
 
-func listCustomerTokens(_ *fastly.ListCustomerTokensInput) ([]*fastly.Token, error) {
-	return listTokens(nil)
+func listCustomerTokens(ctx context.Context, _ *fastly.ListCustomerTokensInput) ([]*fastly.Token, error) {
+	return listTokens(ctx, nil)
 }
 
 func fileTokensOutput() string {

--- a/pkg/commands/authtoken/create.go
+++ b/pkg/commands/authtoken/create.go
@@ -1,11 +1,13 @@
 package authtoken
 
 import (
+	"context"
 	"io"
 	"strings"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
+
 	"github.com/fastly/kingpin"
 
 	"github.com/fastly/cli/pkg/argparser"
@@ -63,7 +65,7 @@ type CreateCommand struct {
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.CreateToken(input)
+	r, err := c.Globals.APIClient.CreateToken(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/authtoken/delete.go
+++ b/pkg/commands/authtoken/delete.go
@@ -2,12 +2,13 @@ package authtoken
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -45,7 +46,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	if c.current {
-		err := c.Globals.APIClient.DeleteTokenSelf()
+		err := c.Globals.APIClient.DeleteTokenSelf(context.TODO())
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err
@@ -62,7 +63,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 			return err
 		}
 
-		err = c.Globals.APIClient.BatchDeleteTokens(input)
+		err = c.Globals.APIClient.BatchDeleteTokens(context.TODO(), input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err
@@ -79,7 +80,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	if c.id != "" {
 		input := c.constructInput()
 
-		err := c.Globals.APIClient.DeleteToken(input)
+		err := c.Globals.APIClient.DeleteToken(context.TODO(), input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err

--- a/pkg/commands/authtoken/describe.go
+++ b/pkg/commands/authtoken/describe.go
@@ -1,11 +1,12 @@
 package authtoken
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -37,7 +38,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.GetTokenSelf()
+	o, err := c.Globals.APIClient.GetTokenSelf(context.TODO())
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/authtoken/list.go
+++ b/pkg/commands/authtoken/list.go
@@ -1,11 +1,12 @@
 package authtoken
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -56,13 +57,13 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 			text.Info(out, "Listing customer tokens for the FASTLY_CUSTOMER_ID environment variable\n\n")
 		}
 		input := c.constructInput()
-		o, err = c.Globals.APIClient.ListCustomerTokens(input)
+		o, err = c.Globals.APIClient.ListCustomerTokens(context.TODO(), input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err
 		}
 	} else {
-		o, err = c.Globals.APIClient.ListTokens(&fastly.ListTokensInput{})
+		o, err = c.Globals.APIClient.ListTokens(context.TODO(), &fastly.ListTokensInput{})
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err

--- a/pkg/commands/backend/create.go
+++ b/pkg/commands/backend/create.go
@@ -1,11 +1,12 @@
 package backend
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -297,7 +298,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		}
 	}
 
-	b, err := c.Globals.APIClient.CreateBackend(&input)
+	b, err := c.Globals.APIClient.CreateBackend(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/backend/delete.go
+++ b/pkg/commands/backend/delete.go
@@ -1,9 +1,10 @@
 package backend
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -85,7 +86,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteBackend(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteBackend(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
 			"Service Version": serviceVersion.Number,

--- a/pkg/commands/backend/describe.go
+++ b/pkg/commands/backend/describe.go
@@ -1,10 +1,11 @@
 package backend
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetBackend(&c.Input)
+	o, err := c.Globals.APIClient.GetBackend(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/backend/list.go
+++ b/pkg/commands/backend/list.go
@@ -1,10 +1,11 @@
 package backend
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListBackends(&c.Input)
+	o, err := c.Globals.APIClient.ListBackends(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/backend/update.go
+++ b/pkg/commands/backend/update.go
@@ -1,10 +1,11 @@
 package backend
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -300,7 +301,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		input.KeepAliveTime = &c.HTTPKaTime.Value
 	}
 
-	b, err := c.Globals.APIClient.UpdateBackend(input)
+	b, err := c.Globals.APIClient.UpdateBackend(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -5,19 +5,21 @@ package compute_test
 // also a mocked HTTP client).
 
 import (
-	"github.com/fastly/go-fastly/v10/fastly"
+	"context"
+
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/testutil"
 )
 
-func getServiceOK(_ *fastly.GetServiceInput) (*fastly.Service, error) {
+func getServiceOK(_ context.Context, _ *fastly.GetServiceInput) (*fastly.Service, error) {
 	return &fastly.Service{
 		ServiceID: fastly.ToPointer("12345"),
 		Name:      fastly.ToPointer("test"),
 	}, nil
 }
 
-func createDomainOK(i *fastly.CreateDomainInput) (*fastly.Domain, error) {
+func createDomainOK(_ context.Context, i *fastly.CreateDomainInput) (*fastly.Domain, error) {
 	return &fastly.Domain{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -25,7 +27,7 @@ func createDomainOK(i *fastly.CreateDomainInput) (*fastly.Domain, error) {
 	}, nil
 }
 
-func createBackendOK(i *fastly.CreateBackendInput) (*fastly.Backend, error) {
+func createBackendOK(_ context.Context, i *fastly.CreateBackendInput) (*fastly.Backend, error) {
 	return &fastly.Backend{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -33,20 +35,20 @@ func createBackendOK(i *fastly.CreateBackendInput) (*fastly.Backend, error) {
 	}, nil
 }
 
-func createConfigStoreOK(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
+func createConfigStoreOK(_ context.Context, i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
 	return &fastly.ConfigStore{
 		Name: i.Name,
 	}, nil
 }
 
-func updateConfigStoreItemOK(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+func updateConfigStoreItemOK(_ context.Context, i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 	return &fastly.ConfigStoreItem{
 		Key:   i.Key,
 		Value: i.Value,
 	}, nil
 }
 
-func createDictionaryOK(i *fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
+func createDictionaryOK(_ context.Context, i *fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
 	return &fastly.Dictionary{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -54,7 +56,7 @@ func createDictionaryOK(i *fastly.CreateDictionaryInput) (*fastly.Dictionary, er
 	}, nil
 }
 
-func createDictionaryItemOK(i *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error) {
+func createDictionaryItemOK(_ context.Context, i *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error) {
 	return &fastly.DictionaryItem{
 		ServiceID:    fastly.ToPointer(i.ServiceID),
 		DictionaryID: fastly.ToPointer(i.DictionaryID),
@@ -63,48 +65,48 @@ func createDictionaryItemOK(i *fastly.CreateDictionaryItemInput) (*fastly.Dictio
 	}, nil
 }
 
-func createKVStoreOK(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+func createKVStoreOK(_ context.Context, i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 	return &fastly.KVStore{
 		StoreID: "example-store",
 		Name:    i.Name,
 	}, nil
 }
 
-func createKVStoreItemOK(_ *fastly.InsertKVStoreKeyInput) error {
+func createKVStoreItemOK(_ context.Context, _ *fastly.InsertKVStoreKeyInput) error {
 	return nil
 }
 
-func createResourceOK(_ *fastly.CreateResourceInput) (*fastly.Resource, error) {
+func createResourceOK(_ context.Context, _ *fastly.CreateResourceInput) (*fastly.Resource, error) {
 	return nil, nil
 }
 
-func getPackageOk(i *fastly.GetPackageInput) (*fastly.Package, error) {
+func getPackageOk(_ context.Context, i *fastly.GetPackageInput) (*fastly.Package, error) {
 	return &fastly.Package{ServiceID: fastly.ToPointer(i.ServiceID), ServiceVersion: fastly.ToPointer(i.ServiceVersion)}, nil
 }
 
-func updatePackageOk(i *fastly.UpdatePackageInput) (*fastly.Package, error) {
+func updatePackageOk(_ context.Context, i *fastly.UpdatePackageInput) (*fastly.Package, error) {
 	return &fastly.Package{ServiceID: fastly.ToPointer(i.ServiceID), ServiceVersion: fastly.ToPointer(i.ServiceVersion)}, nil
 }
 
-func updatePackageError(_ *fastly.UpdatePackageInput) (*fastly.Package, error) {
+func updatePackageError(_ context.Context, _ *fastly.UpdatePackageInput) (*fastly.Package, error) {
 	return nil, testutil.Err
 }
 
-func activateVersionOk(i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+func activateVersionOk(_ context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{ServiceID: fastly.ToPointer(i.ServiceID), Number: fastly.ToPointer(i.ServiceVersion)}, nil
 }
 
-func updateVersionOk(i *fastly.UpdateVersionInput) (*fastly.Version, error) {
+func updateVersionOk(_ context.Context, i *fastly.UpdateVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{ServiceID: fastly.ToPointer(i.ServiceID), Number: fastly.ToPointer(i.ServiceVersion), Comment: i.Comment}, nil
 }
 
-func listDomainsOk(_ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
+func listDomainsOk(_ context.Context, _ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	return []*fastly.Domain{
 		{Name: fastly.ToPointer("https://directly-careful-coyote.edgecompute.app")},
 	}, nil
 }
 
-func listKVStoresOk(_ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+func listKVStoresOk(_ context.Context, _ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
 	return &fastly.ListKVStoresResponse{
 		Data: []fastly.KVStore{
 			{
@@ -119,18 +121,18 @@ func listKVStoresOk(_ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, 
 	}, nil
 }
 
-func listKVStoresEmpty(_ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+func listKVStoresEmpty(_ context.Context, _ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
 	return &fastly.ListKVStoresResponse{}, nil
 }
 
-func getKVStoreOk(_ *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
+func getKVStoreOk(_ context.Context, _ *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
 	return &fastly.KVStore{
 		StoreID: "123",
 		Name:    "store_one",
 	}, nil
 }
 
-func listSecretStoresOk(_ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+func listSecretStoresOk(_ context.Context, _ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
 	return &fastly.SecretStores{
 		Data: []fastly.SecretStore{
 			{
@@ -145,32 +147,32 @@ func listSecretStoresOk(_ *fastly.ListSecretStoresInput) (*fastly.SecretStores, 
 	}, nil
 }
 
-func listSecretStoresEmpty(_ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+func listSecretStoresEmpty(_ context.Context, _ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
 	return &fastly.SecretStores{}, nil
 }
 
-func getSecretStoreOk(_ *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
+func getSecretStoreOk(_ context.Context, _ *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
 	return &fastly.SecretStore{
 		StoreID: "123",
 		Name:    "store_one",
 	}, nil
 }
 
-func createSecretStoreOk(_ *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
+func createSecretStoreOk(_ context.Context, _ *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
 	return &fastly.SecretStore{
 		StoreID: "123",
 		Name:    "store_one",
 	}, nil
 }
 
-func createSecretOk(_ *fastly.CreateSecretInput) (*fastly.Secret, error) {
+func createSecretOk(_ context.Context, _ *fastly.CreateSecretInput) (*fastly.Secret, error) {
 	return &fastly.Secret{
 		Digest: []byte("123"),
 		Name:   "foo",
 	}, nil
 }
 
-func listConfigStoresOk(_ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
+func listConfigStoresOk(_ context.Context, _ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
 	return []*fastly.ConfigStore{
 		{
 			StoreID: "123",
@@ -183,18 +185,18 @@ func listConfigStoresOk(_ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore,
 	}, nil
 }
 
-func listConfigStoresEmpty(_ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
+func listConfigStoresEmpty(_ context.Context, _ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
 	return []*fastly.ConfigStore{}, nil
 }
 
-func getConfigStoreOk(_ *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
+func getConfigStoreOk(_ context.Context, _ *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 	return &fastly.ConfigStore{
 		StoreID: "123",
 		Name:    "example",
 	}, nil
 }
 
-func getServiceDetailsWasm(_ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
+func getServiceDetailsWasm(_ context.Context, _ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 	return &fastly.ServiceDetail{
 		Type: fastly.ToPointer("wasm"),
 	}, nil

--- a/pkg/commands/compute/computeacl/computeacl_test.go
+++ b/pkg/commands/compute/computeacl/computeacl_test.go
@@ -12,7 +12,7 @@ import (
 	sub "github.com/fastly/cli/pkg/commands/compute/computeacl"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 )
 
 func TestComputeACLCreate(t *testing.T) {

--- a/pkg/commands/compute/computeacl/create.go
+++ b/pkg/commands/compute/computeacl/create.go
@@ -1,11 +1,13 @@
 package computeacl
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -52,7 +54,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	acl, err := computeacls.Create(fc, &computeacls.CreateInput{
+	acl, err := computeacls.Create(context.TODO(), fc, &computeacls.CreateInput{
 		Name: &c.name,
 	})
 	if err != nil {

--- a/pkg/commands/compute/computeacl/delete.go
+++ b/pkg/commands/compute/computeacl/delete.go
@@ -1,11 +1,13 @@
 package computeacl
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -52,7 +54,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	err := computeacls.Delete(fc, &computeacls.DeleteInput{
+	err := computeacls.Delete(context.TODO(), fc, &computeacls.DeleteInput{
 		ComputeACLID: &c.id,
 	})
 	if err != nil {

--- a/pkg/commands/compute/computeacl/describe.go
+++ b/pkg/commands/compute/computeacl/describe.go
@@ -1,11 +1,13 @@
 package computeacl
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -52,7 +54,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	acl, err := computeacls.Describe(fc, &computeacls.DescribeInput{
+	acl, err := computeacls.Describe(context.TODO(), fc, &computeacls.DescribeInput{
 		ComputeACLID: &c.id,
 	})
 	if err != nil {

--- a/pkg/commands/compute/computeacl/listacls.go
+++ b/pkg/commands/compute/computeacl/listacls.go
@@ -1,6 +1,7 @@
 package computeacl
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -8,8 +9,9 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 )
 
 // ListCommand calls the Fastly API to list all compute ACLs.
@@ -45,7 +47,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	acls, err := computeacls.ListACLs(fc)
+	acls, err := computeacls.ListACLs(context.TODO(), fc)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/compute/computeacl/listentries.go
+++ b/pkg/commands/compute/computeacl/listentries.go
@@ -1,11 +1,13 @@
 package computeacl
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -62,7 +64,7 @@ func (c *ListEntriesCommand) Exec(in io.Reader, out io.Writer) error {
 	loadAllPages := c.JSONOutput.Enabled || c.Globals.Flags.NonInteractive || c.Globals.Flags.AutoYes
 
 	for {
-		o, err := computeacls.ListEntries(fc, &computeacls.ListEntriesInput{
+		o, err := computeacls.ListEntries(context.TODO(), fc, &computeacls.ListEntriesInput{
 			ComputeACLID: &c.id,
 			Cursor:       &c.cursor,
 			Limit:        &c.limit,

--- a/pkg/commands/compute/computeacl/lookup.go
+++ b/pkg/commands/compute/computeacl/lookup.go
@@ -1,11 +1,13 @@
 package computeacl
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -54,7 +56,7 @@ func (c *LookupCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	entry, err := computeacls.Lookup(fc, &computeacls.LookupInput{
+	entry, err := computeacls.Lookup(context.TODO(), fc, &computeacls.LookupInput{
 		ComputeACLID: &c.id,
 		ComputeACLIP: &c.ip,
 	})

--- a/pkg/commands/compute/computeacl/update.go
+++ b/pkg/commands/compute/computeacl/update.go
@@ -1,13 +1,15 @@
 package computeacl
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -70,7 +72,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 			return err
 		}
 
-		err = computeacls.Update(fc, input)
+		err = computeacls.Update(context.TODO(), fc, input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err
@@ -85,7 +87,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	err = computeacls.Update(fc, input)
+	err = computeacls.Update(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/commands/compute"
@@ -2240,7 +2240,7 @@ func TestDeploy_ActivateBeacon(t *testing.T) {
 	opts := testutil.MockGlobalData(args, &stdout)
 	opts.HTTPClient = recordingHTTP
 	opts.APIClientFactory = mock.APIClient(mock.API{
-		ActivateVersionFn: func(*fastly.ActivateVersionInput) (*fastly.Version, error) {
+		ActivateVersionFn: func(_ context.Context, _ *fastly.ActivateVersionInput) (*fastly.Version, error) {
 			return nil, testutil.Err
 		},
 		CloneVersionFn:      testutil.CloneVersionResult(4),
@@ -2269,7 +2269,7 @@ func TestDeploy_ActivateBeacon(t *testing.T) {
 	testutil.AssertEqual(t, "fastly-notification-relay.edgecompute.app", beaconReq.URL.Hostname())
 }
 
-func createServiceOK(i *fastly.CreateServiceInput) (*fastly.Service, error) {
+func createServiceOK(_ context.Context, i *fastly.CreateServiceInput) (*fastly.Service, error) {
 	return &fastly.Service{
 		ServiceID: fastly.ToPointer("12345"),
 		Name:      i.Name,
@@ -2277,47 +2277,47 @@ func createServiceOK(i *fastly.CreateServiceInput) (*fastly.Service, error) {
 	}, nil
 }
 
-func createServiceError(*fastly.CreateServiceInput) (*fastly.Service, error) {
+func createServiceError(_ context.Context, _ *fastly.CreateServiceInput) (*fastly.Service, error) {
 	return nil, testutil.Err
 }
 
 // NOTE: We don't return testutil.Err but a very specific error message so that
 // the Deploy logic will drop into a nested logic block.
-func createServiceErrorNoTrial(*fastly.CreateServiceInput) (*fastly.Service, error) {
+func createServiceErrorNoTrial(_ context.Context, _ *fastly.CreateServiceInput) (*fastly.Service, error) {
 	return nil, fmt.Errorf("Valid values for 'type' are: 'vcl'")
 }
 
-func getCurrentUser() (*fastly.User, error) {
+func getCurrentUser(_ context.Context) (*fastly.User, error) {
 	return &fastly.User{
 		CustomerID: fastly.ToPointer("abc"),
 	}, nil
 }
 
-func getCurrentUserError() (*fastly.User, error) {
+func getCurrentUserError(_ context.Context) (*fastly.User, error) {
 	return nil, testutil.Err
 }
 
-func deleteServiceOK(_ *fastly.DeleteServiceInput) error {
+func deleteServiceOK(_ context.Context, _ *fastly.DeleteServiceInput) error {
 	return nil
 }
 
-func createDomainError(_ *fastly.CreateDomainInput) (*fastly.Domain, error) {
+func createDomainError(_ context.Context, _ *fastly.CreateDomainInput) (*fastly.Domain, error) {
 	return nil, testutil.Err
 }
 
-func deleteDomainOK(_ *fastly.DeleteDomainInput) error {
+func deleteDomainOK(_ context.Context, _ *fastly.DeleteDomainInput) error {
 	return nil
 }
 
-func createBackendError(_ *fastly.CreateBackendInput) (*fastly.Backend, error) {
+func createBackendError(_ context.Context, _ *fastly.CreateBackendInput) (*fastly.Backend, error) {
 	return nil, testutil.Err
 }
 
-func deleteBackendOK(_ *fastly.DeleteBackendInput) error {
+func deleteBackendOK(_ context.Context, _ *fastly.DeleteBackendInput) error {
 	return nil
 }
 
-func getPackageIdentical(i *fastly.GetPackageInput) (*fastly.Package, error) {
+func getPackageIdentical(_ context.Context, i *fastly.GetPackageInput) (*fastly.Package, error) {
 	return &fastly.Package{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -2328,14 +2328,14 @@ func getPackageIdentical(i *fastly.GetPackageInput) (*fastly.Package, error) {
 	}, nil
 }
 
-func activateVersionError(_ *fastly.ActivateVersionInput) (*fastly.Version, error) {
+func activateVersionError(_ context.Context, _ *fastly.ActivateVersionInput) (*fastly.Version, error) {
 	return nil, testutil.Err
 }
 
-func listDomainsError(_ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
+func listDomainsError(_ context.Context, _ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	return nil, testutil.Err
 }
 
-func listDomainsNone(_ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
+func listDomainsNone(_ context.Context, _ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	return []*fastly.Domain{}, nil
 }

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -18,7 +19,7 @@ import (
 
 	cp "github.com/otiai10/copy"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/config"
@@ -275,7 +276,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 				serviceVersion int
 			)
 			err = spinner.Process("Fetching service details", func(_ *text.SpinnerWrapper) error {
-				serviceDetails, err = c.Globals.APIClient.GetServiceDetails(&fastly.GetServiceInput{
+				serviceDetails, err = c.Globals.APIClient.GetServiceDetails(context.TODO(), &fastly.GetServiceInput{
 					ServiceID: c.CloneFrom,
 				})
 				if err != nil {
@@ -295,7 +296,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 
 				if serviceDetails.ActiveVersion != nil {
 					serviceVersion = fastly.ToValue(serviceDetails.ActiveVersion.Number)
-					pack, err = c.Globals.APIClient.GetPackage(&fastly.GetPackageInput{
+					pack, err = c.Globals.APIClient.GetPackage(context.TODO(), &fastly.GetPackageInput{
 						ServiceID:      c.CloneFrom,
 						ServiceVersion: serviceVersion,
 					})
@@ -305,7 +306,7 @@ func (c *InitCommand) Exec(in io.Reader, out io.Writer) (err error) {
 				} else {
 					for i := len(serviceDetails.Versions) - 1; i >= 0; i-- {
 						serviceVersion = fastly.ToValue(serviceDetails.Versions[i].Number)
-						pack, err = c.Globals.APIClient.GetPackage(&fastly.GetPackageInput{
+						pack, err = c.Globals.APIClient.GetPackage(context.TODO(), &fastly.GetPackageInput{
 							ServiceID:      c.CloneFrom,
 							ServiceVersion: serviceVersion,
 						})

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -1,12 +1,13 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/commands/backend"
@@ -95,7 +96,7 @@ func (b *Backends) Create() error {
 			opts.SSLSNIHostname = &bk.SSLSNIHostname
 		}
 
-		_, err := b.APIClient.CreateBackend(opts)
+		_, err := b.APIClient.CreateBackend(context.TODO(), opts)
 		if err != nil {
 			if !b.isOriginless() {
 				err = fmt.Errorf("error creating backend: %w", err)

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -1,10 +1,11 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"
@@ -50,7 +51,7 @@ type ConfigStoreItem struct {
 
 // Configure prompts the user for specific values related to the service resource.
 func (o *ConfigStores) Configure() error {
-	existingStores, err := o.APIClient.ListConfigStores(&fastly.ListConfigStoresInput{})
+	existingStores, err := o.APIClient.ListConfigStores(context.TODO(), &fastly.ListConfigStoresInput{})
 	if err != nil {
 		return err
 	}
@@ -155,7 +156,7 @@ func (o *ConfigStores) Create() error {
 
 		if configStore.LinkExistingStore {
 			err = o.Spinner.Process(fmt.Sprintf("Retrieving existing Config Store '%s'", configStore.Name), func(_ *text.SpinnerWrapper) error {
-				cs, err = o.APIClient.GetConfigStore(&fastly.GetConfigStoreInput{
+				cs, err = o.APIClient.GetConfigStore(context.TODO(), &fastly.GetConfigStoreInput{
 					StoreID: configStore.ExistingStoreID,
 				})
 				if err != nil {
@@ -168,7 +169,7 @@ func (o *ConfigStores) Create() error {
 			}
 		} else {
 			err = o.Spinner.Process(fmt.Sprintf("Creating config store '%s'", configStore.Name), func(_ *text.SpinnerWrapper) error {
-				cs, err = o.APIClient.CreateConfigStore(&fastly.CreateConfigStoreInput{
+				cs, err = o.APIClient.CreateConfigStore(context.TODO(), &fastly.CreateConfigStoreInput{
 					Name: configStore.Name,
 				})
 				if err != nil {
@@ -184,7 +185,7 @@ func (o *ConfigStores) Create() error {
 		if len(configStore.Items) > 0 {
 			for _, item := range configStore.Items {
 				err = o.Spinner.Process(fmt.Sprintf("Creating config store item '%s'", item.Key), func(_ *text.SpinnerWrapper) error {
-					_, err = o.APIClient.UpdateConfigStoreItem(&fastly.UpdateConfigStoreItemInput{
+					_, err = o.APIClient.UpdateConfigStoreItem(context.TODO(), &fastly.UpdateConfigStoreItemInput{
 						Upsert:  true, // Use upsert to avoid conflicts when reusing a starter kit.
 						StoreID: cs.StoreID,
 						Key:     item.Key,
@@ -203,7 +204,7 @@ func (o *ConfigStores) Create() error {
 
 		// IMPORTANT: We need to link the config store to the Compute Service.
 		err = o.Spinner.Process(fmt.Sprintf("Creating resource link between service and config store '%s'...", cs.Name), func(_ *text.SpinnerWrapper) error {
-			_, err = o.APIClient.CreateResource(&fastly.CreateResourceInput{
+			_, err = o.APIClient.CreateResource(context.TODO(), &fastly.CreateResourceInput{
 				ServiceID:      o.ServiceID,
 				ServiceVersion: o.ServiceVersion,
 				Name:           fastly.ToPointer(cs.Name),

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,7 @@ import (
 
 	petname "github.com/dustinkirkland/golang-petname"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"
@@ -124,7 +125,7 @@ func (d *Domains) Predefined() bool {
 // NOTE: It should set an internal `missing` field (boolean) accordingly so that
 // the Missing() method can report the state of the resource.
 func (d *Domains) Validate() error {
-	available, err := d.APIClient.ListDomains(&fastly.ListDomainsInput{
+	available, err := d.APIClient.ListDomains(context.TODO(), &fastly.ListDomainsInput{
 		ServiceID:      d.ServiceID,
 		ServiceVersion: d.ServiceVersion,
 	})
@@ -163,7 +164,7 @@ func (d *Domains) createDomain(name string, attempt int) error {
 	msg := fmt.Sprintf("Creating domain '%s'", name)
 	d.Spinner.Message(msg + "...")
 
-	_, err = d.APIClient.CreateDomain(&fastly.CreateDomainInput{
+	_, err = d.APIClient.CreateDomain(context.TODO(), &fastly.CreateDomainInput{
 		ServiceID:      d.ServiceID,
 		ServiceVersion: d.ServiceVersion,
 		Name:           &name,

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -1,12 +1,13 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"
@@ -59,7 +60,7 @@ func (o *KVStores) Configure() error {
 	)
 
 	for {
-		kvs, err := o.APIClient.ListKVStores(&fastly.ListKVStoresInput{
+		kvs, err := o.APIClient.ListKVStores(context.TODO(), &fastly.ListKVStoresInput{
 			Cursor: cursor,
 		})
 		if err != nil {
@@ -214,7 +215,7 @@ func (o *KVStores) Create() error {
 
 		if kvStore.LinkExistingStore {
 			err = o.Spinner.Process(fmt.Sprintf("Retrieving existing KV Store '%s'", kvStore.Name), func(_ *text.SpinnerWrapper) error {
-				store, err = o.APIClient.GetKVStore(&fastly.GetKVStoreInput{
+				store, err = o.APIClient.GetKVStore(context.TODO(), &fastly.GetKVStoreInput{
 					StoreID: kvStore.ExistingStoreID,
 				})
 				if err != nil {
@@ -227,7 +228,7 @@ func (o *KVStores) Create() error {
 			}
 		} else {
 			err = o.Spinner.Process(fmt.Sprintf("Creating KV Store '%s'", kvStore.Name), func(_ *text.SpinnerWrapper) error {
-				store, err = o.APIClient.CreateKVStore(&fastly.CreateKVStoreInput{
+				store, err = o.APIClient.CreateKVStore(context.TODO(), &fastly.CreateKVStoreInput{
 					Name: kvStore.Name,
 				})
 				if err != nil {
@@ -252,7 +253,7 @@ func (o *KVStores) Create() error {
 					} else {
 						input.Value = item.Value
 					}
-					err = o.APIClient.InsertKVStoreKey(input)
+					err = o.APIClient.InsertKVStoreKey(context.TODO(), input)
 					if err != nil {
 						return fmt.Errorf("error creating KV Store key: %w", err)
 					}
@@ -266,7 +267,7 @@ func (o *KVStores) Create() error {
 
 		// IMPORTANT: We need to link the KV Store to the Compute Service.
 		err = o.Spinner.Process(fmt.Sprintf("Creating resource link between service and KV Store '%s'...", kvStore.Name), func(_ *text.SpinnerWrapper) error {
-			_, err = o.APIClient.CreateResource(&fastly.CreateResourceInput{
+			_, err = o.APIClient.CreateResource(context.TODO(), &fastly.CreateResourceInput{
 				ServiceID:      o.ServiceID,
 				ServiceVersion: o.ServiceVersion,
 				Name:           fastly.ToPointer(store.Name),

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -1,11 +1,12 @@
 package setup
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	fsterrors "github.com/fastly/cli/pkg/errors"
@@ -63,7 +64,7 @@ func (s *SecretStores) Configure() error {
 	)
 
 	for {
-		o, err := s.APIClient.ListSecretStores(&fastly.ListSecretStoresInput{
+		o, err := s.APIClient.ListSecretStores(context.TODO(), &fastly.ListSecretStoresInput{
 			Cursor: cursor,
 		})
 		if err != nil {
@@ -174,7 +175,7 @@ func (s *SecretStores) Create() error {
 
 		if secretStore.LinkExistingStore {
 			err = s.Spinner.Process(fmt.Sprintf("Retrieving existing Secret Store '%s'", secretStore.Name), func(_ *text.SpinnerWrapper) error {
-				store, err = s.APIClient.GetSecretStore(&fastly.GetSecretStoreInput{
+				store, err = s.APIClient.GetSecretStore(context.TODO(), &fastly.GetSecretStoreInput{
 					StoreID: secretStore.ExistingStoreID,
 				})
 				if err != nil {
@@ -187,7 +188,7 @@ func (s *SecretStores) Create() error {
 			}
 		} else {
 			err = s.Spinner.Process(fmt.Sprintf("Creating Secret Store '%s'", secretStore.Name), func(_ *text.SpinnerWrapper) error {
-				store, err = s.APIClient.CreateSecretStore(&fastly.CreateSecretStoreInput{
+				store, err = s.APIClient.CreateSecretStore(context.TODO(), &fastly.CreateSecretStoreInput{
 					Name: secretStore.Name,
 				})
 				if err != nil {
@@ -202,7 +203,7 @@ func (s *SecretStores) Create() error {
 
 		for _, entry := range secretStore.Entries {
 			err = s.Spinner.Process(fmt.Sprintf("Creating Secret Store entry '%s'...", entry.Name), func(_ *text.SpinnerWrapper) error {
-				_, err = s.APIClient.CreateSecret(&fastly.CreateSecretInput{
+				_, err = s.APIClient.CreateSecret(context.TODO(), &fastly.CreateSecretInput{
 					StoreID: store.StoreID,
 					Name:    entry.Name,
 					Secret:  []byte(entry.Secret),
@@ -220,7 +221,7 @@ func (s *SecretStores) Create() error {
 		err = s.Spinner.Process(fmt.Sprintf("Creating resource link between service and Secret Store '%s'...", store.Name), func(_ *text.SpinnerWrapper) error {
 			// We need to link the secret store to the C@E Service, otherwise the service
 			// will not have access to the store.
-			_, err = s.APIClient.CreateResource(&fastly.CreateResourceInput{
+			_, err = s.APIClient.CreateResource(context.TODO(), &fastly.CreateResourceInput{
 				ServiceID:      s.ServiceID,
 				ServiceVersion: s.ServiceVersion,
 				Name:           fastly.ToPointer(store.Name),

--- a/pkg/commands/compute/update.go
+++ b/pkg/commands/compute/update.go
@@ -1,13 +1,14 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
 
 	"github.com/kennygrant/sanitize"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -107,7 +108,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	serviceVersionNumber := fastly.ToValue(serviceVersion.Number)
 
 	err = spinner.Process("Uploading package", func(_ *text.SpinnerWrapper) error {
-		_, err = c.Globals.APIClient.UpdatePackage(&fastly.UpdatePackageInput{
+		_, err = c.Globals.APIClient.UpdatePackage(context.TODO(), &fastly.UpdatePackageInput{
 			ServiceID:      serviceID,
 			ServiceVersion: serviceVersionNumber,
 			PackagePath:    fastly.ToPointer(packagePath),

--- a/pkg/commands/configstore/configstore_test.go
+++ b/pkg/commands/configstore/configstore_test.go
@@ -1,12 +1,13 @@
 package configstore_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/configstore"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
@@ -28,7 +29,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
-				CreateConfigStoreFn: func(_ *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
+				CreateConfigStoreFn: func(_ context.Context, _ *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -37,7 +38,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
-				CreateConfigStoreFn: func(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
+				CreateConfigStoreFn: func(_ context.Context, i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
 						StoreID: storeID,
 						Name:    i.Name,
@@ -49,7 +50,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--name %s --json", storeName),
 			API: mock.API{
-				CreateConfigStoreFn: func(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
+				CreateConfigStoreFn: func(_ context.Context, i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
 						StoreID:   storeID,
 						Name:      i.Name,
@@ -81,7 +82,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			Args: "--store-id DOES-NOT-EXIST",
 			API: mock.API{
-				DeleteConfigStoreFn: func(i *fastly.DeleteConfigStoreInput) error {
+				DeleteConfigStoreFn: func(_ context.Context, i *fastly.DeleteConfigStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -93,7 +94,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				DeleteConfigStoreFn: func(i *fastly.DeleteConfigStoreInput) error {
+				DeleteConfigStoreFn: func(_ context.Context, i *fastly.DeleteConfigStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -105,7 +106,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
-				DeleteConfigStoreFn: func(i *fastly.DeleteConfigStoreInput) error {
+				DeleteConfigStoreFn: func(_ context.Context, i *fastly.DeleteConfigStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -134,7 +135,7 @@ func TestGetStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				GetConfigStoreFn: func(_ *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
+				GetConfigStoreFn: func(_ context.Context, _ *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -143,7 +144,7 @@ func TestGetStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				GetConfigStoreFn: func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
+				GetConfigStoreFn: func(_ context.Context, i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
 						StoreID:   i.StoreID,
 						Name:      storeName,
@@ -163,14 +164,14 @@ func TestGetStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --metadata", storeID),
 			API: mock.API{
-				GetConfigStoreFn: func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
+				GetConfigStoreFn: func(_ context.Context, i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
 						StoreID:   i.StoreID,
 						Name:      storeName,
 						CreatedAt: &now,
 					}, nil
 				},
-				GetConfigStoreMetadataFn: func(_ *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error) {
+				GetConfigStoreMetadataFn: func(_ context.Context, _ *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error) {
 					return &fastly.ConfigStoreMetadata{
 						ItemCount: 42,
 					}, nil
@@ -190,7 +191,7 @@ func TestGetStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
-				GetConfigStoreFn: func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
+				GetConfigStoreFn: func(_ context.Context, i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
 						StoreID:   i.StoreID,
 						Name:      storeName,
@@ -225,7 +226,7 @@ func TestListStoresCommand(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			API: mock.API{
-				ListConfigStoresFn: func(_ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
+				ListConfigStoresFn: func(_ context.Context, _ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
 					return nil, nil
 				},
 			},
@@ -233,7 +234,7 @@ func TestListStoresCommand(t *testing.T) {
 		},
 		{
 			API: mock.API{
-				ListConfigStoresFn: func(_ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
+				ListConfigStoresFn: func(_ context.Context, _ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
 					return nil, errors.New("unknown error")
 				},
 			},
@@ -241,7 +242,7 @@ func TestListStoresCommand(t *testing.T) {
 		},
 		{
 			API: mock.API{
-				ListConfigStoresFn: func(_ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
+				ListConfigStoresFn: func(_ context.Context, _ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
 					return stores, nil
 				},
 			},
@@ -250,7 +251,7 @@ func TestListStoresCommand(t *testing.T) {
 		{
 			Args: "--json",
 			API: mock.API{
-				ListConfigStoresFn: func(_ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
+				ListConfigStoresFn: func(_ context.Context, _ *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
 					return stores, nil
 				},
 			},
@@ -276,7 +277,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				ListConfigStoreServicesFn: func(_ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
+				ListConfigStoreServicesFn: func(_ context.Context, _ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return nil, nil
 				},
 			},
@@ -285,7 +286,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				ListConfigStoreServicesFn: func(_ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
+				ListConfigStoreServicesFn: func(_ context.Context, _ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return nil, errors.New("unknown error")
 				},
 			},
@@ -294,7 +295,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				ListConfigStoreServicesFn: func(_ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
+				ListConfigStoreServicesFn: func(_ context.Context, _ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return services, nil
 				},
 			},
@@ -303,7 +304,7 @@ func TestListStoreServicesCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
-				ListConfigStoreServicesFn: func(_ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
+				ListConfigStoreServicesFn: func(_ context.Context, _ *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
 					return services, nil
 				},
 			},
@@ -329,7 +330,7 @@ func TestUpdateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --name %s", storeID, storeName),
 			API: mock.API{
-				UpdateConfigStoreFn: func(_ *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
+				UpdateConfigStoreFn: func(_ context.Context, _ *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -338,7 +339,7 @@ func TestUpdateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --name %s", storeID, storeName),
 			API: mock.API{
-				UpdateConfigStoreFn: func(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
+				UpdateConfigStoreFn: func(_ context.Context, i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
 						StoreID:   storeID,
 						Name:      i.Name,
@@ -351,7 +352,7 @@ func TestUpdateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --name %s --json", storeID, storeName),
 			API: mock.API{
-				UpdateConfigStoreFn: func(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
+				UpdateConfigStoreFn: func(_ context.Context, i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
 					return &fastly.ConfigStore{
 						StoreID:   storeID,
 						Name:      i.Name,

--- a/pkg/commands/configstore/create.go
+++ b/pkg/commands/configstore/create.go
@@ -1,9 +1,10 @@
 package configstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -49,7 +50,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.CreateConfigStore(&c.input)
+	o, err := c.Globals.APIClient.CreateConfigStore(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstore/delete.go
+++ b/pkg/commands/configstore/delete.go
@@ -1,9 +1,10 @@
 package configstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -43,7 +44,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	err := c.Globals.APIClient.DeleteConfigStore(&c.input)
+	err := c.Globals.APIClient.DeleteConfigStore(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstore/describe.go
+++ b/pkg/commands/configstore/describe.go
@@ -1,9 +1,10 @@
 package configstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -50,7 +51,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	cs, err := c.Globals.APIClient.GetConfigStore(&c.input)
+	cs, err := c.Globals.APIClient.GetConfigStore(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -58,7 +59,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	var csm *fastly.ConfigStoreMetadata
 	if c.metadata {
-		csm, err = c.Globals.APIClient.GetConfigStoreMetadata(&fastly.GetConfigStoreMetadataInput{
+		csm, err = c.Globals.APIClient.GetConfigStoreMetadata(context.TODO(), &fastly.GetConfigStoreMetadataInput{
 			StoreID: c.input.StoreID,
 		})
 		if err != nil {

--- a/pkg/commands/configstore/helper_test.go
+++ b/pkg/commands/configstore/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 func fmtStore(cs *fastly.ConfigStore, csm *fastly.ConfigStoreMetadata) string {

--- a/pkg/commands/configstore/list.go
+++ b/pkg/commands/configstore/list.go
@@ -1,9 +1,10 @@
 package configstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -39,7 +40,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.ListConfigStores(&fastly.ListConfigStoresInput{})
+	o, err := c.Globals.APIClient.ListConfigStores(context.TODO(), &fastly.ListConfigStoresInput{})
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstore/list_services.go
+++ b/pkg/commands/configstore/list_services.go
@@ -1,9 +1,10 @@
 package configstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -43,7 +44,7 @@ func (c *ListServicesCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.ListConfigStoreServices(&c.input)
+	o, err := c.Globals.APIClient.ListConfigStoreServices(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstore/update.go
+++ b/pkg/commands/configstore/update.go
@@ -1,9 +1,10 @@
 package configstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -50,7 +51,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.UpdateConfigStore(&c.input)
+	o, err := c.Globals.APIClient.UpdateConfigStore(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstoreentry/configstoreentry_test.go
+++ b/pkg/commands/configstoreentry/configstoreentry_test.go
@@ -2,12 +2,13 @@ package configstoreentry_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/configstoreentry"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
@@ -32,7 +33,7 @@ func TestCreateEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
-				CreateConfigStoreItemFn: func(_ *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				CreateConfigStoreItemFn: func(_ context.Context, _ *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -41,7 +42,7 @@ func TestCreateEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
-				CreateConfigStoreItemFn: func(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				CreateConfigStoreItemFn: func(_ context.Context, i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
 						StoreID: i.StoreID,
 						Key:     i.Key,
@@ -54,7 +55,7 @@ func TestCreateEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue),
 			API: mock.API{
-				CreateConfigStoreItemFn: func(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				CreateConfigStoreItemFn: func(_ context.Context, i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
 						StoreID:   i.StoreID,
 						Key:       i.Key,
@@ -116,7 +117,7 @@ func TestDeleteEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				DeleteConfigStoreItemFn: func(_ *fastly.DeleteConfigStoreItemInput) error {
+				DeleteConfigStoreItemFn: func(_ context.Context, _ *fastly.DeleteConfigStoreItemInput) error {
 					return errors.New("invalid request")
 				},
 			},
@@ -125,7 +126,7 @@ func TestDeleteEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				DeleteConfigStoreItemFn: func(_ *fastly.DeleteConfigStoreItemInput) error {
+				DeleteConfigStoreItemFn: func(_ context.Context, _ *fastly.DeleteConfigStoreItemInput) error {
 					return nil
 				},
 			},
@@ -134,7 +135,7 @@ func TestDeleteEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
-				DeleteConfigStoreItemFn: func(_ *fastly.DeleteConfigStoreItemInput) error {
+				DeleteConfigStoreItemFn: func(_ context.Context, _ *fastly.DeleteConfigStoreItemInput) error {
 					return nil
 				},
 			},
@@ -151,10 +152,10 @@ func TestDeleteEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
-				ListConfigStoreItemsFn: func(_ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
+				ListConfigStoreItemsFn: func(_ context.Context, _ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
 				},
-				DeleteConfigStoreItemFn: func(_ *fastly.DeleteConfigStoreItemInput) error {
+				DeleteConfigStoreItemFn: func(_ context.Context, _ *fastly.DeleteConfigStoreItemInput) error {
 					return nil
 				},
 			},
@@ -168,10 +169,10 @@ SUCCESS: Deleted all keys from Config Store '%s'
 		{
 			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
-				ListConfigStoreItemsFn: func(_ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
+				ListConfigStoreItemsFn: func(_ context.Context, _ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
 				},
-				DeleteConfigStoreItemFn: func(_ *fastly.DeleteConfigStoreItemInput) error {
+				DeleteConfigStoreItemFn: func(_ context.Context, _ *fastly.DeleteConfigStoreItemInput) error {
 					return errors.New("whoops")
 				},
 			},
@@ -205,7 +206,7 @@ func TestDescribeEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				GetConfigStoreItemFn: func(_ *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				GetConfigStoreItemFn: func(_ context.Context, _ *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -214,7 +215,7 @@ func TestDescribeEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				GetConfigStoreItemFn: func(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				GetConfigStoreItemFn: func(_ context.Context, i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
 						StoreID:   i.StoreID,
 						Key:       i.Key,
@@ -229,7 +230,7 @@ func TestDescribeEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
-				GetConfigStoreItemFn: func(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				GetConfigStoreItemFn: func(_ context.Context, i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
 						StoreID:   i.StoreID,
 						Key:       i.Key,
@@ -269,7 +270,7 @@ func TestListEntriesCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				ListConfigStoreItemsFn: func(_ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
+				ListConfigStoreItemsFn: func(_ context.Context, _ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -278,7 +279,7 @@ func TestListEntriesCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				ListConfigStoreItemsFn: func(_ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
+				ListConfigStoreItemsFn: func(_ context.Context, _ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
 				},
 			},
@@ -287,7 +288,7 @@ func TestListEntriesCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
-				ListConfigStoreItemsFn: func(_ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
+				ListConfigStoreItemsFn: func(_ context.Context, _ *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
 					return testItems, nil
 				},
 			},
@@ -314,7 +315,7 @@ func TestUpdateEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
-				UpdateConfigStoreItemFn: func(_ *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				UpdateConfigStoreItemFn: func(_ context.Context, _ *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -323,7 +324,7 @@ func TestUpdateEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
-				UpdateConfigStoreItemFn: func(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				UpdateConfigStoreItemFn: func(_ context.Context, i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
 						StoreID: i.StoreID,
 						Key:     i.Key,
@@ -336,7 +337,7 @@ func TestUpdateEntryCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue+"updated"),
 			API: mock.API{
-				UpdateConfigStoreItemFn: func(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+				UpdateConfigStoreItemFn: func(_ context.Context, i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
 					return &fastly.ConfigStoreItem{
 						StoreID:   i.StoreID,
 						Key:       i.Key,

--- a/pkg/commands/configstoreentry/create.go
+++ b/pkg/commands/configstoreentry/create.go
@@ -1,9 +1,10 @@
 package configstoreentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -90,7 +91,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errMaxValueLen
 	}
 
-	o, err := c.Globals.APIClient.CreateConfigStoreItem(&c.input)
+	o, err := c.Globals.APIClient.CreateConfigStoreItem(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstoreentry/delete.go
+++ b/pkg/commands/configstoreentry/delete.go
@@ -1,12 +1,13 @@
 package configstoreentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -92,7 +93,7 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		return c.deleteAllKeys(out)
 	}
 
-	err := c.Globals.APIClient.DeleteConfigStoreItem(&c.input)
+	err := c.Globals.APIClient.DeleteConfigStoreItem(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -118,7 +119,7 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 
 func (c *DeleteCommand) deleteAllKeys(out io.Writer) error {
 	// NOTE: The Config Store returns ALL items (there is no pagination).
-	items, err := c.Globals.APIClient.ListConfigStoreItems(&fastly.ListConfigStoreItemsInput{
+	items, err := c.Globals.APIClient.ListConfigStoreItems(context.TODO(), &fastly.ListConfigStoreItemsInput{
 		StoreID: c.input.StoreID,
 	})
 	if err != nil {
@@ -161,7 +162,7 @@ func (c *DeleteCommand) deleteAllKeys(out io.Writer) error {
 
 			for _, item := range items {
 				text.Output(out, "Deleting key: %s", item.Key)
-				err := c.Globals.APIClient.DeleteConfigStoreItem(&fastly.DeleteConfigStoreItemInput{StoreID: c.input.StoreID, Key: item.Key})
+				err := c.Globals.APIClient.DeleteConfigStoreItem(context.TODO(), &fastly.DeleteConfigStoreItemInput{StoreID: c.input.StoreID, Key: item.Key})
 				if err != nil {
 					c.Globals.ErrLog.Add(fmt.Errorf("failed to delete key '%s': %s", item.Key, err))
 					mu.Lock()

--- a/pkg/commands/configstoreentry/describe.go
+++ b/pkg/commands/configstoreentry/describe.go
@@ -1,9 +1,10 @@
 package configstoreentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -50,7 +51,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.GetConfigStoreItem(&c.input)
+	o, err := c.Globals.APIClient.GetConfigStoreItem(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstoreentry/list.go
+++ b/pkg/commands/configstoreentry/list.go
@@ -1,9 +1,10 @@
 package configstoreentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -43,7 +44,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.ListConfigStoreItems(&c.input)
+	o, err := c.Globals.APIClient.ListConfigStoreItems(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/configstoreentry/update.go
+++ b/pkg/commands/configstoreentry/update.go
@@ -1,9 +1,10 @@
 package configstoreentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -96,7 +97,7 @@ func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errMaxValueLen
 	}
 
-	o, err := c.Globals.APIClient.UpdateConfigStoreItem(&c.input)
+	o, err := c.Globals.APIClient.UpdateConfigStoreItem(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/dashboard/common/print.go
+++ b/pkg/commands/dashboard/common/print.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/text"
 )

--- a/pkg/commands/dashboard/create.go
+++ b/pkg/commands/dashboard/create.go
@@ -1,9 +1,10 @@
 package dashboard
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -43,7 +44,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	dashboard, err := c.Globals.APIClient.CreateObservabilityCustomDashboard(input)
+	dashboard, err := c.Globals.APIClient.CreateObservabilityCustomDashboard(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/dashboard/dashboard_test.go
+++ b/pkg/commands/dashboard/dashboard_test.go
@@ -1,9 +1,10 @@
 package dashboard_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/dashboard"
 	"github.com/fastly/cli/pkg/mock"
@@ -19,7 +20,7 @@ func TestCreate(t *testing.T) {
 		{
 			Name: "validate CreateObservabilityCustomDashboard API error",
 			API: mock.API{
-				CreateObservabilityCustomDashboardFn: func(_ *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+				CreateObservabilityCustomDashboardFn: func(_ context.Context, _ *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -29,7 +30,7 @@ func TestCreate(t *testing.T) {
 		{
 			Name: "validate missing --name flag",
 			API: mock.API{
-				CreateObservabilityCustomDashboardFn: func(_ *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+				CreateObservabilityCustomDashboardFn: func(_ context.Context, _ *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -39,7 +40,7 @@ func TestCreate(t *testing.T) {
 		{
 			Name: "validate optional --description flag",
 			API: mock.API{
-				CreateObservabilityCustomDashboardFn: func(i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+				CreateObservabilityCustomDashboardFn: func(_ context.Context, i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 					return &fastly.ObservabilityCustomDashboard{
 						ID:   "beepboop",
 						Name: i.Name,
@@ -52,7 +53,7 @@ func TestCreate(t *testing.T) {
 		{
 			Name: "validate CreateObservabilityCustomDashboard API success",
 			API: mock.API{
-				CreateObservabilityCustomDashboardFn: func(i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+				CreateObservabilityCustomDashboardFn: func(_ context.Context, i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 					return &fastly.ObservabilityCustomDashboard{
 						ID:          "beepboop",
 						Name:        i.Name,
@@ -77,7 +78,7 @@ func TestDelete(t *testing.T) {
 		{
 			Name: "validate DeleteObservabilityCustomDashboard API error",
 			API: mock.API{
-				DeleteObservabilityCustomDashboardFn: func(_ *fastly.DeleteObservabilityCustomDashboardInput) error {
+				DeleteObservabilityCustomDashboardFn: func(_ context.Context, _ *fastly.DeleteObservabilityCustomDashboardInput) error {
 					return testutil.Err
 				},
 			},
@@ -87,7 +88,7 @@ func TestDelete(t *testing.T) {
 		{
 			Name: "validate DeleteObservabilityCustomDashboard API success",
 			API: mock.API{
-				DeleteObservabilityCustomDashboardFn: func(_ *fastly.DeleteObservabilityCustomDashboardInput) error {
+				DeleteObservabilityCustomDashboardFn: func(_ context.Context, _ *fastly.DeleteObservabilityCustomDashboardInput) error {
 					return nil
 				},
 			},
@@ -108,7 +109,7 @@ func TestDescribe(t *testing.T) {
 		{
 			Name: "validate GetObservabilityCustomDashboard API error",
 			API: mock.API{
-				GetObservabilityCustomDashboardFn: func(_ *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+				GetObservabilityCustomDashboardFn: func(_ context.Context, _ *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -133,7 +134,7 @@ func TestList(t *testing.T) {
 		{
 			Name: "validate ListObservabilityCustomDashboards API error",
 			API: mock.API{
-				ListObservabilityCustomDashboardsFn: func(_ *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error) {
+				ListObservabilityCustomDashboardsFn: func(_ context.Context, _ *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -168,7 +169,7 @@ func TestUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateObservabilityCustomDashboard API error",
 			API: mock.API{
-				UpdateObservabilityCustomDashboardFn: func(_ *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+				UpdateObservabilityCustomDashboardFn: func(_ context.Context, _ *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -178,7 +179,7 @@ func TestUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateObservabilityCustomDashboard API success",
 			API: mock.API{
-				UpdateObservabilityCustomDashboardFn: func(i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+				UpdateObservabilityCustomDashboardFn: func(_ context.Context, i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 					return &fastly.ObservabilityCustomDashboard{
 						ID:          *i.ID,
 						Name:        *i.Name,
@@ -194,7 +195,7 @@ func TestUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
-func getObservabilityCustomDashboard(i *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+func getObservabilityCustomDashboard(_ context.Context, i *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 	t := testutil.Date
 
 	return &fastly.ObservabilityCustomDashboard{
@@ -209,7 +210,7 @@ func getObservabilityCustomDashboard(i *fastly.GetObservabilityCustomDashboardIn
 	}, nil
 }
 
-func listObservabilityCustomDashboards(_ *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error) {
+func listObservabilityCustomDashboards(_ context.Context, _ *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error) {
 	t := testutil.Date
 	vs := &fastly.ListDashboardsResponse{
 		Data: []fastly.ObservabilityCustomDashboard{{

--- a/pkg/commands/dashboard/delete.go
+++ b/pkg/commands/dashboard/delete.go
@@ -1,9 +1,10 @@
 package dashboard
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -41,7 +42,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	err := c.Globals.APIClient.DeleteObservabilityCustomDashboard(input)
+	err := c.Globals.APIClient.DeleteObservabilityCustomDashboard(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/dashboard/describe.go
+++ b/pkg/commands/dashboard/describe.go
@@ -1,9 +1,10 @@
 package dashboard
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/common"
@@ -40,7 +41,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	dashboard, err := c.Globals.APIClient.GetObservabilityCustomDashboard(input)
+	dashboard, err := c.Globals.APIClient.GetObservabilityCustomDashboard(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/dashboard/item/create.go
+++ b/pkg/commands/dashboard/item/create.go
@@ -1,9 +1,10 @@
 package item
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/common"
@@ -62,13 +63,13 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(&fastly.GetObservabilityCustomDashboardInput{ID: &c.dashboardID})
+	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(context.TODO(), &fastly.GetObservabilityCustomDashboardInput{ID: &c.dashboardID})
 	if err != nil {
 		return err
 	}
 
 	input := c.constructInput(d)
-	d, err = c.Globals.APIClient.UpdateObservabilityCustomDashboard(input)
+	d, err = c.Globals.APIClient.UpdateObservabilityCustomDashboard(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/dashboard/item/delete.go
+++ b/pkg/commands/dashboard/item/delete.go
@@ -1,10 +1,11 @@
 package item
 
 import (
+	"context"
 	"io"
 	"slices"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -44,7 +45,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(&fastly.GetObservabilityCustomDashboardInput{ID: &c.dashboardID})
+	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(context.TODO(), &fastly.GetObservabilityCustomDashboardInput{ID: &c.dashboardID})
 	if err != nil {
 		return err
 	}
@@ -56,7 +57,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return di.ID == c.itemID
 	}) {
 		input := c.constructInput(d)
-		d, err = c.Globals.APIClient.UpdateObservabilityCustomDashboard(input)
+		d, err = c.Globals.APIClient.UpdateObservabilityCustomDashboard(context.TODO(), input)
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/dashboard/item/describe.go
+++ b/pkg/commands/dashboard/item/describe.go
@@ -1,10 +1,11 @@
 package item
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/common"
@@ -46,12 +47,12 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(input)
+	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(context.TODO(), input)
 	if err != nil {
 		return err
 	}
 
-	di, err := getItemFromDashboard(d, c.itemID)
+	di, err := getItemFromDashboard(context.TODO(), d, c.itemID)
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ func (c *DescribeCommand) constructInput() *fastly.GetObservabilityCustomDashboa
 	return &fastly.GetObservabilityCustomDashboardInput{ID: &c.dashboardID}
 }
 
-func getItemFromDashboard(d *fastly.ObservabilityCustomDashboard, itemID string) (*fastly.DashboardItem, error) {
+func getItemFromDashboard(_ context.Context, d *fastly.ObservabilityCustomDashboard, itemID string) (*fastly.DashboardItem, error) {
 	for _, di := range d.Items {
 		if di.ID == itemID {
 			return &di, nil

--- a/pkg/commands/dashboard/item/item_test.go
+++ b/pkg/commands/dashboard/item/item_test.go
@@ -1,10 +1,11 @@
 package item_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/dashboard"
 	sub "github.com/fastly/cli/pkg/commands/dashboard/item"
@@ -315,18 +316,18 @@ func TestUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
-func getDashboardOK(_ *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+func getDashboardOK(_ context.Context, _ *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 	d := defaultDashboard()
 	return &d, nil
 }
 
-func updateDashboardOK(i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+func updateDashboardOK(_ context.Context, i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 	d := defaultDashboard()
 	d.Items = *i.Items
 	return &d, nil
 }
 
-func updateDashboardEmpty(_ *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+func updateDashboardEmpty(_ context.Context, _ *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
 	d := defaultDashboard()
 	d.Items = []fastly.DashboardItem{}
 	return &d, nil

--- a/pkg/commands/dashboard/item/update.go
+++ b/pkg/commands/dashboard/item/update.go
@@ -1,11 +1,12 @@
 package item
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"slices"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -64,7 +65,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(&fastly.GetObservabilityCustomDashboardInput{ID: &c.dashboardID})
+	d, err := c.Globals.APIClient.GetObservabilityCustomDashboard(context.TODO(), &fastly.GetObservabilityCustomDashboardInput{ID: &c.dashboardID})
 	if err != nil {
 		return err
 	}
@@ -74,7 +75,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err = c.Globals.APIClient.UpdateObservabilityCustomDashboard(input)
+	d, err = c.Globals.APIClient.UpdateObservabilityCustomDashboard(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/dashboard/list.go
+++ b/pkg/commands/dashboard/list.go
@@ -1,10 +1,11 @@
 package dashboard
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/common"
@@ -55,7 +56,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	loadAllPages := c.JSONOutput.Enabled || c.Globals.Flags.NonInteractive || c.Globals.Flags.AutoYes
 
 	for {
-		o, err := c.Globals.APIClient.ListObservabilityCustomDashboards(input)
+		o, err := c.Globals.APIClient.ListObservabilityCustomDashboards(context.TODO(), input)
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/dashboard/update.go
+++ b/pkg/commands/dashboard/update.go
@@ -1,9 +1,10 @@
 package dashboard
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -45,7 +46,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	dashboard, err := c.Globals.APIClient.UpdateObservabilityCustomDashboard(input)
+	dashboard, err := c.Globals.APIClient.UpdateObservabilityCustomDashboard(context.TODO(), input)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/dictionary/create.go
+++ b/pkg/commands/dictionary/create.go
@@ -1,9 +1,10 @@
 package dictionary
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -100,7 +101,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		input.WriteOnly = fastly.ToPointer(fastly.Compatibool(c.writeOnly.Value))
 	}
 
-	d, err := c.Globals.APIClient.CreateDictionary(&input)
+	d, err := c.Globals.APIClient.CreateDictionary(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/dictionary/delete.go
+++ b/pkg/commands/dictionary/delete.go
@@ -1,9 +1,10 @@
 package dictionary
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	err = c.Globals.APIClient.DeleteDictionary(&c.Input)
+	err = c.Globals.APIClient.DeleteDictionary(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/dictionary/describe.go
+++ b/pkg/commands/dictionary/describe.go
@@ -1,9 +1,10 @@
 package dictionary
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -83,7 +84,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersionNumber
 
-	dictionary, err := c.Globals.APIClient.GetDictionary(&c.Input)
+	dictionary, err := c.Globals.APIClient.GetDictionary(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
@@ -104,7 +105,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 			ServiceVersion: c.Input.ServiceVersion,
 			DictionaryID:   dictionaryID,
 		}
-		info, err = c.Globals.APIClient.GetDictionaryInfo(&infoInput)
+		info, err = c.Globals.APIClient.GetDictionaryInfo(context.TODO(), &infoInput)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Service ID":      serviceID,
@@ -116,7 +117,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 			ServiceID:    c.Input.ServiceID,
 			DictionaryID: dictionaryID,
 		}
-		items, err = c.Globals.APIClient.ListDictionaryItems(&itemInput)
+		items, err = c.Globals.APIClient.ListDictionaryItems(context.TODO(), &itemInput)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Service ID":      serviceID,

--- a/pkg/commands/dictionary/dictionary_test.go
+++ b/pkg/commands/dictionary/dictionary_test.go
@@ -1,11 +1,12 @@
 package dictionary_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/dictionary"
 	"github.com/fastly/cli/pkg/mock"
@@ -218,7 +219,7 @@ func TestUpdateDictionary(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
-func describeDictionaryOK(i *fastly.GetDictionaryInput) (*fastly.Dictionary, error) {
+func describeDictionaryOK(_ context.Context, i *fastly.GetDictionaryInput) (*fastly.Dictionary, error) {
 	return &fastly.Dictionary{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -230,7 +231,7 @@ func describeDictionaryOK(i *fastly.GetDictionaryInput) (*fastly.Dictionary, err
 	}, nil
 }
 
-func describeDictionaryOKDeleted(i *fastly.GetDictionaryInput) (*fastly.Dictionary, error) {
+func describeDictionaryOKDeleted(_ context.Context, i *fastly.GetDictionaryInput) (*fastly.Dictionary, error) {
 	return &fastly.Dictionary{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -243,7 +244,7 @@ func describeDictionaryOKDeleted(i *fastly.GetDictionaryInput) (*fastly.Dictiona
 	}, nil
 }
 
-func createDictionaryOK(i *fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
+func createDictionaryOK(_ context.Context, i *fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
 	if i.WriteOnly == nil {
 		i.WriteOnly = fastly.ToPointer(fastly.Compatibool(false))
 	}
@@ -263,7 +264,7 @@ func createDictionaryOK(i *fastly.CreateDictionaryInput) (*fastly.Dictionary, er
 // that call changes. This function requires i.ID to equal "456" to enforce the
 // input to this call matches the response to GetDictionaryInfo in
 // describeDictionaryOK.
-func getDictionaryInfoOK(i *fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error) {
+func getDictionaryInfoOK(_ context.Context, i *fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error) {
 	if i.DictionaryID == "456" {
 		return &fastly.DictionaryInfo{
 			ItemCount:   fastly.ToPointer(2),
@@ -277,7 +278,7 @@ func getDictionaryInfoOK(i *fastly.GetDictionaryInfoInput) (*fastly.DictionaryIn
 // listDictionaryItemsOK mocks the response from fastly.ListDictionaryItems
 // which is primarily used in the fastly-cli.dictionaryitem package and will
 // need to be updated here if that call changes.
-func listDictionaryItemsOK(i *fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error) {
+func listDictionaryItemsOK(_ context.Context, i *fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error) {
 	return []*fastly.DictionaryItem{
 		{
 			ServiceID:    fastly.ToPointer(i.ServiceID),
@@ -299,19 +300,19 @@ func listDictionaryItemsOK(i *fastly.ListDictionaryItemsInput) ([]*fastly.Dictio
 	}, nil
 }
 
-func createDictionaryDuplicate(*fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
+func createDictionaryDuplicate(_ context.Context, _ *fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
 	return nil, errors.New("Duplicate record")
 }
 
-func deleteDictionaryOK(*fastly.DeleteDictionaryInput) error {
+func deleteDictionaryOK(_ context.Context, _ *fastly.DeleteDictionaryInput) error {
 	return nil
 }
 
-func deleteDictionaryError(*fastly.DeleteDictionaryInput) error {
+func deleteDictionaryError(_ context.Context, _ *fastly.DeleteDictionaryInput) error {
 	return errTest
 }
 
-func listDictionariesOk(i *fastly.ListDictionariesInput) ([]*fastly.Dictionary, error) {
+func listDictionariesOk(_ context.Context, i *fastly.ListDictionariesInput) ([]*fastly.Dictionary, error) {
 	return []*fastly.Dictionary{
 		{
 			ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -334,7 +335,7 @@ func listDictionariesOk(i *fastly.ListDictionariesInput) ([]*fastly.Dictionary, 
 	}, nil
 }
 
-func updateDictionaryNameOK(i *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
+func updateDictionaryNameOK(_ context.Context, i *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
 	return &fastly.Dictionary{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -346,7 +347,7 @@ func updateDictionaryNameOK(i *fastly.UpdateDictionaryInput) (*fastly.Dictionary
 	}, nil
 }
 
-func updateDictionaryWriteOnlyOK(i *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
+func updateDictionaryWriteOnlyOK(_ context.Context, i *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
 	return &fastly.Dictionary{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -358,7 +359,7 @@ func updateDictionaryWriteOnlyOK(i *fastly.UpdateDictionaryInput) (*fastly.Dicti
 	}, nil
 }
 
-func updateDictionaryError(_ *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
+func updateDictionaryError(_ context.Context, _ *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
 	return nil, errTest
 }
 

--- a/pkg/commands/dictionary/list.go
+++ b/pkg/commands/dictionary/list.go
@@ -1,10 +1,11 @@
 package dictionary
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = serviceVersionNumber
 
-	o, err := c.Globals.APIClient.ListDictionaries(&c.Input)
+	o, err := c.Globals.APIClient.ListDictionaries(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/dictionary/update.go
+++ b/pkg/commands/dictionary/update.go
@@ -1,11 +1,12 @@
 package dictionary
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -114,7 +115,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		c.input.WriteOnly = fastly.ToPointer(fastly.Compatibool(writeOnly))
 	}
 
-	d, err := c.Globals.APIClient.UpdateDictionary(&c.input)
+	d, err := c.Globals.APIClient.UpdateDictionary(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/dictionaryentry/create.go
+++ b/pkg/commands/dictionaryentry/create.go
@@ -1,9 +1,10 @@
 package dictionaryentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -61,7 +62,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ItemKey = &c.itemKey
 	c.Input.ItemValue = &c.itemValue
 	c.Input.ServiceID = serviceID
-	_, err = c.Globals.APIClient.CreateDictionaryItem(&c.Input)
+	_, err = c.Globals.APIClient.CreateDictionaryItem(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/dictionaryentry/delete.go
+++ b/pkg/commands/dictionaryentry/delete.go
@@ -1,9 +1,10 @@
 package dictionaryentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -57,7 +58,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	c.Input.ServiceID = serviceID
-	err = c.Globals.APIClient.DeleteDictionaryItem(&c.Input)
+	err = c.Globals.APIClient.DeleteDictionaryItem(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/dictionaryentry/describe.go
+++ b/pkg/commands/dictionaryentry/describe.go
@@ -1,10 +1,11 @@
 package dictionaryentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -68,7 +69,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	c.Input.ServiceID = serviceID
 
-	o, err := c.Globals.APIClient.GetDictionaryItem(&c.Input)
+	o, err := c.Globals.APIClient.GetDictionaryItem(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/dictionaryentry/dictionaryitem_test.go
+++ b/pkg/commands/dictionaryentry/dictionaryitem_test.go
@@ -2,6 +2,7 @@ package dictionaryentry_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -9,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -80,8 +81,8 @@ func TestDictionaryItemsList(t *testing.T) {
 		},
 		{
 			api: mock.API{
-				GetDictionaryItemsFn: func(_ *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
-					return fastly.NewPaginator[fastly.DictionaryItem](&mock.HTTPClient{
+				GetDictionaryItemsFn: func(ctx context.Context, _ *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
+					return fastly.NewPaginator[fastly.DictionaryItem](ctx, &mock.HTTPClient{
 						Errors: []error{
 							testutil.Err,
 						},
@@ -94,8 +95,8 @@ func TestDictionaryItemsList(t *testing.T) {
 		},
 		{
 			api: mock.API{
-				GetDictionaryItemsFn: func(_ *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
-					return fastly.NewPaginator[fastly.DictionaryItem](&mock.HTTPClient{
+				GetDictionaryItemsFn: func(ctx context.Context, _ *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
+					return fastly.NewPaginator[fastly.DictionaryItem](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
 						Responses: []*http.Response{
 							{
@@ -300,7 +301,7 @@ func TestDictionaryItemDelete(t *testing.T) {
 	}
 }
 
-func describeDictionaryItemOK(i *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error) {
+func describeDictionaryItemOK(_ context.Context, i *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error) {
 	return &fastly.DictionaryItem{
 		ServiceID:    fastly.ToPointer(i.ServiceID),
 		DictionaryID: fastly.ToPointer(i.DictionaryID),
@@ -328,7 +329,7 @@ Created (UTC): 2001-02-03 04:05
 Last edited (UTC): 2001-02-03 04:05
 `
 
-func describeDictionaryItemOKDeleted(i *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error) {
+func describeDictionaryItemOKDeleted(_ context.Context, i *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error) {
 	return &fastly.DictionaryItem{
 		ServiceID:    fastly.ToPointer(i.ServiceID),
 		DictionaryID: fastly.ToPointer(i.DictionaryID),
@@ -368,7 +369,7 @@ Item: 2/2
 	Deleted (UTC): 2021-06-15 23:00
 `) + "\n\n"
 
-func createDictionaryItemOK(i *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error) {
+func createDictionaryItemOK(_ context.Context, i *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error) {
 	return &fastly.DictionaryItem{
 		ServiceID:    fastly.ToPointer(i.ServiceID),
 		DictionaryID: fastly.ToPointer(i.DictionaryID),
@@ -379,7 +380,7 @@ func createDictionaryItemOK(i *fastly.CreateDictionaryItemInput) (*fastly.Dictio
 	}, nil
 }
 
-func updateDictionaryItemOK(i *fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error) {
+func updateDictionaryItemOK(_ context.Context, i *fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error) {
 	return &fastly.DictionaryItem{
 		ServiceID:    fastly.ToPointer(i.ServiceID),
 		DictionaryID: fastly.ToPointer(i.DictionaryID),
@@ -390,7 +391,7 @@ func updateDictionaryItemOK(i *fastly.UpdateDictionaryItemInput) (*fastly.Dictio
 	}, nil
 }
 
-func deleteDictionaryItemOK(_ *fastly.DeleteDictionaryItemInput) error {
+func deleteDictionaryItemOK(_ context.Context, _ *fastly.DeleteDictionaryItemInput) error {
 	return nil
 }
 
@@ -419,11 +420,11 @@ var dictionaryItemBatchModifyInputOK = `
 	]
 }`
 
-func batchModifyDictionaryItemsOK(_ *fastly.BatchModifyDictionaryItemsInput) error {
+func batchModifyDictionaryItemsOK(_ context.Context, _ *fastly.BatchModifyDictionaryItemsInput) error {
 	return nil
 }
 
-func batchModifyDictionaryItemsError(_ *fastly.BatchModifyDictionaryItemsInput) error {
+func batchModifyDictionaryItemsError(_ context.Context, _ *fastly.BatchModifyDictionaryItemsInput) error {
 	return errTest
 }
 

--- a/pkg/commands/dictionaryentry/list.go
+++ b/pkg/commands/dictionaryentry/list.go
@@ -1,10 +1,11 @@
 package dictionaryentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -76,7 +77,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.PerPage = &c.perPage
 	c.input.ServiceID = serviceID
 	c.input.Sort = &c.sort
-	paginator := c.Globals.APIClient.GetDictionaryItems(&c.input)
+	paginator := c.Globals.APIClient.GetDictionaryItems(context.TODO(), &c.input)
 
 	var o []*fastly.DictionaryItem
 	for paginator.HasNext() {

--- a/pkg/commands/dictionaryentry/update.go
+++ b/pkg/commands/dictionaryentry/update.go
@@ -1,12 +1,13 @@
 package dictionaryentry
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -81,7 +82,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fmt.Errorf("an empty value is not allowed for either the '--key' or '--value' flags")
 	}
 
-	d, err := c.Globals.APIClient.UpdateDictionaryItem(&c.Input)
+	d, err := c.Globals.APIClient.UpdateDictionaryItem(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -115,7 +116,7 @@ func (c *UpdateCommand) batchModify(out io.Writer) error {
 		return fmt.Errorf("item key not found in file %s", c.file.Value)
 	}
 
-	err = c.Globals.APIClient.BatchModifyDictionaryItems(&c.InputBatch)
+	err = c.Globals.APIClient.BatchModifyDictionaryItems(context.TODO(), &c.InputBatch)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/domain/create.go
+++ b/pkg/commands/domain/create.go
@@ -1,9 +1,10 @@
 package domain
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -96,7 +97,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if c.comment.WasSet {
 		input.Comment = &c.comment.Value
 	}
-	d, err := c.Globals.APIClient.CreateDomain(&input)
+	d, err := c.Globals.APIClient.CreateDomain(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/domain/delete.go
+++ b/pkg/commands/domain/delete.go
@@ -1,9 +1,10 @@
 package domain
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteDomain(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteDomain(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
 			"Service Version": fastly.ToValue(serviceVersion.Number),

--- a/pkg/commands/domain/describe.go
+++ b/pkg/commands/domain/describe.go
@@ -1,10 +1,11 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetDomain(&c.Input)
+	o, err := c.Globals.APIClient.GetDomain(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/domain/domain_test.go
+++ b/pkg/commands/domain/domain_test.go
@@ -1,12 +1,13 @@
 package domain_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/domain"
 	"github.com/fastly/cli/pkg/mock"
@@ -209,7 +210,7 @@ func TestDomainValidate(t *testing.T) {
 			Name: "validate ValidateDomain API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				ValidateDomainFn: func(_ *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error) {
+				ValidateDomainFn: func(_ context.Context, _ *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -220,7 +221,7 @@ func TestDomainValidate(t *testing.T) {
 			Name: "validate ValidateAllDomains API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				ValidateAllDomainsFn: func(_ *fastly.ValidateAllDomainsInput) ([]*fastly.DomainValidationResult, error) {
+				ValidateAllDomainsFn: func(_ context.Context, _ *fastly.ValidateAllDomainsInput) ([]*fastly.DomainValidationResult, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -261,7 +262,7 @@ func TestDomainValidate(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createDomainOK(i *fastly.CreateDomainInput) (*fastly.Domain, error) {
+func createDomainOK(_ context.Context, i *fastly.CreateDomainInput) (*fastly.Domain, error) {
 	return &fastly.Domain{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -269,11 +270,11 @@ func createDomainOK(i *fastly.CreateDomainInput) (*fastly.Domain, error) {
 	}, nil
 }
 
-func createDomainError(_ *fastly.CreateDomainInput) (*fastly.Domain, error) {
+func createDomainError(_ context.Context, _ *fastly.CreateDomainInput) (*fastly.Domain, error) {
 	return nil, errTest
 }
 
-func listDomainsOK(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
+func listDomainsOK(_ context.Context, i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	return []*fastly.Domain{
 		{
 			ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -290,7 +291,7 @@ func listDomainsOK(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	}, nil
 }
 
-func listDomainsError(_ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
+func listDomainsError(_ context.Context, _ *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
 	return nil, errTest
 }
 
@@ -315,7 +316,7 @@ Version: 1
 		Comment: example
 `) + "\n\n"
 
-func getDomainOK(i *fastly.GetDomainInput) (*fastly.Domain, error) {
+func getDomainOK(_ context.Context, i *fastly.GetDomainInput) (*fastly.Domain, error) {
 	return &fastly.Domain{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -324,7 +325,7 @@ func getDomainOK(i *fastly.GetDomainInput) (*fastly.Domain, error) {
 	}, nil
 }
 
-func getDomainError(_ *fastly.GetDomainInput) (*fastly.Domain, error) {
+func getDomainError(_ context.Context, _ *fastly.GetDomainInput) (*fastly.Domain, error) {
 	return nil, errTest
 }
 
@@ -335,7 +336,7 @@ Name: www.test.com
 Comment: test
 `) + "\n"
 
-func updateDomainOK(i *fastly.UpdateDomainInput) (*fastly.Domain, error) {
+func updateDomainOK(_ context.Context, i *fastly.UpdateDomainInput) (*fastly.Domain, error) {
 	return &fastly.Domain{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -343,19 +344,19 @@ func updateDomainOK(i *fastly.UpdateDomainInput) (*fastly.Domain, error) {
 	}, nil
 }
 
-func updateDomainError(_ *fastly.UpdateDomainInput) (*fastly.Domain, error) {
+func updateDomainError(_ context.Context, _ *fastly.UpdateDomainInput) (*fastly.Domain, error) {
 	return nil, errTest
 }
 
-func deleteDomainOK(_ *fastly.DeleteDomainInput) error {
+func deleteDomainOK(_ context.Context, _ *fastly.DeleteDomainInput) error {
 	return nil
 }
 
-func deleteDomainError(_ *fastly.DeleteDomainInput) error {
+func deleteDomainError(_ context.Context, _ *fastly.DeleteDomainInput) error {
 	return errTest
 }
 
-func validateDomain(i *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error) {
+func validateDomain(_ context.Context, i *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error) {
 	return &fastly.DomainValidationResult{
 		Metadata: &fastly.DomainMetadata{
 			ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -367,7 +368,7 @@ func validateDomain(i *fastly.ValidateDomainInput) (*fastly.DomainValidationResu
 	}, nil
 }
 
-func validateAllDomains(i *fastly.ValidateAllDomainsInput) (results []*fastly.DomainValidationResult, err error) {
+func validateAllDomains(_ context.Context, i *fastly.ValidateAllDomainsInput) ([]*fastly.DomainValidationResult, error) {
 	return []*fastly.DomainValidationResult{
 		{
 			Metadata: &fastly.DomainMetadata{

--- a/pkg/commands/domain/list.go
+++ b/pkg/commands/domain/list.go
@@ -1,10 +1,11 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListDomains(&c.Input)
+	o, err := c.Globals.APIClient.ListDomains(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/domain/update.go
+++ b/pkg/commands/domain/update.go
@@ -1,10 +1,11 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -102,7 +103,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		c.input.Comment = &c.Comment.Value
 	}
 
-	d, err := c.Globals.APIClient.UpdateDomain(&c.input)
+	d, err := c.Globals.APIClient.UpdateDomain(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/domain/validate.go
+++ b/pkg/commands/domain/validate.go
@@ -1,10 +1,11 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"
@@ -77,7 +78,7 @@ func (c *ValidateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if c.all {
 		input := c.constructInputAll(serviceID, serviceVersionNumber)
 
-		r, err := c.Globals.APIClient.ValidateAllDomains(input)
+		r, err := c.Globals.APIClient.ValidateAllDomains(context.TODO(), input)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Service ID":      serviceID,
@@ -95,7 +96,7 @@ func (c *ValidateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	r, err := c.Globals.APIClient.ValidateDomain(input)
+	r, err := c.Globals.APIClient.ValidateDomain(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/domainv1/common.go
+++ b/pkg/commands/domainv1/common.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	v1 "github.com/fastly/go-fastly/v10/fastly/domains/v1"
+	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
 
 	"github.com/fastly/cli/pkg/text"
 )

--- a/pkg/commands/domainv1/create.go
+++ b/pkg/commands/domainv1/create.go
@@ -1,12 +1,14 @@
 package domainv1
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	v1 "github.com/fastly/go-fastly/v10/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -64,7 +66,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	d, err := v1.Create(fc, input)
+	d, err := v1.Create(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"FQDN":       c.fqdn,

--- a/pkg/commands/domainv1/delete.go
+++ b/pkg/commands/domainv1/delete.go
@@ -1,11 +1,13 @@
 package domainv1
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	v1 "github.com/fastly/go-fastly/v10/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -44,7 +46,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		DomainID: &c.domainID,
 	}
 
-	err := v1.Delete(fc, input)
+	err := v1.Delete(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Domain ID": c.domainID,

--- a/pkg/commands/domainv1/describe.go
+++ b/pkg/commands/domainv1/describe.go
@@ -1,11 +1,13 @@
 package domainv1
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	v1 "github.com/fastly/go-fastly/v10/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -51,7 +53,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		DomainID: &c.domainID,
 	}
 
-	d, err := v1.Get(fc, input)
+	d, err := v1.Get(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Domain ID": c.domainID,

--- a/pkg/commands/domainv1/domain_test.go
+++ b/pkg/commands/domainv1/domain_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	v1 "github.com/fastly/go-fastly/v10/fastly/domains/v1"
+	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
 
 	root "github.com/fastly/cli/pkg/commands/domainv1"
 	"github.com/fastly/cli/pkg/testutil"

--- a/pkg/commands/domainv1/list.go
+++ b/pkg/commands/domainv1/list.go
@@ -1,11 +1,13 @@
 package domainv1
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	v1 "github.com/fastly/go-fastly/v10/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -80,7 +82,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	for {
-		cl, err := v1.List(fc, input)
+		cl, err := v1.List(context.TODO(), fc, input)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Cursor":     c.cursor.Value,

--- a/pkg/commands/domainv1/update.go
+++ b/pkg/commands/domainv1/update.go
@@ -1,12 +1,14 @@
 package domainv1
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	v1 "github.com/fastly/go-fastly/v10/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -58,7 +60,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	d, err := v1.Update(fc, input)
+	d, err := v1.Update(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Domain ID":  c.domainID,

--- a/pkg/commands/healthcheck/create.go
+++ b/pkg/commands/healthcheck/create.go
@@ -1,9 +1,10 @@
 package healthcheck
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -148,7 +149,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		input.Initial = &c.initial.Value
 	}
 
-	h, err := c.Globals.APIClient.CreateHealthCheck(&input)
+	h, err := c.Globals.APIClient.CreateHealthCheck(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/healthcheck/delete.go
+++ b/pkg/commands/healthcheck/delete.go
@@ -1,9 +1,10 @@
 package healthcheck
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteHealthCheck(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteHealthCheck(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
 			"Service Version": fastly.ToValue(serviceVersion.Number),

--- a/pkg/commands/healthcheck/describe.go
+++ b/pkg/commands/healthcheck/describe.go
@@ -1,10 +1,11 @@
 package healthcheck
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -82,7 +83,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetHealthCheck(&c.Input)
+	o, err := c.Globals.APIClient.GetHealthCheck(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -2,13 +2,14 @@ package healthcheck_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -287,7 +288,7 @@ func TestHealthCheckDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createHealthCheckOK(i *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error) {
+func createHealthCheckOK(_ context.Context, i *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error) {
 	return &fastly.HealthCheck{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -297,11 +298,11 @@ func createHealthCheckOK(i *fastly.CreateHealthCheckInput) (*fastly.HealthCheck,
 	}, nil
 }
 
-func createHealthCheckError(_ *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error) {
+func createHealthCheckError(_ context.Context, _ *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error) {
 	return nil, errTest
 }
 
-func listHealthChecksOK(i *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error) {
+func listHealthChecksOK(_ context.Context, i *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error) {
 	return []*fastly.HealthCheck{
 		{
 			ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -324,7 +325,7 @@ func listHealthChecksOK(i *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck,
 	}, nil
 }
 
-func listHealthChecksError(_ *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error) {
+func listHealthChecksError(_ context.Context, _ *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error) {
 	return nil, errTest
 }
 
@@ -369,7 +370,7 @@ var listHealthChecksVerboseOutput = strings.Join([]string{
 	"		Initial: 0",
 }, "\n") + "\n\n"
 
-func getHealthCheckOK(i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error) {
+func getHealthCheckOK(_ context.Context, i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error) {
 	return &fastly.HealthCheck{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -381,7 +382,7 @@ func getHealthCheckOK(i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error
 	}, nil
 }
 
-func getHealthCheckError(_ *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error) {
+func getHealthCheckError(_ context.Context, _ *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error) {
 	return nil, errTest
 }
 
@@ -402,7 +403,7 @@ var describeHealthCheckOutput = "\n" + strings.Join([]string{
 	"Initial: 0",
 }, "\n") + "\n"
 
-func updateHealthCheckOK(i *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error) {
+func updateHealthCheckOK(_ context.Context, i *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error) {
 	return &fastly.HealthCheck{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -410,14 +411,14 @@ func updateHealthCheckOK(i *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck,
 	}, nil
 }
 
-func updateHealthCheckError(_ *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error) {
+func updateHealthCheckError(_ context.Context, _ *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error) {
 	return nil, errTest
 }
 
-func deleteHealthCheckOK(_ *fastly.DeleteHealthCheckInput) error {
+func deleteHealthCheckOK(_ context.Context, _ *fastly.DeleteHealthCheckInput) error {
 	return nil
 }
 
-func deleteHealthCheckError(_ *fastly.DeleteHealthCheckInput) error {
+func deleteHealthCheckError(_ context.Context, _ *fastly.DeleteHealthCheckInput) error {
 	return errTest
 }

--- a/pkg/commands/healthcheck/list.go
+++ b/pkg/commands/healthcheck/list.go
@@ -1,10 +1,11 @@
 package healthcheck
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListHealthChecks(&c.Input)
+	o, err := c.Globals.APIClient.ListHealthChecks(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/healthcheck/update.go
+++ b/pkg/commands/healthcheck/update.go
@@ -1,9 +1,10 @@
 package healthcheck
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -146,7 +147,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		c.input.Initial = &c.Initial.Value
 	}
 
-	h, err := c.Globals.APIClient.UpdateHealthCheck(&c.input)
+	h, err := c.Globals.APIClient.UpdateHealthCheck(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/ip/ip_test.go
+++ b/pkg/commands/ip/ip_test.go
@@ -1,9 +1,10 @@
 package ip_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/ip"
 	"github.com/fastly/cli/pkg/mock"
@@ -15,7 +16,7 @@ func TestAllIPs(t *testing.T) {
 		{
 			Name: "validate listing IP addresses",
 			API: mock.API{
-				AllIPsFn: func() (v4, v6 fastly.IPAddrs, err error) {
+				AllIPsFn: func(_ context.Context) (v4, v6 fastly.IPAddrs, err error) {
 					return []string{
 							"00.123.45.6/78",
 						}, []string{

--- a/pkg/commands/ip/root.go
+++ b/pkg/commands/ip/root.go
@@ -1,6 +1,7 @@
 package ip
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -28,7 +29,7 @@ func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
 
 // Exec implements the command interface.
 func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
-	ipv4, ipv6, err := c.Globals.APIClient.AllIPs()
+	ipv4, ipv6, err := c.Globals.APIClient.AllIPs(context.TODO())
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/kvstore/create.go
+++ b/pkg/commands/kvstore/create.go
@@ -1,9 +1,10 @@
 package kvstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -44,7 +45,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.CreateKVStore(&c.Input)
+	o, err := c.Globals.APIClient.CreateKVStore(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/kvstore/delete.go
+++ b/pkg/commands/kvstore/delete.go
@@ -1,11 +1,12 @@
 package kvstore
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/kvstoreentry"
@@ -78,7 +79,7 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		text.Break(out)
 	}
 
-	err := c.Globals.APIClient.DeleteKVStore(&c.Input)
+	err := c.Globals.APIClient.DeleteKVStore(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return fmt.Errorf("failed to delete KV store: %w", err)

--- a/pkg/commands/kvstore/describe.go
+++ b/pkg/commands/kvstore/describe.go
@@ -1,9 +1,10 @@
 package kvstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -43,7 +44,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.GetKVStore(&c.Input)
+	o, err := c.Globals.APIClient.GetKVStore(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/kvstore/kvstore_test.go
+++ b/pkg/commands/kvstore/kvstore_test.go
@@ -2,12 +2,13 @@ package kvstore_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/kvstore"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
@@ -31,7 +32,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
-				CreateKVStoreFn: func(_ *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+				CreateKVStoreFn: func(_ context.Context, _ *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -40,7 +41,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--name %s", storeName),
 			API: mock.API{
-				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+				CreateKVStoreFn: func(_ context.Context, i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
 						StoreID: storeID,
 						Name:    i.Name,
@@ -52,7 +53,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--name %s --json", storeName),
 			API: mock.API{
-				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+				CreateKVStoreFn: func(_ context.Context, i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
 						StoreID:   storeID,
 						Name:      i.Name,
@@ -73,7 +74,7 @@ func TestCreateStoreCommand(t *testing.T) {
 			// Location/region indicators are not exposed for us to validate.
 			Args: fmt.Sprintf("--name %s --location %s", storeName, storeLocation),
 			API: mock.API{
-				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+				CreateKVStoreFn: func(_ context.Context, i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
 						StoreID: storeID,
 						Name:    i.Name,
@@ -87,7 +88,7 @@ func TestCreateStoreCommand(t *testing.T) {
 			// Location/region indicators are not exposed for us to validate.
 			Args: fmt.Sprintf("--name %s --location %s --json", storeName, storeLocation),
 			API: mock.API{
-				CreateKVStoreFn: func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+				CreateKVStoreFn: func(_ context.Context, i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
 						StoreID:   storeID,
 						Name:      i.Name,
@@ -119,7 +120,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			Args: "--store-id DOES-NOT-EXIST",
 			API: mock.API{
-				DeleteKVStoreFn: func(i *fastly.DeleteKVStoreInput) error {
+				DeleteKVStoreFn: func(_ context.Context, i *fastly.DeleteKVStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -131,7 +132,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				DeleteKVStoreFn: func(i *fastly.DeleteKVStoreInput) error {
+				DeleteKVStoreFn: func(_ context.Context, i *fastly.DeleteKVStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -143,7 +144,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
-				DeleteKVStoreFn: func(i *fastly.DeleteKVStoreInput) error {
+				DeleteKVStoreFn: func(_ context.Context, i *fastly.DeleteKVStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -172,7 +173,7 @@ func TestGetStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				GetKVStoreFn: func(_ *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
+				GetKVStoreFn: func(_ context.Context, _ *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -181,7 +182,7 @@ func TestGetStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				GetKVStoreFn: func(i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
+				GetKVStoreFn: func(_ context.Context, i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
 						StoreID:   i.StoreID,
 						Name:      storeName,
@@ -202,7 +203,7 @@ func TestGetStoreCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
-				GetKVStoreFn: func(i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
+				GetKVStoreFn: func(_ context.Context, i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
 					return &fastly.KVStore{
 						StoreID:   i.StoreID,
 						Name:      storeName,
@@ -239,14 +240,14 @@ func TestListStoresCommand(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			API: mock.API{
-				ListKVStoresFn: func(_ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+				ListKVStoresFn: func(_ context.Context, _ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
 					return nil, nil
 				},
 			},
 		},
 		{
 			API: mock.API{
-				ListKVStoresFn: func(_ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+				ListKVStoresFn: func(_ context.Context, _ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
 					return nil, errors.New("unknown error")
 				},
 			},
@@ -254,7 +255,7 @@ func TestListStoresCommand(t *testing.T) {
 		},
 		{
 			API: mock.API{
-				ListKVStoresFn: func(_ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+				ListKVStoresFn: func(_ context.Context, _ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
 					return stores, nil
 				},
 			},
@@ -263,7 +264,7 @@ func TestListStoresCommand(t *testing.T) {
 		{
 			Args: "--json",
 			API: mock.API{
-				ListKVStoresFn: func(_ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+				ListKVStoresFn: func(_ context.Context, _ *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
 					return stores, nil
 				},
 			},

--- a/pkg/commands/kvstore/list.go
+++ b/pkg/commands/kvstore/list.go
@@ -1,9 +1,10 @@
 package kvstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -41,7 +42,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	var cursor string
 
 	for {
-		o, err := c.Globals.APIClient.ListKVStores(&fastly.ListKVStoresInput{
+		o, err := c.Globals.APIClient.ListKVStores(context.TODO(), &fastly.ListKVStoresInput{
 			Cursor: cursor,
 		})
 		if err != nil {

--- a/pkg/commands/kvstoreentry/create.go
+++ b/pkg/commands/kvstoreentry/create.go
@@ -1,6 +1,7 @@
 package kvstoreentry
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,7 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"
@@ -86,7 +87,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidKVCombo
 	}
 
-	err := c.Globals.APIClient.InsertKVStoreKey(&c.Input)
+	err := c.Globals.APIClient.InsertKVStoreKey(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -352,7 +353,7 @@ func (c *CreateCommand) CallBatchEndpoint(in io.Reader, out io.Writer) error {
 		Errors  []*fastly.ErrorObject `json:"errors,omitempty"`
 	}
 
-	if err := c.Globals.APIClient.BatchModifyKVStoreKey(&fastly.BatchModifyKVStoreKeyInput{
+	if err := c.Globals.APIClient.BatchModifyKVStoreKey(context.TODO(), &fastly.BatchModifyKVStoreKeyInput{
 		StoreID: c.Input.StoreID,
 		Body:    in,
 	}); err != nil {
@@ -399,7 +400,7 @@ func (c *CreateCommand) CallBatchEndpoint(in io.Reader, out io.Writer) error {
 }
 
 func insertKey(opts insertKeyOptions) error {
-	return opts.client.InsertKVStoreKey(&fastly.InsertKVStoreKeyInput{
+	return opts.client.InsertKVStoreKey(context.TODO(), &fastly.InsertKVStoreKeyInput{
 		Body:    opts.file,
 		StoreID: opts.id,
 		Key:     opts.key,

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -1,13 +1,14 @@
 package kvstoreentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
 	"sync"
 	"sync/atomic"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -94,7 +95,7 @@ func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
 		Key:     c.key.Value,
 	}
 
-	err := c.Globals.APIClient.DeleteKVStoreKey(&input)
+	err := c.Globals.APIClient.DeleteKVStoreKey(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -135,7 +136,7 @@ func (c *DeleteCommand) DeleteAllKeys(out io.Writer) error {
 	}
 	spinner.Message(spinnerMessage + "...")
 
-	p := c.Globals.APIClient.NewListKVStoreKeysPaginator(&fastly.ListKVStoreKeysInput{
+	p := c.Globals.APIClient.NewListKVStoreKeysPaginator(context.TODO(), &fastly.ListKVStoreKeysInput{
 		StoreID: c.StoreID,
 	})
 
@@ -172,7 +173,7 @@ func (c *DeleteCommand) DeleteAllKeys(out io.Writer) error {
 		go func() {
 			defer wg.Done()
 			for key := range keysCh {
-				err := c.Globals.APIClient.DeleteKVStoreKey(&fastly.DeleteKVStoreKeyInput{StoreID: c.StoreID, Key: key})
+				err := c.Globals.APIClient.DeleteKVStoreKey(context.TODO(), &fastly.DeleteKVStoreKeyInput{StoreID: c.StoreID, Key: key})
 				if err != nil {
 					select {
 					case errorsCh <- key:

--- a/pkg/commands/kvstoreentry/describe.go
+++ b/pkg/commands/kvstoreentry/describe.go
@@ -1,10 +1,11 @@
 package kvstoreentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -45,7 +46,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	value, err := c.Globals.APIClient.GetKVStoreKey(&c.Input)
+	value, err := c.Globals.APIClient.GetKVStoreKey(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -1,13 +1,14 @@
 package kvstoreentry_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/kvstoreentry"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
@@ -30,7 +31,7 @@ func TestCreateCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
-				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
+				InsertKVStoreKeyFn: func(_ context.Context, _ *fastly.InsertKVStoreKeyInput) error {
 					return errors.New("invalid request")
 				},
 			},
@@ -39,7 +40,7 @@ func TestCreateCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s", storeID, itemKey, itemValue),
 			API: mock.API{
-				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
+				InsertKVStoreKeyFn: func(_ context.Context, _ *fastly.InsertKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -48,7 +49,7 @@ func TestCreateCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --value %s --json", storeID, itemKey, itemValue),
 			API: mock.API{
-				InsertKVStoreKeyFn: func(_ *fastly.InsertKVStoreKeyInput) error {
+				InsertKVStoreKeyFn: func(_ context.Context, _ *fastly.InsertKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -58,7 +59,7 @@ func TestCreateCommand(t *testing.T) {
 			Args:  fmt.Sprintf("--store-id %s --stdin", storeID),
 			Stdin: []string{`{"key":"example","value":"VkFMVUU="}`},
 			API: mock.API{
-				BatchModifyKVStoreKeyFn: func(_ *fastly.BatchModifyKVStoreKeyInput) error {
+				BatchModifyKVStoreKeyFn: func(_ context.Context, _ *fastly.BatchModifyKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -67,7 +68,7 @@ func TestCreateCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --file %s", storeID, filepath.Join("testdata", "data.json")),
 			API: mock.API{
-				BatchModifyKVStoreKeyFn: func(_ *fastly.BatchModifyKVStoreKeyInput) error {
+				BatchModifyKVStoreKeyFn: func(_ context.Context, _ *fastly.BatchModifyKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -77,7 +78,7 @@ func TestCreateCommand(t *testing.T) {
 			Args:  fmt.Sprintf("--store-id %s --dir %s", storeID, filepath.Join("testdata", "example")),
 			Stdin: []string{"y"},
 			API: mock.API{
-				InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+				InsertKVStoreKeyFn: func(_ context.Context, i *fastly.InsertKVStoreKeyInput) error {
 					if i.Key == "foo.txt" {
 						return nil
 					}
@@ -90,7 +91,7 @@ func TestCreateCommand(t *testing.T) {
 			Args:  fmt.Sprintf("--store-id %s --dir %s --dir-allow-hidden", storeID, filepath.Join("testdata", "example")),
 			Stdin: []string{"y"},
 			API: mock.API{
-				InsertKVStoreKeyFn: func(i *fastly.InsertKVStoreKeyInput) error {
+				InsertKVStoreKeyFn: func(_ context.Context, i *fastly.InsertKVStoreKeyInput) error {
 					if i.Key == "foo.txt" || i.Key == ".hiddenfile" {
 						return nil
 					}
@@ -130,7 +131,7 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ context.Context, _ *fastly.DeleteKVStoreKeyInput) error {
 					return errors.New("invalid request")
 				},
 			},
@@ -139,7 +140,7 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ context.Context, _ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -148,7 +149,7 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
-				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ context.Context, _ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -157,13 +158,13 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
-				NewListKVStoreKeysPaginatorFn: func(_ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
+				NewListKVStoreKeysPaginatorFn: func(_ context.Context, _ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
 					return &mockKVStoresEntriesPaginator{
 						next: true,
 						keys: []string{"foo", "bar", "baz"},
 					}
 				},
-				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ context.Context, _ *fastly.DeleteKVStoreKeyInput) error {
 					return nil
 				},
 			},
@@ -172,13 +173,13 @@ func TestDeleteCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --all --auto-yes", storeID),
 			API: mock.API{
-				NewListKVStoreKeysPaginatorFn: func(_ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
+				NewListKVStoreKeysPaginatorFn: func(_ context.Context, _ *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
 					return &mockKVStoresEntriesPaginator{
 						next: true,
 						keys: []string{"foo", "bar", "baz"},
 					}
 				},
-				DeleteKVStoreKeyFn: func(_ *fastly.DeleteKVStoreKeyInput) error {
+				DeleteKVStoreKeyFn: func(_ context.Context, _ *fastly.DeleteKVStoreKeyInput) error {
 					return errors.New("whoops")
 				},
 			},
@@ -204,7 +205,7 @@ func TestGetCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
+				GetKVStoreKeyFn: func(_ context.Context, _ *fastly.GetKVStoreKeyInput) (string, error) {
 					return "", errors.New("invalid request")
 				},
 			},
@@ -213,7 +214,7 @@ func TestGetCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s", storeID, itemKey),
 			API: mock.API{
-				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
+				GetKVStoreKeyFn: func(_ context.Context, _ *fastly.GetKVStoreKeyInput) (string, error) {
 					return itemValue, nil
 				},
 			},
@@ -222,7 +223,7 @@ func TestGetCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --key %s --json", storeID, itemKey),
 			API: mock.API{
-				GetKVStoreKeyFn: func(_ *fastly.GetKVStoreKeyInput) (string, error) {
+				GetKVStoreKeyFn: func(_ context.Context, _ *fastly.GetKVStoreKeyInput) (string, error) {
 					return itemValue, nil
 				},
 			},
@@ -248,7 +249,7 @@ func TestListCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+				ListKVStoreKeysFn: func(_ context.Context, _ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -257,7 +258,7 @@ func TestListCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s", storeID),
 			API: mock.API{
-				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+				ListKVStoreKeysFn: func(_ context.Context, _ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return &fastly.ListKVStoreKeysResponse{Data: testItems}, nil
 				},
 			},
@@ -266,7 +267,7 @@ func TestListCommand(t *testing.T) {
 		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
-				ListKVStoreKeysFn: func(_ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+				ListKVStoreKeysFn: func(_ context.Context, _ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
 					return &fastly.ListKVStoreKeysResponse{Data: testItems}, nil
 				},
 			},

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -1,10 +1,11 @@
 package kvstoreentry
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -83,7 +84,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	for {
-		o, err := c.Globals.APIClient.ListKVStoreKeys(&c.Input)
+		o, err := c.Globals.APIClient.ListKVStoreKeys(context.TODO(), &c.Input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			if !c.JSONOutput.Enabled {

--- a/pkg/commands/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_integration_test.go
@@ -2,12 +2,13 @@ package azureblob_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -281,7 +282,7 @@ func TestBlobStorageDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createBlobStorageOK(i *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error) {
+func createBlobStorageOK(_ context.Context, i *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error) {
 	s := fastly.BlobStorage{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -304,11 +305,11 @@ func createBlobStorageOK(i *fastly.CreateBlobStorageInput) (*fastly.BlobStorage,
 	return &s, nil
 }
 
-func createBlobStorageError(_ *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error) {
+func createBlobStorageError(_ context.Context, _ *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error) {
 	return nil, errTest
 }
 
-func listBlobStoragesOK(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error) {
+func listBlobStoragesOK(_ context.Context, i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error) {
 	return []*fastly.BlobStorage{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -351,7 +352,7 @@ func listBlobStoragesOK(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage,
 	}, nil
 }
 
-func listBlobStoragesError(_ *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error) {
+func listBlobStoragesError(_ context.Context, _ *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error) {
 	return nil, errTest
 }
 
@@ -410,7 +411,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getBlobStorageOK(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
+func getBlobStorageOK(_ context.Context, i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
 	return &fastly.BlobStorage{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -433,7 +434,7 @@ func getBlobStorageOK(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error
 	}, nil
 }
 
-func getBlobStorageError(_ *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
+func getBlobStorageError(_ context.Context, _ *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
 	return nil, errTest
 }
 
@@ -459,7 +460,7 @@ Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Version: 1
 `) + "\n"
 
-func updateBlobStorageOK(i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {
+func updateBlobStorageOK(_ context.Context, i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {
 	return &fastly.BlobStorage{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -480,15 +481,15 @@ func updateBlobStorageOK(i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage,
 	}, nil
 }
 
-func updateBlobStorageError(_ *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {
+func updateBlobStorageError(_ context.Context, _ *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {
 	return nil, errTest
 }
 
-func deleteBlobStorageOK(_ *fastly.DeleteBlobStorageInput) error {
+func deleteBlobStorageOK(_ context.Context, _ *fastly.DeleteBlobStorageInput) error {
 	return nil
 }
 
-func deleteBlobStorageError(_ *fastly.DeleteBlobStorageInput) error {
+func deleteBlobStorageError(_ context.Context, _ *fastly.DeleteBlobStorageInput) error {
 	return errTest
 }
 

--- a/pkg/commands/logging/azureblob/azureblob_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/azureblob"

--- a/pkg/commands/logging/azureblob/create.go
+++ b/pkg/commands/logging/azureblob/create.go
@@ -1,10 +1,11 @@
 package azureblob
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -199,7 +200,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateBlobStorage(input)
+	d, err := c.Globals.APIClient.CreateBlobStorage(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/azureblob/delete.go
+++ b/pkg/commands/logging/azureblob/delete.go
@@ -1,9 +1,10 @@
 package azureblob
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteBlobStorage(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteBlobStorage(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
 			"Service Version": fastly.ToValue(serviceVersion.Number),

--- a/pkg/commands/logging/azureblob/describe.go
+++ b/pkg/commands/logging/azureblob/describe.go
@@ -1,9 +1,10 @@
 package azureblob
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetBlobStorage(&c.Input)
+	o, err := c.Globals.APIClient.GetBlobStorage(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/azureblob/list.go
+++ b/pkg/commands/logging/azureblob/list.go
@@ -1,10 +1,11 @@
 package azureblob
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListBlobStorages(&c.Input)
+	o, err := c.Globals.APIClient.ListBlobStorages(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/azureblob/update.go
+++ b/pkg/commands/logging/azureblob/update.go
@@ -1,9 +1,10 @@
 package azureblob
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -197,7 +198,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	azureblob, err := c.Globals.APIClient.UpdateBlobStorage(input)
+	azureblob, err := c.Globals.APIClient.UpdateBlobStorage(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_integration_test.go
@@ -2,12 +2,13 @@ package bigquery_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestBigQueryDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createBigQueryOK(i *fastly.CreateBigQueryInput) (*fastly.BigQuery, error) {
+func createBigQueryOK(_ context.Context, i *fastly.CreateBigQueryInput) (*fastly.BigQuery, error) {
 	return &fastly.BigQuery{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -280,11 +281,11 @@ func createBigQueryOK(i *fastly.CreateBigQueryInput) (*fastly.BigQuery, error) {
 	}, nil
 }
 
-func createBigQueryError(_ *fastly.CreateBigQueryInput) (*fastly.BigQuery, error) {
+func createBigQueryError(_ context.Context, _ *fastly.CreateBigQueryInput) (*fastly.BigQuery, error) {
 	return nil, errTest
 }
 
-func listBigQueriesOK(i *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error) {
+func listBigQueriesOK(_ context.Context, i *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error) {
 	return []*fastly.BigQuery{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -321,7 +322,7 @@ func listBigQueriesOK(i *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error)
 	}, nil
 }
 
-func listBigQueriesError(_ *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error) {
+func listBigQueriesError(_ context.Context, _ *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error) {
 	return nil, errTest
 }
 
@@ -372,7 +373,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getBigQueryOK(i *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
+func getBigQueryOK(_ context.Context, i *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
 	return &fastly.BigQuery{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -391,7 +392,7 @@ func getBigQueryOK(i *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
 	}, nil
 }
 
-func getBigQueryError(_ *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
+func getBigQueryError(_ context.Context, _ *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
 	return nil, errTest
 }
 
@@ -413,7 +414,7 @@ User: service-account@domain.com
 Version: 1
 `) + "\n"
 
-func updateBigQueryOK(i *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error) {
+func updateBigQueryOK(_ context.Context, i *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error) {
 	return &fastly.BigQuery{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -430,14 +431,14 @@ func updateBigQueryOK(i *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error) {
 	}, nil
 }
 
-func updateBigQueryError(_ *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error) {
+func updateBigQueryError(_ context.Context, _ *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error) {
 	return nil, errTest
 }
 
-func deleteBigQueryOK(_ *fastly.DeleteBigQueryInput) error {
+func deleteBigQueryOK(_ context.Context, _ *fastly.DeleteBigQueryInput) error {
 	return nil
 }
 
-func deleteBigQueryError(_ *fastly.DeleteBigQueryInput) error {
+func deleteBigQueryError(_ context.Context, _ *fastly.DeleteBigQueryInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/bigquery/bigquery_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/bigquery"

--- a/pkg/commands/logging/bigquery/create.go
+++ b/pkg/commands/logging/bigquery/create.go
@@ -1,9 +1,10 @@
 package bigquery
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -171,7 +172,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateBigQuery(input)
+	d, err := c.Globals.APIClient.CreateBigQuery(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/bigquery/delete.go
+++ b/pkg/commands/logging/bigquery/delete.go
@@ -1,9 +1,10 @@
 package bigquery
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteBigQuery(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteBigQuery(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
 			"Service Version": fastly.ToValue(serviceVersion.Number),

--- a/pkg/commands/logging/bigquery/describe.go
+++ b/pkg/commands/logging/bigquery/describe.go
@@ -1,9 +1,10 @@
 package bigquery
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetBigQuery(&c.Input)
+	o, err := c.Globals.APIClient.GetBigQuery(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/bigquery/list.go
+++ b/pkg/commands/logging/bigquery/list.go
@@ -1,10 +1,11 @@
 package bigquery
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListBigQueries(&c.Input)
+	o, err := c.Globals.APIClient.ListBigQueries(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/bigquery/update.go
+++ b/pkg/commands/logging/bigquery/update.go
@@ -1,9 +1,10 @@
 package bigquery
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -174,7 +175,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	bq, err := c.Globals.APIClient.UpdateBigQuery(input)
+	bq, err := c.Globals.APIClient.UpdateBigQuery(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
@@ -2,12 +2,13 @@ package cloudfiles_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -280,7 +281,7 @@ func TestCloudfilesDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createCloudfilesOK(i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
+func createCloudfilesOK(_ context.Context, i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
 	s := fastly.Cloudfiles{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -293,11 +294,11 @@ func createCloudfilesOK(i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, er
 	return &s, nil
 }
 
-func createCloudfilesError(_ *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
+func createCloudfilesError(_ context.Context, _ *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
 	return nil, errTest
 }
 
-func listCloudfilesOK(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
+func listCloudfilesOK(_ context.Context, i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
 	return []*fastly.Cloudfiles{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -342,7 +343,7 @@ func listCloudfilesOK(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, erro
 	}, nil
 }
 
-func listCloudfilesError(_ *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
+func listCloudfilesError(_ context.Context, _ *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
 	return nil, errTest
 }
 
@@ -399,7 +400,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getCloudfilesOK(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
+func getCloudfilesOK(_ context.Context, i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
 	return &fastly.Cloudfiles{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -422,7 +423,7 @@ func getCloudfilesOK(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
 	}, nil
 }
 
-func getCloudfilesError(_ *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
+func getCloudfilesError(_ context.Context, _ *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
 	return nil, errTest
 }
 
@@ -447,7 +448,7 @@ User: username
 Version: 1
 `) + "\n"
 
-func updateCloudfilesOK(i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
+func updateCloudfilesOK(_ context.Context, i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
 	return &fastly.Cloudfiles{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -469,15 +470,15 @@ func updateCloudfilesOK(i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, er
 	}, nil
 }
 
-func updateCloudfilesError(_ *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
+func updateCloudfilesError(_ context.Context, _ *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
 	return nil, errTest
 }
 
-func deleteCloudfilesOK(_ *fastly.DeleteCloudfilesInput) error {
+func deleteCloudfilesOK(_ context.Context, _ *fastly.DeleteCloudfilesInput) error {
 	return nil
 }
 
-func deleteCloudfilesError(_ *fastly.DeleteCloudfilesInput) error {
+func deleteCloudfilesError(_ context.Context, _ *fastly.DeleteCloudfilesInput) error {
 	return errTest
 }
 

--- a/pkg/commands/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/cloudfiles"

--- a/pkg/commands/logging/cloudfiles/create.go
+++ b/pkg/commands/logging/cloudfiles/create.go
@@ -1,10 +1,11 @@
 package cloudfiles
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -199,7 +200,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateCloudfiles(input)
+	d, err := c.Globals.APIClient.CreateCloudfiles(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/cloudfiles/delete.go
+++ b/pkg/commands/logging/cloudfiles/delete.go
@@ -1,9 +1,10 @@
 package cloudfiles
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteCloudfiles(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteCloudfiles(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
 			"Service Version": fastly.ToValue(serviceVersion.Number),

--- a/pkg/commands/logging/cloudfiles/describe.go
+++ b/pkg/commands/logging/cloudfiles/describe.go
@@ -1,9 +1,10 @@
 package cloudfiles
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetCloudfiles(&c.Input)
+	o, err := c.Globals.APIClient.GetCloudfiles(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/cloudfiles/list.go
+++ b/pkg/commands/logging/cloudfiles/list.go
@@ -1,10 +1,11 @@
 package cloudfiles
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListCloudfiles(&c.Input)
+	o, err := c.Globals.APIClient.ListCloudfiles(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/cloudfiles/update.go
+++ b/pkg/commands/logging/cloudfiles/update.go
@@ -1,9 +1,10 @@
 package cloudfiles
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -211,7 +212,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	cloudfiles, err := c.Globals.APIClient.UpdateCloudfiles(input)
+	cloudfiles, err := c.Globals.APIClient.UpdateCloudfiles(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/datadog/create.go
+++ b/pkg/commands/logging/datadog/create.go
@@ -1,9 +1,10 @@
 package datadog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -148,7 +149,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateDatadog(input)
+	d, err := c.Globals.APIClient.CreateDatadog(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/logging/datadog/datadog_integration_test.go
@@ -2,12 +2,13 @@ package datadog_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestDatadogDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createDatadogOK(i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
+func createDatadogOK(_ context.Context, i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
 	s := fastly.Datadog{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -285,11 +286,11 @@ func createDatadogOK(i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
 	return &s, nil
 }
 
-func createDatadogError(_ *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
+func createDatadogError(_ context.Context, _ *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
 	return nil, errTest
 }
 
-func listDatadogsOK(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
+func listDatadogsOK(_ context.Context, i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
 	return []*fastly.Datadog{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -318,7 +319,7 @@ func listDatadogsOK(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
 	}, nil
 }
 
-func listDatadogsError(_ *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
+func listDatadogsError(_ context.Context, _ *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
 	return nil, errTest
 }
 
@@ -359,7 +360,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getDatadogOK(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
+func getDatadogOK(_ context.Context, i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
 	return &fastly.Datadog{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -374,7 +375,7 @@ func getDatadogOK(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
 	}, nil
 }
 
-func getDatadogError(_ *fastly.GetDatadogInput) (*fastly.Datadog, error) {
+func getDatadogError(_ context.Context, _ *fastly.GetDatadogInput) (*fastly.Datadog, error) {
 	return nil, errTest
 }
 
@@ -391,7 +392,7 @@ Token: abc
 Version: 1
 `) + "\n"
 
-func updateDatadogOK(i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
+func updateDatadogOK(_ context.Context, i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
 	return &fastly.Datadog{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -404,14 +405,14 @@ func updateDatadogOK(i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
 	}, nil
 }
 
-func updateDatadogError(_ *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
+func updateDatadogError(_ context.Context, _ *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
 	return nil, errTest
 }
 
-func deleteDatadogOK(_ *fastly.DeleteDatadogInput) error {
+func deleteDatadogOK(_ context.Context, _ *fastly.DeleteDatadogInput) error {
 	return nil
 }
 
-func deleteDatadogError(_ *fastly.DeleteDatadogInput) error {
+func deleteDatadogError(_ context.Context, _ *fastly.DeleteDatadogInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/datadog/datadog_test.go
+++ b/pkg/commands/logging/datadog/datadog_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/datadog"

--- a/pkg/commands/logging/datadog/delete.go
+++ b/pkg/commands/logging/datadog/delete.go
@@ -1,9 +1,10 @@
 package datadog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteDatadog(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteDatadog(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/datadog/describe.go
+++ b/pkg/commands/logging/datadog/describe.go
@@ -1,9 +1,10 @@
 package datadog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetDatadog(&c.Input)
+	o, err := c.Globals.APIClient.GetDatadog(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/datadog/list.go
+++ b/pkg/commands/logging/datadog/list.go
@@ -1,10 +1,11 @@
 package datadog
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListDatadog(&c.Input)
+	o, err := c.Globals.APIClient.ListDatadog(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/datadog/update.go
+++ b/pkg/commands/logging/datadog/update.go
@@ -1,9 +1,10 @@
 package datadog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -153,7 +154,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	datadog, err := c.Globals.APIClient.UpdateDatadog(input)
+	datadog, err := c.Globals.APIClient.UpdateDatadog(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/digitalocean/create.go
+++ b/pkg/commands/logging/digitalocean/create.go
@@ -1,10 +1,11 @@
 package digitalocean
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -207,7 +208,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateDigitalOcean(input)
+	d, err := c.Globals.APIClient.CreateDigitalOcean(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/digitalocean/delete.go
+++ b/pkg/commands/logging/digitalocean/delete.go
@@ -1,9 +1,10 @@
 package digitalocean
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteDigitalOcean(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteDigitalOcean(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/digitalocean/describe.go
+++ b/pkg/commands/logging/digitalocean/describe.go
@@ -1,9 +1,10 @@
 package digitalocean
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetDigitalOcean(&c.Input)
+	o, err := c.Globals.APIClient.GetDigitalOcean(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
@@ -2,12 +2,13 @@ package digitalocean_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -280,7 +281,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createDigitalOceanOK(i *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error) {
+func createDigitalOceanOK(_ context.Context, i *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error) {
 	s := fastly.DigitalOcean{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -293,11 +294,11 @@ func createDigitalOceanOK(i *fastly.CreateDigitalOceanInput) (*fastly.DigitalOce
 	return &s, nil
 }
 
-func createDigitalOceanError(_ *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error) {
+func createDigitalOceanError(_ context.Context, _ *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error) {
 	return nil, errTest
 }
 
-func listDigitalOceansOK(i *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error) {
+func listDigitalOceansOK(_ context.Context, i *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error) {
 	return []*fastly.DigitalOcean{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -340,7 +341,7 @@ func listDigitalOceansOK(i *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOce
 	}, nil
 }
 
-func listDigitalOceansError(_ *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error) {
+func listDigitalOceansError(_ context.Context, _ *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error) {
 	return nil, errTest
 }
 
@@ -395,7 +396,7 @@ Version: 1
 		Public key: `+pgpPublicKey()+`
 `) + "\n\n"
 
-func getDigitalOceanOK(i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error) {
+func getDigitalOceanOK(_ context.Context, i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error) {
 	return &fastly.DigitalOcean{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -418,7 +419,7 @@ func getDigitalOceanOK(i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, er
 	}, nil
 }
 
-func getDigitalOceanError(_ *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error) {
+func getDigitalOceanError(_ context.Context, _ *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error) {
 	return nil, errTest
 }
 
@@ -443,7 +444,7 @@ Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Version: 1
 `) + "\n"
 
-func updateDigitalOceanOK(i *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error) {
+func updateDigitalOceanOK(_ context.Context, i *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error) {
 	return &fastly.DigitalOcean{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -465,15 +466,15 @@ func updateDigitalOceanOK(i *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOce
 	}, nil
 }
 
-func updateDigitalOceanError(_ *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error) {
+func updateDigitalOceanError(_ context.Context, _ *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error) {
 	return nil, errTest
 }
 
-func deleteDigitalOceanOK(_ *fastly.DeleteDigitalOceanInput) error {
+func deleteDigitalOceanOK(_ context.Context, _ *fastly.DeleteDigitalOceanInput) error {
 	return nil
 }
 
-func deleteDigitalOceanError(_ *fastly.DeleteDigitalOceanInput) error {
+func deleteDigitalOceanError(_ context.Context, _ *fastly.DeleteDigitalOceanInput) error {
 	return errTest
 }
 

--- a/pkg/commands/logging/digitalocean/digitalocean_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/digitalocean"

--- a/pkg/commands/logging/digitalocean/list.go
+++ b/pkg/commands/logging/digitalocean/list.go
@@ -1,10 +1,11 @@
 package digitalocean
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListDigitalOceans(&c.Input)
+	o, err := c.Globals.APIClient.ListDigitalOceans(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/digitalocean/update.go
+++ b/pkg/commands/logging/digitalocean/update.go
@@ -1,9 +1,10 @@
 package digitalocean
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -208,7 +209,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	digitalocean, err := c.Globals.APIClient.UpdateDigitalOcean(input)
+	digitalocean, err := c.Globals.APIClient.UpdateDigitalOcean(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/elasticsearch/create.go
+++ b/pkg/commands/logging/elasticsearch/create.go
@@ -1,9 +1,10 @@
 package elasticsearch
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -199,7 +200,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateElasticsearch(input)
+	d, err := c.Globals.APIClient.CreateElasticsearch(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/elasticsearch/delete.go
+++ b/pkg/commands/logging/elasticsearch/delete.go
@@ -1,9 +1,10 @@
 package elasticsearch
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteElasticsearch(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteElasticsearch(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/elasticsearch/describe.go
+++ b/pkg/commands/logging/elasticsearch/describe.go
@@ -1,9 +1,10 @@
 package elasticsearch
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetElasticsearch(&c.Input)
+	o, err := c.Globals.APIClient.GetElasticsearch(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
@@ -2,12 +2,13 @@ package elasticsearch_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestElasticsearchDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createElasticsearchOK(i *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
+func createElasticsearchOK(_ context.Context, i *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
 	return &fastly.Elasticsearch{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -295,11 +296,11 @@ func createElasticsearchOK(i *fastly.CreateElasticsearchInput) (*fastly.Elastics
 	}, nil
 }
 
-func createElasticsearchError(_ *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
+func createElasticsearchError(_ context.Context, _ *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
 	return nil, errTest
 }
 
-func listElasticsearchsOK(i *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
+func listElasticsearchsOK(_ context.Context, i *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
 	return []*fastly.Elasticsearch{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -346,7 +347,7 @@ func listElasticsearchsOK(i *fastly.ListElasticsearchInput) ([]*fastly.Elasticse
 	}, nil
 }
 
-func listElasticsearchsError(_ *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
+func listElasticsearchsError(_ context.Context, _ *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
 	return nil, errTest
 }
 
@@ -401,7 +402,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getElasticsearchOK(i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
+func getElasticsearchOK(_ context.Context, i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
 	return &fastly.Elasticsearch{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -425,7 +426,7 @@ func getElasticsearchOK(i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch,
 	}, nil
 }
 
-func getElasticsearchError(_ *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
+func getElasticsearchError(_ context.Context, _ *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
 	return nil, errTest
 }
 
@@ -449,7 +450,7 @@ User: user
 Version: 1
 `) + "\n"
 
-func updateElasticsearchOK(i *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
+func updateElasticsearchOK(_ context.Context, i *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
 	return &fastly.Elasticsearch{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -472,14 +473,14 @@ func updateElasticsearchOK(i *fastly.UpdateElasticsearchInput) (*fastly.Elastics
 	}, nil
 }
 
-func updateElasticsearchError(_ *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
+func updateElasticsearchError(_ context.Context, _ *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
 	return nil, errTest
 }
 
-func deleteElasticsearchOK(_ *fastly.DeleteElasticsearchInput) error {
+func deleteElasticsearchOK(_ context.Context, _ *fastly.DeleteElasticsearchInput) error {
 	return nil
 }
 
-func deleteElasticsearchError(_ *fastly.DeleteElasticsearchInput) error {
+func deleteElasticsearchError(_ context.Context, _ *fastly.DeleteElasticsearchInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/elasticsearch"

--- a/pkg/commands/logging/elasticsearch/list.go
+++ b/pkg/commands/logging/elasticsearch/list.go
@@ -1,10 +1,11 @@
 package elasticsearch
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListElasticsearch(&c.Input)
+	o, err := c.Globals.APIClient.ListElasticsearch(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/elasticsearch/update.go
+++ b/pkg/commands/logging/elasticsearch/update.go
@@ -1,9 +1,10 @@
 package elasticsearch
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -205,7 +206,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	elasticsearch, err := c.Globals.APIClient.UpdateElasticsearch(input)
+	elasticsearch, err := c.Globals.APIClient.UpdateElasticsearch(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/ftp/create.go
+++ b/pkg/commands/logging/ftp/create.go
@@ -1,10 +1,11 @@
 package ftp
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -195,7 +196,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateFTP(input)
+	d, err := c.Globals.APIClient.CreateFTP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/ftp/delete.go
+++ b/pkg/commands/logging/ftp/delete.go
@@ -1,9 +1,10 @@
 package ftp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteFTP(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteFTP(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/ftp/describe.go
+++ b/pkg/commands/logging/ftp/describe.go
@@ -1,9 +1,10 @@
 package ftp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -77,7 +78,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetFTP(&c.Input)
+	o, err := c.Globals.APIClient.GetFTP(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/logging/ftp/ftp_integration_test.go
@@ -2,12 +2,13 @@ package ftp_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -280,7 +281,7 @@ func TestFTPDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createFTPOK(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
+func createFTPOK(_ context.Context, i *fastly.CreateFTPInput) (*fastly.FTP, error) {
 	return &fastly.FTP{
 		ServiceID:        fastly.ToPointer(i.ServiceID),
 		ServiceVersion:   fastly.ToPointer(i.ServiceVersion),
@@ -289,11 +290,11 @@ func createFTPOK(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
 	}, nil
 }
 
-func createFTPError(_ *fastly.CreateFTPInput) (*fastly.FTP, error) {
+func createFTPError(_ context.Context, _ *fastly.CreateFTPInput) (*fastly.FTP, error) {
 	return nil, errTest
 }
 
-func listFTPsOK(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+func listFTPsOK(_ context.Context, i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
 	return []*fastly.FTP{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -338,7 +339,7 @@ func listFTPsOK(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
 	}, nil
 }
 
-func listFTPsError(_ *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+func listFTPsError(_ context.Context, _ *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
 	return nil, errTest
 }
 
@@ -395,7 +396,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
+func getFTPOK(_ context.Context, i *fastly.GetFTPInput) (*fastly.FTP, error) {
 	return &fastly.FTP{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -418,7 +419,7 @@ func getFTPOK(i *fastly.GetFTPInput) (*fastly.FTP, error) {
 	}, nil
 }
 
-func getFTPError(_ *fastly.GetFTPInput) (*fastly.FTP, error) {
+func getFTPError(_ context.Context, _ *fastly.GetFTPInput) (*fastly.FTP, error) {
 	return nil, errTest
 }
 
@@ -443,7 +444,7 @@ Username: anonymous
 Version: 1
 `) + "\n"
 
-func updateFTPOK(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+func updateFTPOK(_ context.Context, i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
 	return &fastly.FTP{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -465,15 +466,15 @@ func updateFTPOK(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
 	}, nil
 }
 
-func updateFTPError(_ *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+func updateFTPError(_ context.Context, _ *fastly.UpdateFTPInput) (*fastly.FTP, error) {
 	return nil, errTest
 }
 
-func deleteFTPOK(_ *fastly.DeleteFTPInput) error {
+func deleteFTPOK(_ context.Context, _ *fastly.DeleteFTPInput) error {
 	return nil
 }
 
-func deleteFTPError(_ *fastly.DeleteFTPInput) error {
+func deleteFTPError(_ context.Context, _ *fastly.DeleteFTPInput) error {
 	return errTest
 }
 

--- a/pkg/commands/logging/ftp/ftp_test.go
+++ b/pkg/commands/logging/ftp/ftp_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/ftp"

--- a/pkg/commands/logging/ftp/list.go
+++ b/pkg/commands/logging/ftp/list.go
@@ -1,10 +1,11 @@
 package ftp
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListFTPs(&c.Input)
+	o, err := c.Globals.APIClient.ListFTPs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/ftp/update.go
+++ b/pkg/commands/logging/ftp/update.go
@@ -1,9 +1,10 @@
 package ftp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -202,7 +203,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	ftp, err := c.Globals.APIClient.UpdateFTP(input)
+	ftp, err := c.Globals.APIClient.UpdateFTP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/gcs/create.go
+++ b/pkg/commands/logging/gcs/create.go
@@ -1,10 +1,11 @@
 package gcs
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -195,7 +196,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateGCS(input)
+	d, err := c.Globals.APIClient.CreateGCS(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/gcs/delete.go
+++ b/pkg/commands/logging/gcs/delete.go
@@ -1,9 +1,10 @@
 package gcs
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteGCS(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteGCS(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/gcs/describe.go
+++ b/pkg/commands/logging/gcs/describe.go
@@ -1,9 +1,10 @@
 package gcs
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetGCS(&c.Input)
+	o, err := c.Globals.APIClient.GetGCS(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -2,12 +2,13 @@ package gcs_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -289,7 +290,7 @@ func TestGCSDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createGCSOK(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
+func createGCSOK(_ context.Context, i *fastly.CreateGCSInput) (*fastly.GCS, error) {
 	return &fastly.GCS{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -297,11 +298,11 @@ func createGCSOK(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
 	}, nil
 }
 
-func createGCSError(_ *fastly.CreateGCSInput) (*fastly.GCS, error) {
+func createGCSError(_ context.Context, _ *fastly.CreateGCSInput) (*fastly.GCS, error) {
 	return nil, errTest
 }
 
-func listGCSsOK(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+func listGCSsOK(_ context.Context, i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
 	return []*fastly.GCS{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -346,7 +347,7 @@ func listGCSsOK(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
 	}, nil
 }
 
-func listGCSsError(_ *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+func listGCSsError(_ context.Context, _ *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
 	return nil, errTest
 }
 
@@ -403,7 +404,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
+func getGCSOK(_ context.Context, i *fastly.GetGCSInput) (*fastly.GCS, error) {
 	return &fastly.GCS{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -426,7 +427,7 @@ func getGCSOK(i *fastly.GetGCSInput) (*fastly.GCS, error) {
 	}, nil
 }
 
-func getGCSError(_ *fastly.GetGCSInput) (*fastly.GCS, error) {
+func getGCSError(_ context.Context, _ *fastly.GetGCSInput) (*fastly.GCS, error) {
 	return nil, errTest
 }
 
@@ -452,7 +453,7 @@ User: foo@example.com
 Version: 1
 `) + "\n"
 
-func updateGCSOK(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+func updateGCSOK(_ context.Context, i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
 	return &fastly.GCS{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -473,14 +474,14 @@ func updateGCSOK(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
 	}, nil
 }
 
-func updateGCSError(_ *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+func updateGCSError(_ context.Context, _ *fastly.UpdateGCSInput) (*fastly.GCS, error) {
 	return nil, errTest
 }
 
-func deleteGCSOK(_ *fastly.DeleteGCSInput) error {
+func deleteGCSOK(_ context.Context, _ *fastly.DeleteGCSInput) error {
 	return nil
 }
 
-func deleteGCSError(_ *fastly.DeleteGCSInput) error {
+func deleteGCSError(_ context.Context, _ *fastly.DeleteGCSInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/gcs/gcs_test.go
+++ b/pkg/commands/logging/gcs/gcs_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/gcs"

--- a/pkg/commands/logging/gcs/list.go
+++ b/pkg/commands/logging/gcs/list.go
@@ -1,10 +1,11 @@
 package gcs
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListGCSs(&c.Input)
+	o, err := c.Globals.APIClient.ListGCSs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/gcs/update.go
+++ b/pkg/commands/logging/gcs/update.go
@@ -1,9 +1,10 @@
 package gcs
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -191,7 +192,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	gcs, err := c.Globals.APIClient.UpdateGCS(input)
+	gcs, err := c.Globals.APIClient.UpdateGCS(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/googlepubsub/create.go
+++ b/pkg/commands/logging/googlepubsub/create.go
@@ -1,9 +1,10 @@
 package googlepubsub
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -158,7 +159,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreatePubsub(input)
+	d, err := c.Globals.APIClient.CreatePubsub(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/googlepubsub/delete.go
+++ b/pkg/commands/logging/googlepubsub/delete.go
@@ -1,9 +1,10 @@
 package googlepubsub
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeletePubsub(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeletePubsub(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/googlepubsub/describe.go
+++ b/pkg/commands/logging/googlepubsub/describe.go
@@ -1,9 +1,10 @@
 package googlepubsub
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetPubsub(&c.Input)
+	o, err := c.Globals.APIClient.GetPubsub(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
@@ -2,12 +2,13 @@ package googlepubsub_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestGooglePubSubDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createGooglePubSubOK(i *fastly.CreatePubsubInput) (*fastly.Pubsub, error) {
+func createGooglePubSubOK(_ context.Context, i *fastly.CreatePubsubInput) (*fastly.Pubsub, error) {
 	return &fastly.Pubsub{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -289,11 +290,11 @@ func createGooglePubSubOK(i *fastly.CreatePubsubInput) (*fastly.Pubsub, error) {
 	}, nil
 }
 
-func createGooglePubSubError(_ *fastly.CreatePubsubInput) (*fastly.Pubsub, error) {
+func createGooglePubSubError(_ context.Context, _ *fastly.CreatePubsubInput) (*fastly.Pubsub, error) {
 	return nil, errTest
 }
 
-func listGooglePubSubsOK(i *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error) {
+func listGooglePubSubsOK(_ context.Context, i *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error) {
 	return []*fastly.Pubsub{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -328,7 +329,7 @@ func listGooglePubSubsOK(i *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error) {
 	}, nil
 }
 
-func listGooglePubSubsError(_ *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error) {
+func listGooglePubSubsError(_ context.Context, _ *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error) {
 	return nil, errTest
 }
 
@@ -375,7 +376,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getGooglePubSubOK(i *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
+func getGooglePubSubOK(_ context.Context, i *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
 	return &fastly.Pubsub{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -393,7 +394,7 @@ func getGooglePubSubOK(i *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
 	}, nil
 }
 
-func getGooglePubSubError(_ *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
+func getGooglePubSubError(_ context.Context, _ *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
 	return nil, errTest
 }
 
@@ -413,7 +414,7 @@ User: user@example.com
 Version: 1
 `) + "\n"
 
-func updateGooglePubSubOK(i *fastly.UpdatePubsubInput) (*fastly.Pubsub, error) {
+func updateGooglePubSubOK(_ context.Context, i *fastly.UpdatePubsubInput) (*fastly.Pubsub, error) {
 	return &fastly.Pubsub{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -429,14 +430,14 @@ func updateGooglePubSubOK(i *fastly.UpdatePubsubInput) (*fastly.Pubsub, error) {
 	}, nil
 }
 
-func updateGooglePubSubError(_ *fastly.UpdatePubsubInput) (*fastly.Pubsub, error) {
+func updateGooglePubSubError(_ context.Context, _ *fastly.UpdatePubsubInput) (*fastly.Pubsub, error) {
 	return nil, errTest
 }
 
-func deleteGooglePubSubOK(_ *fastly.DeletePubsubInput) error {
+func deleteGooglePubSubOK(_ context.Context, _ *fastly.DeletePubsubInput) error {
 	return nil
 }
 
-func deleteGooglePubSubError(_ *fastly.DeletePubsubInput) error {
+func deleteGooglePubSubError(_ context.Context, _ *fastly.DeletePubsubInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/googlepubsub"

--- a/pkg/commands/logging/googlepubsub/list.go
+++ b/pkg/commands/logging/googlepubsub/list.go
@@ -1,10 +1,11 @@
 package googlepubsub
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListPubsubs(&c.Input)
+	o, err := c.Globals.APIClient.ListPubsubs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/googlepubsub/update.go
+++ b/pkg/commands/logging/googlepubsub/update.go
@@ -1,9 +1,10 @@
 package googlepubsub
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -161,7 +162,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	googlepubsub, err := c.Globals.APIClient.UpdatePubsub(input)
+	googlepubsub, err := c.Globals.APIClient.UpdatePubsub(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/grafanacloudlogs/create.go
+++ b/pkg/commands/logging/grafanacloudlogs/create.go
@@ -1,6 +1,7 @@
 package grafanacloudlogs
 
 import (
+	"context"
 	"io"
 
 	"4d63.com/optional"
@@ -11,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a GrafanaCloudLogs logging endpoint.
@@ -159,7 +160,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateGrafanaCloudLogs(input)
+	d, err := c.Globals.APIClient.CreateGrafanaCloudLogs(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/grafanacloudlogs/delete.go
+++ b/pkg/commands/logging/grafanacloudlogs/delete.go
@@ -1,9 +1,10 @@
 package grafanacloudlogs
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteGrafanaCloudLogs(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteGrafanaCloudLogs(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/grafanacloudlogs/describe.go
+++ b/pkg/commands/logging/grafanacloudlogs/describe.go
@@ -1,9 +1,10 @@
 package grafanacloudlogs
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetGrafanaCloudLogs(&c.Input)
+	o, err := c.Globals.APIClient.GetGrafanaCloudLogs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/grafanacloudlogs/grafanacloud_logs_integration_test.go
+++ b/pkg/commands/logging/grafanacloudlogs/grafanacloud_logs_integration_test.go
@@ -2,6 +2,7 @@ package grafanacloudlogs_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
@@ -11,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 func TestGrafanaCloudLogsCreate(t *testing.T) {
@@ -271,7 +272,7 @@ func TestGrafanaCloudLogsDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createGrafanaCloudLogsOK(i *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+func createGrafanaCloudLogsOK(_ context.Context, i *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
 	return &fastly.GrafanaCloudLogs{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -279,11 +280,11 @@ func createGrafanaCloudLogsOK(i *fastly.CreateGrafanaCloudLogsInput) (*fastly.Gr
 	}, nil
 }
 
-func createGrafanaCloudLogsError(_ *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+func createGrafanaCloudLogsError(_ context.Context, _ *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
 	return nil, errTest
 }
 
-func listGrafanaCloudLogsOK(i *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error) {
+func listGrafanaCloudLogsOK(_ context.Context, i *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error) {
 	return []*fastly.GrafanaCloudLogs{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -318,7 +319,7 @@ func listGrafanaCloudLogsOK(i *fastly.ListGrafanaCloudLogsInput) ([]*fastly.Graf
 	}, nil
 }
 
-func listGrafanaCloudLogsError(_ *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error) {
+func listGrafanaCloudLogsError(_ context.Context, _ *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error) {
 	return nil, errTest
 }
 
@@ -365,7 +366,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getGrafanaCloudLogsOK(i *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+func getGrafanaCloudLogsOK(_ context.Context, i *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
 	return &fastly.GrafanaCloudLogs{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -383,7 +384,7 @@ func getGrafanaCloudLogsOK(i *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaC
 	}, nil
 }
 
-func getGrafanaCloudLogsError(_ *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+func getGrafanaCloudLogsError(_ context.Context, _ *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
 	return nil, errTest
 }
 
@@ -403,7 +404,7 @@ User: 123456
 Version: 1
 `) + "\n"
 
-func updateGrafanaCloudLogsOK(i *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+func updateGrafanaCloudLogsOK(_ context.Context, i *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
 	return &fastly.GrafanaCloudLogs{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -420,14 +421,14 @@ func updateGrafanaCloudLogsOK(i *fastly.UpdateGrafanaCloudLogsInput) (*fastly.Gr
 	}, nil
 }
 
-func updateGrafanaCloudLogsError(_ *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+func updateGrafanaCloudLogsError(_ context.Context, _ *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
 	return nil, errTest
 }
 
-func deleteGrafanaCloudLogsOK(_ *fastly.DeleteGrafanaCloudLogsInput) error {
+func deleteGrafanaCloudLogsOK(_ context.Context, _ *fastly.DeleteGrafanaCloudLogsInput) error {
 	return nil
 }
 
-func deleteGrafanaCloudLogsError(_ *fastly.DeleteGrafanaCloudLogsInput) error {
+func deleteGrafanaCloudLogsError(_ context.Context, _ *fastly.DeleteGrafanaCloudLogsInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/grafanacloudlogs/grafanacloudlogs_test.go
+++ b/pkg/commands/logging/grafanacloudlogs/grafanacloudlogs_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/grafanacloudlogs"

--- a/pkg/commands/logging/grafanacloudlogs/list.go
+++ b/pkg/commands/logging/grafanacloudlogs/list.go
@@ -1,10 +1,11 @@
 package grafanacloudlogs
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListGrafanaCloudLogs(&c.Input)
+	o, err := c.Globals.APIClient.ListGrafanaCloudLogs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/grafanacloudlogs/update.go
+++ b/pkg/commands/logging/grafanacloudlogs/update.go
@@ -1,9 +1,10 @@
 package grafanacloudlogs
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -161,7 +162,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	grafanacloudlogs, err := c.Globals.APIClient.UpdateGrafanaCloudLogs(input)
+	grafanacloudlogs, err := c.Globals.APIClient.UpdateGrafanaCloudLogs(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/heroku/create.go
+++ b/pkg/commands/logging/heroku/create.go
@@ -1,9 +1,10 @@
 package heroku
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -147,7 +148,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateHeroku(input)
+	d, err := c.Globals.APIClient.CreateHeroku(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/heroku/delete.go
+++ b/pkg/commands/logging/heroku/delete.go
@@ -1,9 +1,10 @@
 package heroku
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteHeroku(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteHeroku(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/heroku/describe.go
+++ b/pkg/commands/logging/heroku/describe.go
@@ -1,9 +1,10 @@
 package heroku
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetHeroku(&c.Input)
+	o, err := c.Globals.APIClient.GetHeroku(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/logging/heroku/heroku_integration_test.go
@@ -2,12 +2,13 @@ package heroku_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestHerokuDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createHerokuOK(i *fastly.CreateHerokuInput) (*fastly.Heroku, error) {
+func createHerokuOK(_ context.Context, i *fastly.CreateHerokuInput) (*fastly.Heroku, error) {
 	s := fastly.Heroku{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -285,11 +286,11 @@ func createHerokuOK(i *fastly.CreateHerokuInput) (*fastly.Heroku, error) {
 	return &s, nil
 }
 
-func createHerokuError(_ *fastly.CreateHerokuInput) (*fastly.Heroku, error) {
+func createHerokuError(_ context.Context, _ *fastly.CreateHerokuInput) (*fastly.Heroku, error) {
 	return nil, errTest
 }
 
-func listHerokusOK(i *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
+func listHerokusOK(_ context.Context, i *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
 	return []*fastly.Heroku{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -318,7 +319,7 @@ func listHerokusOK(i *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
 	}, nil
 }
 
-func listHerokusError(_ *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
+func listHerokusError(_ context.Context, _ *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
 	return nil, errTest
 }
 
@@ -359,7 +360,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getHerokuOK(i *fastly.GetHerokuInput) (*fastly.Heroku, error) {
+func getHerokuOK(_ context.Context, i *fastly.GetHerokuInput) (*fastly.Heroku, error) {
 	return &fastly.Heroku{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -374,7 +375,7 @@ func getHerokuOK(i *fastly.GetHerokuInput) (*fastly.Heroku, error) {
 	}, nil
 }
 
-func getHerokuError(_ *fastly.GetHerokuInput) (*fastly.Heroku, error) {
+func getHerokuError(_ context.Context, _ *fastly.GetHerokuInput) (*fastly.Heroku, error) {
 	return nil, errTest
 }
 
@@ -391,7 +392,7 @@ URL: example.com
 Version: 1
 `) + "\n"
 
-func updateHerokuOK(i *fastly.UpdateHerokuInput) (*fastly.Heroku, error) {
+func updateHerokuOK(_ context.Context, i *fastly.UpdateHerokuInput) (*fastly.Heroku, error) {
 	return &fastly.Heroku{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -405,14 +406,14 @@ func updateHerokuOK(i *fastly.UpdateHerokuInput) (*fastly.Heroku, error) {
 	}, nil
 }
 
-func updateHerokuError(_ *fastly.UpdateHerokuInput) (*fastly.Heroku, error) {
+func updateHerokuError(_ context.Context, _ *fastly.UpdateHerokuInput) (*fastly.Heroku, error) {
 	return nil, errTest
 }
 
-func deleteHerokuOK(_ *fastly.DeleteHerokuInput) error {
+func deleteHerokuOK(_ context.Context, _ *fastly.DeleteHerokuInput) error {
 	return nil
 }
 
-func deleteHerokuError(_ *fastly.DeleteHerokuInput) error {
+func deleteHerokuError(_ context.Context, _ *fastly.DeleteHerokuInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/heroku/heroku_test.go
+++ b/pkg/commands/logging/heroku/heroku_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/heroku"

--- a/pkg/commands/logging/heroku/list.go
+++ b/pkg/commands/logging/heroku/list.go
@@ -1,10 +1,11 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListHerokus(&c.Input)
+	o, err := c.Globals.APIClient.ListHerokus(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/heroku/update.go
+++ b/pkg/commands/logging/heroku/update.go
@@ -1,9 +1,10 @@
 package heroku
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -153,7 +154,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	heroku, err := c.Globals.APIClient.UpdateHeroku(input)
+	heroku, err := c.Globals.APIClient.UpdateHeroku(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/honeycomb/create.go
+++ b/pkg/commands/logging/honeycomb/create.go
@@ -1,9 +1,10 @@
 package honeycomb
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -147,7 +148,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateHoneycomb(input)
+	d, err := c.Globals.APIClient.CreateHoneycomb(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/honeycomb/delete.go
+++ b/pkg/commands/logging/honeycomb/delete.go
@@ -1,9 +1,10 @@
 package honeycomb
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteHoneycomb(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteHoneycomb(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/honeycomb/describe.go
+++ b/pkg/commands/logging/honeycomb/describe.go
@@ -1,9 +1,10 @@
 package honeycomb
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetHoneycomb(&c.Input)
+	o, err := c.Globals.APIClient.GetHoneycomb(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
@@ -2,12 +2,13 @@ package honeycomb_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestHoneycombDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createHoneycombOK(i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
+func createHoneycombOK(_ context.Context, i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
 	s := fastly.Honeycomb{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -285,11 +286,11 @@ func createHoneycombOK(i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error
 	return &s, nil
 }
 
-func createHoneycombError(_ *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
+func createHoneycombError(_ context.Context, _ *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
 	return nil, errTest
 }
 
-func listHoneycombsOK(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
+func listHoneycombsOK(_ context.Context, i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
 	return []*fastly.Honeycomb{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -318,7 +319,7 @@ func listHoneycombsOK(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error
 	}, nil
 }
 
-func listHoneycombsError(_ *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
+func listHoneycombsError(_ context.Context, _ *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
 	return nil, errTest
 }
 
@@ -359,7 +360,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getHoneycombOK(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
+func getHoneycombOK(_ context.Context, i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
 	return &fastly.Honeycomb{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -374,7 +375,7 @@ func getHoneycombOK(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
 	}, nil
 }
 
-func getHoneycombError(_ *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
+func getHoneycombError(_ context.Context, _ *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
 	return nil, errTest
 }
 
@@ -391,7 +392,7 @@ Token: tkn
 Version: 1
 `) + "\n"
 
-func updateHoneycombOK(i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
+func updateHoneycombOK(_ context.Context, i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
 	return &fastly.Honeycomb{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -405,14 +406,14 @@ func updateHoneycombOK(i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error
 	}, nil
 }
 
-func updateHoneycombError(_ *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
+func updateHoneycombError(_ context.Context, _ *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
 	return nil, errTest
 }
 
-func deleteHoneycombOK(_ *fastly.DeleteHoneycombInput) error {
+func deleteHoneycombOK(_ context.Context, _ *fastly.DeleteHoneycombInput) error {
 	return nil
 }
 
-func deleteHoneycombError(_ *fastly.DeleteHoneycombInput) error {
+func deleteHoneycombError(_ context.Context, _ *fastly.DeleteHoneycombInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/honeycomb/honeycomb_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/honeycomb"

--- a/pkg/commands/logging/honeycomb/list.go
+++ b/pkg/commands/logging/honeycomb/list.go
@@ -1,10 +1,11 @@
 package honeycomb
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListHoneycombs(&c.Input)
+	o, err := c.Globals.APIClient.ListHoneycombs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/honeycomb/update.go
+++ b/pkg/commands/logging/honeycomb/update.go
@@ -1,9 +1,10 @@
 package honeycomb
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -153,7 +154,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	honeycomb, err := c.Globals.APIClient.UpdateHoneycomb(input)
+	honeycomb, err := c.Globals.APIClient.UpdateHoneycomb(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/https/create.go
+++ b/pkg/commands/logging/https/create.go
@@ -1,9 +1,10 @@
 package https
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -214,7 +215,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateHTTPS(input)
+	d, err := c.Globals.APIClient.CreateHTTPS(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/https/delete.go
+++ b/pkg/commands/logging/https/delete.go
@@ -1,9 +1,10 @@
 package https
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteHTTPS(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteHTTPS(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/https/describe.go
+++ b/pkg/commands/logging/https/describe.go
@@ -1,9 +1,10 @@
 package https
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetHTTPS(&c.Input)
+	o, err := c.Globals.APIClient.GetHTTPS(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -2,13 +2,14 @@ package https_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -273,7 +274,7 @@ func TestHTTPSDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createHTTPSOK(i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
+func createHTTPSOK(_ context.Context, i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
 	return &fastly.HTTPS{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -298,11 +299,11 @@ func createHTTPSOK(i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
 	}, nil
 }
 
-func createHTTPSError(_ *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
+func createHTTPSError(_ context.Context, _ *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
 	return nil, errTest
 }
 
-func listHTTPSsOK(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
+func listHTTPSsOK(_ context.Context, i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
 	return []*fastly.HTTPS{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -353,7 +354,7 @@ func listHTTPSsOK(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
 	}, nil
 }
 
-func listHTTPSsError(_ *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
+func listHTTPSsError(_ context.Context, _ *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
 	return nil, errTest
 }
 
@@ -416,7 +417,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getHTTPSOK(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
+func getHTTPSOK(_ context.Context, i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
 	return &fastly.HTTPS{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -442,7 +443,7 @@ func getHTTPSOK(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
 	}, nil
 }
 
-func getHTTPSError(_ *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
+func getHTTPSError(_ context.Context, _ *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
 	return nil, errTest
 }
 
@@ -470,7 +471,7 @@ URL: example.com
 Version: 1
 `) + "\n"
 
-func updateHTTPSOK(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
+func updateHTTPSOK(_ context.Context, i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
 	return &fastly.HTTPS{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -495,14 +496,14 @@ func updateHTTPSOK(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
 	}, nil
 }
 
-func updateHTTPSError(_ *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
+func updateHTTPSError(_ context.Context, _ *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
 	return nil, errTest
 }
 
-func deleteHTTPSOK(_ *fastly.DeleteHTTPSInput) error {
+func deleteHTTPSOK(_ context.Context, _ *fastly.DeleteHTTPSInput) error {
 	return nil
 }
 
-func deleteHTTPSError(_ *fastly.DeleteHTTPSInput) error {
+func deleteHTTPSError(_ context.Context, _ *fastly.DeleteHTTPSInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/https/https_test.go
+++ b/pkg/commands/logging/https/https_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/https"

--- a/pkg/commands/logging/https/list.go
+++ b/pkg/commands/logging/https/list.go
@@ -1,10 +1,11 @@
 package https
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListHTTPS(&c.Input)
+	o, err := c.Globals.APIClient.ListHTTPS(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/https/update.go
+++ b/pkg/commands/logging/https/update.go
@@ -1,9 +1,10 @@
 package https
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -219,7 +220,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	https, err := c.Globals.APIClient.UpdateHTTPS(input)
+	https, err := c.Globals.APIClient.UpdateHTTPS(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kafka/create.go
+++ b/pkg/commands/logging/kafka/create.go
@@ -1,10 +1,11 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -230,7 +231,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateKafka(input)
+	d, err := c.Globals.APIClient.CreateKafka(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kafka/delete.go
+++ b/pkg/commands/logging/kafka/delete.go
@@ -1,9 +1,10 @@
 package kafka
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteKafka(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteKafka(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/kafka/describe.go
+++ b/pkg/commands/logging/kafka/describe.go
@@ -1,9 +1,10 @@
 package kafka
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetKafka(&c.Input)
+	o, err := c.Globals.APIClient.GetKafka(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/logging/kafka/kafka_integration_test.go
@@ -2,12 +2,13 @@ package kafka_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -281,7 +282,7 @@ func TestKafkaDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createKafkaOK(i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
+func createKafkaOK(_ context.Context, i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
 	return &fastly.Kafka{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -307,11 +308,11 @@ func createKafkaOK(i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
 	}, nil
 }
 
-func createKafkaError(_ *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
+func createKafkaError(_ context.Context, _ *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
 	return nil, errTest
 }
 
-func listKafkasOK(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
+func listKafkasOK(_ context.Context, i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
 	return []*fastly.Kafka{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -364,7 +365,7 @@ func listKafkasOK(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
 	}, nil
 }
 
-func listKafkasError(_ *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
+func listKafkasError(_ context.Context, _ *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
 	return nil, errTest
 }
 
@@ -429,7 +430,7 @@ Version: 1
 		Processing region: us
   `) + "\n\n"
 
-func getKafkaOK(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+func getKafkaOK(_ context.Context, i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
 	return &fastly.Kafka{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -451,7 +452,7 @@ func getKafkaOK(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
 	}, nil
 }
 
-func getKafkaError(_ *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+func getKafkaError(_ context.Context, _ *fastly.GetKafkaInput) (*fastly.Kafka, error) {
 	return nil, errTest
 }
 
@@ -480,7 +481,7 @@ Use TLS: true
 Version: 1
 `
 
-func updateKafkaOK(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
+func updateKafkaOK(_ context.Context, i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
 	return &fastly.Kafka{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -501,7 +502,7 @@ func updateKafkaOK(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
 	}, nil
 }
 
-func updateKafkaSASL(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
+func updateKafkaSASL(_ context.Context, i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
 	return &fastly.Kafka{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -527,14 +528,14 @@ func updateKafkaSASL(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
 	}, nil
 }
 
-func updateKafkaError(_ *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
+func updateKafkaError(_ context.Context, _ *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
 	return nil, errTest
 }
 
-func deleteKafkaOK(_ *fastly.DeleteKafkaInput) error {
+func deleteKafkaOK(_ context.Context, _ *fastly.DeleteKafkaInput) error {
 	return nil
 }
 
-func deleteKafkaError(_ *fastly.DeleteKafkaInput) error {
+func deleteKafkaError(_ context.Context, _ *fastly.DeleteKafkaInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/kafka/kafka_test.go
+++ b/pkg/commands/logging/kafka/kafka_test.go
@@ -2,9 +2,10 @@ package kafka_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/kafka"
@@ -568,7 +569,7 @@ func updateCommandMissingServiceID() *kafka.UpdateCommand {
 	return res
 }
 
-func getKafkaSASL(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+func getKafkaSASL(_ context.Context, i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
 	return &fastly.Kafka{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),

--- a/pkg/commands/logging/kafka/list.go
+++ b/pkg/commands/logging/kafka/list.go
@@ -1,10 +1,11 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListKafkas(&c.Input)
+	o, err := c.Globals.APIClient.ListKafkas(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kafka/update.go
+++ b/pkg/commands/logging/kafka/update.go
@@ -1,10 +1,11 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -243,7 +244,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	kafka, err := c.Globals.APIClient.UpdateKafka(input)
+	kafka, err := c.Globals.APIClient.UpdateKafka(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kinesis/create.go
+++ b/pkg/commands/logging/kinesis/create.go
@@ -1,10 +1,11 @@
 package kinesis
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -190,7 +191,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateKinesis(input)
+	d, err := c.Globals.APIClient.CreateKinesis(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kinesis/delete.go
+++ b/pkg/commands/logging/kinesis/delete.go
@@ -1,9 +1,10 @@
 package kinesis
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -85,7 +86,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteKinesis(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteKinesis(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/kinesis/describe.go
+++ b/pkg/commands/logging/kinesis/describe.go
@@ -1,9 +1,10 @@
 package kinesis
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetKinesis(&c.Input)
+	o, err := c.Globals.APIClient.GetKinesis(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_integration_test.go
@@ -2,12 +2,13 @@ package kinesis_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -314,7 +315,7 @@ func TestKinesisDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createKinesisOK(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
+func createKinesisOK(_ context.Context, i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
 	return &fastly.Kinesis{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -322,11 +323,11 @@ func createKinesisOK(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
 	}, nil
 }
 
-func createKinesisError(_ *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
+func createKinesisError(_ context.Context, _ *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
 	return nil, errTest
 }
 
-func listKinesesOK(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
+func listKinesesOK(_ context.Context, i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
 	return []*fastly.Kinesis{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -359,7 +360,7 @@ func listKinesesOK(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
 	}, nil
 }
 
-func listKinesesError(_ *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
+func listKinesesError(_ context.Context, _ *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
 	return nil, errTest
 }
 
@@ -404,7 +405,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getKinesisOK(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
+func getKinesisOK(_ context.Context, i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
 	return &fastly.Kinesis{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -421,7 +422,7 @@ func getKinesisOK(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
 	}, nil
 }
 
-func getKinesisError(_ *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
+func getKinesisError(_ context.Context, _ *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
 	return nil, errTest
 }
 
@@ -440,7 +441,7 @@ Stream name: my-logs
 Version: 1
 `) + "\n"
 
-func updateKinesisOK(i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
+func updateKinesisOK(_ context.Context, i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
 	return &fastly.Kinesis{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -456,14 +457,14 @@ func updateKinesisOK(i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
 	}, nil
 }
 
-func updateKinesisError(_ *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
+func updateKinesisError(_ context.Context, _ *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
 	return nil, errTest
 }
 
-func deleteKinesisOK(_ *fastly.DeleteKinesisInput) error {
+func deleteKinesisOK(_ context.Context, _ *fastly.DeleteKinesisInput) error {
 	return nil
 }
 
-func deleteKinesisError(_ *fastly.DeleteKinesisInput) error {
+func deleteKinesisError(_ context.Context, _ *fastly.DeleteKinesisInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/kinesis/kinesis_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/kinesis"

--- a/pkg/commands/logging/kinesis/list.go
+++ b/pkg/commands/logging/kinesis/list.go
@@ -1,10 +1,11 @@
 package kinesis
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListKinesis(&c.Input)
+	o, err := c.Globals.APIClient.ListKinesis(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/kinesis/update.go
+++ b/pkg/commands/logging/kinesis/update.go
@@ -1,9 +1,10 @@
 package kinesis
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -171,7 +172,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	kinesis, err := c.Globals.APIClient.UpdateKinesis(input)
+	kinesis, err := c.Globals.APIClient.UpdateKinesis(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/loggly/create.go
+++ b/pkg/commands/logging/loggly/create.go
@@ -1,9 +1,10 @@
 package loggly
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -142,7 +143,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateLoggly(input)
+	d, err := c.Globals.APIClient.CreateLoggly(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/loggly/delete.go
+++ b/pkg/commands/logging/loggly/delete.go
@@ -1,9 +1,10 @@
 package loggly
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteLoggly(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteLoggly(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/loggly/describe.go
+++ b/pkg/commands/logging/loggly/describe.go
@@ -1,9 +1,10 @@
 package loggly
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetLoggly(&c.Input)
+	o, err := c.Globals.APIClient.GetLoggly(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/loggly/list.go
+++ b/pkg/commands/logging/loggly/list.go
@@ -1,10 +1,11 @@
 package loggly
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListLoggly(&c.Input)
+	o, err := c.Globals.APIClient.ListLoggly(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/logging/loggly/loggly_integration_test.go
@@ -2,12 +2,13 @@ package loggly_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestLogglyDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createLogglyOK(i *fastly.CreateLogglyInput) (*fastly.Loggly, error) {
+func createLogglyOK(_ context.Context, i *fastly.CreateLogglyInput) (*fastly.Loggly, error) {
 	s := fastly.Loggly{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -285,11 +286,11 @@ func createLogglyOK(i *fastly.CreateLogglyInput) (*fastly.Loggly, error) {
 	return &s, nil
 }
 
-func createLogglyError(_ *fastly.CreateLogglyInput) (*fastly.Loggly, error) {
+func createLogglyError(_ context.Context, _ *fastly.CreateLogglyInput) (*fastly.Loggly, error) {
 	return nil, errTest
 }
 
-func listLogglysOK(i *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
+func listLogglysOK(_ context.Context, i *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
 	return []*fastly.Loggly{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -316,7 +317,7 @@ func listLogglysOK(i *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
 	}, nil
 }
 
-func listLogglysError(_ *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
+func listLogglysError(_ context.Context, _ *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
 	return nil, errTest
 }
 
@@ -355,7 +356,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getLogglyOK(i *fastly.GetLogglyInput) (*fastly.Loggly, error) {
+func getLogglyOK(_ context.Context, i *fastly.GetLogglyInput) (*fastly.Loggly, error) {
 	return &fastly.Loggly{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -369,7 +370,7 @@ func getLogglyOK(i *fastly.GetLogglyInput) (*fastly.Loggly, error) {
 	}, nil
 }
 
-func getLogglyError(_ *fastly.GetLogglyInput) (*fastly.Loggly, error) {
+func getLogglyError(_ context.Context, _ *fastly.GetLogglyInput) (*fastly.Loggly, error) {
 	return nil, errTest
 }
 
@@ -385,7 +386,7 @@ Token: abc
 Version: 1
 `) + "\n"
 
-func updateLogglyOK(i *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
+func updateLogglyOK(_ context.Context, i *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
 	return &fastly.Loggly{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -397,14 +398,14 @@ func updateLogglyOK(i *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
 	}, nil
 }
 
-func updateLogglyError(_ *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
+func updateLogglyError(_ context.Context, _ *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
 	return nil, errTest
 }
 
-func deleteLogglyOK(_ *fastly.DeleteLogglyInput) error {
+func deleteLogglyOK(_ context.Context, _ *fastly.DeleteLogglyInput) error {
 	return nil
 }
 
-func deleteLogglyError(_ *fastly.DeleteLogglyInput) error {
+func deleteLogglyError(_ context.Context, _ *fastly.DeleteLogglyInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/loggly/loggly_test.go
+++ b/pkg/commands/logging/loggly/loggly_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/loggly"

--- a/pkg/commands/logging/loggly/update.go
+++ b/pkg/commands/logging/loggly/update.go
@@ -1,9 +1,10 @@
 package loggly
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -147,7 +148,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	loggly, err := c.Globals.APIClient.UpdateLoggly(input)
+	loggly, err := c.Globals.APIClient.UpdateLoggly(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/logshuttle/create.go
+++ b/pkg/commands/logging/logshuttle/create.go
@@ -1,9 +1,10 @@
 package logshuttle
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -147,7 +148,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateLogshuttle(input)
+	d, err := c.Globals.APIClient.CreateLogshuttle(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/logshuttle/delete.go
+++ b/pkg/commands/logging/logshuttle/delete.go
@@ -1,9 +1,10 @@
 package logshuttle
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteLogshuttle(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteLogshuttle(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/logshuttle/describe.go
+++ b/pkg/commands/logging/logshuttle/describe.go
@@ -1,9 +1,10 @@
 package logshuttle
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetLogshuttle(&c.Input)
+	o, err := c.Globals.APIClient.GetLogshuttle(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/logshuttle/list.go
+++ b/pkg/commands/logging/logshuttle/list.go
@@ -1,10 +1,11 @@
 package logshuttle
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListLogshuttles(&c.Input)
+	o, err := c.Globals.APIClient.ListLogshuttles(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
@@ -2,12 +2,13 @@ package logshuttle_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestLogshuttleDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createLogshuttleOK(i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
+func createLogshuttleOK(_ context.Context, i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
 	s := fastly.Logshuttle{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -285,11 +286,11 @@ func createLogshuttleOK(i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, er
 	return &s, nil
 }
 
-func createLogshuttleError(_ *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
+func createLogshuttleError(_ context.Context, _ *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
 	return nil, errTest
 }
 
-func listLogshuttlesOK(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
+func listLogshuttlesOK(_ context.Context, i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
 	return []*fastly.Logshuttle{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -318,7 +319,7 @@ func listLogshuttlesOK(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, er
 	}, nil
 }
 
-func listLogshuttlesError(_ *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
+func listLogshuttlesError(_ context.Context, _ *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
 	return nil, errTest
 }
 
@@ -359,7 +360,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getLogshuttleOK(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
+func getLogshuttleOK(_ context.Context, i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
 	return &fastly.Logshuttle{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -374,7 +375,7 @@ func getLogshuttleOK(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
 	}, nil
 }
 
-func getLogshuttleError(_ *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
+func getLogshuttleError(_ context.Context, _ *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
 	return nil, errTest
 }
 
@@ -391,7 +392,7 @@ URL: example.com
 Version: 1
 `) + "\n"
 
-func updateLogshuttleOK(i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
+func updateLogshuttleOK(_ context.Context, i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
 	return &fastly.Logshuttle{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -405,14 +406,14 @@ func updateLogshuttleOK(i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, er
 	}, nil
 }
 
-func updateLogshuttleError(_ *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
+func updateLogshuttleError(_ context.Context, _ *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
 	return nil, errTest
 }
 
-func deleteLogshuttleOK(_ *fastly.DeleteLogshuttleInput) error {
+func deleteLogshuttleOK(_ context.Context, _ *fastly.DeleteLogshuttleInput) error {
 	return nil
 }
 
-func deleteLogshuttleError(_ *fastly.DeleteLogshuttleInput) error {
+func deleteLogshuttleError(_ context.Context, _ *fastly.DeleteLogshuttleInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/logshuttle/logshuttle_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/logshuttle"

--- a/pkg/commands/logging/logshuttle/update.go
+++ b/pkg/commands/logging/logshuttle/update.go
@@ -1,9 +1,10 @@
 package logshuttle
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -154,7 +155,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	logshuttle, err := c.Globals.APIClient.UpdateLogshuttle(input)
+	logshuttle, err := c.Globals.APIClient.UpdateLogshuttle(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/newrelic/create.go
+++ b/pkg/commands/logging/newrelic/create.go
@@ -1,9 +1,10 @@
 package newrelic
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -103,7 +104,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	l, err := c.Globals.APIClient.CreateNewRelic(input)
+	l, err := c.Globals.APIClient.CreateNewRelic(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelic/delete.go
+++ b/pkg/commands/logging/newrelic/delete.go
@@ -1,9 +1,10 @@
 package newrelic
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -85,7 +86,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	err = c.Globals.APIClient.DeleteNewRelic(input)
+	err = c.Globals.APIClient.DeleteNewRelic(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelic/describe.go
+++ b/pkg/commands/logging/newrelic/describe.go
@@ -1,9 +1,10 @@
 package newrelic
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.GetNewRelic(input)
+	o, err := c.Globals.APIClient.GetNewRelic(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelic/list.go
+++ b/pkg/commands/logging/newrelic/list.go
@@ -1,10 +1,11 @@
 package newrelic
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -80,7 +81,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.ListNewRelic(input)
+	o, err := c.Globals.APIClient.ListNewRelic(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/logging/newrelic/newrelic_test.go
@@ -1,9 +1,10 @@
 package newrelic_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/logging"
 	sub "github.com/fastly/cli/pkg/commands/logging/newrelic"
@@ -38,7 +39,7 @@ func TestNewRelicCreate(t *testing.T) {
 			Name: "validate CreateNewRelic API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateNewRelicFn: func(_ *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
+				CreateNewRelicFn: func(_ context.Context, _ *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -49,7 +50,7 @@ func TestNewRelicCreate(t *testing.T) {
 			Name: "validate CreateNewRelic API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateNewRelicFn: func(i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
+				CreateNewRelicFn: func(_ context.Context, i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
 						Name:           i.Name,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -65,7 +66,7 @@ func TestNewRelicCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				CreateNewRelicFn: func(i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
+				CreateNewRelicFn: func(_ context.Context, i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
 						Name:           i.Name,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -118,7 +119,7 @@ func TestNewRelicDelete(t *testing.T) {
 			Name: "validate DeleteNewRelic API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteNewRelicFn: func(_ *fastly.DeleteNewRelicInput) error {
+				DeleteNewRelicFn: func(_ context.Context, _ *fastly.DeleteNewRelicInput) error {
 					return testutil.Err
 				},
 			},
@@ -129,7 +130,7 @@ func TestNewRelicDelete(t *testing.T) {
 			Name: "validate DeleteNewRelic API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteNewRelicFn: func(_ *fastly.DeleteNewRelicInput) error {
+				DeleteNewRelicFn: func(_ context.Context, _ *fastly.DeleteNewRelicInput) error {
 					return nil
 				},
 			},
@@ -141,7 +142,7 @@ func TestNewRelicDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				DeleteNewRelicFn: func(_ *fastly.DeleteNewRelicInput) error {
+				DeleteNewRelicFn: func(_ context.Context, _ *fastly.DeleteNewRelicInput) error {
 					return nil
 				},
 			},
@@ -174,7 +175,7 @@ func TestNewRelicDescribe(t *testing.T) {
 			Name: "validate GetNewRelic API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				GetNewRelicFn: func(_ *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
+				GetNewRelicFn: func(_ context.Context, _ *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -219,7 +220,7 @@ func TestNewRelicList(t *testing.T) {
 			Name: "validate ListNewRelics API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				ListNewRelicFn: func(_ *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error) {
+				ListNewRelicFn: func(_ context.Context, _ *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -295,7 +296,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			Name: "validate UpdateNewRelic API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateNewRelicFn: func(_ *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+				UpdateNewRelicFn: func(_ context.Context, _ *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -306,7 +307,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			Name: "validate UpdateNewRelic API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateNewRelicFn: func(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
 						Name:           i.NewName,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -322,7 +323,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				UpdateNewRelicFn: func(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
 						Name:           i.NewName,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -338,7 +339,7 @@ func TestNewRelicUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
-func getNewRelic(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
+func getNewRelic(_ context.Context, i *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
 	t := testutil.Date
 
 	return &fastly.NewRelic{
@@ -353,7 +354,7 @@ func getNewRelic(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
 	}, nil
 }
 
-func listNewRelic(i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error) {
+func listNewRelic(_ context.Context, i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error) {
 	t := testutil.Date
 	vs := []*fastly.NewRelic{
 		{

--- a/pkg/commands/logging/newrelic/update.go
+++ b/pkg/commands/logging/newrelic/update.go
@@ -1,10 +1,11 @@
 package newrelic
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -104,7 +105,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	l, err := c.Globals.APIClient.UpdateNewRelic(input)
+	l, err := c.Globals.APIClient.UpdateNewRelic(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelicotlp/create.go
+++ b/pkg/commands/logging/newrelicotlp/create.go
@@ -1,9 +1,10 @@
 package newrelicotlp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -105,7 +106,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	l, err := c.Globals.APIClient.CreateNewRelicOTLP(input)
+	l, err := c.Globals.APIClient.CreateNewRelicOTLP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelicotlp/delete.go
+++ b/pkg/commands/logging/newrelicotlp/delete.go
@@ -1,9 +1,10 @@
 package newrelicotlp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -85,7 +86,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	err = c.Globals.APIClient.DeleteNewRelicOTLP(input)
+	err = c.Globals.APIClient.DeleteNewRelicOTLP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelicotlp/describe.go
+++ b/pkg/commands/logging/newrelicotlp/describe.go
@@ -1,9 +1,10 @@
 package newrelicotlp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.GetNewRelicOTLP(input)
+	o, err := c.Globals.APIClient.GetNewRelicOTLP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelicotlp/list.go
+++ b/pkg/commands/logging/newrelicotlp/list.go
@@ -1,10 +1,11 @@
 package newrelicotlp
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -80,7 +81,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.ListNewRelicOTLP(input)
+	o, err := c.Globals.APIClient.ListNewRelicOTLP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/newrelicotlp/newrelicotlp_test.go
+++ b/pkg/commands/logging/newrelicotlp/newrelicotlp_test.go
@@ -1,9 +1,10 @@
 package newrelicotlp_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/logging"
 	sub "github.com/fastly/cli/pkg/commands/logging/newrelicotlp"
@@ -38,7 +39,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 			Name: "validate CreateNewRelicOTLP API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateNewRelicOTLPFn: func(_ *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+				CreateNewRelicOTLPFn: func(_ context.Context, _ *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -49,7 +50,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 			Name: "validate CreateNewRelicOTLP API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateNewRelicOTLPFn: func(i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+				CreateNewRelicOTLPFn: func(_ context.Context, i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
 						Name:           i.Name,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -65,7 +66,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				CreateNewRelicOTLPFn: func(i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+				CreateNewRelicOTLPFn: func(_ context.Context, i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
 						Name:           i.Name,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -118,7 +119,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 			Name: "validate DeleteNewRelic API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteNewRelicOTLPFn: func(_ *fastly.DeleteNewRelicOTLPInput) error {
+				DeleteNewRelicOTLPFn: func(_ context.Context, _ *fastly.DeleteNewRelicOTLPInput) error {
 					return testutil.Err
 				},
 			},
@@ -129,7 +130,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 			Name: "validate DeleteNewRelic API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteNewRelicOTLPFn: func(_ *fastly.DeleteNewRelicOTLPInput) error {
+				DeleteNewRelicOTLPFn: func(_ context.Context, _ *fastly.DeleteNewRelicOTLPInput) error {
 					return nil
 				},
 			},
@@ -141,7 +142,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				DeleteNewRelicOTLPFn: func(_ *fastly.DeleteNewRelicOTLPInput) error {
+				DeleteNewRelicOTLPFn: func(_ context.Context, _ *fastly.DeleteNewRelicOTLPInput) error {
 					return nil
 				},
 			},
@@ -174,7 +175,7 @@ func TestNewRelicDescribe(t *testing.T) {
 			Name: "validate GetNewRelic API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				GetNewRelicOTLPFn: func(_ *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+				GetNewRelicOTLPFn: func(_ context.Context, _ *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -219,7 +220,7 @@ func TestNewRelicList(t *testing.T) {
 			Name: "validate ListNewRelics API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				ListNewRelicOTLPFn: func(_ *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error) {
+				ListNewRelicOTLPFn: func(_ context.Context, _ *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -295,7 +296,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			Name: "validate UpdateNewRelic API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateNewRelicOTLPFn: func(_ *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+				UpdateNewRelicOTLPFn: func(_ context.Context, _ *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -306,7 +307,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			Name: "validate UpdateNewRelic API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateNewRelicOTLPFn: func(i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
 						Name:           i.NewName,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -322,7 +323,7 @@ func TestNewRelicUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				UpdateNewRelicOTLPFn: func(i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
 						Name:           i.NewName,
 						ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -338,7 +339,7 @@ func TestNewRelicUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
-func getNewRelic(i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+func getNewRelic(_ context.Context, i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 	t := testutil.Date
 
 	return &fastly.NewRelicOTLP{
@@ -353,7 +354,7 @@ func getNewRelic(i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 	}, nil
 }
 
-func listNewRelic(i *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error) {
+func listNewRelic(_ context.Context, i *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error) {
 	t := testutil.Date
 	vs := []*fastly.NewRelicOTLP{
 		{

--- a/pkg/commands/logging/newrelicotlp/update.go
+++ b/pkg/commands/logging/newrelicotlp/update.go
@@ -1,10 +1,11 @@
 package newrelicotlp
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -106,7 +107,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	l, err := c.Globals.APIClient.UpdateNewRelicOTLP(input)
+	l, err := c.Globals.APIClient.UpdateNewRelicOTLP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/logging/openstack/create.go
+++ b/pkg/commands/logging/openstack/create.go
@@ -1,10 +1,11 @@
 package openstack
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -206,7 +207,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateOpenstack(input)
+	d, err := c.Globals.APIClient.CreateOpenstack(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/openstack/delete.go
+++ b/pkg/commands/logging/openstack/delete.go
@@ -1,9 +1,10 @@
 package openstack
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteOpenstack(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteOpenstack(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/openstack/describe.go
+++ b/pkg/commands/logging/openstack/describe.go
@@ -1,9 +1,10 @@
 package openstack
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetOpenstack(&c.Input)
+	o, err := c.Globals.APIClient.GetOpenstack(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/openstack/list.go
+++ b/pkg/commands/logging/openstack/list.go
@@ -1,10 +1,11 @@
 package openstack
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListOpenstack(&c.Input)
+	o, err := c.Globals.APIClient.ListOpenstack(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/logging/openstack/openstack_integration_test.go
@@ -2,12 +2,13 @@ package openstack_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -280,7 +281,7 @@ func TestOpenstackDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createOpenstackOK(i *fastly.CreateOpenstackInput) (*fastly.Openstack, error) {
+func createOpenstackOK(_ context.Context, i *fastly.CreateOpenstackInput) (*fastly.Openstack, error) {
 	s := fastly.Openstack{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -293,11 +294,11 @@ func createOpenstackOK(i *fastly.CreateOpenstackInput) (*fastly.Openstack, error
 	return &s, nil
 }
 
-func createOpenstackError(_ *fastly.CreateOpenstackInput) (*fastly.Openstack, error) {
+func createOpenstackError(_ context.Context, _ *fastly.CreateOpenstackInput) (*fastly.Openstack, error) {
 	return nil, errTest
 }
 
-func listOpenstacksOK(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error) {
+func listOpenstacksOK(_ context.Context, i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error) {
 	return []*fastly.Openstack{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -344,7 +345,7 @@ func listOpenstacksOK(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
 	}, nil
 }
 
-func listOpenstacksError(_ *fastly.ListOpenstackInput) ([]*fastly.Openstack, error) {
+func listOpenstacksError(_ context.Context, _ *fastly.ListOpenstackInput) ([]*fastly.Openstack, error) {
 	return nil, errTest
 }
 
@@ -403,7 +404,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getOpenstackOK(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
+func getOpenstackOK(_ context.Context, i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 	return &fastly.Openstack{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -427,7 +428,7 @@ func getOpenstackOK(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 	}, nil
 }
 
-func getOpenstackError(_ *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
+func getOpenstackError(_ context.Context, _ *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
 	return nil, errTest
 }
 
@@ -453,7 +454,7 @@ User: user
 Version: 1
 `) + "\n"
 
-func updateOpenstackOK(i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error) {
+func updateOpenstackOK(_ context.Context, i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error) {
 	return &fastly.Openstack{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -475,15 +476,15 @@ func updateOpenstackOK(i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error
 	}, nil
 }
 
-func updateOpenstackError(_ *fastly.UpdateOpenstackInput) (*fastly.Openstack, error) {
+func updateOpenstackError(_ context.Context, _ *fastly.UpdateOpenstackInput) (*fastly.Openstack, error) {
 	return nil, errTest
 }
 
-func deleteOpenstackOK(_ *fastly.DeleteOpenstackInput) error {
+func deleteOpenstackOK(_ context.Context, _ *fastly.DeleteOpenstackInput) error {
 	return nil
 }
 
-func deleteOpenstackError(_ *fastly.DeleteOpenstackInput) error {
+func deleteOpenstackError(_ context.Context, _ *fastly.DeleteOpenstackInput) error {
 	return errTest
 }
 

--- a/pkg/commands/logging/openstack/openstack_test.go
+++ b/pkg/commands/logging/openstack/openstack_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/openstack"

--- a/pkg/commands/logging/openstack/update.go
+++ b/pkg/commands/logging/openstack/update.go
@@ -1,9 +1,10 @@
 package openstack
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -209,7 +210,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	openstack, err := c.Globals.APIClient.UpdateOpenstack(input)
+	openstack, err := c.Globals.APIClient.UpdateOpenstack(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/papertrail/create.go
+++ b/pkg/commands/logging/papertrail/create.go
@@ -1,9 +1,10 @@
 package papertrail
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -148,7 +149,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreatePapertrail(input)
+	d, err := c.Globals.APIClient.CreatePapertrail(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/papertrail/delete.go
+++ b/pkg/commands/logging/papertrail/delete.go
@@ -1,9 +1,10 @@
 package papertrail
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeletePapertrail(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeletePapertrail(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/papertrail/describe.go
+++ b/pkg/commands/logging/papertrail/describe.go
@@ -1,9 +1,10 @@
 package papertrail
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetPapertrail(&c.Input)
+	o, err := c.Globals.APIClient.GetPapertrail(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/papertrail/list.go
+++ b/pkg/commands/logging/papertrail/list.go
@@ -1,10 +1,11 @@
 package papertrail
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListPapertrails(&c.Input)
+	o, err := c.Globals.APIClient.ListPapertrails(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_integration_test.go
@@ -2,12 +2,13 @@ package papertrail_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestPapertrailDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createPapertrailOK(i *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
+func createPapertrailOK(_ context.Context, i *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
 	return &fastly.Papertrail{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -280,11 +281,11 @@ func createPapertrailOK(i *fastly.CreatePapertrailInput) (*fastly.Papertrail, er
 	}, nil
 }
 
-func createPapertrailError(_ *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
+func createPapertrailError(_ context.Context, _ *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
 	return nil, errTest
 }
 
-func listPapertrailsOK(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
+func listPapertrailsOK(_ context.Context, i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
 	return []*fastly.Papertrail{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -313,7 +314,7 @@ func listPapertrailsOK(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, er
 	}, nil
 }
 
-func listPapertrailsError(_ *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
+func listPapertrailsError(_ context.Context, _ *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
 	return nil, errTest
 }
 
@@ -354,7 +355,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getPapertrailOK(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
+func getPapertrailOK(_ context.Context, i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
 	return &fastly.Papertrail{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -369,7 +370,7 @@ func getPapertrailOK(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
 	}, nil
 }
 
-func getPapertrailError(_ *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
+func getPapertrailError(_ context.Context, _ *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
 	return nil, errTest
 }
 
@@ -386,7 +387,7 @@ Service ID: 123
 Version: 1
 `) + "\n"
 
-func updatePapertrailOK(i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
+func updatePapertrailOK(_ context.Context, i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
 	return &fastly.Papertrail{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -400,14 +401,14 @@ func updatePapertrailOK(i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, er
 	}, nil
 }
 
-func updatePapertrailError(_ *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
+func updatePapertrailError(_ context.Context, _ *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
 	return nil, errTest
 }
 
-func deletePapertrailOK(_ *fastly.DeletePapertrailInput) error {
+func deletePapertrailOK(_ context.Context, _ *fastly.DeletePapertrailInput) error {
 	return nil
 }
 
-func deletePapertrailError(_ *fastly.DeletePapertrailInput) error {
+func deletePapertrailError(_ context.Context, _ *fastly.DeletePapertrailInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/papertrail/papertrail_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/papertrail"

--- a/pkg/commands/logging/papertrail/update.go
+++ b/pkg/commands/logging/papertrail/update.go
@@ -1,9 +1,10 @@
 package papertrail
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -158,7 +159,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	papertrail, err := c.Globals.APIClient.UpdatePapertrail(input)
+	papertrail, err := c.Globals.APIClient.UpdatePapertrail(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/s3/create.go
+++ b/pkg/commands/logging/s3/create.go
@@ -1,10 +1,11 @@
 package s3
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -295,7 +296,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateS3(input)
+	d, err := c.Globals.APIClient.CreateS3(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/s3/delete.go
+++ b/pkg/commands/logging/s3/delete.go
@@ -1,9 +1,10 @@
 package s3
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteS3(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteS3(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/s3/describe.go
+++ b/pkg/commands/logging/s3/describe.go
@@ -1,9 +1,10 @@
 package s3
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetS3(&c.Input)
+	o, err := c.Globals.APIClient.GetS3(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/s3/list.go
+++ b/pkg/commands/logging/s3/list.go
@@ -1,10 +1,11 @@
 package s3
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListS3s(&c.Input)
+	o, err := c.Globals.APIClient.ListS3s(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/s3/s3_integration_test.go
+++ b/pkg/commands/logging/s3/s3_integration_test.go
@@ -2,12 +2,13 @@ package s3_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -339,7 +340,7 @@ func TestS3Delete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createS3OK(i *fastly.CreateS3Input) (*fastly.S3, error) {
+func createS3OK(_ context.Context, i *fastly.CreateS3Input) (*fastly.S3, error) {
 	return &fastly.S3{
 		ServiceID:        fastly.ToPointer(i.ServiceID),
 		ServiceVersion:   fastly.ToPointer(i.ServiceVersion),
@@ -348,11 +349,11 @@ func createS3OK(i *fastly.CreateS3Input) (*fastly.S3, error) {
 	}, nil
 }
 
-func createS3Error(_ *fastly.CreateS3Input) (*fastly.S3, error) {
+func createS3Error(_ context.Context, _ *fastly.CreateS3Input) (*fastly.S3, error) {
 	return nil, errTest
 }
 
-func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
+func listS3sOK(_ context.Context, i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 	return []*fastly.S3{
 		{
 			ServiceID:                    fastly.ToPointer(i.ServiceID),
@@ -405,7 +406,7 @@ func listS3sOK(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
 	}, nil
 }
 
-func listS3sError(_ *fastly.ListS3sInput) ([]*fastly.S3, error) {
+func listS3sError(_ context.Context, _ *fastly.ListS3sInput) ([]*fastly.S3, error) {
 	return nil, errTest
 }
 
@@ -471,7 +472,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
+func getS3OK(_ context.Context, i *fastly.GetS3Input) (*fastly.S3, error) {
 	return &fastly.S3{
 		ServiceID:                    fastly.ToPointer(i.ServiceID),
 		ServiceVersion:               fastly.ToPointer(i.ServiceVersion),
@@ -497,7 +498,7 @@ func getS3OK(i *fastly.GetS3Input) (*fastly.S3, error) {
 	}, nil
 }
 
-func getS3Error(_ *fastly.GetS3Input) (*fastly.S3, error) {
+func getS3Error(_ context.Context, _ *fastly.GetS3Input) (*fastly.S3, error) {
 	return nil, errTest
 }
 
@@ -526,7 +527,7 @@ Timestamp format: %Y-%m-%dT%H:%M:%S.000
 Version: 1
 `) + "\n"
 
-func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
+func updateS3OK(_ context.Context, i *fastly.UpdateS3Input) (*fastly.S3, error) {
 	return &fastly.S3{
 		ServiceID:                    fastly.ToPointer(i.ServiceID),
 		ServiceVersion:               fastly.ToPointer(i.ServiceVersion),
@@ -551,15 +552,15 @@ func updateS3OK(i *fastly.UpdateS3Input) (*fastly.S3, error) {
 	}, nil
 }
 
-func updateS3Error(_ *fastly.UpdateS3Input) (*fastly.S3, error) {
+func updateS3Error(_ context.Context, _ *fastly.UpdateS3Input) (*fastly.S3, error) {
 	return nil, errTest
 }
 
-func deleteS3OK(_ *fastly.DeleteS3Input) error {
+func deleteS3OK(_ context.Context, _ *fastly.DeleteS3Input) error {
 	return nil
 }
 
-func deleteS3Error(_ *fastly.DeleteS3Input) error {
+func deleteS3Error(_ context.Context, _ *fastly.DeleteS3Input) error {
 	return errTest
 }
 

--- a/pkg/commands/logging/s3/s3_test.go
+++ b/pkg/commands/logging/s3/s3_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/s3"

--- a/pkg/commands/logging/s3/update.go
+++ b/pkg/commands/logging/s3/update.go
@@ -1,9 +1,10 @@
 package s3
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -246,7 +247,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	s3, err := c.Globals.APIClient.UpdateS3(input)
+	s3, err := c.Globals.APIClient.UpdateS3(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/scalyr/create.go
+++ b/pkg/commands/logging/scalyr/create.go
@@ -1,9 +1,10 @@
 package scalyr
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -146,7 +147,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
-	d, err := c.Globals.APIClient.CreateScalyr(input)
+	d, err := c.Globals.APIClient.CreateScalyr(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/scalyr/delete.go
+++ b/pkg/commands/logging/scalyr/delete.go
@@ -1,9 +1,10 @@
 package scalyr
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteScalyr(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteScalyr(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/scalyr/describe.go
+++ b/pkg/commands/logging/scalyr/describe.go
@@ -1,9 +1,10 @@
 package scalyr
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetScalyr(&c.Input)
+	o, err := c.Globals.APIClient.GetScalyr(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/scalyr/list.go
+++ b/pkg/commands/logging/scalyr/list.go
@@ -1,10 +1,11 @@
 package scalyr
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListScalyrs(&c.Input)
+	o, err := c.Globals.APIClient.ListScalyrs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_integration_test.go
@@ -2,12 +2,13 @@ package scalyr_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	fsterrs "github.com/fastly/cli/pkg/errors"
@@ -281,7 +282,7 @@ func TestScalyrDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createScalyrOK(i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
+func createScalyrOK(_ context.Context, i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
 	s := fastly.Scalyr{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -316,11 +317,11 @@ func createScalyrOK(i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
 	return &s, nil
 }
 
-func createScalyrError(_ *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
+func createScalyrError(_ context.Context, _ *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
 	return nil, errTest
 }
 
-func listScalyrsOK(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
+func listScalyrsOK(_ context.Context, i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
 	return []*fastly.Scalyr{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -351,7 +352,7 @@ func listScalyrsOK(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
 	}, nil
 }
 
-func listScalyrsError(_ *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
+func listScalyrsError(_ context.Context, _ *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
 	return nil, errTest
 }
 
@@ -394,7 +395,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getScalyrOK(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
+func getScalyrOK(_ context.Context, i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
 	return &fastly.Scalyr{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -410,7 +411,7 @@ func getScalyrOK(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
 	}, nil
 }
 
-func getScalyrError(_ *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
+func getScalyrError(_ context.Context, _ *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
 	return nil, errTest
 }
 
@@ -428,7 +429,7 @@ Token: abc
 Version: 1
 `) + "\n"
 
-func updateScalyrOK(i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
+func updateScalyrOK(_ context.Context, i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
 	return &fastly.Scalyr{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -442,14 +443,14 @@ func updateScalyrOK(i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
 	}, nil
 }
 
-func updateScalyrError(_ *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
+func updateScalyrError(_ context.Context, _ *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
 	return nil, errTest
 }
 
-func deleteScalyrOK(_ *fastly.DeleteScalyrInput) error {
+func deleteScalyrOK(_ context.Context, _ *fastly.DeleteScalyrInput) error {
 	return nil
 }
 
-func deleteScalyrError(_ *fastly.DeleteScalyrInput) error {
+func deleteScalyrError(_ context.Context, _ *fastly.DeleteScalyrInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/scalyr/scalyr_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/scalyr"

--- a/pkg/commands/logging/scalyr/update.go
+++ b/pkg/commands/logging/scalyr/update.go
@@ -1,9 +1,10 @@
 package scalyr
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -149,7 +150,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	scalyr, err := c.Globals.APIClient.UpdateScalyr(input)
+	scalyr, err := c.Globals.APIClient.UpdateScalyr(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sftp/create.go
+++ b/pkg/commands/logging/sftp/create.go
@@ -1,10 +1,11 @@
 package sftp
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -219,7 +220,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateSFTP(input)
+	d, err := c.Globals.APIClient.CreateSFTP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sftp/delete.go
+++ b/pkg/commands/logging/sftp/delete.go
@@ -1,9 +1,10 @@
 package sftp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteSFTP(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteSFTP(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/sftp/describe.go
+++ b/pkg/commands/logging/sftp/describe.go
@@ -1,9 +1,10 @@
 package sftp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetSFTP(&c.Input)
+	o, err := c.Globals.APIClient.GetSFTP(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sftp/list.go
+++ b/pkg/commands/logging/sftp/list.go
@@ -1,10 +1,11 @@
 package sftp
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListSFTPs(&c.Input)
+	o, err := c.Globals.APIClient.ListSFTPs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/logging/sftp/sftp_integration_test.go
@@ -2,12 +2,13 @@ package sftp_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -280,7 +281,7 @@ func TestSFTPDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createSFTPOK(i *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
+func createSFTPOK(_ context.Context, i *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
 	s := fastly.SFTP{
 		ServiceID:        fastly.ToPointer(i.ServiceID),
 		ServiceVersion:   fastly.ToPointer(i.ServiceVersion),
@@ -294,11 +295,11 @@ func createSFTPOK(i *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
 	return &s, nil
 }
 
-func createSFTPError(_ *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
+func createSFTPError(_ context.Context, _ *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
 	return nil, errTest
 }
 
-func listSFTPsOK(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
+func listSFTPsOK(_ context.Context, i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 	return []*fastly.SFTP{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -347,7 +348,7 @@ func listSFTPsOK(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 	}, nil
 }
 
-func listSFTPsError(_ *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
+func listSFTPsError(_ context.Context, _ *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
 	return nil, errTest
 }
 
@@ -410,7 +411,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getSFTPOK(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
+func getSFTPOK(_ context.Context, i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 	return &fastly.SFTP{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -436,7 +437,7 @@ func getSFTPOK(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 	}, nil
 }
 
-func getSFTPError(_ *fastly.GetSFTPInput) (*fastly.SFTP, error) {
+func getSFTPError(_ context.Context, _ *fastly.GetSFTPInput) (*fastly.SFTP, error) {
 	return nil, errTest
 }
 
@@ -464,7 +465,7 @@ User: user
 Version: 1
 `
 
-func updateSFTPOK(i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
+func updateSFTPOK(_ context.Context, i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
 	return &fastly.SFTP{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -488,15 +489,15 @@ func updateSFTPOK(i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
 	}, nil
 }
 
-func updateSFTPError(_ *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
+func updateSFTPError(_ context.Context, _ *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
 	return nil, errTest
 }
 
-func deleteSFTPOK(_ *fastly.DeleteSFTPInput) error {
+func deleteSFTPOK(_ context.Context, _ *fastly.DeleteSFTPInput) error {
 	return nil
 }
 
-func deleteSFTPError(_ *fastly.DeleteSFTPInput) error {
+func deleteSFTPError(_ context.Context, _ *fastly.DeleteSFTPInput) error {
 	return errTest
 }
 

--- a/pkg/commands/logging/sftp/sftp_test.go
+++ b/pkg/commands/logging/sftp/sftp_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/sftp"

--- a/pkg/commands/logging/sftp/update.go
+++ b/pkg/commands/logging/sftp/update.go
@@ -1,9 +1,10 @@
 package sftp
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -219,7 +220,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	sftp, err := c.Globals.APIClient.UpdateSFTP(input)
+	sftp, err := c.Globals.APIClient.UpdateSFTP(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/splunk/create.go
+++ b/pkg/commands/logging/splunk/create.go
@@ -1,9 +1,10 @@
 package splunk
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -173,7 +174,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateSplunk(input)
+	d, err := c.Globals.APIClient.CreateSplunk(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/splunk/delete.go
+++ b/pkg/commands/logging/splunk/delete.go
@@ -1,9 +1,10 @@
 package splunk
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteSplunk(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteSplunk(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/splunk/describe.go
+++ b/pkg/commands/logging/splunk/describe.go
@@ -1,9 +1,10 @@
 package splunk
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetSplunk(&c.Input)
+	o, err := c.Globals.APIClient.GetSplunk(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/splunk/list.go
+++ b/pkg/commands/logging/splunk/list.go
@@ -1,10 +1,11 @@
 package splunk
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListSplunks(&c.Input)
+	o, err := c.Globals.APIClient.ListSplunks(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/logging/splunk/splunk_integration_test.go
@@ -2,12 +2,13 @@ package splunk_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestSplunkDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createSplunkOK(i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
+func createSplunkOK(_ context.Context, i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
 	return &fastly.Splunk{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -280,11 +281,11 @@ func createSplunkOK(i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
 	}, nil
 }
 
-func createSplunkError(_ *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
+func createSplunkError(_ context.Context, _ *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
 	return nil, errTest
 }
 
-func listSplunksOK(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
+func listSplunksOK(_ context.Context, i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
 	return []*fastly.Splunk{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -321,7 +322,7 @@ func listSplunksOK(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
 	}, nil
 }
 
-func listSplunksError(_ *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
+func listSplunksError(_ context.Context, _ *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
 	return nil, errTest
 }
 
@@ -370,7 +371,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getSplunkOK(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
+func getSplunkOK(_ context.Context, i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
 	return &fastly.Splunk{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -389,7 +390,7 @@ func getSplunkOK(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
 	}, nil
 }
 
-func getSplunkError(_ *fastly.GetSplunkInput) (*fastly.Splunk, error) {
+func getSplunkError(_ context.Context, _ *fastly.GetSplunkInput) (*fastly.Splunk, error) {
 	return nil, errTest
 }
 
@@ -410,7 +411,7 @@ URL: example.com
 Version: 1
 `) + "\n"
 
-func updateSplunkOK(i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
+func updateSplunkOK(_ context.Context, i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
 	return &fastly.Splunk{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -428,14 +429,14 @@ func updateSplunkOK(i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
 	}, nil
 }
 
-func updateSplunkError(_ *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
+func updateSplunkError(_ context.Context, _ *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
 	return nil, errTest
 }
 
-func deleteSplunkOK(_ *fastly.DeleteSplunkInput) error {
+func deleteSplunkOK(_ context.Context, _ *fastly.DeleteSplunkInput) error {
 	return nil
 }
 
-func deleteSplunkError(_ *fastly.DeleteSplunkInput) error {
+func deleteSplunkError(_ context.Context, _ *fastly.DeleteSplunkInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/splunk/splunk_test.go
+++ b/pkg/commands/logging/splunk/splunk_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/splunk"

--- a/pkg/commands/logging/splunk/update.go
+++ b/pkg/commands/logging/splunk/update.go
@@ -1,9 +1,10 @@
 package splunk
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -178,7 +179,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	splunk, err := c.Globals.APIClient.UpdateSplunk(input)
+	splunk, err := c.Globals.APIClient.UpdateSplunk(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sumologic/create.go
+++ b/pkg/commands/logging/sumologic/create.go
@@ -1,9 +1,10 @@
 package sumologic
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -148,7 +149,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateSumologic(input)
+	d, err := c.Globals.APIClient.CreateSumologic(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sumologic/delete.go
+++ b/pkg/commands/logging/sumologic/delete.go
@@ -1,9 +1,10 @@
 package sumologic
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteSumologic(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteSumologic(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/sumologic/describe.go
+++ b/pkg/commands/logging/sumologic/describe.go
@@ -1,9 +1,10 @@
 package sumologic
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetSumologic(&c.Input)
+	o, err := c.Globals.APIClient.GetSumologic(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sumologic/list.go
+++ b/pkg/commands/logging/sumologic/list.go
@@ -1,10 +1,11 @@
 package sumologic
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListSumologics(&c.Input)
+	o, err := c.Globals.APIClient.ListSumologics(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_integration_test.go
@@ -2,12 +2,13 @@ package sumologic_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestSumologicDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createSumologicOK(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+func createSumologicOK(_ context.Context, i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
 	return &fastly.Sumologic{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -280,11 +281,11 @@ func createSumologicOK(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error
 	}, nil
 }
 
-func createSumologicError(_ *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+func createSumologicError(_ context.Context, _ *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
 	return nil, errTest
 }
 
-func listSumologicsOK(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+func listSumologicsOK(_ context.Context, i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
 	return []*fastly.Sumologic{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -313,7 +314,7 @@ func listSumologicsOK(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error
 	}, nil
 }
 
-func listSumologicsError(_ *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+func listSumologicsError(_ context.Context, _ *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
 	return nil, errTest
 }
 
@@ -354,7 +355,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getSumologicOK(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+func getSumologicOK(_ context.Context, i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
 	return &fastly.Sumologic{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -369,7 +370,7 @@ func getSumologicOK(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
 	}, nil
 }
 
-func getSumologicError(_ *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+func getSumologicError(_ context.Context, _ *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
 	return nil, errTest
 }
 
@@ -386,7 +387,7 @@ URL: example.com
 Version: 1
 `) + "\n"
 
-func updateSumologicOK(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+func updateSumologicOK(_ context.Context, i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
 	return &fastly.Sumologic{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -400,14 +401,14 @@ func updateSumologicOK(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error
 	}, nil
 }
 
-func updateSumologicError(_ *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+func updateSumologicError(_ context.Context, _ *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
 	return nil, errTest
 }
 
-func deleteSumologicOK(_ *fastly.DeleteSumologicInput) error {
+func deleteSumologicOK(_ context.Context, _ *fastly.DeleteSumologicInput) error {
 	return nil
 }
 
-func deleteSumologicError(_ *fastly.DeleteSumologicInput) error {
+func deleteSumologicError(_ context.Context, _ *fastly.DeleteSumologicInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/sumologic/sumologic_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/sumologic"

--- a/pkg/commands/logging/sumologic/update.go
+++ b/pkg/commands/logging/sumologic/update.go
@@ -1,9 +1,10 @@
 package sumologic
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -153,7 +154,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
-	sumologic, err := c.Globals.APIClient.UpdateSumologic(input)
+	sumologic, err := c.Globals.APIClient.UpdateSumologic(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/syslog/create.go
+++ b/pkg/commands/logging/syslog/create.go
@@ -1,9 +1,10 @@
 package syslog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -190,7 +191,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	d, err := c.Globals.APIClient.CreateSyslog(input)
+	d, err := c.Globals.APIClient.CreateSyslog(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/syslog/delete.go
+++ b/pkg/commands/logging/syslog/delete.go
@@ -1,9 +1,10 @@
 package syslog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -84,7 +85,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	if err := c.Globals.APIClient.DeleteSyslog(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteSyslog(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}

--- a/pkg/commands/logging/syslog/describe.go
+++ b/pkg/commands/logging/syslog/describe.go
@@ -1,9 +1,10 @@
 package syslog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetSyslog(&c.Input)
+	o, err := c.Globals.APIClient.GetSyslog(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/syslog/list.go
+++ b/pkg/commands/logging/syslog/list.go
@@ -1,10 +1,11 @@
 package syslog
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListSyslogs(&c.Input)
+	o, err := c.Globals.APIClient.ListSyslogs(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/logging/syslog/syslog_integration_test.go
@@ -2,12 +2,13 @@ package syslog_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -272,7 +273,7 @@ func TestSyslogDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createSyslogOK(i *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
+func createSyslogOK(_ context.Context, i *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
 	return &fastly.Syslog{
 		ServiceID:      fastly.ToPointer(i.ServiceID),
 		ServiceVersion: fastly.ToPointer(i.ServiceVersion),
@@ -280,11 +281,11 @@ func createSyslogOK(i *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
 	}, nil
 }
 
-func createSyslogError(_ *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
+func createSyslogError(_ context.Context, _ *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
 	return nil, errTest
 }
 
-func listSyslogsOK(i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
+func listSyslogsOK(_ context.Context, i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
 	return []*fastly.Syslog{
 		{
 			ServiceID:         fastly.ToPointer(i.ServiceID),
@@ -331,7 +332,7 @@ func listSyslogsOK(i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
 	}, nil
 }
 
-func listSyslogsError(_ *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
+func listSyslogsError(_ context.Context, _ *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
 	return nil, errTest
 }
 
@@ -390,7 +391,7 @@ Version: 1
 		Processing region: us
 `) + "\n\n"
 
-func getSyslogOK(i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
+func getSyslogOK(_ context.Context, i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
 	return &fastly.Syslog{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -414,7 +415,7 @@ func getSyslogOK(i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
 	}, nil
 }
 
-func getSyslogError(_ *fastly.GetSyslogInput) (*fastly.Syslog, error) {
+func getSyslogError(_ context.Context, _ *fastly.GetSyslogInput) (*fastly.Syslog, error) {
 	return nil, errTest
 }
 
@@ -440,7 +441,7 @@ Use TLS: true
 Version: 1
 `
 
-func updateSyslogOK(i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
+func updateSyslogOK(_ context.Context, i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
 	return &fastly.Syslog{
 		ServiceID:         fastly.ToPointer(i.ServiceID),
 		ServiceVersion:    fastly.ToPointer(i.ServiceVersion),
@@ -463,14 +464,14 @@ func updateSyslogOK(i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
 	}, nil
 }
 
-func updateSyslogError(_ *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
+func updateSyslogError(_ context.Context, _ *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
 	return nil, errTest
 }
 
-func deleteSyslogOK(_ *fastly.DeleteSyslogInput) error {
+func deleteSyslogOK(_ context.Context, _ *fastly.DeleteSyslogInput) error {
 	return nil
 }
 
-func deleteSyslogError(_ *fastly.DeleteSyslogInput) error {
+func deleteSyslogError(_ context.Context, _ *fastly.DeleteSyslogInput) error {
 	return errTest
 }

--- a/pkg/commands/logging/syslog/syslog_test.go
+++ b/pkg/commands/logging/syslog/syslog_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/syslog"

--- a/pkg/commands/logging/syslog/update.go
+++ b/pkg/commands/logging/syslog/update.go
@@ -1,9 +1,10 @@
 package syslog
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -196,7 +197,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	syslog, err := c.Globals.APIClient.UpdateSyslog(input)
+	syslog, err := c.Globals.APIClient.UpdateSyslog(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/logtail/root.go
+++ b/pkg/commands/logtail/root.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/tomnomnom/linkheader"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/debug"
@@ -302,7 +302,7 @@ func (c *RootCommand) adjustTimes() {
 
 // enableManagedLogging enables managed logging in our API.
 func (c *RootCommand) enableManagedLogging(out io.Writer) error {
-	_, err := c.Globals.APIClient.CreateManagedLogging(&c.Input)
+	_, err := c.Globals.APIClient.CreateManagedLogging(context.TODO(), &c.Input)
 	if err != nil && err != fastly.ErrManagedLoggingEnabled {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/objectstorage/accesskeys/accesskeys_test.go
+++ b/pkg/commands/objectstorage/accesskeys/accesskeys_test.go
@@ -12,7 +12,7 @@ import (
 	sub "github.com/fastly/cli/pkg/commands/objectstorage/accesskeys"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v10/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
 )
 
 const (

--- a/pkg/commands/objectstorage/accesskeys/create.go
+++ b/pkg/commands/objectstorage/accesskeys/create.go
@@ -1,11 +1,13 @@
 package accesskeys
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -58,7 +60,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	accessKey, err := accesskeys.Create(fc, &accesskeys.CreateInput{
+	accessKey, err := accesskeys.Create(context.TODO(), fc, &accesskeys.CreateInput{
 		Description: &c.description,
 		Permission:  &c.permission,
 		Buckets:     &c.buckets,

--- a/pkg/commands/objectstorage/accesskeys/delete.go
+++ b/pkg/commands/objectstorage/accesskeys/delete.go
@@ -1,11 +1,13 @@
 package accesskeys
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -52,7 +54,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	err := accesskeys.Delete(fc, &accesskeys.DeleteInput{
+	err := accesskeys.Delete(context.TODO(), fc, &accesskeys.DeleteInput{
 		AccessKeyID: &c.id,
 	})
 	if err != nil {

--- a/pkg/commands/objectstorage/accesskeys/get.go
+++ b/pkg/commands/objectstorage/accesskeys/get.go
@@ -1,11 +1,13 @@
 package accesskeys
 
 import (
+	"context"
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -52,7 +54,7 @@ func (c *GetCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	accessKey, err := accesskeys.Get(fc, &accesskeys.GetInput{
+	accessKey, err := accesskeys.Get(context.TODO(), fc, &accesskeys.GetInput{
 		AccessKeyID: &c.accessKeyID,
 	})
 	if err != nil {

--- a/pkg/commands/objectstorage/accesskeys/list.go
+++ b/pkg/commands/objectstorage/accesskeys/list.go
@@ -1,6 +1,7 @@
 package accesskeys
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -8,8 +9,9 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
 )
 
 // ListCommand calls the Fastly API to list all access keys.
@@ -45,7 +47,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	accessKeys, err := accesskeys.ListAccessKeys(fc)
+	accessKeys, err := accesskeys.ListAccessKeys(context.TODO(), fc)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/pop/pop_test.go
+++ b/pkg/commands/pop/pop_test.go
@@ -2,10 +2,11 @@ package pop_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -17,7 +18,7 @@ func TestAllDatacenters(t *testing.T) {
 	var stdout bytes.Buffer
 	args := testutil.SplitArgs("pops")
 	api := mock.API{
-		AllDatacentersFn: func() ([]fastly.Datacenter, error) {
+		AllDatacentersFn: func(_ context.Context) ([]fastly.Datacenter, error) {
 			return []fastly.Datacenter{
 				{
 					Name:   fastly.ToPointer("Foobar"),

--- a/pkg/commands/pop/root.go
+++ b/pkg/commands/pop/root.go
@@ -1,10 +1,11 @@
 package pop
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -30,7 +31,7 @@ func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
 
 // Exec implements the command interface.
 func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
-	dcs, err := c.Globals.APIClient.AllDatacenters()
+	dcs, err := c.Globals.APIClient.AllDatacenters(context.TODO())
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/products/products_test.go
+++ b/pkg/commands/products/products_test.go
@@ -3,10 +3,7 @@ package products_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
-
 	root "github.com/fastly/cli/pkg/commands/products"
-	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 )
 
@@ -22,44 +19,6 @@ func TestProductEnablement(t *testing.T) {
 			WantError: "invalid flag combination: --enable and --disable",
 		},
 		{
-			Name: "validate API error for product status",
-			API: mock.API{
-				GetProductFn: func(_ *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error) {
-					return nil, testutil.Err
-				},
-			},
-			Args: "--service-id 123",
-			WantOutput: `PRODUCT                ENABLED
-bot_management         false
-brotli_compression     false
-domain_inspector       false
-fanout                 false
-image_optimizer        false
-log_explorer_insights  false
-origin_inspector       false
-websockets             false
-`,
-		},
-		{
-			Name: "validate API success for product status",
-			API: mock.API{
-				GetProductFn: func(_ *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error) {
-					return nil, nil
-				},
-			},
-			Args: "--service-id 123",
-			WantOutput: `PRODUCT                ENABLED
-bot_management         true
-brotli_compression     true
-domain_inspector       true
-fanout                 true
-image_optimizer        true
-log_explorer_insights  true
-origin_inspector       true
-websockets             true
-`,
-		},
-		{
 			Name:      "validate flag parsing error for enabling product",
 			Args:      "--service-id 123 --enable foo",
 			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
@@ -70,67 +29,9 @@ websockets             true
 			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
 		},
 		{
-			Name: "validate success for enabling product",
-			API: mock.API{
-				EnableProductFn: func(_ *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error) {
-					return nil, nil
-				},
-			},
-			Args:       "--service-id 123 --enable brotli_compression",
-			WantOutput: "SUCCESS: Successfully enabled product 'brotli_compression'",
-		},
-		{
-			Name: "validate success for disabling product",
-			API: mock.API{
-				DisableProductFn: func(_ *fastly.ProductEnablementInput) error {
-					return nil
-				},
-			},
-			Args:       "--service-id 123 --disable brotli_compression",
-			WantOutput: "SUCCESS: Successfully disabled product 'brotli_compression'",
-		},
-		{
 			Name:      "validate invalid json/verbose flag combo",
 			Args:      "--service-id 123 --json --verbose",
 			WantError: "invalid flag combination, --verbose and --json",
-		},
-		{
-			Name: "validate API error for product status with --json output",
-			API: mock.API{
-				GetProductFn: func(_ *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error) {
-					return nil, testutil.Err
-				},
-			},
-			Args: "--service-id 123 --json",
-			WantOutput: `{
-  "bot_management": false,
-  "brotli_compression": false,
-  "domain_inspector": false,
-  "fanout": false,
-  "image_optimizer": false,
-  "log_explorer_insights": false,
-  "origin_inspector": false,
-  "websockets": false
-}`,
-		},
-		{
-			Name: "validate API success for product status with --json output",
-			API: mock.API{
-				GetProductFn: func(_ *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error) {
-					return nil, nil
-				},
-			},
-			Args: "--service-id 123 --json",
-			WantOutput: `{
-  "bot_management": true,
-  "brotli_compression": true,
-  "domain_inspector": true,
-  "fanout": true,
-  "image_optimizer": true,
-  "log_explorer_insights": true,
-  "origin_inspector": true,
-  "websockets": true
-}`,
 		},
 	}
 

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"
@@ -176,7 +177,7 @@ func (c *CreateCommand) validateToken(token, endpoint string, spinner text.Spinn
 			return fmt.Errorf("error regenerating Fastly API client: %w", err)
 		}
 
-		t, err = client.GetTokenSelf()
+		t, err = client.GetTokenSelf(context.TODO())
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return fmt.Errorf("error validating token: %w", err)
@@ -192,7 +193,7 @@ func (c *CreateCommand) validateToken(token, endpoint string, spinner text.Spinn
 
 	var user *fastly.User
 	err = spinner.Process("Getting user data", func(_ *text.SpinnerWrapper) error {
-		user, err = client.GetUser(&fastly.GetUserInput{
+		user, err = client.GetUser(context.TODO(), &fastly.GetUserInput{
 			UserID: fastly.ToValue(t.UserID),
 		})
 		if err != nil {

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -1,12 +1,13 @@
 package profile_test
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/profile"
 	"github.com/fastly/cli/pkg/config"
@@ -701,7 +702,7 @@ func TestProfileUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
-func getToken() (*fastly.Token, error) {
+func getToken(_ context.Context) (*fastly.Token, error) {
 	t := testutil.Date
 
 	return &fastly.Token{
@@ -717,7 +718,7 @@ func getToken() (*fastly.Token, error) {
 	}, nil
 }
 
-func getUser(i *fastly.GetUserInput) (*fastly.User, error) {
+func getUser(_ context.Context, i *fastly.GetUserInput) (*fastly.User, error) {
 	t := testutil.Date
 
 	return &fastly.User{

--- a/pkg/commands/profile/update.go
+++ b/pkg/commands/profile/update.go
@@ -1,11 +1,12 @@
 package profile
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"
@@ -180,7 +181,7 @@ func (c *UpdateCommand) validateToken(token, endpoint string, spinner text.Spinn
 			return fmt.Errorf("error regenerating Fastly API client: %w", err)
 		}
 
-		t, err = client.GetTokenSelf()
+		t, err = client.GetTokenSelf(context.TODO())
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return fmt.Errorf("error validating token: %w", err)
@@ -196,7 +197,7 @@ func (c *UpdateCommand) validateToken(token, endpoint string, spinner text.Spinn
 
 	var user *fastly.User
 	err = spinner.Process("Getting user data", func(_ *text.SpinnerWrapper) error {
-		user, err = client.GetUser(&fastly.GetUserInput{
+		user, err = client.GetUser(context.TODO(), &fastly.GetUserInput{
 			UserID: fastly.ToValue(t.UserID),
 		})
 		if err != nil {

--- a/pkg/commands/purge/purge_test.go
+++ b/pkg/commands/purge/purge_test.go
@@ -1,10 +1,11 @@
 package purge_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/purge"
 	"github.com/fastly/cli/pkg/mock"
@@ -26,7 +27,7 @@ func TestPurgeAll(t *testing.T) {
 		{
 			Name: "validate PurgeAll API error",
 			API: mock.API{
-				PurgeAllFn: func(_ *fastly.PurgeAllInput) (*fastly.Purge, error) {
+				PurgeAllFn: func(_ context.Context, _ *fastly.PurgeAllInput) (*fastly.Purge, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -36,7 +37,7 @@ func TestPurgeAll(t *testing.T) {
 		{
 			Name: "validate PurgeAll API success",
 			API: mock.API{
-				PurgeAllFn: func(_ *fastly.PurgeAllInput) (*fastly.Purge, error) {
+				PurgeAllFn: func(_ context.Context, _ *fastly.PurgeAllInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status: fastly.ToPointer("ok"),
 					}, nil
@@ -61,7 +62,7 @@ func TestPurgeKeys(t *testing.T) {
 		{
 			Name: "validate PurgeKeys API error",
 			API: mock.API{
-				PurgeKeysFn: func(_ *fastly.PurgeKeysInput) (map[string]string, error) {
+				PurgeKeysFn: func(_ context.Context, _ *fastly.PurgeKeysInput) (map[string]string, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -71,7 +72,7 @@ func TestPurgeKeys(t *testing.T) {
 		{
 			Name: "validate PurgeKeys API success",
 			API: mock.API{
-				PurgeKeysFn: func(i *fastly.PurgeKeysInput) (map[string]string, error) {
+				PurgeKeysFn: func(_ context.Context, i *fastly.PurgeKeysInput) (map[string]string, error) {
 					// Track the keys parsed
 					keys = i.Keys
 
@@ -111,7 +112,7 @@ func TestPurgeKey(t *testing.T) {
 		{
 			Name: "validate PurgeKey API error",
 			API: mock.API{
-				PurgeKeyFn: func(_ *fastly.PurgeKeyInput) (*fastly.Purge, error) {
+				PurgeKeyFn: func(_ context.Context, _ *fastly.PurgeKeyInput) (*fastly.Purge, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -121,7 +122,7 @@ func TestPurgeKey(t *testing.T) {
 		{
 			Name: "validate PurgeKey API success",
 			API: mock.API{
-				PurgeKeyFn: func(_ *fastly.PurgeKeyInput) (*fastly.Purge, error) {
+				PurgeKeyFn: func(_ context.Context, _ *fastly.PurgeKeyInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status:  fastly.ToPointer("ok"),
 						PurgeID: fastly.ToPointer("123"),
@@ -134,7 +135,7 @@ func TestPurgeKey(t *testing.T) {
 		{
 			Name: "validate PurgeKey API success with soft purge",
 			API: mock.API{
-				PurgeKeyFn: func(_ *fastly.PurgeKeyInput) (*fastly.Purge, error) {
+				PurgeKeyFn: func(_ context.Context, _ *fastly.PurgeKeyInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status:  fastly.ToPointer("ok"),
 						PurgeID: fastly.ToPointer("123"),
@@ -154,7 +155,7 @@ func TestPurgeURL(t *testing.T) {
 		{
 			Name: "validate Purge API error",
 			API: mock.API{
-				PurgeFn: func(_ *fastly.PurgeInput) (*fastly.Purge, error) {
+				PurgeFn: func(_ context.Context, _ *fastly.PurgeInput) (*fastly.Purge, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -164,7 +165,7 @@ func TestPurgeURL(t *testing.T) {
 		{
 			Name: "validate Purge API success",
 			API: mock.API{
-				PurgeFn: func(_ *fastly.PurgeInput) (*fastly.Purge, error) {
+				PurgeFn: func(_ context.Context, _ *fastly.PurgeInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status:  fastly.ToPointer("ok"),
 						PurgeID: fastly.ToPointer("123"),
@@ -177,7 +178,7 @@ func TestPurgeURL(t *testing.T) {
 		{
 			Name: "validate Purge API success with soft purge",
 			API: mock.API{
-				PurgeFn: func(_ *fastly.PurgeInput) (*fastly.Purge, error) {
+				PurgeFn: func(_ context.Context, _ *fastly.PurgeInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status:  fastly.ToPointer("ok"),
 						PurgeID: fastly.ToPointer("123"),

--- a/pkg/commands/purge/root.go
+++ b/pkg/commands/purge/root.go
@@ -2,13 +2,14 @@ package purge
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -135,7 +136,7 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 }
 
 func (c *RootCommand) purgeAll(serviceID string, out io.Writer) error {
-	p, err := c.Globals.APIClient.PurgeAll(&fastly.PurgeAllInput{
+	p, err := c.Globals.APIClient.PurgeAll(context.TODO(), &fastly.PurgeAllInput{
 		ServiceID: serviceID,
 	})
 	if err != nil {
@@ -157,7 +158,7 @@ func (c *RootCommand) purgeKeys(serviceID string, out io.Writer) error {
 		return err
 	}
 
-	m, err := c.Globals.APIClient.PurgeKeys(&fastly.PurgeKeysInput{
+	m, err := c.Globals.APIClient.PurgeKeys(context.TODO(), &fastly.PurgeKeysInput{
 		ServiceID: serviceID,
 		Keys:      keys,
 		Soft:      c.soft,
@@ -188,7 +189,7 @@ func (c *RootCommand) purgeKeys(serviceID string, out io.Writer) error {
 }
 
 func (c *RootCommand) purgeKey(serviceID string, out io.Writer) error {
-	p, err := c.Globals.APIClient.PurgeKey(&fastly.PurgeKeyInput{
+	p, err := c.Globals.APIClient.PurgeKey(context.TODO(), &fastly.PurgeKeyInput{
 		ServiceID: serviceID,
 		Key:       c.key,
 		Soft:      c.soft,
@@ -206,7 +207,7 @@ func (c *RootCommand) purgeKey(serviceID string, out io.Writer) error {
 }
 
 func (c *RootCommand) purgeURL(out io.Writer) error {
-	p, err := c.Globals.APIClient.Purge(&fastly.PurgeInput{
+	p, err := c.Globals.APIClient.Purge(context.TODO(), &fastly.PurgeInput{
 		URL:  c.url,
 		Soft: c.soft,
 	})

--- a/pkg/commands/ratelimit/create.go
+++ b/pkg/commands/ratelimit/create.go
@@ -1,12 +1,13 @@
 package ratelimit
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -157,7 +158,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input.ServiceID = serviceID
 	input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.CreateERL(input)
+	o, err := c.Globals.APIClient.CreateERL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/ratelimit/delete.go
+++ b/pkg/commands/ratelimit/delete.go
@@ -1,9 +1,10 @@
 package ratelimit
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -33,7 +34,7 @@ type DeleteCommand struct {
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	err := c.Globals.APIClient.DeleteERL(input)
+	err := c.Globals.APIClient.DeleteERL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"User ID": c.id,

--- a/pkg/commands/ratelimit/describe.go
+++ b/pkg/commands/ratelimit/describe.go
@@ -1,10 +1,11 @@
 package ratelimit
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -40,7 +41,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.GetERL(c.constructInput())
+	o, err := c.Globals.APIClient.GetERL(context.TODO(), c.constructInput())
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/ratelimit/list.go
+++ b/pkg/commands/ratelimit/list.go
@@ -1,10 +1,11 @@
 package ratelimit
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -79,7 +80,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		ServiceVersion: fastly.ToValue(serviceVersion.Number),
 	}
 
-	o, err := c.Globals.APIClient.ListERLs(input)
+	o, err := c.Globals.APIClient.ListERLs(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/ratelimit/ratelimit_test.go
+++ b/pkg/commands/ratelimit/ratelimit_test.go
@@ -1,9 +1,10 @@
 package ratelimit_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/ratelimit"
 	"github.com/fastly/cli/pkg/mock"
@@ -15,7 +16,7 @@ func TestRateLimitCreate(t *testing.T) {
 		{
 			Name: "validate CreateERL API error",
 			API: mock.API{
-				CreateERLFn: func(_ *fastly.CreateERLInput) (*fastly.ERL, error) {
+				CreateERLFn: func(_ context.Context, _ *fastly.CreateERLInput) (*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
 				ListVersionsFn: testutil.ListVersions,
@@ -26,7 +27,7 @@ func TestRateLimitCreate(t *testing.T) {
 		{
 			Name: "validate CreateERL API success",
 			API: mock.API{
-				CreateERLFn: func(i *fastly.CreateERLInput) (*fastly.ERL, error) {
+				CreateERLFn: func(_ context.Context, i *fastly.CreateERLInput) (*fastly.ERL, error) {
 					return &fastly.ERL{
 						Name:          i.Name,
 						RateLimiterID: fastly.ToPointer("123"),
@@ -47,7 +48,7 @@ func TestRateLimitDelete(t *testing.T) {
 		{
 			Name: "validate DeleteERL API error",
 			API: mock.API{
-				DeleteERLFn: func(_ *fastly.DeleteERLInput) error {
+				DeleteERLFn: func(_ context.Context, _ *fastly.DeleteERLInput) error {
 					return testutil.Err
 				},
 			},
@@ -57,7 +58,7 @@ func TestRateLimitDelete(t *testing.T) {
 		{
 			Name: "validate DeleteERL API success",
 			API: mock.API{
-				DeleteERLFn: func(_ *fastly.DeleteERLInput) error {
+				DeleteERLFn: func(_ context.Context, _ *fastly.DeleteERLInput) error {
 					return nil
 				},
 			},
@@ -74,7 +75,7 @@ func TestRateLimitDescribe(t *testing.T) {
 		{
 			Name: "validate GetERL API error",
 			API: mock.API{
-				GetERLFn: func(_ *fastly.GetERLInput) (*fastly.ERL, error) {
+				GetERLFn: func(_ context.Context, _ *fastly.GetERLInput) (*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -84,7 +85,7 @@ func TestRateLimitDescribe(t *testing.T) {
 		{
 			Name: "validate ListERL API success",
 			API: mock.API{
-				GetERLFn: func(_ *fastly.GetERLInput) (*fastly.ERL, error) {
+				GetERLFn: func(_ context.Context, _ *fastly.GetERLInput) (*fastly.ERL, error) {
 					return &fastly.ERL{
 						RateLimiterID:      fastly.ToPointer("123"),
 						Name:               fastly.ToPointer("example"),
@@ -108,7 +109,7 @@ func TestRateLimitList(t *testing.T) {
 		{
 			Name: "validate ListERL API error",
 			API: mock.API{
-				ListERLsFn: func(_ *fastly.ListERLsInput) ([]*fastly.ERL, error) {
+				ListERLsFn: func(_ context.Context, _ *fastly.ListERLsInput) ([]*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
 				ListVersionsFn: testutil.ListVersions,
@@ -119,7 +120,7 @@ func TestRateLimitList(t *testing.T) {
 		{
 			Name: "validate ListERL API success",
 			API: mock.API{
-				ListERLsFn: func(_ *fastly.ListERLsInput) ([]*fastly.ERL, error) {
+				ListERLsFn: func(_ context.Context, _ *fastly.ListERLsInput) ([]*fastly.ERL, error) {
 					return []*fastly.ERL{
 						{
 							RateLimiterID:      fastly.ToPointer("123"),
@@ -146,7 +147,7 @@ func TesRateLimittUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateERL API error",
 			API: mock.API{
-				UpdateERLFn: func(_ *fastly.UpdateERLInput) (*fastly.ERL, error) {
+				UpdateERLFn: func(_ context.Context, _ *fastly.UpdateERLInput) (*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -156,7 +157,7 @@ func TesRateLimittUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateERL API success",
 			API: mock.API{
-				UpdateERLFn: func(i *fastly.UpdateERLInput) (*fastly.ERL, error) {
+				UpdateERLFn: func(_ context.Context, i *fastly.UpdateERLInput) (*fastly.ERL, error) {
 					return &fastly.ERL{
 						Name:          i.Name,
 						RateLimiterID: fastly.ToPointer("123"),

--- a/pkg/commands/ratelimit/update.go
+++ b/pkg/commands/ratelimit/update.go
@@ -1,12 +1,13 @@
 package ratelimit
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -83,7 +84,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	input := c.constructInput()
-	o, err := c.Globals.APIClient.UpdateERL(input)
+	o, err := c.Globals.APIClient.UpdateERL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/resourcelink/create.go
+++ b/pkg/commands/resourcelink/create.go
@@ -1,9 +1,10 @@
 package resourcelink
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -111,7 +112,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.CreateResource(&c.input)
+	o, err := c.Globals.APIClient.CreateResource(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"ID":              c.input.ResourceID,

--- a/pkg/commands/resourcelink/delete.go
+++ b/pkg/commands/resourcelink/delete.go
@@ -1,9 +1,10 @@
 package resourcelink
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -99,7 +100,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	err = c.Globals.APIClient.DeleteResource(&c.input)
+	err = c.Globals.APIClient.DeleteResource(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"ID":              c.input.ResourceID,

--- a/pkg/commands/resourcelink/describe.go
+++ b/pkg/commands/resourcelink/describe.go
@@ -1,9 +1,10 @@
 package resourcelink
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -86,7 +87,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.GetResource(&c.input)
+	o, err := c.Globals.APIClient.GetResource(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"ID":              c.input.ResourceID,

--- a/pkg/commands/resourcelink/list.go
+++ b/pkg/commands/resourcelink/list.go
@@ -1,10 +1,11 @@
 package resourcelink
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListResources(&c.input)
+	o, err := c.Globals.APIClient.ListResources(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      c.input.ServiceID,

--- a/pkg/commands/resourcelink/update.go
+++ b/pkg/commands/resourcelink/update.go
@@ -1,9 +1,10 @@
 package resourcelink
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -110,7 +111,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.ServiceID = serviceID
 	c.input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.UpdateResource(&c.input)
+	o, err := c.Globals.APIClient.UpdateResource(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"ID":              c.input.ResourceID,

--- a/pkg/commands/secretstore/create.go
+++ b/pkg/commands/secretstore/create.go
@@ -1,9 +1,10 @@
 package secretstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -44,7 +45,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.CreateSecretStore(&c.Input)
+	o, err := c.Globals.APIClient.CreateSecretStore(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/secretstore/delete.go
+++ b/pkg/commands/secretstore/delete.go
@@ -1,9 +1,10 @@
 package secretstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -44,7 +45,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	err := c.Globals.APIClient.DeleteSecretStore(&c.Input)
+	err := c.Globals.APIClient.DeleteSecretStore(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/secretstore/describe.go
+++ b/pkg/commands/secretstore/describe.go
@@ -1,9 +1,10 @@
 package secretstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -44,7 +45,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.GetSecretStore(&c.Input)
+	o, err := c.Globals.APIClient.GetSecretStore(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/secretstore/helper_test.go
+++ b/pkg/commands/secretstore/helper_test.go
@@ -3,7 +3,7 @@ package secretstore_test
 import (
 	"bytes"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/text"
 )

--- a/pkg/commands/secretstore/list.go
+++ b/pkg/commands/secretstore/list.go
@@ -1,9 +1,10 @@
 package secretstore
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -47,7 +48,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	var data []fastly.SecretStore
 
 	for {
-		o, err := c.Globals.APIClient.ListSecretStores(&c.Input)
+		o, err := c.Globals.APIClient.ListSecretStores(context.TODO(), &c.Input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err

--- a/pkg/commands/secretstore/secretstore_test.go
+++ b/pkg/commands/secretstore/secretstore_test.go
@@ -2,13 +2,14 @@ package secretstore_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/commands/secretstore"
@@ -39,7 +40,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("create --name %s", storeName),
 			api: mock.API{
-				CreateSecretStoreFn: func(_ *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
+				CreateSecretStoreFn: func(_ context.Context, _ *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -49,7 +50,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("create --name %s", storeName),
 			api: mock.API{
-				CreateSecretStoreFn: func(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
+				CreateSecretStoreFn: func(_ context.Context, i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
 					return &fastly.SecretStore{
 						StoreID: storeID,
 						Name:    i.Name,
@@ -62,7 +63,7 @@ func TestCreateStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("create --name %s --json", storeName),
 			api: mock.API{
-				CreateSecretStoreFn: func(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
+				CreateSecretStoreFn: func(_ context.Context, i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
 					return &fastly.SecretStore{
 						StoreID:   storeID,
 						Name:      i.Name,
@@ -84,9 +85,9 @@ func TestCreateStoreCommand(t *testing.T) {
 
 			f := testcase.api.CreateSecretStoreFn
 			var apiInvoked bool
-			testcase.api.CreateSecretStoreFn = func(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
+			testcase.api.CreateSecretStoreFn = func(ctx context.Context, i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
 				apiInvoked = true
-				return f(i)
+				return f(ctx, i)
 			}
 
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {
@@ -122,7 +123,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			args: "delete --store-id DOES-NOT-EXIST",
 			api: mock.API{
-				DeleteSecretStoreFn: func(i *fastly.DeleteSecretStoreInput) error {
+				DeleteSecretStoreFn: func(_ context.Context, i *fastly.DeleteSecretStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -135,7 +136,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("delete --store-id %s", storeID),
 			api: mock.API{
-				DeleteSecretStoreFn: func(i *fastly.DeleteSecretStoreInput) error {
+				DeleteSecretStoreFn: func(_ context.Context, i *fastly.DeleteSecretStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -148,7 +149,7 @@ func TestDeleteStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("delete --store-id %s --json", storeID),
 			api: mock.API{
-				DeleteSecretStoreFn: func(i *fastly.DeleteSecretStoreInput) error {
+				DeleteSecretStoreFn: func(_ context.Context, i *fastly.DeleteSecretStoreInput) error {
 					if i.StoreID != storeID {
 						return errStoreNotFound
 					}
@@ -169,9 +170,9 @@ func TestDeleteStoreCommand(t *testing.T) {
 
 			f := testcase.api.DeleteSecretStoreFn
 			var apiInvoked bool
-			testcase.api.DeleteSecretStoreFn = func(i *fastly.DeleteSecretStoreInput) error {
+			testcase.api.DeleteSecretStoreFn = func(ctx context.Context, i *fastly.DeleteSecretStoreInput) error {
 				apiInvoked = true
-				return f(i)
+				return f(ctx, i)
 			}
 
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {
@@ -209,7 +210,7 @@ func TestDescribeStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("get --store-id %s", storeID),
 			api: mock.API{
-				GetSecretStoreFn: func(_ *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
+				GetSecretStoreFn: func(_ context.Context, _ *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
 					return nil, errors.New("invalid request")
 				},
 			},
@@ -219,7 +220,7 @@ func TestDescribeStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("get --store-id %s", storeID),
 			api: mock.API{
-				GetSecretStoreFn: func(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
+				GetSecretStoreFn: func(_ context.Context, i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
 					return &fastly.SecretStore{
 						StoreID: i.StoreID,
 						Name:    storeName,
@@ -235,7 +236,7 @@ func TestDescribeStoreCommand(t *testing.T) {
 		{
 			args: fmt.Sprintf("get --store-id %s --json", storeID),
 			api: mock.API{
-				GetSecretStoreFn: func(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
+				GetSecretStoreFn: func(_ context.Context, i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
 					return &fastly.SecretStore{
 						StoreID: i.StoreID,
 						Name:    storeName,
@@ -259,9 +260,9 @@ func TestDescribeStoreCommand(t *testing.T) {
 
 			f := testcase.api.GetSecretStoreFn
 			var apiInvoked bool
-			testcase.api.GetSecretStoreFn = func(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
+			testcase.api.GetSecretStoreFn = func(ctx context.Context, i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
 				apiInvoked = true
-				return f(i)
+				return f(ctx, i)
 			}
 
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {
@@ -304,7 +305,7 @@ func TestListStoresCommand(t *testing.T) {
 		{
 			args: "list",
 			api: mock.API{
-				ListSecretStoresFn: func(_ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+				ListSecretStoresFn: func(_ context.Context, _ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
 					return nil, nil
 				},
 			},
@@ -313,7 +314,7 @@ func TestListStoresCommand(t *testing.T) {
 		{
 			args: "list",
 			api: mock.API{
-				ListSecretStoresFn: func(_ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+				ListSecretStoresFn: func(_ context.Context, _ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
 					return nil, errors.New("unknown error")
 				},
 			},
@@ -323,7 +324,7 @@ func TestListStoresCommand(t *testing.T) {
 		{
 			args: "list",
 			api: mock.API{
-				ListSecretStoresFn: func(_ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+				ListSecretStoresFn: func(_ context.Context, _ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
 					return stores, nil
 				},
 			},
@@ -333,7 +334,7 @@ func TestListStoresCommand(t *testing.T) {
 		{
 			args: "list --json",
 			api: mock.API{
-				ListSecretStoresFn: func(_ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+				ListSecretStoresFn: func(_ context.Context, _ *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
 					return stores, nil
 				},
 			},
@@ -351,9 +352,9 @@ func TestListStoresCommand(t *testing.T) {
 
 			f := testcase.api.ListSecretStoresFn
 			var apiInvoked bool
-			testcase.api.ListSecretStoresFn = func(i *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+			testcase.api.ListSecretStoresFn = func(ctx context.Context, i *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
 				apiInvoked = true
-				return f(i)
+				return f(ctx, i)
 			}
 
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {

--- a/pkg/commands/secretstoreentry/create.go
+++ b/pkg/commands/secretstoreentry/create.go
@@ -2,6 +2,7 @@ package secretstoreentry
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -9,7 +10,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -150,13 +151,13 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 		return errMaxSecretLength
 	}
 
-	ck, err := c.Globals.APIClient.CreateClientKey()
+	ck, err := c.Globals.APIClient.CreateClientKey(context.TODO())
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
 	}
 
-	sk, err := c.Globals.APIClient.GetSigningKey()
+	sk, err := c.Globals.APIClient.GetSigningKey(context.TODO())
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err
@@ -183,7 +184,7 @@ func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 	c.Input.Secret = wrapped
 	c.Input.ClientKey = ck.PublicKey
 
-	o, err := c.Globals.APIClient.CreateSecret(&c.Input)
+	o, err := c.Globals.APIClient.CreateSecret(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/secretstoreentry/delete.go
+++ b/pkg/commands/secretstoreentry/delete.go
@@ -1,9 +1,10 @@
 package secretstoreentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -45,7 +46,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	err := c.Globals.APIClient.DeleteSecret(&c.Input)
+	err := c.Globals.APIClient.DeleteSecret(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/secretstoreentry/describe.go
+++ b/pkg/commands/secretstoreentry/describe.go
@@ -1,9 +1,10 @@
 package secretstoreentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -45,7 +46,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.GetSecret(&c.Input)
+	o, err := c.Globals.APIClient.GetSecret(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/secretstoreentry/helper_test.go
+++ b/pkg/commands/secretstoreentry/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 func fmtSecret(s *fastly.Secret) string {

--- a/pkg/commands/secretstoreentry/list.go
+++ b/pkg/commands/secretstoreentry/list.go
@@ -1,9 +1,10 @@
 package secretstoreentry
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -47,7 +48,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	for {
-		o, err := c.Globals.APIClient.ListSecrets(&c.Input)
+		o, err := c.Globals.APIClient.ListSecrets(context.TODO(), &c.Input)
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err

--- a/pkg/commands/service/create.go
+++ b/pkg/commands/service/create.go
@@ -1,9 +1,10 @@
 package service
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -49,7 +50,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if c.stype.WasSet {
 		input.Type = &c.stype.Value
 	}
-	s, err := c.Globals.APIClient.CreateService(&input)
+	s, err := c.Globals.APIClient.CreateService(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service Name": input.Name,

--- a/pkg/commands/service/delete.go
+++ b/pkg/commands/service/delete.go
@@ -1,10 +1,11 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"
@@ -60,7 +61,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 
 	if c.force {
-		s, err := c.Globals.APIClient.GetServiceDetails(&fastly.GetServiceInput{
+		s, err := c.Globals.APIClient.GetServiceDetails(context.TODO(), &fastly.GetServiceInput{
 			ServiceID: serviceID,
 		})
 		if err != nil {
@@ -71,7 +72,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		}
 
 		if s.ActiveVersion != nil && fastly.ToValue(s.ActiveVersion.Number) != 0 {
-			_, err := c.Globals.APIClient.DeactivateVersion(&fastly.DeactivateVersionInput{
+			_, err := c.Globals.APIClient.DeactivateVersion(context.TODO(), &fastly.DeactivateVersionInput{
 				ServiceID:      serviceID,
 				ServiceVersion: fastly.ToValue(s.ActiveVersion.Number),
 			})
@@ -85,7 +86,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		}
 	}
 
-	if err := c.Globals.APIClient.DeleteService(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteService(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,
 		})

--- a/pkg/commands/service/describe.go
+++ b/pkg/commands/service/describe.go
@@ -1,10 +1,11 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -71,7 +72,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	c.Input.ServiceID = serviceID
 
-	o, err := c.Globals.APIClient.GetServiceDetails(&c.Input)
+	o, err := c.Globals.APIClient.GetServiceDetails(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/service/list.go
+++ b/pkg/commands/service/list.go
@@ -1,11 +1,12 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -53,7 +54,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.input.Page = &c.page
 	c.input.PerPage = &c.perPage
 	c.input.Sort = &c.sort
-	paginator := c.Globals.APIClient.GetServices(&c.input)
+	paginator := c.Globals.APIClient.GetServices(context.TODO(), &c.input)
 
 	var o []*fastly.Service
 	for paginator.HasNext() {

--- a/pkg/commands/service/search.go
+++ b/pkg/commands/service/search.go
@@ -1,9 +1,10 @@
 package service
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -43,7 +44,7 @@ func (c *SearchCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	service, err := c.Globals.APIClient.SearchService(&c.Input)
+	service, err := c.Globals.APIClient.SearchService(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service Name": c.Input.Name,

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -11,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -85,8 +86,8 @@ func TestServiceList(t *testing.T) {
 	}{
 		{
 			api: mock.API{
-				GetServicesFn: func(_ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
-					return fastly.NewPaginator[fastly.Service](&mock.HTTPClient{
+				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
+					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{
 							testutil.Err,
 						},
@@ -99,8 +100,8 @@ func TestServiceList(t *testing.T) {
 		},
 		{
 			api: mock.API{
-				GetServicesFn: func(_ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
-					return fastly.NewPaginator[fastly.Service](&mock.HTTPClient{
+				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
+					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
 						Responses: []*http.Response{
 							{
@@ -136,8 +137,8 @@ func TestServiceList(t *testing.T) {
 		},
 		{
 			api: mock.API{
-				GetServicesFn: func(_ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
-					return fastly.NewPaginator[fastly.Service](&mock.HTTPClient{
+				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
+					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
 						Responses: []*http.Response{
 							{
@@ -504,14 +505,14 @@ func TestServiceDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createServiceOK(i *fastly.CreateServiceInput) (*fastly.Service, error) {
+func createServiceOK(_ context.Context, i *fastly.CreateServiceInput) (*fastly.Service, error) {
 	return &fastly.Service{
 		ServiceID: fastly.ToPointer("12345"),
 		Name:      i.Name,
 	}, nil
 }
 
-func createServiceError(*fastly.CreateServiceInput) (*fastly.Service, error) {
+func createServiceError(_ context.Context, _ *fastly.CreateServiceInput) (*fastly.Service, error) {
 	return nil, errTest
 }
 
@@ -576,7 +577,7 @@ Service 3/3
 	Versions: 0
 `) + "\n\n"
 
-func getServiceOK(_ *fastly.GetServiceInput) (*fastly.Service, error) {
+func getServiceOK(_ context.Context, _ *fastly.GetServiceInput) (*fastly.Service, error) {
 	return &fastly.Service{
 		ServiceID: fastly.ToPointer("12345"),
 		Name:      fastly.ToPointer("Foo"),
@@ -584,7 +585,7 @@ func getServiceOK(_ *fastly.GetServiceInput) (*fastly.Service, error) {
 	}, nil
 }
 
-func describeServiceOK(_ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
+func describeServiceOK(_ context.Context, _ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 	return &fastly.ServiceDetail{
 		ServiceID:  fastly.ToPointer("123"),
 		Name:       fastly.ToPointer("Foo"),
@@ -623,7 +624,7 @@ func describeServiceOK(_ *fastly.GetServiceInput) (*fastly.ServiceDetail, error)
 	}, nil
 }
 
-func describeServiceError(_ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
+func describeServiceError(_ context.Context, _ *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
 	return nil, errTest
 }
 
@@ -698,7 +699,7 @@ Versions: 2
 		Last edited (UTC): 2001-03-04 04:05
 `) + "\n"
 
-func searchServiceOK(_ *fastly.SearchServiceInput) (*fastly.Service, error) {
+func searchServiceOK(_ context.Context, _ *fastly.SearchServiceInput) (*fastly.Service, error) {
 	return &fastly.Service{
 		ServiceID:  fastly.ToPointer("123"),
 		Name:       fastly.ToPointer("Foo"),
@@ -778,20 +779,20 @@ Versions: 2
 		Last edited (UTC): 2001-03-04 04:05
 `) + "\n"
 
-func updateServiceOK(_ *fastly.UpdateServiceInput) (*fastly.Service, error) {
+func updateServiceOK(_ context.Context, _ *fastly.UpdateServiceInput) (*fastly.Service, error) {
 	return &fastly.Service{
 		ServiceID: fastly.ToPointer("12345"),
 	}, nil
 }
 
-func updateServiceError(*fastly.UpdateServiceInput) (*fastly.Service, error) {
+func updateServiceError(_ context.Context, _ *fastly.UpdateServiceInput) (*fastly.Service, error) {
 	return nil, errTest
 }
 
-func deleteServiceOK(*fastly.DeleteServiceInput) error {
+func deleteServiceOK(_ context.Context, _ *fastly.DeleteServiceInput) error {
 	return nil
 }
 
-func deleteServiceError(*fastly.DeleteServiceInput) error {
+func deleteServiceError(_ context.Context, _ *fastly.DeleteServiceInput) error {
 	return errTest
 }

--- a/pkg/commands/service/update.go
+++ b/pkg/commands/service/update.go
@@ -1,10 +1,11 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -71,7 +72,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		c.input.Comment = &c.comment.Value
 	}
 
-	s, err := c.Globals.APIClient.UpdateService(&c.input)
+	s, err := c.Globals.APIClient.UpdateService(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":   serviceID,

--- a/pkg/commands/serviceauth/create.go
+++ b/pkg/commands/serviceauth/create.go
@@ -1,9 +1,10 @@
 package serviceauth
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -74,7 +75,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		ID: c.userID,
 	}
 
-	s, err := c.Globals.APIClient.CreateServiceAuthorization(&c.input)
+	s, err := c.Globals.APIClient.CreateServiceAuthorization(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/serviceauth/delete.go
+++ b/pkg/commands/serviceauth/delete.go
@@ -1,9 +1,10 @@
 package serviceauth
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -32,7 +33,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
-	if err := c.Globals.APIClient.DeleteServiceAuthorization(&c.Input); err != nil {
+	if err := c.Globals.APIClient.DeleteServiceAuthorization(context.TODO(), &c.Input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service Authorization ID": c.Input.ID,
 		})

--- a/pkg/commands/serviceauth/describe.go
+++ b/pkg/commands/serviceauth/describe.go
@@ -1,10 +1,11 @@
 package serviceauth
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -43,7 +44,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.GetServiceAuthorization(&c.Input)
+	o, err := c.Globals.APIClient.GetServiceAuthorization(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service Authorization ID": c.Input.ID,

--- a/pkg/commands/serviceauth/list.go
+++ b/pkg/commands/serviceauth/list.go
@@ -1,6 +1,7 @@
 package serviceauth
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // ListCommand calls the Fastly API to list service authorizations.
@@ -39,7 +40,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	o, err := c.Globals.APIClient.ListServiceAuthorizations(&c.input)
+	o, err := c.Globals.APIClient.ListServiceAuthorizations(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Page Number": c.input.PageNumber,

--- a/pkg/commands/serviceauth/service_test.go
+++ b/pkg/commands/serviceauth/service_test.go
@@ -2,12 +2,13 @@ package serviceauth_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -269,21 +270,21 @@ func TestServiceAuthDelete(t *testing.T) {
 
 var errTest = errors.New("fixture error")
 
-func createServiceAuthError(*fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+func createServiceAuthError(_ context.Context, _ *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
 	return nil, errTest
 }
 
-func createServiceAuthOK(_ *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+func createServiceAuthOK(_ context.Context, _ *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
 	return &fastly.ServiceAuthorization{
 		ID: "12345",
 	}, nil
 }
 
-func listServiceAuthError(*fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error) {
+func listServiceAuthError(_ context.Context, _ *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error) {
 	return nil, errTest
 }
 
-func listServiceAuthOK(_ *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error) {
+func listServiceAuthOK(_ context.Context, _ *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error) {
 	return &fastly.ServiceAuthorizations{
 		Items: []*fastly.ServiceAuthorization{
 			{
@@ -300,11 +301,11 @@ func listServiceAuthOK(_ *fastly.ListServiceAuthorizationsInput) (*fastly.Servic
 	}, nil
 }
 
-func describeServiceAuthError(*fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+func describeServiceAuthError(_ context.Context, _ *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
 	return nil, errTest
 }
 
-func describeServiceAuthOK(_ *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+func describeServiceAuthOK(_ context.Context, _ *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
 	return &fastly.ServiceAuthorization{
 		ID: "12345",
 		User: &fastly.SAUser{
@@ -317,20 +318,20 @@ func describeServiceAuthOK(_ *fastly.GetServiceAuthorizationInput) (*fastly.Serv
 	}, nil
 }
 
-func updateServiceAuthError(*fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+func updateServiceAuthError(_ context.Context, _ *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
 	return nil, errTest
 }
 
-func updateServiceAuthOK(_ *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+func updateServiceAuthOK(_ context.Context, _ *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
 	return &fastly.ServiceAuthorization{
 		ID: "12345",
 	}, nil
 }
 
-func deleteServiceAuthError(*fastly.DeleteServiceAuthorizationInput) error {
+func deleteServiceAuthError(_ context.Context, _ *fastly.DeleteServiceAuthorizationInput) error {
 	return errTest
 }
 
-func deleteServiceAuthOK(_ *fastly.DeleteServiceAuthorizationInput) error {
+func deleteServiceAuthOK(_ context.Context, _ *fastly.DeleteServiceAuthorizationInput) error {
 	return nil
 }

--- a/pkg/commands/serviceauth/update.go
+++ b/pkg/commands/serviceauth/update.go
@@ -1,9 +1,10 @@
 package serviceauth
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -34,7 +35,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec invokes the application logic for the command.
 func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
-	s, err := c.Globals.APIClient.UpdateServiceAuthorization(&c.input)
+	s, err := c.Globals.APIClient.UpdateServiceAuthorization(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service Authorization ID": c.input.ID,

--- a/pkg/commands/serviceversion/activate.go
+++ b/pkg/commands/serviceversion/activate.go
@@ -1,9 +1,10 @@
 package serviceversion
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -75,7 +76,7 @@ func (c *ActivateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	ver, err := c.Globals.APIClient.ActivateVersion(&c.Input)
+	ver, err := c.Globals.APIClient.ActivateVersion(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/serviceversion/clone.go
+++ b/pkg/commands/serviceversion/clone.go
@@ -1,9 +1,10 @@
 package serviceversion
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"
@@ -66,7 +67,7 @@ func (c *CloneCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	ver, err := c.Globals.APIClient.CloneVersion(&c.Input)
+	ver, err := c.Globals.APIClient.CloneVersion(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/serviceversion/deactivate.go
+++ b/pkg/commands/serviceversion/deactivate.go
@@ -1,9 +1,10 @@
 package serviceversion
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -69,7 +70,7 @@ func (c *DeactivateCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	ver, err := c.Globals.APIClient.DeactivateVersion(&c.Input)
+	ver, err := c.Globals.APIClient.DeactivateVersion(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/serviceversion/list.go
+++ b/pkg/commands/serviceversion/list.go
@@ -1,11 +1,12 @@
 package serviceversion
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -63,7 +64,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	c.Input.ServiceID = serviceID
 
-	o, err := c.Globals.APIClient.ListVersions(&c.Input)
+	o, err := c.Globals.APIClient.ListVersions(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/serviceversion/lock.go
+++ b/pkg/commands/serviceversion/lock.go
@@ -1,9 +1,10 @@
 package serviceversion
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -69,7 +70,7 @@ func (c *LockCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceID = serviceID
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	ver, err := c.Globals.APIClient.LockVersion(&c.Input)
+	ver, err := c.Globals.APIClient.LockVersion(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -1,10 +1,11 @@
 package serviceversion_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/serviceversion"
 	"github.com/fastly/cli/pkg/mock"
@@ -361,7 +362,7 @@ Versions: 4
 		Last edited (UTC): 2000-01-04 01:00
 `) + "\n\n"
 
-func updateVersionOK(i *fastly.UpdateVersionInput) (*fastly.Version, error) {
+func updateVersionOK(_ context.Context, i *fastly.UpdateVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{
 		Number:    fastly.ToPointer(i.ServiceVersion),
 		ServiceID: fastly.ToPointer("123"),
@@ -372,11 +373,11 @@ func updateVersionOK(i *fastly.UpdateVersionInput) (*fastly.Version, error) {
 	}, nil
 }
 
-func updateVersionError(_ *fastly.UpdateVersionInput) (*fastly.Version, error) {
+func updateVersionError(_ context.Context, _ *fastly.UpdateVersionInput) (*fastly.Version, error) {
 	return nil, testutil.Err
 }
 
-func activateVersionOK(i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+func activateVersionOK(_ context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{
 		Number:    fastly.ToPointer(i.ServiceVersion),
 		ServiceID: fastly.ToPointer("123"),
@@ -387,11 +388,11 @@ func activateVersionOK(i *fastly.ActivateVersionInput) (*fastly.Version, error) 
 	}, nil
 }
 
-func activateVersionError(_ *fastly.ActivateVersionInput) (*fastly.Version, error) {
+func activateVersionError(_ context.Context, _ *fastly.ActivateVersionInput) (*fastly.Version, error) {
 	return nil, testutil.Err
 }
 
-func deactivateVersionOK(i *fastly.DeactivateVersionInput) (*fastly.Version, error) {
+func deactivateVersionOK(_ context.Context, i *fastly.DeactivateVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{
 		Number:    fastly.ToPointer(i.ServiceVersion),
 		ServiceID: fastly.ToPointer("123"),
@@ -402,11 +403,11 @@ func deactivateVersionOK(i *fastly.DeactivateVersionInput) (*fastly.Version, err
 	}, nil
 }
 
-func deactivateVersionError(_ *fastly.DeactivateVersionInput) (*fastly.Version, error) {
+func deactivateVersionError(_ context.Context, _ *fastly.DeactivateVersionInput) (*fastly.Version, error) {
 	return nil, testutil.Err
 }
 
-func stageVersionOK(i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+func stageVersionOK(_ context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{
 		Number:    fastly.ToPointer(i.ServiceVersion),
 		ServiceID: fastly.ToPointer("123"),
@@ -418,11 +419,11 @@ func stageVersionOK(i *fastly.ActivateVersionInput) (*fastly.Version, error) {
 	}, nil
 }
 
-func stageVersionError(_ *fastly.ActivateVersionInput) (*fastly.Version, error) {
+func stageVersionError(_ context.Context, _ *fastly.ActivateVersionInput) (*fastly.Version, error) {
 	return nil, testutil.Err
 }
 
-func unstageVersionOK(i *fastly.DeactivateVersionInput) (*fastly.Version, error) {
+func unstageVersionOK(_ context.Context, i *fastly.DeactivateVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{
 		Number:    fastly.ToPointer(i.ServiceVersion),
 		ServiceID: fastly.ToPointer("123"),
@@ -434,11 +435,11 @@ func unstageVersionOK(i *fastly.DeactivateVersionInput) (*fastly.Version, error)
 	}, nil
 }
 
-func unstageVersionError(_ *fastly.DeactivateVersionInput) (*fastly.Version, error) {
+func unstageVersionError(_ context.Context, _ *fastly.DeactivateVersionInput) (*fastly.Version, error) {
 	return nil, testutil.Err
 }
 
-func lockVersionOK(i *fastly.LockVersionInput) (*fastly.Version, error) {
+func lockVersionOK(_ context.Context, i *fastly.LockVersionInput) (*fastly.Version, error) {
 	return &fastly.Version{
 		Number:    fastly.ToPointer(i.ServiceVersion),
 		ServiceID: fastly.ToPointer("123"),
@@ -450,6 +451,6 @@ func lockVersionOK(i *fastly.LockVersionInput) (*fastly.Version, error) {
 	}, nil
 }
 
-func lockVersionError(_ *fastly.LockVersionInput) (*fastly.Version, error) {
+func lockVersionError(_ context.Context, _ *fastly.LockVersionInput) (*fastly.Version, error) {
 	return nil, testutil.Err
 }

--- a/pkg/commands/serviceversion/stage.go
+++ b/pkg/commands/serviceversion/stage.go
@@ -1,9 +1,10 @@
 package serviceversion
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -71,7 +72,7 @@ func (c *StageCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 	c.Input.Environment = "staging"
 
-	ver, err := c.Globals.APIClient.ActivateVersion(&c.Input)
+	ver, err := c.Globals.APIClient.ActivateVersion(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/serviceversion/unstage.go
+++ b/pkg/commands/serviceversion/unstage.go
@@ -1,9 +1,10 @@
 package serviceversion
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -70,7 +71,7 @@ func (c *UnstageCommand) Exec(_ io.Reader, out io.Writer) error {
 	c.Input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 	c.Input.Environment = "staging"
 
-	ver, err := c.Globals.APIClient.DeactivateVersion(&c.Input)
+	ver, err := c.Globals.APIClient.DeactivateVersion(context.TODO(), &c.Input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/serviceversion/update.go
+++ b/pkg/commands/serviceversion/update.go
@@ -1,10 +1,11 @@
 package serviceversion
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"
@@ -89,7 +90,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 	c.input.Comment = &c.comment.Value
 
-	ver, err := c.Globals.APIClient.UpdateVersion(&c.input)
+	ver, err := c.Globals.APIClient.UpdateVersion(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/sso/sso_test.go
+++ b/pkg/commands/sso/sso_test.go
@@ -1,11 +1,12 @@
 package sso_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/auth"
 	"github.com/fastly/cli/pkg/config"
@@ -157,7 +158,7 @@ func TestSSO(t *testing.T) {
 		{
 			Args: "pops",
 			API: mock.API{
-				AllDatacentersFn: func() ([]fastly.Datacenter, error) {
+				AllDatacentersFn: func(_ context.Context) ([]fastly.Datacenter, error) {
 					return []fastly.Datacenter{
 						{
 							Name:   fastly.ToPointer("Foobar"),
@@ -235,7 +236,7 @@ func TestSSO(t *testing.T) {
 		{
 			Args: "pops",
 			API: mock.API{
-				AllDatacentersFn: func() ([]fastly.Datacenter, error) {
+				AllDatacentersFn: func(_ context.Context) ([]fastly.Datacenter, error) {
 					return []fastly.Datacenter{
 						{
 							Name:   fastly.ToPointer("Foobar"),

--- a/pkg/commands/stats/historical.go
+++ b/pkg/commands/stats/historical.go
@@ -1,11 +1,12 @@
 package stats
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -81,7 +82,7 @@ func (c *HistoricalCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	var envelope statsResponse
-	err = c.Globals.APIClient.GetStatsJSON(&input, &envelope)
+	err = c.Globals.APIClient.GetStatsJSON(context.TODO(), &input, &envelope)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID": serviceID,

--- a/pkg/commands/stats/historical_test.go
+++ b/pkg/commands/stats/historical_test.go
@@ -2,12 +2,13 @@ package stats_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -87,7 +88,7 @@ Requests:                                        0
 var historicalJSONOK = `{"start_time":0}
 `
 
-func getStatsJSONOK(_ *fastly.GetStatsInput, o any) error {
+func getStatsJSONOK(_ context.Context, _ *fastly.GetStatsInput, o any) error {
 	msg := []byte(`
 {
   "status": "success",
@@ -104,6 +105,6 @@ func getStatsJSONOK(_ *fastly.GetStatsInput, o any) error {
 	return json.Unmarshal(msg, o)
 }
 
-func getStatsJSONError(_ *fastly.GetStatsInput, _ any) error {
+func getStatsJSONError(_ context.Context, _ *fastly.GetStatsInput, _ any) error {
 	return errTest
 }

--- a/pkg/commands/stats/realtime.go
+++ b/pkg/commands/stats/realtime.go
@@ -1,11 +1,12 @@
 package stats
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"
@@ -84,7 +85,7 @@ func loopJSON(client api.RealtimeStatsInterface, service string, out io.Writer) 
 			Data      []json.RawMessage `json:"data"`
 		}
 
-		err := client.GetRealtimeStatsJSON(&fastly.GetRealtimeStatsInput{
+		err := client.GetRealtimeStatsJSON(context.TODO(), &fastly.GetRealtimeStatsInput{
 			ServiceID: service,
 			Timestamp: timestamp,
 		}, &envelope)
@@ -109,7 +110,7 @@ func loopText(client api.RealtimeStatsInterface, service string, out io.Writer) 
 	for {
 		var envelope realtimeResponse
 
-		err := client.GetRealtimeStatsJSON(&fastly.GetRealtimeStatsInput{
+		err := client.GetRealtimeStatsJSON(context.TODO(), &fastly.GetRealtimeStatsInput{
 			ServiceID: service,
 			Timestamp: timestamp,
 		}, &envelope)

--- a/pkg/commands/stats/regions.go
+++ b/pkg/commands/stats/regions.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -24,7 +25,7 @@ func NewRegionsCommand(parent argparser.Registerer, g *global.Data) *RegionsComm
 
 // Exec implements the command interface.
 func (c *RegionsCommand) Exec(_ io.Reader, out io.Writer) error {
-	resp, err := c.Globals.APIClient.GetRegions()
+	resp, err := c.Globals.APIClient.GetRegions(context.TODO())
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return fmt.Errorf("fetching regions: %w", err)

--- a/pkg/commands/stats/regions_test.go
+++ b/pkg/commands/stats/regions_test.go
@@ -2,12 +2,13 @@ package stats_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"
@@ -50,7 +51,7 @@ func TestRegions(t *testing.T) {
 	}
 }
 
-func getRegionsOK() (*fastly.RegionsResponse, error) {
+func getRegionsOK(_ context.Context) (*fastly.RegionsResponse, error) {
 	return &fastly.RegionsResponse{
 		Data: []string{"foo", "bar", "baz"},
 	}, nil
@@ -58,6 +59,6 @@ func getRegionsOK() (*fastly.RegionsResponse, error) {
 
 var errTest = errors.New("fixture error")
 
-func getRegionsError() (*fastly.RegionsResponse, error) {
+func getRegionsError(_ context.Context) (*fastly.RegionsResponse, error) {
 	return nil, errTest
 }

--- a/pkg/commands/stats/template.go
+++ b/pkg/commands/stats/template.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 var blockTemplate = template.Must(template.New("stats_block").Parse(

--- a/pkg/commands/tls/config/config_test.go
+++ b/pkg/commands/tls/config/config_test.go
@@ -1,10 +1,11 @@
 package config_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/config"
 	"github.com/fastly/cli/pkg/mock"
@@ -26,7 +27,7 @@ func TestDescribe(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				GetCustomTLSConfigurationFn: func(_ *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
+				GetCustomTLSConfigurationFn: func(_ context.Context, _ *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -36,7 +37,7 @@ func TestDescribe(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				GetCustomTLSConfigurationFn: func(_ *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
+				GetCustomTLSConfigurationFn: func(_ context.Context, _ *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
 					t := testutil.Date
 					return &fastly.CustomTLSConfiguration{
 						ID:   mockResponseID,
@@ -70,7 +71,7 @@ func TestList(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				ListCustomTLSConfigurationsFn: func(_ *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error) {
+				ListCustomTLSConfigurationsFn: func(_ context.Context, _ *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -79,7 +80,7 @@ func TestList(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				ListCustomTLSConfigurationsFn: func(_ *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error) {
+				ListCustomTLSConfigurationsFn: func(_ context.Context, _ *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error) {
 					t := testutil.Date
 					return []*fastly.CustomTLSConfiguration{
 						{
@@ -125,7 +126,7 @@ func TestUpdate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				UpdateCustomTLSConfigurationFn: func(_ *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
+				UpdateCustomTLSConfigurationFn: func(_ context.Context, _ *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -135,7 +136,7 @@ func TestUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				UpdateCustomTLSConfigurationFn: func(_ *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
+				UpdateCustomTLSConfigurationFn: func(_ context.Context, _ *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
 					return &fastly.CustomTLSConfiguration{
 						ID: mockResponseID,
 					}, nil

--- a/pkg/commands/tls/config/describe.go
+++ b/pkg/commands/tls/config/describe.go
@@ -1,10 +1,11 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -46,7 +47,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.GetCustomTLSConfiguration(input)
+	o, err := c.Globals.APIClient.GetCustomTLSConfiguration(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Configuration ID": c.id,

--- a/pkg/commands/tls/config/list.go
+++ b/pkg/commands/tls/config/list.go
@@ -1,11 +1,12 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -48,7 +49,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListCustomTLSConfigurations(input)
+	o, err := c.Globals.APIClient.ListCustomTLSConfigurations(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter Bulk": c.filterBulk,

--- a/pkg/commands/tls/config/update.go
+++ b/pkg/commands/tls/config/update.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -34,7 +35,7 @@ type UpdateCommand struct {
 func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.UpdateCustomTLSConfiguration(input)
+	r, err := c.Globals.APIClient.UpdateCustomTLSConfiguration(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Configuration ID": c.id,

--- a/pkg/commands/tls/custom/activation/activation_test.go
+++ b/pkg/commands/tls/custom/activation/activation_test.go
@@ -1,10 +1,11 @@
 package activation_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/activation"
@@ -35,7 +36,7 @@ func TestTLSCustomActivationEnable(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				CreateTLSActivationFn: func(_ *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error) {
+				CreateTLSActivationFn: func(_ context.Context, _ *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -45,7 +46,7 @@ func TestTLSCustomActivationEnable(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				CreateTLSActivationFn: func(_ *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error) {
+				CreateTLSActivationFn: func(_ context.Context, _ *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error) {
 					return &fastly.TLSActivation{
 						ID: mockResponseID,
 						Certificate: &fastly.CustomTLSCertificate{
@@ -71,7 +72,7 @@ func TestTLSCustomActivationDisable(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				DeleteTLSActivationFn: func(_ *fastly.DeleteTLSActivationInput) error {
+				DeleteTLSActivationFn: func(_ context.Context, _ *fastly.DeleteTLSActivationInput) error {
 					return testutil.Err
 				},
 			},
@@ -81,7 +82,7 @@ func TestTLSCustomActivationDisable(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				DeleteTLSActivationFn: func(_ *fastly.DeleteTLSActivationInput) error {
+				DeleteTLSActivationFn: func(_ context.Context, _ *fastly.DeleteTLSActivationInput) error {
 					return nil
 				},
 			},
@@ -102,7 +103,7 @@ func TestTLSCustomActivationDescribe(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				GetTLSActivationFn: func(_ *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error) {
+				GetTLSActivationFn: func(_ context.Context, _ *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -112,7 +113,7 @@ func TestTLSCustomActivationDescribe(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				GetTLSActivationFn: func(_ *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error) {
+				GetTLSActivationFn: func(_ context.Context, _ *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error) {
 					t := testutil.Date
 					return &fastly.TLSActivation{
 						ID:        mockResponseID,
@@ -133,7 +134,7 @@ func TestTLSCustomActivationList(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				ListTLSActivationsFn: func(_ *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error) {
+				ListTLSActivationsFn: func(_ context.Context, _ *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -142,7 +143,7 @@ func TestTLSCustomActivationList(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				ListTLSActivationsFn: func(_ *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error) {
+				ListTLSActivationsFn: func(_ context.Context, _ *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error) {
 					t := testutil.Date
 					return []*fastly.TLSActivation{
 						{
@@ -175,7 +176,7 @@ func TestTLSCustomActivationUpdate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				UpdateTLSActivationFn: func(_ *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error) {
+				UpdateTLSActivationFn: func(_ context.Context, _ *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -185,7 +186,7 @@ func TestTLSCustomActivationUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				UpdateTLSActivationFn: func(_ *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error) {
+				UpdateTLSActivationFn: func(_ context.Context, _ *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error) {
 					return &fastly.TLSActivation{
 						ID: mockResponseID,
 						Certificate: &fastly.CustomTLSCertificate{

--- a/pkg/commands/tls/custom/activation/create.go
+++ b/pkg/commands/tls/custom/activation/create.go
@@ -1,9 +1,10 @@
 package activation
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -35,7 +36,7 @@ type CreateCommand struct {
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.CreateTLSActivation(input)
+	r, err := c.Globals.APIClient.CreateTLSActivation(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Activation ID":             c.id,

--- a/pkg/commands/tls/custom/activation/delete.go
+++ b/pkg/commands/tls/custom/activation/delete.go
@@ -1,9 +1,10 @@
 package activation
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -33,7 +34,7 @@ type DeleteCommand struct {
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	err := c.Globals.APIClient.DeleteTLSActivation(input)
+	err := c.Globals.APIClient.DeleteTLSActivation(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Activation ID": c.id,

--- a/pkg/commands/tls/custom/activation/describe.go
+++ b/pkg/commands/tls/custom/activation/describe.go
@@ -1,10 +1,11 @@
 package activation
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -46,7 +47,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.GetTLSActivation(input)
+	o, err := c.Globals.APIClient.GetTLSActivation(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Activation ID": c.id,

--- a/pkg/commands/tls/custom/activation/list.go
+++ b/pkg/commands/tls/custom/activation/list.go
@@ -1,10 +1,11 @@
 package activation
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -51,7 +52,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListTLSActivations(input)
+	o, err := c.Globals.APIClient.ListTLSActivations(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter TLS Certificate ID":   c.filterTLSCertID,

--- a/pkg/commands/tls/custom/activation/update.go
+++ b/pkg/commands/tls/custom/activation/update.go
@@ -1,9 +1,10 @@
 package activation
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -34,7 +35,7 @@ type UpdateCommand struct {
 func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.UpdateTLSActivation(input)
+	r, err := c.Globals.APIClient.UpdateTLSActivation(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Activation ID":             c.id,

--- a/pkg/commands/tls/custom/certificate/certificate_test.go
+++ b/pkg/commands/tls/custom/certificate/certificate_test.go
@@ -1,10 +1,11 @@
 package certificate_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/certificate"
@@ -40,7 +41,7 @@ func TestTLSCustomCertCreate(t *testing.T) {
 		{
 			Name: "validate custom cert is submitted",
 			API: mock.API{
-				CreateCustomTLSCertificateFn: func(certInput *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				CreateCustomTLSCertificateFn: func(_ context.Context, certInput *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					content = certInput.CertBlob
 					return &fastly.CustomTLSCertificate{
 						ID: mockResponseID,
@@ -54,7 +55,7 @@ func TestTLSCustomCertCreate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				CreateCustomTLSCertificateFn: func(certInput *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				CreateCustomTLSCertificateFn: func(_ context.Context, certInput *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					content = certInput.CertBlob
 					return nil, testutil.Err
 				},
@@ -66,7 +67,7 @@ func TestTLSCustomCertCreate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				CreateCustomTLSCertificateFn: func(certInput *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				CreateCustomTLSCertificateFn: func(_ context.Context, certInput *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					content = certInput.CertBlob
 					return &fastly.CustomTLSCertificate{
 						ID: mockResponseID,
@@ -91,7 +92,7 @@ func TestTLSCustomCertDelete(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				DeleteCustomTLSCertificateFn: func(_ *fastly.DeleteCustomTLSCertificateInput) error {
+				DeleteCustomTLSCertificateFn: func(_ context.Context, _ *fastly.DeleteCustomTLSCertificateInput) error {
 					return testutil.Err
 				},
 			},
@@ -101,7 +102,7 @@ func TestTLSCustomCertDelete(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				DeleteCustomTLSCertificateFn: func(_ *fastly.DeleteCustomTLSCertificateInput) error {
+				DeleteCustomTLSCertificateFn: func(_ context.Context, _ *fastly.DeleteCustomTLSCertificateInput) error {
 					return nil
 				},
 			},
@@ -122,7 +123,7 @@ func TestTLSCustomCertDescribe(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				GetCustomTLSCertificateFn: func(_ *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				GetCustomTLSCertificateFn: func(_ context.Context, _ *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -132,7 +133,7 @@ func TestTLSCustomCertDescribe(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				GetCustomTLSCertificateFn: func(_ *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				GetCustomTLSCertificateFn: func(_ context.Context, _ *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					t := testutil.Date
 					return &fastly.CustomTLSCertificate{
 						ID:                 mockResponseID,
@@ -160,7 +161,7 @@ func TestTLSCustomCertList(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				ListCustomTLSCertificatesFn: func(_ *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error) {
+				ListCustomTLSCertificatesFn: func(_ context.Context, _ *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -169,7 +170,7 @@ func TestTLSCustomCertList(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				ListCustomTLSCertificatesFn: func(_ *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error) {
+				ListCustomTLSCertificatesFn: func(_ context.Context, _ *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error) {
 					t := testutil.Date
 					return []*fastly.CustomTLSCertificate{
 						{
@@ -220,7 +221,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				UpdateCustomTLSCertificateFn: func(_ context.Context, certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					content = certInput.CertBlob
 					return nil, testutil.Err
 				},
@@ -232,7 +233,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				UpdateCustomTLSCertificateFn: func(_ context.Context, certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					content = certInput.CertBlob
 					return &fastly.CustomTLSCertificate{
 						ID: mockResponseID,
@@ -246,7 +247,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess + " with --name for different output",
 			API: mock.API{
-				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				UpdateCustomTLSCertificateFn: func(_ context.Context, certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					content = certInput.CertBlob
 					return &fastly.CustomTLSCertificate{
 						ID:   mockResponseID,
@@ -261,7 +262,7 @@ func TestTLSCustomCertUpdate(t *testing.T) {
 		{
 			Name: "validate custom cert is submitted",
 			API: mock.API{
-				UpdateCustomTLSCertificateFn: func(certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+				UpdateCustomTLSCertificateFn: func(_ context.Context, certInput *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
 					content = certInput.CertBlob
 					return &fastly.CustomTLSCertificate{
 						ID: mockResponseID,

--- a/pkg/commands/tls/custom/certificate/create.go
+++ b/pkg/commands/tls/custom/certificate/create.go
@@ -1,12 +1,13 @@
 package certificate
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -48,7 +49,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	r, err := c.Globals.APIClient.CreateCustomTLSCertificate(input)
+	r, err := c.Globals.APIClient.CreateCustomTLSCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Certificate ID":   c.id,

--- a/pkg/commands/tls/custom/certificate/delete.go
+++ b/pkg/commands/tls/custom/certificate/delete.go
@@ -1,9 +1,10 @@
 package certificate
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -33,7 +34,7 @@ type DeleteCommand struct {
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	err := c.Globals.APIClient.DeleteCustomTLSCertificate(input)
+	err := c.Globals.APIClient.DeleteCustomTLSCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Certificate ID": c.id,

--- a/pkg/commands/tls/custom/certificate/describe.go
+++ b/pkg/commands/tls/custom/certificate/describe.go
@@ -1,10 +1,11 @@
 package certificate
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -42,7 +43,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.GetCustomTLSCertificate(input)
+	o, err := c.Globals.APIClient.GetCustomTLSCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Certificate ID": c.id,

--- a/pkg/commands/tls/custom/certificate/list.go
+++ b/pkg/commands/tls/custom/certificate/list.go
@@ -1,10 +1,11 @@
 package certificate
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -53,7 +54,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListCustomTLSCertificates(input)
+	o, err := c.Globals.APIClient.ListCustomTLSCertificates(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter Not After":     c.filterNotAfter,

--- a/pkg/commands/tls/custom/certificate/update.go
+++ b/pkg/commands/tls/custom/certificate/update.go
@@ -1,12 +1,13 @@
 package certificate
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -47,7 +48,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	r, err := c.Globals.APIClient.UpdateCustomTLSCertificate(input)
+	r, err := c.Globals.APIClient.UpdateCustomTLSCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Certificate ID":   c.id,

--- a/pkg/commands/tls/custom/domain/domain_test.go
+++ b/pkg/commands/tls/custom/domain/domain_test.go
@@ -1,9 +1,10 @@
 package domain_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/domain"
@@ -22,7 +23,7 @@ func TestList(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				ListTLSDomainsFn: func(_ *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error) {
+				ListTLSDomainsFn: func(_ context.Context, _ *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -31,7 +32,7 @@ func TestList(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				ListTLSDomainsFn: func(_ *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error) {
+				ListTLSDomainsFn: func(_ context.Context, _ *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error) {
 					return []*fastly.TLSDomain{
 						{
 							ID:   mockResponseID,

--- a/pkg/commands/tls/custom/domain/list.go
+++ b/pkg/commands/tls/custom/domain/list.go
@@ -1,10 +1,11 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -55,7 +56,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListTLSDomains(input)
+	o, err := c.Globals.APIClient.ListTLSDomains(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter In Use":            c.filterInUse,

--- a/pkg/commands/tls/custom/privatekey/create.go
+++ b/pkg/commands/tls/custom/privatekey/create.go
@@ -1,12 +1,13 @@
 package privatekey
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -43,7 +44,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	r, err := c.Globals.APIClient.CreatePrivateKey(input)
+	r, err := c.Globals.APIClient.CreatePrivateKey(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Private Key Name": c.name,

--- a/pkg/commands/tls/custom/privatekey/delete.go
+++ b/pkg/commands/tls/custom/privatekey/delete.go
@@ -1,9 +1,10 @@
 package privatekey
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -33,7 +34,7 @@ type DeleteCommand struct {
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	err := c.Globals.APIClient.DeletePrivateKey(input)
+	err := c.Globals.APIClient.DeletePrivateKey(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Private Key ID": c.id,

--- a/pkg/commands/tls/custom/privatekey/describe.go
+++ b/pkg/commands/tls/custom/privatekey/describe.go
@@ -1,10 +1,11 @@
 package privatekey
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -42,7 +43,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.GetPrivateKey(input)
+	o, err := c.Globals.APIClient.GetPrivateKey(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Certificate ID": c.id,

--- a/pkg/commands/tls/custom/privatekey/list.go
+++ b/pkg/commands/tls/custom/privatekey/list.go
@@ -1,10 +1,11 @@
 package privatekey
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -45,7 +46,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListPrivateKeys(input)
+	o, err := c.Globals.APIClient.ListPrivateKeys(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter In Use": c.filterInUse,

--- a/pkg/commands/tls/custom/privatekey/privatekey_test.go
+++ b/pkg/commands/tls/custom/privatekey/privatekey_test.go
@@ -1,9 +1,10 @@
 package privatekey_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/privatekey"
@@ -41,7 +42,7 @@ func TestTLSCustomPrivateKeyCreate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				CreatePrivateKeyFn: func(i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
+				CreatePrivateKeyFn: func(_ context.Context, i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
 					content = i.Key
 					return nil, testutil.Err
 				},
@@ -53,7 +54,7 @@ func TestTLSCustomPrivateKeyCreate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				CreatePrivateKeyFn: func(i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
+				CreatePrivateKeyFn: func(_ context.Context, i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
 					content = i.Key
 					return &fastly.PrivateKey{
 						ID:   mockResponseID,
@@ -68,7 +69,7 @@ func TestTLSCustomPrivateKeyCreate(t *testing.T) {
 		{
 			Name: "validate custom key is submitted",
 			API: mock.API{
-				CreatePrivateKeyFn: func(i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
+				CreatePrivateKeyFn: func(_ context.Context, i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
 					content = i.Key
 					return &fastly.PrivateKey{
 						ID:   mockResponseID,
@@ -99,7 +100,7 @@ func TestTLSCustomPrivateKeyDelete(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				DeletePrivateKeyFn: func(_ *fastly.DeletePrivateKeyInput) error {
+				DeletePrivateKeyFn: func(_ context.Context, _ *fastly.DeletePrivateKeyInput) error {
 					return testutil.Err
 				},
 			},
@@ -109,7 +110,7 @@ func TestTLSCustomPrivateKeyDelete(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				DeletePrivateKeyFn: func(_ *fastly.DeletePrivateKeyInput) error {
+				DeletePrivateKeyFn: func(_ context.Context, _ *fastly.DeletePrivateKeyInput) error {
 					return nil
 				},
 			},
@@ -130,7 +131,7 @@ func TestTLSCustomPrivateKeyDescribe(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				GetPrivateKeyFn: func(_ *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error) {
+				GetPrivateKeyFn: func(_ context.Context, _ *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -140,7 +141,7 @@ func TestTLSCustomPrivateKeyDescribe(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				GetPrivateKeyFn: func(_ *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error) {
+				GetPrivateKeyFn: func(_ context.Context, _ *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error) {
 					t := testutil.Date
 					return &fastly.PrivateKey{
 						ID:            mockResponseID,
@@ -165,7 +166,7 @@ func TestTLSCustomPrivateKeyList(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				ListPrivateKeysFn: func(_ *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error) {
+				ListPrivateKeysFn: func(_ context.Context, _ *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -174,7 +175,7 @@ func TestTLSCustomPrivateKeyList(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				ListPrivateKeysFn: func(_ *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error) {
+				ListPrivateKeysFn: func(_ context.Context, _ *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error) {
 					t := testutil.Date
 					return []*fastly.PrivateKey{
 						{

--- a/pkg/commands/tls/platform/create.go
+++ b/pkg/commands/tls/platform/create.go
@@ -1,9 +1,10 @@
 package platform
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -41,7 +42,7 @@ type CreateCommand struct {
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.CreateBulkCertificate(input)
+	r, err := c.Globals.APIClient.CreateBulkCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Allow Untrusted": c.allowUntrusted.Value,

--- a/pkg/commands/tls/platform/delete.go
+++ b/pkg/commands/tls/platform/delete.go
@@ -1,9 +1,10 @@
 package platform
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -33,7 +34,7 @@ type DeleteCommand struct {
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	err := c.Globals.APIClient.DeleteBulkCertificate(input)
+	err := c.Globals.APIClient.DeleteBulkCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Bulk Certificate ID": c.id,

--- a/pkg/commands/tls/platform/describe.go
+++ b/pkg/commands/tls/platform/describe.go
@@ -1,10 +1,11 @@
 package platform
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -42,7 +43,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.GetBulkCertificate(input)
+	o, err := c.Globals.APIClient.GetBulkCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Bulk Certificate ID": c.id,

--- a/pkg/commands/tls/platform/list.go
+++ b/pkg/commands/tls/platform/list.go
@@ -1,10 +1,11 @@
 package platform
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -47,7 +48,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListBulkCertificates(input)
+	o, err := c.Globals.APIClient.ListBulkCertificates(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter TLS Domain ID": c.filterTLSDomainID,

--- a/pkg/commands/tls/platform/platform_test.go
+++ b/pkg/commands/tls/platform/platform_test.go
@@ -1,10 +1,11 @@
 package platform_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/platform"
 	"github.com/fastly/cli/pkg/mock"
@@ -33,7 +34,7 @@ func TestTLSPlatformUpload(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				CreateBulkCertificateFn: func(_ *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error) {
+				CreateBulkCertificateFn: func(_ context.Context, _ *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -43,7 +44,7 @@ func TestTLSPlatformUpload(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				CreateBulkCertificateFn: func(_ *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error) {
+				CreateBulkCertificateFn: func(_ context.Context, _ *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error) {
 					return &fastly.BulkCertificate{
 						ID: mockResponseID,
 					}, nil
@@ -66,7 +67,7 @@ func TestTLSPlatformDelete(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				DeleteBulkCertificateFn: func(_ *fastly.DeleteBulkCertificateInput) error {
+				DeleteBulkCertificateFn: func(_ context.Context, _ *fastly.DeleteBulkCertificateInput) error {
 					return testutil.Err
 				},
 			},
@@ -76,7 +77,7 @@ func TestTLSPlatformDelete(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				DeleteBulkCertificateFn: func(_ *fastly.DeleteBulkCertificateInput) error {
+				DeleteBulkCertificateFn: func(_ context.Context, _ *fastly.DeleteBulkCertificateInput) error {
 					return nil
 				},
 			},
@@ -97,7 +98,7 @@ func TestTLSPlatformDescribe(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				GetBulkCertificateFn: func(_ *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error) {
+				GetBulkCertificateFn: func(_ context.Context, _ *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -107,7 +108,7 @@ func TestTLSPlatformDescribe(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				GetBulkCertificateFn: func(_ *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error) {
+				GetBulkCertificateFn: func(_ context.Context, _ *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error) {
 					t := testutil.Date
 					return &fastly.BulkCertificate{
 						ID:        "123",
@@ -130,7 +131,7 @@ func TestTLSPlatformList(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				ListBulkCertificatesFn: func(_ *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error) {
+				ListBulkCertificatesFn: func(_ context.Context, _ *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -139,7 +140,7 @@ func TestTLSPlatformList(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				ListBulkCertificatesFn: func(_ *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error) {
+				ListBulkCertificatesFn: func(_ context.Context, _ *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error) {
 					t := testutil.Date
 					return []*fastly.BulkCertificate{
 						{
@@ -179,7 +180,7 @@ func TestTLSPlatformUpdate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				UpdateBulkCertificateFn: func(_ *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error) {
+				UpdateBulkCertificateFn: func(_ context.Context, _ *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -189,7 +190,7 @@ func TestTLSPlatformUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				UpdateBulkCertificateFn: func(_ *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error) {
+				UpdateBulkCertificateFn: func(_ context.Context, _ *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error) {
 					return &fastly.BulkCertificate{
 						ID: mockResponseID,
 					}, nil

--- a/pkg/commands/tls/platform/update.go
+++ b/pkg/commands/tls/platform/update.go
@@ -1,9 +1,10 @@
 package platform
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -55,7 +56,7 @@ type UpdateCommand struct {
 func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.UpdateBulkCertificate(input)
+	r, err := c.Globals.APIClient.UpdateBulkCertificate(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Bulk Certificate ID": c.id,

--- a/pkg/commands/tls/subscription/create.go
+++ b/pkg/commands/tls/subscription/create.go
@@ -1,9 +1,10 @@
 package subscription
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -45,7 +46,7 @@ type CreateCommand struct {
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.CreateTLSSubscription(input)
+	r, err := c.Globals.APIClient.CreateTLSSubscription(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Domains":               c.domains,

--- a/pkg/commands/tls/subscription/delete.go
+++ b/pkg/commands/tls/subscription/delete.go
@@ -1,9 +1,10 @@
 package subscription
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -37,7 +38,7 @@ type DeleteCommand struct {
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	err := c.Globals.APIClient.DeleteTLSSubscription(input)
+	err := c.Globals.APIClient.DeleteTLSSubscription(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Subscription ID": c.id,

--- a/pkg/commands/tls/subscription/describe.go
+++ b/pkg/commands/tls/subscription/describe.go
@@ -1,10 +1,11 @@
 package subscription
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -46,7 +47,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.GetTLSSubscription(input)
+	o, err := c.Globals.APIClient.GetTLSSubscription(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Subscription ID": c.id,

--- a/pkg/commands/tls/subscription/list.go
+++ b/pkg/commands/tls/subscription/list.go
@@ -1,10 +1,11 @@
 package subscription
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -55,7 +56,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListTLSSubscriptions(input)
+	o, err := c.Globals.APIClient.ListTLSSubscriptions(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Filter Active":        c.filterHasActiveOrder,

--- a/pkg/commands/tls/subscription/subscription_test.go
+++ b/pkg/commands/tls/subscription/subscription_test.go
@@ -1,10 +1,11 @@
 package subscription_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/subscription"
 	"github.com/fastly/cli/pkg/mock"
@@ -28,7 +29,7 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				CreateTLSSubscriptionFn: func(_ *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				CreateTLSSubscriptionFn: func(_ context.Context, _ *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -38,7 +39,7 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				CreateTLSSubscriptionFn: func(_ *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				CreateTLSSubscriptionFn: func(_ context.Context, _ *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return &fastly.TLSSubscription{
 						ID:                   mockResponseID,
 						CertificateAuthority: certificateAuthority,
@@ -54,7 +55,7 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 		{
 			Name: "validate cert-auth == certainly",
 			API: mock.API{
-				CreateTLSSubscriptionFn: func(i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				CreateTLSSubscriptionFn: func(_ context.Context, i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return &fastly.TLSSubscription{
 						ID:                   mockResponseID,
 						CertificateAuthority: i.CertificateAuthority,
@@ -68,7 +69,7 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 		{
 			Name: "validate cert-auth == lets-encrypt",
 			API: mock.API{
-				CreateTLSSubscriptionFn: func(i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				CreateTLSSubscriptionFn: func(_ context.Context, i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return &fastly.TLSSubscription{
 						ID:                   mockResponseID,
 						CertificateAuthority: i.CertificateAuthority,
@@ -82,7 +83,7 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 		{
 			Name: "validate cert-auth == globalsign",
 			API: mock.API{
-				CreateTLSSubscriptionFn: func(i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				CreateTLSSubscriptionFn: func(_ context.Context, i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return &fastly.TLSSubscription{
 						ID:                   mockResponseID,
 						CertificateAuthority: i.CertificateAuthority,
@@ -96,7 +97,7 @@ func TestTLSSubscriptionCreate(t *testing.T) {
 		{
 			Name: "validate cert-auth is invalid",
 			API: mock.API{
-				CreateTLSSubscriptionFn: func(i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				CreateTLSSubscriptionFn: func(_ context.Context, i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return &fastly.TLSSubscription{
 						ID:                   mockResponseID,
 						CertificateAuthority: i.CertificateAuthority,
@@ -121,7 +122,7 @@ func TestTLSSubscriptionDelete(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				DeleteTLSSubscriptionFn: func(_ *fastly.DeleteTLSSubscriptionInput) error {
+				DeleteTLSSubscriptionFn: func(_ context.Context, _ *fastly.DeleteTLSSubscriptionInput) error {
 					return testutil.Err
 				},
 			},
@@ -131,7 +132,7 @@ func TestTLSSubscriptionDelete(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				DeleteTLSSubscriptionFn: func(_ *fastly.DeleteTLSSubscriptionInput) error {
+				DeleteTLSSubscriptionFn: func(_ context.Context, _ *fastly.DeleteTLSSubscriptionInput) error {
 					return nil
 				},
 			},
@@ -152,7 +153,7 @@ func TestTLSSubscriptionDescribe(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				GetTLSSubscriptionFn: func(_ *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				GetTLSSubscriptionFn: func(_ context.Context, _ *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -162,7 +163,7 @@ func TestTLSSubscriptionDescribe(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				GetTLSSubscriptionFn: func(_ *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				GetTLSSubscriptionFn: func(_ context.Context, _ *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					t := testutil.Date
 					return &fastly.TLSSubscription{
 						ID:                   mockResponseID,
@@ -186,7 +187,7 @@ func TestTLSSubscriptionList(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				ListTLSSubscriptionsFn: func(_ *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error) {
+				ListTLSSubscriptionsFn: func(_ context.Context, _ *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -195,7 +196,7 @@ func TestTLSSubscriptionList(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				ListTLSSubscriptionsFn: func(_ *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error) {
+				ListTLSSubscriptionsFn: func(_ context.Context, _ *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error) {
 					t := testutil.Date
 					return []*fastly.TLSSubscription{
 						{
@@ -225,7 +226,7 @@ func TestTLSSubscriptionUpdate(t *testing.T) {
 		{
 			Name: validateAPIError,
 			API: mock.API{
-				UpdateTLSSubscriptionFn: func(_ *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				UpdateTLSSubscriptionFn: func(_ context.Context, _ *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -235,7 +236,7 @@ func TestTLSSubscriptionUpdate(t *testing.T) {
 		{
 			Name: validateAPISuccess,
 			API: mock.API{
-				UpdateTLSSubscriptionFn: func(_ *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+				UpdateTLSSubscriptionFn: func(_ context.Context, _ *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
 					return &fastly.TLSSubscription{
 						ID:                   mockResponseID,
 						CertificateAuthority: certificateAuthority,

--- a/pkg/commands/tls/subscription/update.go
+++ b/pkg/commands/tls/subscription/update.go
@@ -1,9 +1,10 @@
 package subscription
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -43,7 +44,7 @@ type UpdateCommand struct {
 func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.UpdateTLSSubscription(input)
+	r, err := c.Globals.APIClient.UpdateTLSSubscription(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"TLS Subscription ID": c.id,

--- a/pkg/commands/tools/domain/status.go
+++ b/pkg/commands/tools/domain/status.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -8,8 +9,9 @@ import (
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/status"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/status"
 )
 
 // GetDomainStatusCommand calls the Fastly API to check the availability of a domain name.
@@ -66,7 +68,7 @@ func (g *GetDomainStatusCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to acquire the Fastly API client")
 	}
 
-	st, err := status.Get(fc, input)
+	st, err := status.Get(context.TODO(), fc, input)
 	if err != nil {
 		g.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/tools/domain/status_test.go
+++ b/pkg/commands/tools/domain/status_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/fastly/cli/pkg/commands/tools"
 	"github.com/fastly/cli/pkg/commands/tools/domain"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/status"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/status"
 )
 
 func TestNewDomainsV1ToolsStatusCommand(t *testing.T) {

--- a/pkg/commands/tools/domain/suggest.go
+++ b/pkg/commands/tools/domain/suggest.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,8 +11,9 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/suggest"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/suggest"
 )
 
 // GetDomainSuggestionsCommand calls the Fastly API and results domain search results for a given query.
@@ -79,7 +81,7 @@ func (g *GetDomainSuggestionsCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to acquire the Fastly API client")
 	}
 
-	suggestions, err := suggest.Get(fc, input)
+	suggestions, err := suggest.Get(context.TODO(), fc, input)
 	if err != nil {
 		g.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/tools/domain/suggest_test.go
+++ b/pkg/commands/tools/domain/suggest_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/fastly/cli/pkg/commands/tools"
 	"github.com/fastly/cli/pkg/commands/tools/domain"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v10/fastly"
-	"github.com/fastly/go-fastly/v10/fastly/domains/v1/tools/suggest"
+	"github.com/fastly/go-fastly/v11/fastly"
+
+	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/suggest"
 )
 
 func TestNewDomainsV1ToolsSuggestCommand(t *testing.T) {

--- a/pkg/commands/user/create.go
+++ b/pkg/commands/user/create.go
@@ -1,9 +1,10 @@
 package user
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -39,7 +40,7 @@ type CreateCommand struct {
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	r, err := c.Globals.APIClient.CreateUser(input)
+	r, err := c.Globals.APIClient.CreateUser(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"User Login": c.login,

--- a/pkg/commands/user/delete.go
+++ b/pkg/commands/user/delete.go
@@ -1,9 +1,10 @@
 package user
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -30,7 +31,7 @@ type DeleteCommand struct {
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input := c.constructInput()
 
-	err := c.Globals.APIClient.DeleteUser(input)
+	err := c.Globals.APIClient.DeleteUser(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"User ID": c.id,

--- a/pkg/commands/user/describe.go
+++ b/pkg/commands/user/describe.go
@@ -1,10 +1,11 @@
 package user
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -38,7 +39,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	if c.current {
-		o, err := c.Globals.APIClient.GetCurrentUser()
+		o, err := c.Globals.APIClient.GetCurrentUser(context.TODO())
 		if err != nil {
 			c.Globals.ErrLog.Add(err)
 			return err
@@ -57,7 +58,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	o, err := c.Globals.APIClient.GetUser(input)
+	o, err := c.Globals.APIClient.GetUser(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.Add(err)
 		return err

--- a/pkg/commands/user/list.go
+++ b/pkg/commands/user/list.go
@@ -1,10 +1,11 @@
 package user
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -46,7 +47,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput()
 
-	o, err := c.Globals.APIClient.ListCustomerUsers(input)
+	o, err := c.Globals.APIClient.ListCustomerUsers(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Customer ID": c.customerID.Value,

--- a/pkg/commands/user/update.go
+++ b/pkg/commands/user/update.go
@@ -1,10 +1,11 @@
 package user
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -44,7 +45,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 			return err
 		}
 
-		err = c.Globals.APIClient.ResetUserPassword(input)
+		err = c.Globals.APIClient.ResetUserPassword(context.TODO(), input)
 		if err != nil {
 			return err
 		}
@@ -58,7 +59,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	r, err := c.Globals.APIClient.UpdateUser(input)
+	r, err := c.Globals.APIClient.UpdateUser(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"User ID": c.id,

--- a/pkg/commands/user/user_test.go
+++ b/pkg/commands/user/user_test.go
@@ -1,10 +1,11 @@
 package user_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/user"
 	"github.com/fastly/cli/pkg/mock"
@@ -16,7 +17,7 @@ func TestUserCreate(t *testing.T) {
 		{
 			Name: "validate CreateUser API error",
 			API: mock.API{
-				CreateUserFn: func(_ *fastly.CreateUserInput) (*fastly.User, error) {
+				CreateUserFn: func(_ context.Context, _ *fastly.CreateUserInput) (*fastly.User, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -26,7 +27,7 @@ func TestUserCreate(t *testing.T) {
 		{
 			Name: "validate CreateUser API success",
 			API: mock.API{
-				CreateUserFn: func(i *fastly.CreateUserInput) (*fastly.User, error) {
+				CreateUserFn: func(_ context.Context, i *fastly.CreateUserInput) (*fastly.User, error) {
 					return &fastly.User{
 						Name: i.Name,
 						Role: fastly.ToPointer("user"),
@@ -50,7 +51,7 @@ func TestUserDelete(t *testing.T) {
 		{
 			Name: "validate DeleteUser API error",
 			API: mock.API{
-				DeleteUserFn: func(_ *fastly.DeleteUserInput) error {
+				DeleteUserFn: func(_ context.Context, _ *fastly.DeleteUserInput) error {
 					return testutil.Err
 				},
 			},
@@ -60,7 +61,7 @@ func TestUserDelete(t *testing.T) {
 		{
 			Name: "validate DeleteUser API success",
 			API: mock.API{
-				DeleteUserFn: func(_ *fastly.DeleteUserInput) error {
+				DeleteUserFn: func(_ context.Context, _ *fastly.DeleteUserInput) error {
 					return nil
 				},
 			},
@@ -81,7 +82,7 @@ func TestUserDescribe(t *testing.T) {
 		{
 			Name: "validate GetUser API error",
 			API: mock.API{
-				GetUserFn: func(_ *fastly.GetUserInput) (*fastly.User, error) {
+				GetUserFn: func(_ context.Context, _ *fastly.GetUserInput) (*fastly.User, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -91,7 +92,7 @@ func TestUserDescribe(t *testing.T) {
 		{
 			Name: "validate GetCurrentUser API error",
 			API: mock.API{
-				GetCurrentUserFn: func() (*fastly.User, error) {
+				GetCurrentUserFn: func(_ context.Context) (*fastly.User, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -128,7 +129,7 @@ func TestUserList(t *testing.T) {
 		{
 			Name: "validate ListUsers API error",
 			API: mock.API{
-				ListCustomerUsersFn: func(_ *fastly.ListCustomerUsersInput) ([]*fastly.User, error) {
+				ListCustomerUsersFn: func(_ context.Context, _ *fastly.ListCustomerUsersInput) ([]*fastly.User, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -180,7 +181,7 @@ func TestUserUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateUser API error",
 			API: mock.API{
-				UpdateUserFn: func(_ *fastly.UpdateUserInput) (*fastly.User, error) {
+				UpdateUserFn: func(_ context.Context, _ *fastly.UpdateUserInput) (*fastly.User, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -190,7 +191,7 @@ func TestUserUpdate(t *testing.T) {
 		{
 			Name: "validate ResetUserPassword API error",
 			API: mock.API{
-				ResetUserPasswordFn: func(_ *fastly.ResetUserPasswordInput) error {
+				ResetUserPasswordFn: func(_ context.Context, _ *fastly.ResetUserPasswordInput) error {
 					return testutil.Err
 				},
 			},
@@ -200,7 +201,7 @@ func TestUserUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateUser API success",
 			API: mock.API{
-				UpdateUserFn: func(i *fastly.UpdateUserInput) (*fastly.User, error) {
+				UpdateUserFn: func(_ context.Context, i *fastly.UpdateUserInput) (*fastly.User, error) {
 					return &fastly.User{
 						UserID: fastly.ToPointer(i.UserID),
 						Name:   i.Name,
@@ -214,7 +215,7 @@ func TestUserUpdate(t *testing.T) {
 		{
 			Name: "validate ResetUserPassword API success",
 			API: mock.API{
-				ResetUserPasswordFn: func(_ *fastly.ResetUserPasswordInput) error {
+				ResetUserPasswordFn: func(_ context.Context, _ *fastly.ResetUserPasswordInput) error {
 					return nil
 				},
 			},
@@ -226,7 +227,7 @@ func TestUserUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "update"}, scenarios)
 }
 
-func getUser(i *fastly.GetUserInput) (*fastly.User, error) {
+func getUser(_ context.Context, i *fastly.GetUserInput) (*fastly.User, error) {
 	t := testutil.Date
 
 	return &fastly.User{
@@ -247,7 +248,7 @@ func getUser(i *fastly.GetUserInput) (*fastly.User, error) {
 	}, nil
 }
 
-func getCurrentUser() (*fastly.User, error) {
+func getCurrentUser(_ context.Context) (*fastly.User, error) {
 	t := testutil.Date
 
 	return &fastly.User{
@@ -268,9 +269,9 @@ func getCurrentUser() (*fastly.User, error) {
 	}, nil
 }
 
-func listUsers(_ *fastly.ListCustomerUsersInput) ([]*fastly.User, error) {
-	user, _ := getUser(&fastly.GetUserInput{UserID: "123"})
-	userCurrent, _ := getCurrentUser()
+func listUsers(ctx context.Context, _ *fastly.ListCustomerUsersInput) ([]*fastly.User, error) {
+	user, _ := getUser(ctx, &fastly.GetUserInput{UserID: "123"})
+	userCurrent, _ := getCurrentUser(ctx)
 	vs := []*fastly.User{
 		user,
 		userCurrent,

--- a/pkg/commands/vcl/condition/condition_test.go
+++ b/pkg/commands/vcl/condition/condition_test.go
@@ -1,11 +1,12 @@
 package condition_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	sub "github.com/fastly/cli/pkg/commands/vcl/condition"
@@ -227,7 +228,7 @@ Version: 1
 
 var errTest = errors.New("fixture error")
 
-func createConditionOK(i *fastly.CreateConditionInput) (*fastly.Condition, error) {
+func createConditionOK(_ context.Context, i *fastly.CreateConditionInput) (*fastly.Condition, error) {
 	priority := 10
 	if i.Priority != nil {
 		priority = *i.Priority
@@ -248,19 +249,19 @@ func createConditionOK(i *fastly.CreateConditionInput) (*fastly.Condition, error
 	}, nil
 }
 
-func createConditionError(_ *fastly.CreateConditionInput) (*fastly.Condition, error) {
+func createConditionError(_ context.Context, _ *fastly.CreateConditionInput) (*fastly.Condition, error) {
 	return nil, errTest
 }
 
-func deleteConditionOK(_ *fastly.DeleteConditionInput) error {
+func deleteConditionOK(_ context.Context, _ *fastly.DeleteConditionInput) error {
 	return nil
 }
 
-func deleteConditionError(_ *fastly.DeleteConditionInput) error {
+func deleteConditionError(_ context.Context, _ *fastly.DeleteConditionInput) error {
 	return errTest
 }
 
-func updateConditionOK(i *fastly.UpdateConditionInput) (*fastly.Condition, error) {
+func updateConditionOK(_ context.Context, i *fastly.UpdateConditionInput) (*fastly.Condition, error) {
 	priority := 10
 	if i.Priority != nil {
 		priority = *i.Priority
@@ -286,11 +287,11 @@ func updateConditionOK(i *fastly.UpdateConditionInput) (*fastly.Condition, error
 	}, nil
 }
 
-func updateConditionError(_ *fastly.UpdateConditionInput) (*fastly.Condition, error) {
+func updateConditionError(_ context.Context, _ *fastly.UpdateConditionInput) (*fastly.Condition, error) {
 	return nil, errTest
 }
 
-func getConditionOK(i *fastly.GetConditionInput) (*fastly.Condition, error) {
+func getConditionOK(_ context.Context, i *fastly.GetConditionInput) (*fastly.Condition, error) {
 	priority := 10
 	conditionType := "CACHE"
 	statement := "false"
@@ -305,11 +306,11 @@ func getConditionOK(i *fastly.GetConditionInput) (*fastly.Condition, error) {
 	}, nil
 }
 
-func getConditionError(_ *fastly.GetConditionInput) (*fastly.Condition, error) {
+func getConditionError(_ context.Context, _ *fastly.GetConditionInput) (*fastly.Condition, error) {
 	return nil, errTest
 }
 
-func listConditionsOK(i *fastly.ListConditionsInput) ([]*fastly.Condition, error) {
+func listConditionsOK(_ context.Context, i *fastly.ListConditionsInput) ([]*fastly.Condition, error) {
 	return []*fastly.Condition{
 		{
 			ServiceID:      fastly.ToPointer(i.ServiceID),
@@ -330,6 +331,6 @@ func listConditionsOK(i *fastly.ListConditionsInput) ([]*fastly.Condition, error
 	}, nil
 }
 
-func listConditionsError(_ *fastly.ListConditionsInput) ([]*fastly.Condition, error) {
+func listConditionsError(_ context.Context, _ *fastly.ListConditionsInput) ([]*fastly.Condition, error) {
 	return nil, errTest
 }

--- a/pkg/commands/vcl/condition/create.go
+++ b/pkg/commands/vcl/condition/create.go
@@ -1,9 +1,10 @@
 package condition
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -113,7 +114,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if c.priority.WasSet {
 		input.Priority = &c.priority.Value
 	}
-	r, err := c.Globals.APIClient.CreateCondition(&input)
+	r, err := c.Globals.APIClient.CreateCondition(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/condition/delete.go
+++ b/pkg/commands/vcl/condition/delete.go
@@ -1,9 +1,10 @@
 package condition
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -87,7 +88,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 	input.Name = c.name
 
-	if err := c.Globals.APIClient.DeleteCondition(&input); err != nil {
+	if err := c.Globals.APIClient.DeleteCondition(context.TODO(), &input); err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,
 			"Service Version": fastly.ToValue(serviceVersion.Number),

--- a/pkg/commands/vcl/condition/describe.go
+++ b/pkg/commands/vcl/condition/describe.go
@@ -1,10 +1,11 @@
 package condition
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 	input.Name = c.name
 
-	r, err := c.Globals.APIClient.GetCondition(&input)
+	r, err := c.Globals.APIClient.GetCondition(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/condition/list.go
+++ b/pkg/commands/vcl/condition/list.go
@@ -1,10 +1,11 @@
 package condition
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"
@@ -79,7 +80,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	input.ServiceID = serviceID
 	input.ServiceVersion = fastly.ToValue(serviceVersion.Number)
 
-	o, err := c.Globals.APIClient.ListConditions(&input)
+	o, err := c.Globals.APIClient.ListConditions(context.TODO(), &input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/condition/update.go
+++ b/pkg/commands/vcl/condition/update.go
@@ -1,10 +1,11 @@
 package condition
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -116,7 +117,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		c.input.Statement = &c.comment.Value
 	}
 
-	r, err := c.Globals.APIClient.UpdateCondition(&c.input)
+	r, err := c.Globals.APIClient.UpdateCondition(context.TODO(), &c.input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/custom/create.go
+++ b/pkg/commands/vcl/custom/create.go
@@ -1,9 +1,10 @@
 package custom
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -89,7 +90,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	v, err := c.Globals.APIClient.CreateVCL(input)
+	v, err := c.Globals.APIClient.CreateVCL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/custom/custom_test.go
+++ b/pkg/commands/vcl/custom/custom_test.go
@@ -1,9 +1,10 @@
 package custom_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	sub "github.com/fastly/cli/pkg/commands/vcl/custom"
@@ -34,7 +35,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			Name: "validate CreateVCL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateVCLFn: func(_ *fastly.CreateVCLInput) (*fastly.VCL, error) {
+				CreateVCLFn: func(_ context.Context, _ *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -45,7 +46,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			Name: "validate CreateVCL API success for non-main VCL",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateVCLFn: func(i *fastly.CreateVCLInput) (*fastly.VCL, error) {
+				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -75,7 +76,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			Name: "validate CreateVCL API success for main VCL",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateVCLFn: func(i *fastly.CreateVCLInput) (*fastly.VCL, error) {
+				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					// Track the contents parsed
 					content = *i.Content
@@ -107,7 +108,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				CreateVCLFn: func(i *fastly.CreateVCLInput) (*fastly.VCL, error) {
+				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -137,7 +138,7 @@ func TestVCLCustomCreate(t *testing.T) {
 			Name: "validate CreateVCL API success with inline VCL content",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateVCLFn: func(i *fastly.CreateVCLInput) (*fastly.VCL, error) {
+				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -205,7 +206,7 @@ func TestVCLCustomDelete(t *testing.T) {
 			Name: "validate DeleteVCL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteVCLFn: func(_ *fastly.DeleteVCLInput) error {
+				DeleteVCLFn: func(_ context.Context, _ *fastly.DeleteVCLInput) error {
 					return testutil.Err
 				},
 			},
@@ -216,7 +217,7 @@ func TestVCLCustomDelete(t *testing.T) {
 			Name: "validate DeleteVCL API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteVCLFn: func(_ *fastly.DeleteVCLInput) error {
+				DeleteVCLFn: func(_ context.Context, _ *fastly.DeleteVCLInput) error {
 					return nil
 				},
 			},
@@ -228,7 +229,7 @@ func TestVCLCustomDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				DeleteVCLFn: func(_ *fastly.DeleteVCLInput) error {
+				DeleteVCLFn: func(_ context.Context, _ *fastly.DeleteVCLInput) error {
 					return nil
 				},
 			},
@@ -261,7 +262,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 			Name: "validate GetVCL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				GetVCLFn: func(_ *fastly.GetVCLInput) (*fastly.VCL, error) {
+				GetVCLFn: func(_ context.Context, _ *fastly.GetVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -306,7 +307,7 @@ func TestVCLCustomList(t *testing.T) {
 			Name: "validate ListVCLs API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				ListVCLsFn: func(_ *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
+				ListVCLsFn: func(_ context.Context, _ *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -383,7 +384,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			Name: "validate UpdateVCL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateVCLFn: func(_ *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+				UpdateVCLFn: func(_ context.Context, _ *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -394,7 +395,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			Name: "validate UpdateVCL API success with --new-name",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateVCLFn: func(i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					return &fastly.VCL{
 						Content:        fastly.ToPointer("# untouched"),
 						Main:           fastly.ToPointer(true),
@@ -411,7 +412,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			Name: "validate UpdateVCL API success with --content",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateVCLFn: func(i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
 
@@ -433,7 +434,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				UpdateVCLFn: func(i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
 
@@ -455,7 +456,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
-func getVCL(i *fastly.GetVCLInput) (*fastly.VCL, error) {
+func getVCL(_ context.Context, i *fastly.GetVCLInput) (*fastly.VCL, error) {
 	t := testutil.Date
 
 	return &fastly.VCL{
@@ -471,7 +472,7 @@ func getVCL(i *fastly.GetVCLInput) (*fastly.VCL, error) {
 	}, nil
 }
 
-func listVCLs(i *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
+func listVCLs(_ context.Context, i *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
 	t := testutil.Date
 	vs := []*fastly.VCL{
 		{

--- a/pkg/commands/vcl/custom/delete.go
+++ b/pkg/commands/vcl/custom/delete.go
@@ -1,9 +1,10 @@
 package custom
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -85,7 +86,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	err = c.Globals.APIClient.DeleteVCL(input)
+	err = c.Globals.APIClient.DeleteVCL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/custom/describe.go
+++ b/pkg/commands/vcl/custom/describe.go
@@ -1,10 +1,11 @@
 package custom
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -81,7 +82,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.GetVCL(input)
+	o, err := c.Globals.APIClient.GetVCL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/custom/list.go
+++ b/pkg/commands/vcl/custom/list.go
@@ -1,10 +1,11 @@
 package custom
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -80,7 +81,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.ListVCLs(input)
+	o, err := c.Globals.APIClient.ListVCLs(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/custom/update.go
+++ b/pkg/commands/vcl/custom/update.go
@@ -1,10 +1,11 @@
 package custom
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -97,7 +98,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	v, err := c.Globals.APIClient.UpdateVCL(input)
+	v, err := c.Globals.APIClient.UpdateVCL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/describe.go
+++ b/pkg/commands/vcl/describe.go
@@ -1,10 +1,11 @@
 package vcl
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -79,7 +80,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.GetGeneratedVCL(input)
+	o, err := c.Globals.APIClient.GetGeneratedVCL(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/snippet/create.go
+++ b/pkg/commands/vcl/snippet/create.go
@@ -1,9 +1,10 @@
 package snippet
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -97,7 +98,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	v, err := c.Globals.APIClient.CreateSnippet(input)
+	v, err := c.Globals.APIClient.CreateSnippet(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/snippet/delete.go
+++ b/pkg/commands/vcl/snippet/delete.go
@@ -1,9 +1,10 @@
 package snippet
 
 import (
+	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -85,7 +86,7 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	err = c.Globals.APIClient.DeleteSnippet(input)
+	err = c.Globals.APIClient.DeleteSnippet(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/snippet/describe.go
+++ b/pkg/commands/vcl/snippet/describe.go
@@ -1,10 +1,11 @@
 package snippet
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -95,7 +96,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 			return err
 		}
 
-		o, err := c.Globals.APIClient.GetDynamicSnippet(input)
+		o, err := c.Globals.APIClient.GetDynamicSnippet(context.TODO(), input)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Service ID":      serviceID,
@@ -120,7 +121,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	o, err := c.Globals.APIClient.GetSnippet(input)
+	o, err := c.Globals.APIClient.GetSnippet(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/snippet/list.go
+++ b/pkg/commands/vcl/snippet/list.go
@@ -1,10 +1,11 @@
 package snippet
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -80,7 +81,7 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	input := c.constructInput(serviceID, fastly.ToValue(serviceVersion.Number))
 
-	o, err := c.Globals.APIClient.ListSnippets(input)
+	o, err := c.Globals.APIClient.ListSnippets(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -1,9 +1,10 @@
 package snippet_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	sub "github.com/fastly/cli/pkg/commands/vcl/snippet"
@@ -39,7 +40,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			Name: "validate CreateSnippet API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateSnippetFn: func(_ *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+				CreateSnippetFn: func(_ context.Context, _ *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -50,7 +51,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			Name: "validate CreateSnippet API success for versioned Snippet",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -84,7 +85,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			Name: "validate CreateSnippet API success for dynamic Snippet",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -118,7 +119,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			Name: "validate Priority set",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -153,7 +154,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -187,7 +188,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 			Name: "validate CreateSnippet API success with inline Snippet content",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				CreateSnippetFn: func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 					if i.Content == nil {
@@ -259,7 +260,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 			Name: "validate DeleteSnippet API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteSnippetFn: func(_ *fastly.DeleteSnippetInput) error {
+				DeleteSnippetFn: func(_ context.Context, _ *fastly.DeleteSnippetInput) error {
 					return testutil.Err
 				},
 			},
@@ -270,7 +271,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 			Name: "validate DeleteSnippet API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				DeleteSnippetFn: func(_ *fastly.DeleteSnippetInput) error {
+				DeleteSnippetFn: func(_ context.Context, _ *fastly.DeleteSnippetInput) error {
 					return nil
 				},
 			},
@@ -282,7 +283,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				DeleteSnippetFn: func(_ *fastly.DeleteSnippetInput) error {
+				DeleteSnippetFn: func(_ context.Context, _ *fastly.DeleteSnippetInput) error {
 					return nil
 				},
 			},
@@ -325,7 +326,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 			Name: "validate GetSnippet API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				GetSnippetFn: func(_ *fastly.GetSnippetInput) (*fastly.Snippet, error) {
+				GetSnippetFn: func(_ context.Context, _ *fastly.GetSnippetInput) (*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -379,7 +380,7 @@ func TestVCLSnippetList(t *testing.T) {
 			Name: "validate ListSnippets API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				ListSnippetsFn: func(_ *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
+				ListSnippetsFn: func(_ context.Context, _ *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -482,7 +483,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			Name: "validate UpdateSnippet API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateSnippetFn: func(_ *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+				UpdateSnippetFn: func(_ context.Context, _ *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -493,7 +494,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			Name: "validate UpdateSnippet API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateSnippetFn: func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 
@@ -515,7 +516,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			Name: "validate UpdateDynamicSnippet API success",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				UpdateDynamicSnippetFn: func(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+				UpdateDynamicSnippetFn: func(_ context.Context, i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 
@@ -535,7 +536,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
 				CloneVersionFn: testutil.CloneVersionResult(4),
-				UpdateSnippetFn: func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
 
@@ -558,7 +559,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
 }
 
-func getSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
+func getSnippet(_ context.Context, i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
 	t := testutil.Date
 
 	return &fastly.Snippet{
@@ -577,7 +578,7 @@ func getSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
 	}, nil
 }
 
-func getDynamicSnippet(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+func getDynamicSnippet(_ context.Context, i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
 	t := testutil.Date
 
 	return &fastly.DynamicSnippet{
@@ -590,7 +591,7 @@ func getDynamicSnippet(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet
 	}, nil
 }
 
-func listSnippets(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
+func listSnippets(_ context.Context, i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
 	t := testutil.Date
 	vs := []*fastly.Snippet{
 		{

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -1,10 +1,11 @@
 package snippet
 
 import (
+	"context"
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"4d63.com/optional"
 
@@ -119,7 +120,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 			})
 			return err
 		}
-		v, err := c.Globals.APIClient.UpdateDynamicSnippet(input)
+		v, err := c.Globals.APIClient.UpdateDynamicSnippet(context.TODO(), input)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Service ID":      serviceID,
@@ -139,7 +140,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		})
 		return err
 	}
-	v, err := c.Globals.APIClient.UpdateSnippet(input)
+	v, err := c.Globals.APIClient.UpdateSnippet(context.TODO(), input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Service ID":      serviceID,

--- a/pkg/commands/vcl/vcl_test.go
+++ b/pkg/commands/vcl/vcl_test.go
@@ -1,9 +1,10 @@
 package vcl_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	"github.com/fastly/cli/pkg/mock"
@@ -25,7 +26,7 @@ func TestVCLDescribe(t *testing.T) {
 			Name: "validate DescribeVCL API error",
 			API: mock.API{
 				ListVersionsFn: testutil.ListVersions,
-				GetGeneratedVCLFn: func(_ *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+				GetGeneratedVCLFn: func(_ context.Context, _ *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
 			},
@@ -55,7 +56,7 @@ func TestVCLDescribe(t *testing.T) {
 	testutil.RunCLIScenarios(t, []string{root.CommandName, "describe"}, scenarios)
 }
 
-func getVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+func getVCL(_ context.Context, i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
 	t := testutil.Date
 
 	return &fastly.VCL{

--- a/pkg/errors/deduce.go
+++ b/pkg/errors/deduce.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // Deduce attempts to deduce a RemediationError from a plain error. If the error

--- a/pkg/errors/deduce_test.go
+++ b/pkg/errors/deduce_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 func TestDeduce(t *testing.T) {

--- a/pkg/errors/log.go
+++ b/pkg/errors/log.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // LogPath is the location of the fastly CLI error log.

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -1,2064 +1,2046 @@
 package mock
 
 import (
+	"context"
 	"crypto/ed25519"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // API is a mock implementation of api.Interface that's used for testing.
 // The zero value is useful, but will panic on all methods. Provide function
 // implementations for the method(s) your test will call.
 type API struct {
-	AllDatacentersFn func() (datacenters []fastly.Datacenter, err error)
-	AllIPsFn         func() (v4, v6 fastly.IPAddrs, err error)
-
-	CreateServiceFn     func(*fastly.CreateServiceInput) (*fastly.Service, error)
-	GetServicesFn       func(*fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service]
-	ListServicesFn      func(*fastly.ListServicesInput) ([]*fastly.Service, error)
-	GetServiceFn        func(*fastly.GetServiceInput) (*fastly.Service, error)
-	GetServiceDetailsFn func(*fastly.GetServiceInput) (*fastly.ServiceDetail, error)
-	UpdateServiceFn     func(*fastly.UpdateServiceInput) (*fastly.Service, error)
-	DeleteServiceFn     func(*fastly.DeleteServiceInput) error
-	SearchServiceFn     func(*fastly.SearchServiceInput) (*fastly.Service, error)
-
-	CloneVersionFn      func(*fastly.CloneVersionInput) (*fastly.Version, error)
-	ListVersionsFn      func(*fastly.ListVersionsInput) ([]*fastly.Version, error)
-	GetVersionFn        func(*fastly.GetVersionInput) (*fastly.Version, error)
-	UpdateVersionFn     func(*fastly.UpdateVersionInput) (*fastly.Version, error)
-	ActivateVersionFn   func(*fastly.ActivateVersionInput) (*fastly.Version, error)
-	DeactivateVersionFn func(*fastly.DeactivateVersionInput) (*fastly.Version, error)
-	LockVersionFn       func(*fastly.LockVersionInput) (*fastly.Version, error)
-	LatestVersionFn     func(*fastly.LatestVersionInput) (*fastly.Version, error)
-
-	CreateDomainFn       func(*fastly.CreateDomainInput) (*fastly.Domain, error)
-	ListDomainsFn        func(*fastly.ListDomainsInput) ([]*fastly.Domain, error)
-	GetDomainFn          func(*fastly.GetDomainInput) (*fastly.Domain, error)
-	UpdateDomainFn       func(*fastly.UpdateDomainInput) (*fastly.Domain, error)
-	DeleteDomainFn       func(*fastly.DeleteDomainInput) error
-	ValidateDomainFn     func(i *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error)
-	ValidateAllDomainsFn func(i *fastly.ValidateAllDomainsInput) (results []*fastly.DomainValidationResult, err error)
-
-	CreateBackendFn func(*fastly.CreateBackendInput) (*fastly.Backend, error)
-	ListBackendsFn  func(*fastly.ListBackendsInput) ([]*fastly.Backend, error)
-	GetBackendFn    func(*fastly.GetBackendInput) (*fastly.Backend, error)
-	UpdateBackendFn func(*fastly.UpdateBackendInput) (*fastly.Backend, error)
-	DeleteBackendFn func(*fastly.DeleteBackendInput) error
-
-	CreateHealthCheckFn func(*fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error)
-	ListHealthChecksFn  func(*fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error)
-	GetHealthCheckFn    func(*fastly.GetHealthCheckInput) (*fastly.HealthCheck, error)
-	UpdateHealthCheckFn func(*fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
-	DeleteHealthCheckFn func(*fastly.DeleteHealthCheckInput) error
-
-	GetPackageFn    func(*fastly.GetPackageInput) (*fastly.Package, error)
-	UpdatePackageFn func(*fastly.UpdatePackageInput) (*fastly.Package, error)
-
-	CreateDictionaryFn func(*fastly.CreateDictionaryInput) (*fastly.Dictionary, error)
-	GetDictionaryFn    func(*fastly.GetDictionaryInput) (*fastly.Dictionary, error)
-	DeleteDictionaryFn func(*fastly.DeleteDictionaryInput) error
-	ListDictionariesFn func(*fastly.ListDictionariesInput) ([]*fastly.Dictionary, error)
-	UpdateDictionaryFn func(*fastly.UpdateDictionaryInput) (*fastly.Dictionary, error)
-
-	GetDictionaryItemsFn         func(*fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem]
-	ListDictionaryItemsFn        func(*fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error)
-	GetDictionaryItemFn          func(*fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error)
-	CreateDictionaryItemFn       func(*fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error)
-	UpdateDictionaryItemFn       func(*fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error)
-	DeleteDictionaryItemFn       func(*fastly.DeleteDictionaryItemInput) error
-	BatchModifyDictionaryItemsFn func(*fastly.BatchModifyDictionaryItemsInput) error
-
-	GetDictionaryInfoFn func(*fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error)
-
-	CreateBigQueryFn func(*fastly.CreateBigQueryInput) (*fastly.BigQuery, error)
-	ListBigQueriesFn func(*fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error)
-	GetBigQueryFn    func(*fastly.GetBigQueryInput) (*fastly.BigQuery, error)
-	UpdateBigQueryFn func(*fastly.UpdateBigQueryInput) (*fastly.BigQuery, error)
-	DeleteBigQueryFn func(*fastly.DeleteBigQueryInput) error
-
-	CreateS3Fn func(*fastly.CreateS3Input) (*fastly.S3, error)
-	ListS3sFn  func(*fastly.ListS3sInput) ([]*fastly.S3, error)
-	GetS3Fn    func(*fastly.GetS3Input) (*fastly.S3, error)
-	UpdateS3Fn func(*fastly.UpdateS3Input) (*fastly.S3, error)
-	DeleteS3Fn func(*fastly.DeleteS3Input) error
-
-	CreateKinesisFn func(*fastly.CreateKinesisInput) (*fastly.Kinesis, error)
-	ListKinesisFn   func(*fastly.ListKinesisInput) ([]*fastly.Kinesis, error)
-	GetKinesisFn    func(*fastly.GetKinesisInput) (*fastly.Kinesis, error)
-	UpdateKinesisFn func(*fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
-	DeleteKinesisFn func(*fastly.DeleteKinesisInput) error
-
-	CreateSyslogFn func(*fastly.CreateSyslogInput) (*fastly.Syslog, error)
-	ListSyslogsFn  func(*fastly.ListSyslogsInput) ([]*fastly.Syslog, error)
-	GetSyslogFn    func(*fastly.GetSyslogInput) (*fastly.Syslog, error)
-	UpdateSyslogFn func(*fastly.UpdateSyslogInput) (*fastly.Syslog, error)
-	DeleteSyslogFn func(*fastly.DeleteSyslogInput) error
-
-	CreateLogentriesFn func(*fastly.CreateLogentriesInput) (*fastly.Logentries, error)
-	ListLogentriesFn   func(*fastly.ListLogentriesInput) ([]*fastly.Logentries, error)
-	GetLogentriesFn    func(*fastly.GetLogentriesInput) (*fastly.Logentries, error)
-	UpdateLogentriesFn func(*fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
-	DeleteLogentriesFn func(*fastly.DeleteLogentriesInput) error
-
-	CreatePapertrailFn func(*fastly.CreatePapertrailInput) (*fastly.Papertrail, error)
-	ListPapertrailsFn  func(*fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error)
-	GetPapertrailFn    func(*fastly.GetPapertrailInput) (*fastly.Papertrail, error)
-	UpdatePapertrailFn func(*fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
-	DeletePapertrailFn func(*fastly.DeletePapertrailInput) error
-
-	CreateSumologicFn func(*fastly.CreateSumologicInput) (*fastly.Sumologic, error)
-	ListSumologicsFn  func(*fastly.ListSumologicsInput) ([]*fastly.Sumologic, error)
-	GetSumologicFn    func(*fastly.GetSumologicInput) (*fastly.Sumologic, error)
-	UpdateSumologicFn func(*fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
-	DeleteSumologicFn func(*fastly.DeleteSumologicInput) error
-
-	CreateGCSFn func(*fastly.CreateGCSInput) (*fastly.GCS, error)
-	ListGCSsFn  func(*fastly.ListGCSsInput) ([]*fastly.GCS, error)
-	GetGCSFn    func(*fastly.GetGCSInput) (*fastly.GCS, error)
-	UpdateGCSFn func(*fastly.UpdateGCSInput) (*fastly.GCS, error)
-	DeleteGCSFn func(*fastly.DeleteGCSInput) error
-
-	CreateGrafanaCloudLogsFn func(*fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
-	ListGrafanaCloudLogsFn   func(*fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error)
-	GetGrafanaCloudLogsFn    func(*fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
-	UpdateGrafanaCloudLogsFn func(*fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
-	DeleteGrafanaCloudLogsFn func(*fastly.DeleteGrafanaCloudLogsInput) error
-
-	CreateFTPFn func(*fastly.CreateFTPInput) (*fastly.FTP, error)
-	ListFTPsFn  func(*fastly.ListFTPsInput) ([]*fastly.FTP, error)
-	GetFTPFn    func(*fastly.GetFTPInput) (*fastly.FTP, error)
-	UpdateFTPFn func(*fastly.UpdateFTPInput) (*fastly.FTP, error)
-	DeleteFTPFn func(*fastly.DeleteFTPInput) error
-
-	CreateSplunkFn func(*fastly.CreateSplunkInput) (*fastly.Splunk, error)
-	ListSplunksFn  func(*fastly.ListSplunksInput) ([]*fastly.Splunk, error)
-	GetSplunkFn    func(*fastly.GetSplunkInput) (*fastly.Splunk, error)
-	UpdateSplunkFn func(*fastly.UpdateSplunkInput) (*fastly.Splunk, error)
-	DeleteSplunkFn func(*fastly.DeleteSplunkInput) error
-
-	CreateScalyrFn func(*fastly.CreateScalyrInput) (*fastly.Scalyr, error)
-	ListScalyrsFn  func(*fastly.ListScalyrsInput) ([]*fastly.Scalyr, error)
-	GetScalyrFn    func(*fastly.GetScalyrInput) (*fastly.Scalyr, error)
-	UpdateScalyrFn func(*fastly.UpdateScalyrInput) (*fastly.Scalyr, error)
-	DeleteScalyrFn func(*fastly.DeleteScalyrInput) error
-
-	CreateLogglyFn func(*fastly.CreateLogglyInput) (*fastly.Loggly, error)
-	ListLogglyFn   func(*fastly.ListLogglyInput) ([]*fastly.Loggly, error)
-	GetLogglyFn    func(*fastly.GetLogglyInput) (*fastly.Loggly, error)
-	UpdateLogglyFn func(*fastly.UpdateLogglyInput) (*fastly.Loggly, error)
-	DeleteLogglyFn func(*fastly.DeleteLogglyInput) error
-
-	CreateHoneycombFn func(*fastly.CreateHoneycombInput) (*fastly.Honeycomb, error)
-	ListHoneycombsFn  func(*fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error)
-	GetHoneycombFn    func(*fastly.GetHoneycombInput) (*fastly.Honeycomb, error)
-	UpdateHoneycombFn func(*fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error)
-	DeleteHoneycombFn func(*fastly.DeleteHoneycombInput) error
-
-	CreateHerokuFn func(*fastly.CreateHerokuInput) (*fastly.Heroku, error)
-	ListHerokusFn  func(*fastly.ListHerokusInput) ([]*fastly.Heroku, error)
-	GetHerokuFn    func(*fastly.GetHerokuInput) (*fastly.Heroku, error)
-	UpdateHerokuFn func(*fastly.UpdateHerokuInput) (*fastly.Heroku, error)
-	DeleteHerokuFn func(*fastly.DeleteHerokuInput) error
-
-	CreateSFTPFn func(*fastly.CreateSFTPInput) (*fastly.SFTP, error)
-	ListSFTPsFn  func(*fastly.ListSFTPsInput) ([]*fastly.SFTP, error)
-	GetSFTPFn    func(*fastly.GetSFTPInput) (*fastly.SFTP, error)
-	UpdateSFTPFn func(*fastly.UpdateSFTPInput) (*fastly.SFTP, error)
-	DeleteSFTPFn func(*fastly.DeleteSFTPInput) error
-
-	CreateLogshuttleFn func(*fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error)
-	ListLogshuttlesFn  func(*fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error)
-	GetLogshuttleFn    func(*fastly.GetLogshuttleInput) (*fastly.Logshuttle, error)
-	UpdateLogshuttleFn func(*fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
-	DeleteLogshuttleFn func(*fastly.DeleteLogshuttleInput) error
-
-	CreateCloudfilesFn func(*fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error)
-	ListCloudfilesFn   func(*fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error)
-	GetCloudfilesFn    func(*fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error)
-	UpdateCloudfilesFn func(*fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error)
-	DeleteCloudfilesFn func(*fastly.DeleteCloudfilesInput) error
-
-	CreateDigitalOceanFn func(*fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error)
-	ListDigitalOceansFn  func(*fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error)
-	GetDigitalOceanFn    func(*fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error)
-	UpdateDigitalOceanFn func(*fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error)
-	DeleteDigitalOceanFn func(*fastly.DeleteDigitalOceanInput) error
-
-	CreateElasticsearchFn func(*fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error)
-	ListElasticsearchFn   func(*fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error)
-	GetElasticsearchFn    func(*fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error)
-	UpdateElasticsearchFn func(*fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error)
-	DeleteElasticsearchFn func(*fastly.DeleteElasticsearchInput) error
-
-	CreateBlobStorageFn func(*fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error)
-	ListBlobStoragesFn  func(*fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error)
-	GetBlobStorageFn    func(*fastly.GetBlobStorageInput) (*fastly.BlobStorage, error)
-	UpdateBlobStorageFn func(*fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error)
-	DeleteBlobStorageFn func(*fastly.DeleteBlobStorageInput) error
-
-	CreateDatadogFn func(*fastly.CreateDatadogInput) (*fastly.Datadog, error)
-	ListDatadogFn   func(*fastly.ListDatadogInput) ([]*fastly.Datadog, error)
-	GetDatadogFn    func(*fastly.GetDatadogInput) (*fastly.Datadog, error)
-	UpdateDatadogFn func(*fastly.UpdateDatadogInput) (*fastly.Datadog, error)
-	DeleteDatadogFn func(*fastly.DeleteDatadogInput) error
-
-	CreateHTTPSFn func(*fastly.CreateHTTPSInput) (*fastly.HTTPS, error)
-	ListHTTPSFn   func(*fastly.ListHTTPSInput) ([]*fastly.HTTPS, error)
-	GetHTTPSFn    func(*fastly.GetHTTPSInput) (*fastly.HTTPS, error)
-	UpdateHTTPSFn func(*fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
-	DeleteHTTPSFn func(*fastly.DeleteHTTPSInput) error
-
-	CreateKafkaFn func(*fastly.CreateKafkaInput) (*fastly.Kafka, error)
-	ListKafkasFn  func(*fastly.ListKafkasInput) ([]*fastly.Kafka, error)
-	GetKafkaFn    func(*fastly.GetKafkaInput) (*fastly.Kafka, error)
-	UpdateKafkaFn func(*fastly.UpdateKafkaInput) (*fastly.Kafka, error)
-	DeleteKafkaFn func(*fastly.DeleteKafkaInput) error
-
-	CreatePubsubFn func(*fastly.CreatePubsubInput) (*fastly.Pubsub, error)
-	ListPubsubsFn  func(*fastly.ListPubsubsInput) ([]*fastly.Pubsub, error)
-	GetPubsubFn    func(*fastly.GetPubsubInput) (*fastly.Pubsub, error)
-	UpdatePubsubFn func(*fastly.UpdatePubsubInput) (*fastly.Pubsub, error)
-	DeletePubsubFn func(*fastly.DeletePubsubInput) error
-
-	CreateOpenstackFn func(*fastly.CreateOpenstackInput) (*fastly.Openstack, error)
-	ListOpenstacksFn  func(*fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
-	GetOpenstackFn    func(*fastly.GetOpenstackInput) (*fastly.Openstack, error)
-	UpdateOpenstackFn func(*fastly.UpdateOpenstackInput) (*fastly.Openstack, error)
-	DeleteOpenstackFn func(*fastly.DeleteOpenstackInput) error
-
-	GetRegionsFn   func() (*fastly.RegionsResponse, error)
-	GetStatsJSONFn func(i *fastly.GetStatsInput, dst any) error
-
-	CreateManagedLoggingFn func(*fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
-
-	GetGeneratedVCLFn func(*fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
-
-	CreateVCLFn func(*fastly.CreateVCLInput) (*fastly.VCL, error)
-	ListVCLsFn  func(*fastly.ListVCLsInput) ([]*fastly.VCL, error)
-	GetVCLFn    func(*fastly.GetVCLInput) (*fastly.VCL, error)
-	UpdateVCLFn func(*fastly.UpdateVCLInput) (*fastly.VCL, error)
-	DeleteVCLFn func(*fastly.DeleteVCLInput) error
-
-	CreateSnippetFn        func(i *fastly.CreateSnippetInput) (*fastly.Snippet, error)
-	ListSnippetsFn         func(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error)
-	GetSnippetFn           func(i *fastly.GetSnippetInput) (*fastly.Snippet, error)
-	GetDynamicSnippetFn    func(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error)
-	UpdateSnippetFn        func(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error)
-	UpdateDynamicSnippetFn func(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error)
-	DeleteSnippetFn        func(i *fastly.DeleteSnippetInput) error
-
-	PurgeFn     func(i *fastly.PurgeInput) (*fastly.Purge, error)
-	PurgeKeyFn  func(i *fastly.PurgeKeyInput) (*fastly.Purge, error)
-	PurgeKeysFn func(i *fastly.PurgeKeysInput) (map[string]string, error)
-	PurgeAllFn  func(i *fastly.PurgeAllInput) (*fastly.Purge, error)
-
-	CreateACLFn func(i *fastly.CreateACLInput) (*fastly.ACL, error)
-	DeleteACLFn func(i *fastly.DeleteACLInput) error
-	GetACLFn    func(i *fastly.GetACLInput) (*fastly.ACL, error)
-	ListACLsFn  func(i *fastly.ListACLsInput) ([]*fastly.ACL, error)
-	UpdateACLFn func(i *fastly.UpdateACLInput) (*fastly.ACL, error)
-
-	CreateACLEntryFn        func(i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error)
-	DeleteACLEntryFn        func(i *fastly.DeleteACLEntryInput) error
-	GetACLEntryFn           func(i *fastly.GetACLEntryInput) (*fastly.ACLEntry, error)
-	GetACLEntriesFn         func(i *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry]
-	ListACLEntriesFn        func(i *fastly.ListACLEntriesInput) ([]*fastly.ACLEntry, error)
-	UpdateACLEntryFn        func(i *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error)
-	BatchModifyACLEntriesFn func(i *fastly.BatchModifyACLEntriesInput) error
-
-	CreateNewRelicFn func(i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error)
-	DeleteNewRelicFn func(i *fastly.DeleteNewRelicInput) error
-	GetNewRelicFn    func(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error)
-	ListNewRelicFn   func(i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error)
-	UpdateNewRelicFn func(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error)
-
-	CreateNewRelicOTLPFn func(i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
-	DeleteNewRelicOTLPFn func(i *fastly.DeleteNewRelicOTLPInput) error
-	GetNewRelicOTLPFn    func(i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
-	ListNewRelicOTLPFn   func(i *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error)
-	UpdateNewRelicOTLPFn func(i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
-
-	CreateUserFn        func(i *fastly.CreateUserInput) (*fastly.User, error)
-	DeleteUserFn        func(i *fastly.DeleteUserInput) error
-	GetCurrentUserFn    func() (*fastly.User, error)
-	GetUserFn           func(i *fastly.GetUserInput) (*fastly.User, error)
-	ListCustomerUsersFn func(i *fastly.ListCustomerUsersInput) ([]*fastly.User, error)
-	UpdateUserFn        func(i *fastly.UpdateUserInput) (*fastly.User, error)
-	ResetUserPasswordFn func(i *fastly.ResetUserPasswordInput) error
-
-	BatchDeleteTokensFn  func(i *fastly.BatchDeleteTokensInput) error
-	CreateTokenFn        func(i *fastly.CreateTokenInput) (*fastly.Token, error)
-	DeleteTokenFn        func(i *fastly.DeleteTokenInput) error
-	DeleteTokenSelfFn    func() error
-	GetTokenSelfFn       func() (*fastly.Token, error)
-	ListCustomerTokensFn func(i *fastly.ListCustomerTokensInput) ([]*fastly.Token, error)
-	ListTokensFn         func(i *fastly.ListTokensInput) ([]*fastly.Token, error)
-
-	NewListKVStoreKeysPaginatorFn func(i *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries
-
-	GetCustomTLSConfigurationFn    func(i *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
-	ListCustomTLSConfigurationsFn  func(i *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error)
-	UpdateCustomTLSConfigurationFn func(i *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
-	GetTLSActivationFn             func(i *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error)
-	ListTLSActivationsFn           func(i *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error)
-	UpdateTLSActivationFn          func(i *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error)
-	CreateTLSActivationFn          func(i *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error)
-	DeleteTLSActivationFn          func(i *fastly.DeleteTLSActivationInput) error
-
-	CreateCustomTLSCertificateFn func(i *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
-	DeleteCustomTLSCertificateFn func(i *fastly.DeleteCustomTLSCertificateInput) error
-	GetCustomTLSCertificateFn    func(i *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
-	ListCustomTLSCertificatesFn  func(i *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error)
-	UpdateCustomTLSCertificateFn func(i *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
-
-	ListTLSDomainsFn func(i *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error)
-
-	CreatePrivateKeyFn func(i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error)
-	DeletePrivateKeyFn func(i *fastly.DeletePrivateKeyInput) error
-	GetPrivateKeyFn    func(i *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error)
-	ListPrivateKeysFn  func(i *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error)
-
-	CreateBulkCertificateFn func(i *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error)
-	DeleteBulkCertificateFn func(i *fastly.DeleteBulkCertificateInput) error
-	GetBulkCertificateFn    func(i *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error)
-	ListBulkCertificatesFn  func(i *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error)
-	UpdateBulkCertificateFn func(i *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error)
-
-	CreateTLSSubscriptionFn func(i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
-	DeleteTLSSubscriptionFn func(i *fastly.DeleteTLSSubscriptionInput) error
-	GetTLSSubscriptionFn    func(i *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error)
-	ListTLSSubscriptionsFn  func(i *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error)
-	UpdateTLSSubscriptionFn func(i *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
-
-	ListServiceAuthorizationsFn  func(i *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error)
-	GetServiceAuthorizationFn    func(i *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
-	CreateServiceAuthorizationFn func(i *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
-	UpdateServiceAuthorizationFn func(i *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
-	DeleteServiceAuthorizationFn func(i *fastly.DeleteServiceAuthorizationInput) error
-
-	CreateConfigStoreFn       func(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error)
-	DeleteConfigStoreFn       func(i *fastly.DeleteConfigStoreInput) error
-	GetConfigStoreFn          func(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error)
-	GetConfigStoreMetadataFn  func(i *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error)
-	ListConfigStoresFn        func(i *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error)
-	ListConfigStoreServicesFn func(i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error)
-	UpdateConfigStoreFn       func(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error)
-
-	CreateConfigStoreItemFn func(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
-	DeleteConfigStoreItemFn func(i *fastly.DeleteConfigStoreItemInput) error
-	GetConfigStoreItemFn    func(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
-	ListConfigStoreItemsFn  func(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error)
-	UpdateConfigStoreItemFn func(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
-
-	CreateKVStoreFn         func(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error)
-	GetKVStoreFn            func(i *fastly.GetKVStoreInput) (*fastly.KVStore, error)
-	ListKVStoresFn          func(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error)
-	DeleteKVStoreFn         func(i *fastly.DeleteKVStoreInput) error
-	ListKVStoreKeysFn       func(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error)
-	GetKVStoreKeyFn         func(i *fastly.GetKVStoreKeyInput) (string, error)
-	InsertKVStoreKeyFn      func(i *fastly.InsertKVStoreKeyInput) error
-	DeleteKVStoreKeyFn      func(i *fastly.DeleteKVStoreKeyInput) error
-	BatchModifyKVStoreKeyFn func(i *fastly.BatchModifyKVStoreKeyInput) error
-
-	CreateSecretStoreFn func(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error)
-	GetSecretStoreFn    func(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error)
-	DeleteSecretStoreFn func(i *fastly.DeleteSecretStoreInput) error
-	ListSecretStoresFn  func(i *fastly.ListSecretStoresInput) (*fastly.SecretStores, error)
-	CreateSecretFn      func(i *fastly.CreateSecretInput) (*fastly.Secret, error)
-	GetSecretFn         func(i *fastly.GetSecretInput) (*fastly.Secret, error)
-	DeleteSecretFn      func(i *fastly.DeleteSecretInput) error
-	ListSecretsFn       func(i *fastly.ListSecretsInput) (*fastly.Secrets, error)
-	CreateClientKeyFn   func() (*fastly.ClientKey, error)
-	GetSigningKeyFn     func() (ed25519.PublicKey, error)
-
-	CreateResourceFn func(i *fastly.CreateResourceInput) (*fastly.Resource, error)
-	DeleteResourceFn func(i *fastly.DeleteResourceInput) error
-	GetResourceFn    func(i *fastly.GetResourceInput) (*fastly.Resource, error)
-	ListResourcesFn  func(i *fastly.ListResourcesInput) ([]*fastly.Resource, error)
-	UpdateResourceFn func(i *fastly.UpdateResourceInput) (*fastly.Resource, error)
-
-	CreateERLFn func(i *fastly.CreateERLInput) (*fastly.ERL, error)
-	DeleteERLFn func(i *fastly.DeleteERLInput) error
-	GetERLFn    func(i *fastly.GetERLInput) (*fastly.ERL, error)
-	ListERLsFn  func(i *fastly.ListERLsInput) ([]*fastly.ERL, error)
-	UpdateERLFn func(i *fastly.UpdateERLInput) (*fastly.ERL, error)
-
-	CreateConditionFn func(i *fastly.CreateConditionInput) (*fastly.Condition, error)
-	DeleteConditionFn func(i *fastly.DeleteConditionInput) error
-	GetConditionFn    func(i *fastly.GetConditionInput) (*fastly.Condition, error)
-	ListConditionsFn  func(i *fastly.ListConditionsInput) ([]*fastly.Condition, error)
-	UpdateConditionFn func(i *fastly.UpdateConditionInput) (*fastly.Condition, error)
-
-	GetProductFn     func(i *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error)
-	EnableProductFn  func(i *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error)
-	DisableProductFn func(i *fastly.ProductEnablementInput) error
-
-	ListAlertDefinitionsFn  func(i *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error)
-	CreateAlertDefinitionFn func(i *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error)
-	GetAlertDefinitionFn    func(i *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error)
-	UpdateAlertDefinitionFn func(i *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error)
-	DeleteAlertDefinitionFn func(i *fastly.DeleteAlertDefinitionInput) error
-	TestAlertDefinitionFn   func(i *fastly.TestAlertDefinitionInput) error
-	ListAlertHistoryFn      func(i *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error)
-
-	ListObservabilityCustomDashboardsFn  func(i *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error)
-	CreateObservabilityCustomDashboardFn func(i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
-	GetObservabilityCustomDashboardFn    func(i *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
-	UpdateObservabilityCustomDashboardFn func(i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
-	DeleteObservabilityCustomDashboardFn func(i *fastly.DeleteObservabilityCustomDashboardInput) error
+	AllDatacentersFn func(context.Context) ([]fastly.Datacenter, error)
+	AllIPsFn         func(context.Context) (fastly.IPAddrs, fastly.IPAddrs, error)
+
+	CreateServiceFn     func(context.Context, *fastly.CreateServiceInput) (*fastly.Service, error)
+	GetServicesFn       func(context.Context, *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service]
+	ListServicesFn      func(context.Context, *fastly.ListServicesInput) ([]*fastly.Service, error)
+	GetServiceFn        func(context.Context, *fastly.GetServiceInput) (*fastly.Service, error)
+	GetServiceDetailsFn func(context.Context, *fastly.GetServiceInput) (*fastly.ServiceDetail, error)
+	UpdateServiceFn     func(context.Context, *fastly.UpdateServiceInput) (*fastly.Service, error)
+	DeleteServiceFn     func(context.Context, *fastly.DeleteServiceInput) error
+	SearchServiceFn     func(context.Context, *fastly.SearchServiceInput) (*fastly.Service, error)
+
+	CloneVersionFn      func(context.Context, *fastly.CloneVersionInput) (*fastly.Version, error)
+	ListVersionsFn      func(context.Context, *fastly.ListVersionsInput) ([]*fastly.Version, error)
+	GetVersionFn        func(context.Context, *fastly.GetVersionInput) (*fastly.Version, error)
+	UpdateVersionFn     func(context.Context, *fastly.UpdateVersionInput) (*fastly.Version, error)
+	ActivateVersionFn   func(context.Context, *fastly.ActivateVersionInput) (*fastly.Version, error)
+	DeactivateVersionFn func(context.Context, *fastly.DeactivateVersionInput) (*fastly.Version, error)
+	LockVersionFn       func(context.Context, *fastly.LockVersionInput) (*fastly.Version, error)
+	LatestVersionFn     func(context.Context, *fastly.LatestVersionInput) (*fastly.Version, error)
+
+	CreateDomainFn       func(context.Context, *fastly.CreateDomainInput) (*fastly.Domain, error)
+	ListDomainsFn        func(context.Context, *fastly.ListDomainsInput) ([]*fastly.Domain, error)
+	GetDomainFn          func(context.Context, *fastly.GetDomainInput) (*fastly.Domain, error)
+	UpdateDomainFn       func(context.Context, *fastly.UpdateDomainInput) (*fastly.Domain, error)
+	DeleteDomainFn       func(context.Context, *fastly.DeleteDomainInput) error
+	ValidateDomainFn     func(context.Context, *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error)
+	ValidateAllDomainsFn func(context.Context, *fastly.ValidateAllDomainsInput) ([]*fastly.DomainValidationResult, error)
+
+	CreateBackendFn func(context.Context, *fastly.CreateBackendInput) (*fastly.Backend, error)
+	ListBackendsFn  func(context.Context, *fastly.ListBackendsInput) ([]*fastly.Backend, error)
+	GetBackendFn    func(context.Context, *fastly.GetBackendInput) (*fastly.Backend, error)
+	UpdateBackendFn func(context.Context, *fastly.UpdateBackendInput) (*fastly.Backend, error)
+	DeleteBackendFn func(context.Context, *fastly.DeleteBackendInput) error
+
+	CreateHealthCheckFn func(context.Context, *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error)
+	ListHealthChecksFn  func(context.Context, *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error)
+	GetHealthCheckFn    func(context.Context, *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error)
+	UpdateHealthCheckFn func(context.Context, *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error)
+	DeleteHealthCheckFn func(context.Context, *fastly.DeleteHealthCheckInput) error
+
+	GetPackageFn    func(context.Context, *fastly.GetPackageInput) (*fastly.Package, error)
+	UpdatePackageFn func(context.Context, *fastly.UpdatePackageInput) (*fastly.Package, error)
+
+	CreateDictionaryFn func(context.Context, *fastly.CreateDictionaryInput) (*fastly.Dictionary, error)
+	GetDictionaryFn    func(context.Context, *fastly.GetDictionaryInput) (*fastly.Dictionary, error)
+	DeleteDictionaryFn func(context.Context, *fastly.DeleteDictionaryInput) error
+	ListDictionariesFn func(context.Context, *fastly.ListDictionariesInput) ([]*fastly.Dictionary, error)
+	UpdateDictionaryFn func(context.Context, *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error)
+
+	GetDictionaryItemsFn         func(context.Context, *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem]
+	ListDictionaryItemsFn        func(context.Context, *fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error)
+	GetDictionaryItemFn          func(context.Context, *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error)
+	CreateDictionaryItemFn       func(context.Context, *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error)
+	UpdateDictionaryItemFn       func(context.Context, *fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error)
+	DeleteDictionaryItemFn       func(context.Context, *fastly.DeleteDictionaryItemInput) error
+	BatchModifyDictionaryItemsFn func(context.Context, *fastly.BatchModifyDictionaryItemsInput) error
+
+	GetDictionaryInfoFn func(context.Context, *fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error)
+
+	CreateBigQueryFn func(context.Context, *fastly.CreateBigQueryInput) (*fastly.BigQuery, error)
+	ListBigQueriesFn func(context.Context, *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error)
+	GetBigQueryFn    func(context.Context, *fastly.GetBigQueryInput) (*fastly.BigQuery, error)
+	UpdateBigQueryFn func(context.Context, *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error)
+	DeleteBigQueryFn func(context.Context, *fastly.DeleteBigQueryInput) error
+
+	CreateS3Fn func(context.Context, *fastly.CreateS3Input) (*fastly.S3, error)
+	ListS3sFn  func(context.Context, *fastly.ListS3sInput) ([]*fastly.S3, error)
+	GetS3Fn    func(context.Context, *fastly.GetS3Input) (*fastly.S3, error)
+	UpdateS3Fn func(context.Context, *fastly.UpdateS3Input) (*fastly.S3, error)
+	DeleteS3Fn func(context.Context, *fastly.DeleteS3Input) error
+
+	CreateKinesisFn func(context.Context, *fastly.CreateKinesisInput) (*fastly.Kinesis, error)
+	ListKinesisFn   func(context.Context, *fastly.ListKinesisInput) ([]*fastly.Kinesis, error)
+	GetKinesisFn    func(context.Context, *fastly.GetKinesisInput) (*fastly.Kinesis, error)
+	UpdateKinesisFn func(context.Context, *fastly.UpdateKinesisInput) (*fastly.Kinesis, error)
+	DeleteKinesisFn func(context.Context, *fastly.DeleteKinesisInput) error
+
+	CreateSyslogFn func(context.Context, *fastly.CreateSyslogInput) (*fastly.Syslog, error)
+	ListSyslogsFn  func(context.Context, *fastly.ListSyslogsInput) ([]*fastly.Syslog, error)
+	GetSyslogFn    func(context.Context, *fastly.GetSyslogInput) (*fastly.Syslog, error)
+	UpdateSyslogFn func(context.Context, *fastly.UpdateSyslogInput) (*fastly.Syslog, error)
+	DeleteSyslogFn func(context.Context, *fastly.DeleteSyslogInput) error
+
+	CreateLogentriesFn func(context.Context, *fastly.CreateLogentriesInput) (*fastly.Logentries, error)
+	ListLogentriesFn   func(context.Context, *fastly.ListLogentriesInput) ([]*fastly.Logentries, error)
+	GetLogentriesFn    func(context.Context, *fastly.GetLogentriesInput) (*fastly.Logentries, error)
+	UpdateLogentriesFn func(context.Context, *fastly.UpdateLogentriesInput) (*fastly.Logentries, error)
+	DeleteLogentriesFn func(context.Context, *fastly.DeleteLogentriesInput) error
+
+	CreatePapertrailFn func(context.Context, *fastly.CreatePapertrailInput) (*fastly.Papertrail, error)
+	ListPapertrailsFn  func(context.Context, *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error)
+	GetPapertrailFn    func(context.Context, *fastly.GetPapertrailInput) (*fastly.Papertrail, error)
+	UpdatePapertrailFn func(context.Context, *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error)
+	DeletePapertrailFn func(context.Context, *fastly.DeletePapertrailInput) error
+
+	CreateSumologicFn func(context.Context, *fastly.CreateSumologicInput) (*fastly.Sumologic, error)
+	ListSumologicsFn  func(context.Context, *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error)
+	GetSumologicFn    func(context.Context, *fastly.GetSumologicInput) (*fastly.Sumologic, error)
+	UpdateSumologicFn func(context.Context, *fastly.UpdateSumologicInput) (*fastly.Sumologic, error)
+	DeleteSumologicFn func(context.Context, *fastly.DeleteSumologicInput) error
+
+	CreateGCSFn func(context.Context, *fastly.CreateGCSInput) (*fastly.GCS, error)
+	ListGCSsFn  func(context.Context, *fastly.ListGCSsInput) ([]*fastly.GCS, error)
+	GetGCSFn    func(context.Context, *fastly.GetGCSInput) (*fastly.GCS, error)
+	UpdateGCSFn func(context.Context, *fastly.UpdateGCSInput) (*fastly.GCS, error)
+	DeleteGCSFn func(context.Context, *fastly.DeleteGCSInput) error
+
+	CreateGrafanaCloudLogsFn func(context.Context, *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
+	ListGrafanaCloudLogsFn   func(context.Context, *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error)
+	GetGrafanaCloudLogsFn    func(context.Context, *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
+	UpdateGrafanaCloudLogsFn func(context.Context, *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error)
+	DeleteGrafanaCloudLogsFn func(context.Context, *fastly.DeleteGrafanaCloudLogsInput) error
+
+	CreateFTPFn func(context.Context, *fastly.CreateFTPInput) (*fastly.FTP, error)
+	ListFTPsFn  func(context.Context, *fastly.ListFTPsInput) ([]*fastly.FTP, error)
+	GetFTPFn    func(context.Context, *fastly.GetFTPInput) (*fastly.FTP, error)
+	UpdateFTPFn func(context.Context, *fastly.UpdateFTPInput) (*fastly.FTP, error)
+	DeleteFTPFn func(context.Context, *fastly.DeleteFTPInput) error
+
+	CreateSplunkFn func(context.Context, *fastly.CreateSplunkInput) (*fastly.Splunk, error)
+	ListSplunksFn  func(context.Context, *fastly.ListSplunksInput) ([]*fastly.Splunk, error)
+	GetSplunkFn    func(context.Context, *fastly.GetSplunkInput) (*fastly.Splunk, error)
+	UpdateSplunkFn func(context.Context, *fastly.UpdateSplunkInput) (*fastly.Splunk, error)
+	DeleteSplunkFn func(context.Context, *fastly.DeleteSplunkInput) error
+
+	CreateScalyrFn func(context.Context, *fastly.CreateScalyrInput) (*fastly.Scalyr, error)
+	ListScalyrsFn  func(context.Context, *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error)
+	GetScalyrFn    func(context.Context, *fastly.GetScalyrInput) (*fastly.Scalyr, error)
+	UpdateScalyrFn func(context.Context, *fastly.UpdateScalyrInput) (*fastly.Scalyr, error)
+	DeleteScalyrFn func(context.Context, *fastly.DeleteScalyrInput) error
+
+	CreateLogglyFn func(context.Context, *fastly.CreateLogglyInput) (*fastly.Loggly, error)
+	ListLogglyFn   func(context.Context, *fastly.ListLogglyInput) ([]*fastly.Loggly, error)
+	GetLogglyFn    func(context.Context, *fastly.GetLogglyInput) (*fastly.Loggly, error)
+	UpdateLogglyFn func(context.Context, *fastly.UpdateLogglyInput) (*fastly.Loggly, error)
+	DeleteLogglyFn func(context.Context, *fastly.DeleteLogglyInput) error
+
+	CreateHoneycombFn func(context.Context, *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error)
+	ListHoneycombsFn  func(context.Context, *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error)
+	GetHoneycombFn    func(context.Context, *fastly.GetHoneycombInput) (*fastly.Honeycomb, error)
+	UpdateHoneycombFn func(context.Context, *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error)
+	DeleteHoneycombFn func(context.Context, *fastly.DeleteHoneycombInput) error
+
+	CreateHerokuFn func(context.Context, *fastly.CreateHerokuInput) (*fastly.Heroku, error)
+	ListHerokusFn  func(context.Context, *fastly.ListHerokusInput) ([]*fastly.Heroku, error)
+	GetHerokuFn    func(context.Context, *fastly.GetHerokuInput) (*fastly.Heroku, error)
+	UpdateHerokuFn func(context.Context, *fastly.UpdateHerokuInput) (*fastly.Heroku, error)
+	DeleteHerokuFn func(context.Context, *fastly.DeleteHerokuInput) error
+
+	CreateSFTPFn func(context.Context, *fastly.CreateSFTPInput) (*fastly.SFTP, error)
+	ListSFTPsFn  func(context.Context, *fastly.ListSFTPsInput) ([]*fastly.SFTP, error)
+	GetSFTPFn    func(context.Context, *fastly.GetSFTPInput) (*fastly.SFTP, error)
+	UpdateSFTPFn func(context.Context, *fastly.UpdateSFTPInput) (*fastly.SFTP, error)
+	DeleteSFTPFn func(context.Context, *fastly.DeleteSFTPInput) error
+
+	CreateLogshuttleFn func(context.Context, *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error)
+	ListLogshuttlesFn  func(context.Context, *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error)
+	GetLogshuttleFn    func(context.Context, *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error)
+	UpdateLogshuttleFn func(context.Context, *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error)
+	DeleteLogshuttleFn func(context.Context, *fastly.DeleteLogshuttleInput) error
+
+	CreateCloudfilesFn func(context.Context, *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error)
+	ListCloudfilesFn   func(context.Context, *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error)
+	GetCloudfilesFn    func(context.Context, *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error)
+	UpdateCloudfilesFn func(context.Context, *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error)
+	DeleteCloudfilesFn func(context.Context, *fastly.DeleteCloudfilesInput) error
+
+	CreateDigitalOceanFn func(context.Context, *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error)
+	ListDigitalOceansFn  func(context.Context, *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error)
+	GetDigitalOceanFn    func(context.Context, *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error)
+	UpdateDigitalOceanFn func(context.Context, *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error)
+	DeleteDigitalOceanFn func(context.Context, *fastly.DeleteDigitalOceanInput) error
+
+	CreateElasticsearchFn func(context.Context, *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error)
+	ListElasticsearchFn   func(context.Context, *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error)
+	GetElasticsearchFn    func(context.Context, *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error)
+	UpdateElasticsearchFn func(context.Context, *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error)
+	DeleteElasticsearchFn func(context.Context, *fastly.DeleteElasticsearchInput) error
+
+	CreateBlobStorageFn func(context.Context, *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error)
+	ListBlobStoragesFn  func(context.Context, *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error)
+	GetBlobStorageFn    func(context.Context, *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error)
+	UpdateBlobStorageFn func(context.Context, *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error)
+	DeleteBlobStorageFn func(context.Context, *fastly.DeleteBlobStorageInput) error
+
+	CreateDatadogFn func(context.Context, *fastly.CreateDatadogInput) (*fastly.Datadog, error)
+	ListDatadogFn   func(context.Context, *fastly.ListDatadogInput) ([]*fastly.Datadog, error)
+	GetDatadogFn    func(context.Context, *fastly.GetDatadogInput) (*fastly.Datadog, error)
+	UpdateDatadogFn func(context.Context, *fastly.UpdateDatadogInput) (*fastly.Datadog, error)
+	DeleteDatadogFn func(context.Context, *fastly.DeleteDatadogInput) error
+
+	CreateHTTPSFn func(context.Context, *fastly.CreateHTTPSInput) (*fastly.HTTPS, error)
+	ListHTTPSFn   func(context.Context, *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error)
+	GetHTTPSFn    func(context.Context, *fastly.GetHTTPSInput) (*fastly.HTTPS, error)
+	UpdateHTTPSFn func(context.Context, *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error)
+	DeleteHTTPSFn func(context.Context, *fastly.DeleteHTTPSInput) error
+
+	CreateKafkaFn func(context.Context, *fastly.CreateKafkaInput) (*fastly.Kafka, error)
+	ListKafkasFn  func(context.Context, *fastly.ListKafkasInput) ([]*fastly.Kafka, error)
+	GetKafkaFn    func(context.Context, *fastly.GetKafkaInput) (*fastly.Kafka, error)
+	UpdateKafkaFn func(context.Context, *fastly.UpdateKafkaInput) (*fastly.Kafka, error)
+	DeleteKafkaFn func(context.Context, *fastly.DeleteKafkaInput) error
+
+	CreatePubsubFn func(context.Context, *fastly.CreatePubsubInput) (*fastly.Pubsub, error)
+	ListPubsubsFn  func(context.Context, *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error)
+	GetPubsubFn    func(context.Context, *fastly.GetPubsubInput) (*fastly.Pubsub, error)
+	UpdatePubsubFn func(context.Context, *fastly.UpdatePubsubInput) (*fastly.Pubsub, error)
+	DeletePubsubFn func(context.Context, *fastly.DeletePubsubInput) error
+
+	CreateOpenstackFn func(context.Context, *fastly.CreateOpenstackInput) (*fastly.Openstack, error)
+	ListOpenstacksFn  func(context.Context, *fastly.ListOpenstackInput) ([]*fastly.Openstack, error)
+	GetOpenstackFn    func(context.Context, *fastly.GetOpenstackInput) (*fastly.Openstack, error)
+	UpdateOpenstackFn func(context.Context, *fastly.UpdateOpenstackInput) (*fastly.Openstack, error)
+	DeleteOpenstackFn func(context.Context, *fastly.DeleteOpenstackInput) error
+
+	GetRegionsFn   func(context.Context) (*fastly.RegionsResponse, error)
+	GetStatsJSONFn func(context.Context, *fastly.GetStatsInput, any) error
+
+	CreateManagedLoggingFn func(context.Context, *fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error)
+
+	GetGeneratedVCLFn func(context.Context, *fastly.GetGeneratedVCLInput) (*fastly.VCL, error)
+
+	CreateVCLFn func(context.Context, *fastly.CreateVCLInput) (*fastly.VCL, error)
+	ListVCLsFn  func(context.Context, *fastly.ListVCLsInput) ([]*fastly.VCL, error)
+	GetVCLFn    func(context.Context, *fastly.GetVCLInput) (*fastly.VCL, error)
+	UpdateVCLFn func(context.Context, *fastly.UpdateVCLInput) (*fastly.VCL, error)
+	DeleteVCLFn func(context.Context, *fastly.DeleteVCLInput) error
+
+	CreateSnippetFn        func(context.Context, *fastly.CreateSnippetInput) (*fastly.Snippet, error)
+	ListSnippetsFn         func(context.Context, *fastly.ListSnippetsInput) ([]*fastly.Snippet, error)
+	GetSnippetFn           func(context.Context, *fastly.GetSnippetInput) (*fastly.Snippet, error)
+	GetDynamicSnippetFn    func(context.Context, *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	UpdateSnippetFn        func(context.Context, *fastly.UpdateSnippetInput) (*fastly.Snippet, error)
+	UpdateDynamicSnippetFn func(context.Context, *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error)
+	DeleteSnippetFn        func(context.Context, *fastly.DeleteSnippetInput) error
+
+	PurgeFn     func(context.Context, *fastly.PurgeInput) (*fastly.Purge, error)
+	PurgeKeyFn  func(context.Context, *fastly.PurgeKeyInput) (*fastly.Purge, error)
+	PurgeKeysFn func(context.Context, *fastly.PurgeKeysInput) (map[string]string, error)
+	PurgeAllFn  func(context.Context, *fastly.PurgeAllInput) (*fastly.Purge, error)
+
+	CreateACLFn func(context.Context, *fastly.CreateACLInput) (*fastly.ACL, error)
+	DeleteACLFn func(context.Context, *fastly.DeleteACLInput) error
+	GetACLFn    func(context.Context, *fastly.GetACLInput) (*fastly.ACL, error)
+	ListACLsFn  func(context.Context, *fastly.ListACLsInput) ([]*fastly.ACL, error)
+	UpdateACLFn func(context.Context, *fastly.UpdateACLInput) (*fastly.ACL, error)
+
+	CreateACLEntryFn        func(context.Context, *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error)
+	DeleteACLEntryFn        func(context.Context, *fastly.DeleteACLEntryInput) error
+	GetACLEntryFn           func(context.Context, *fastly.GetACLEntryInput) (*fastly.ACLEntry, error)
+	GetACLEntriesFn         func(context.Context, *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry]
+	ListACLEntriesFn        func(context.Context, *fastly.ListACLEntriesInput) ([]*fastly.ACLEntry, error)
+	UpdateACLEntryFn        func(context.Context, *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error)
+	BatchModifyACLEntriesFn func(context.Context, *fastly.BatchModifyACLEntriesInput) error
+
+	CreateNewRelicFn func(context.Context, *fastly.CreateNewRelicInput) (*fastly.NewRelic, error)
+	DeleteNewRelicFn func(context.Context, *fastly.DeleteNewRelicInput) error
+	GetNewRelicFn    func(context.Context, *fastly.GetNewRelicInput) (*fastly.NewRelic, error)
+	ListNewRelicFn   func(context.Context, *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error)
+	UpdateNewRelicFn func(context.Context, *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error)
+
+	CreateNewRelicOTLPFn func(context.Context, *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
+	DeleteNewRelicOTLPFn func(context.Context, *fastly.DeleteNewRelicOTLPInput) error
+	GetNewRelicOTLPFn    func(context.Context, *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
+	ListNewRelicOTLPFn   func(context.Context, *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error)
+	UpdateNewRelicOTLPFn func(context.Context, *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error)
+
+	CreateUserFn        func(context.Context, *fastly.CreateUserInput) (*fastly.User, error)
+	DeleteUserFn        func(context.Context, *fastly.DeleteUserInput) error
+	GetCurrentUserFn    func(context.Context) (*fastly.User, error)
+	GetUserFn           func(context.Context, *fastly.GetUserInput) (*fastly.User, error)
+	ListCustomerUsersFn func(context.Context, *fastly.ListCustomerUsersInput) ([]*fastly.User, error)
+	UpdateUserFn        func(context.Context, *fastly.UpdateUserInput) (*fastly.User, error)
+	ResetUserPasswordFn func(context.Context, *fastly.ResetUserPasswordInput) error
+
+	BatchDeleteTokensFn  func(context.Context, *fastly.BatchDeleteTokensInput) error
+	CreateTokenFn        func(context.Context, *fastly.CreateTokenInput) (*fastly.Token, error)
+	DeleteTokenFn        func(context.Context, *fastly.DeleteTokenInput) error
+	DeleteTokenSelfFn    func(context.Context) error
+	GetTokenSelfFn       func(context.Context) (*fastly.Token, error)
+	ListCustomerTokensFn func(context.Context, *fastly.ListCustomerTokensInput) ([]*fastly.Token, error)
+	ListTokensFn         func(context.Context, *fastly.ListTokensInput) ([]*fastly.Token, error)
+
+	NewListKVStoreKeysPaginatorFn func(context.Context, *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries
+
+	GetCustomTLSConfigurationFn    func(context.Context, *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
+	ListCustomTLSConfigurationsFn  func(context.Context, *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error)
+	UpdateCustomTLSConfigurationFn func(context.Context, *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error)
+	GetTLSActivationFn             func(context.Context, *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error)
+	ListTLSActivationsFn           func(context.Context, *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error)
+	UpdateTLSActivationFn          func(context.Context, *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error)
+	CreateTLSActivationFn          func(context.Context, *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error)
+	DeleteTLSActivationFn          func(context.Context, *fastly.DeleteTLSActivationInput) error
+
+	CreateCustomTLSCertificateFn func(context.Context, *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
+	DeleteCustomTLSCertificateFn func(context.Context, *fastly.DeleteCustomTLSCertificateInput) error
+	GetCustomTLSCertificateFn    func(context.Context, *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
+	ListCustomTLSCertificatesFn  func(context.Context, *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error)
+	UpdateCustomTLSCertificateFn func(context.Context, *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error)
+
+	ListTLSDomainsFn func(context.Context, *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error)
+
+	CreatePrivateKeyFn func(context.Context, *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error)
+	DeletePrivateKeyFn func(context.Context, *fastly.DeletePrivateKeyInput) error
+	GetPrivateKeyFn    func(context.Context, *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error)
+	ListPrivateKeysFn  func(context.Context, *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error)
+
+	CreateBulkCertificateFn func(context.Context, *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error)
+	DeleteBulkCertificateFn func(context.Context, *fastly.DeleteBulkCertificateInput) error
+	GetBulkCertificateFn    func(context.Context, *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error)
+	ListBulkCertificatesFn  func(context.Context, *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error)
+	UpdateBulkCertificateFn func(context.Context, *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error)
+
+	CreateTLSSubscriptionFn func(context.Context, *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
+	DeleteTLSSubscriptionFn func(context.Context, *fastly.DeleteTLSSubscriptionInput) error
+	GetTLSSubscriptionFn    func(context.Context, *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error)
+	ListTLSSubscriptionsFn  func(context.Context, *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error)
+	UpdateTLSSubscriptionFn func(context.Context, *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error)
+
+	ListServiceAuthorizationsFn  func(context.Context, *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error)
+	GetServiceAuthorizationFn    func(context.Context, *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
+	CreateServiceAuthorizationFn func(context.Context, *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
+	UpdateServiceAuthorizationFn func(context.Context, *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error)
+	DeleteServiceAuthorizationFn func(context.Context, *fastly.DeleteServiceAuthorizationInput) error
+
+	CreateConfigStoreFn       func(context.Context, *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error)
+	DeleteConfigStoreFn       func(context.Context, *fastly.DeleteConfigStoreInput) error
+	GetConfigStoreFn          func(context.Context, *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error)
+	GetConfigStoreMetadataFn  func(context.Context, *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error)
+	ListConfigStoresFn        func(context.Context, *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error)
+	ListConfigStoreServicesFn func(context.Context, *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error)
+	UpdateConfigStoreFn       func(context.Context, *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error)
+
+	CreateConfigStoreItemFn func(context.Context, *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
+	DeleteConfigStoreItemFn func(context.Context, *fastly.DeleteConfigStoreItemInput) error
+	GetConfigStoreItemFn    func(context.Context, *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
+	ListConfigStoreItemsFn  func(context.Context, *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error)
+	UpdateConfigStoreItemFn func(context.Context, *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error)
+
+	CreateKVStoreFn         func(context.Context, *fastly.CreateKVStoreInput) (*fastly.KVStore, error)
+	GetKVStoreFn            func(context.Context, *fastly.GetKVStoreInput) (*fastly.KVStore, error)
+	ListKVStoresFn          func(context.Context, *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error)
+	DeleteKVStoreFn         func(context.Context, *fastly.DeleteKVStoreInput) error
+	ListKVStoreKeysFn       func(context.Context, *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error)
+	GetKVStoreKeyFn         func(context.Context, *fastly.GetKVStoreKeyInput) (string, error)
+	InsertKVStoreKeyFn      func(context.Context, *fastly.InsertKVStoreKeyInput) error
+	DeleteKVStoreKeyFn      func(context.Context, *fastly.DeleteKVStoreKeyInput) error
+	BatchModifyKVStoreKeyFn func(context.Context, *fastly.BatchModifyKVStoreKeyInput) error
+
+	CreateSecretStoreFn func(context.Context, *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error)
+	GetSecretStoreFn    func(context.Context, *fastly.GetSecretStoreInput) (*fastly.SecretStore, error)
+	DeleteSecretStoreFn func(context.Context, *fastly.DeleteSecretStoreInput) error
+	ListSecretStoresFn  func(context.Context, *fastly.ListSecretStoresInput) (*fastly.SecretStores, error)
+	CreateSecretFn      func(context.Context, *fastly.CreateSecretInput) (*fastly.Secret, error)
+	GetSecretFn         func(context.Context, *fastly.GetSecretInput) (*fastly.Secret, error)
+	DeleteSecretFn      func(context.Context, *fastly.DeleteSecretInput) error
+	ListSecretsFn       func(context.Context, *fastly.ListSecretsInput) (*fastly.Secrets, error)
+	CreateClientKeyFn   func(context.Context) (*fastly.ClientKey, error)
+	GetSigningKeyFn     func(context.Context) (ed25519.PublicKey, error)
+
+	CreateResourceFn func(context.Context, *fastly.CreateResourceInput) (*fastly.Resource, error)
+	DeleteResourceFn func(context.Context, *fastly.DeleteResourceInput) error
+	GetResourceFn    func(context.Context, *fastly.GetResourceInput) (*fastly.Resource, error)
+	ListResourcesFn  func(context.Context, *fastly.ListResourcesInput) ([]*fastly.Resource, error)
+	UpdateResourceFn func(context.Context, *fastly.UpdateResourceInput) (*fastly.Resource, error)
+
+	CreateERLFn func(context.Context, *fastly.CreateERLInput) (*fastly.ERL, error)
+	DeleteERLFn func(context.Context, *fastly.DeleteERLInput) error
+	GetERLFn    func(context.Context, *fastly.GetERLInput) (*fastly.ERL, error)
+	ListERLsFn  func(context.Context, *fastly.ListERLsInput) ([]*fastly.ERL, error)
+	UpdateERLFn func(context.Context, *fastly.UpdateERLInput) (*fastly.ERL, error)
+
+	CreateConditionFn func(context.Context, *fastly.CreateConditionInput) (*fastly.Condition, error)
+	DeleteConditionFn func(context.Context, *fastly.DeleteConditionInput) error
+	GetConditionFn    func(context.Context, *fastly.GetConditionInput) (*fastly.Condition, error)
+	ListConditionsFn  func(context.Context, *fastly.ListConditionsInput) ([]*fastly.Condition, error)
+	UpdateConditionFn func(context.Context, *fastly.UpdateConditionInput) (*fastly.Condition, error)
+
+	ListAlertDefinitionsFn  func(context.Context, *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error)
+	CreateAlertDefinitionFn func(context.Context, *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error)
+	GetAlertDefinitionFn    func(context.Context, *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error)
+	UpdateAlertDefinitionFn func(context.Context, *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error)
+	DeleteAlertDefinitionFn func(context.Context, *fastly.DeleteAlertDefinitionInput) error
+	TestAlertDefinitionFn   func(context.Context, *fastly.TestAlertDefinitionInput) error
+	ListAlertHistoryFn      func(context.Context, *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error)
+
+	ListObservabilityCustomDashboardsFn  func(context.Context, *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error)
+	CreateObservabilityCustomDashboardFn func(context.Context, *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
+	GetObservabilityCustomDashboardFn    func(context.Context, *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
+	UpdateObservabilityCustomDashboardFn func(context.Context, *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error)
+	DeleteObservabilityCustomDashboardFn func(context.Context, *fastly.DeleteObservabilityCustomDashboardInput) error
 }
 
 // AllDatacenters implements Interface.
-func (m API) AllDatacenters() ([]fastly.Datacenter, error) {
-	return m.AllDatacentersFn()
+func (m API) AllDatacenters(ctx context.Context) ([]fastly.Datacenter, error) {
+	return m.AllDatacentersFn(ctx)
 }
 
 // AllIPs implements Interface.
-func (m API) AllIPs() (fastly.IPAddrs, fastly.IPAddrs, error) {
-	return m.AllIPsFn()
+func (m API) AllIPs(ctx context.Context) (fastly.IPAddrs, fastly.IPAddrs, error) {
+	return m.AllIPsFn(ctx)
 }
 
 // CreateService implements Interface.
-func (m API) CreateService(i *fastly.CreateServiceInput) (*fastly.Service, error) {
-	return m.CreateServiceFn(i)
+func (m API) CreateService(ctx context.Context, i *fastly.CreateServiceInput) (*fastly.Service, error) {
+	return m.CreateServiceFn(ctx, i)
 }
 
 // GetServices implements Interface.
-func (m API) GetServices(i *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
-	return m.GetServicesFn(i)
+func (m API) GetServices(ctx context.Context, i *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
+	return m.GetServicesFn(ctx, i)
 }
 
 // ListServices implements Interface.
-func (m API) ListServices(i *fastly.ListServicesInput) ([]*fastly.Service, error) {
-	return m.ListServicesFn(i)
+func (m API) ListServices(ctx context.Context, i *fastly.ListServicesInput) ([]*fastly.Service, error) {
+	return m.ListServicesFn(ctx, i)
 }
 
 // GetService implements Interface.
-func (m API) GetService(i *fastly.GetServiceInput) (*fastly.Service, error) {
-	return m.GetServiceFn(i)
+func (m API) GetService(ctx context.Context, i *fastly.GetServiceInput) (*fastly.Service, error) {
+	return m.GetServiceFn(ctx, i)
 }
 
 // GetServiceDetails implements Interface.
-func (m API) GetServiceDetails(i *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
-	return m.GetServiceDetailsFn(i)
+func (m API) GetServiceDetails(ctx context.Context, i *fastly.GetServiceInput) (*fastly.ServiceDetail, error) {
+	return m.GetServiceDetailsFn(ctx, i)
 }
 
 // SearchService implements Interface.
-func (m API) SearchService(i *fastly.SearchServiceInput) (*fastly.Service, error) {
-	return m.SearchServiceFn(i)
+func (m API) SearchService(ctx context.Context, i *fastly.SearchServiceInput) (*fastly.Service, error) {
+	return m.SearchServiceFn(ctx, i)
 }
 
 // UpdateService implements Interface.
-func (m API) UpdateService(i *fastly.UpdateServiceInput) (*fastly.Service, error) {
-	return m.UpdateServiceFn(i)
+func (m API) UpdateService(ctx context.Context, i *fastly.UpdateServiceInput) (*fastly.Service, error) {
+	return m.UpdateServiceFn(ctx, i)
 }
 
 // DeleteService implements Interface.
-func (m API) DeleteService(i *fastly.DeleteServiceInput) error {
-	return m.DeleteServiceFn(i)
+func (m API) DeleteService(ctx context.Context, i *fastly.DeleteServiceInput) error {
+	return m.DeleteServiceFn(ctx, i)
 }
 
 // CloneVersion implements Interface.
-func (m API) CloneVersion(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return m.CloneVersionFn(i)
+func (m API) CloneVersion(ctx context.Context, i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return m.CloneVersionFn(ctx, i)
 }
 
 // ListVersions implements Interface.
-func (m API) ListVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-	return m.ListVersionsFn(i)
+func (m API) ListVersions(ctx context.Context, i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+	return m.ListVersionsFn(ctx, i)
 }
 
 // GetVersion implements Interface.
-func (m API) GetVersion(i *fastly.GetVersionInput) (*fastly.Version, error) {
-	return m.GetVersionFn(i)
+func (m API) GetVersion(ctx context.Context, i *fastly.GetVersionInput) (*fastly.Version, error) {
+	return m.GetVersionFn(ctx, i)
 }
 
 // UpdateVersion implements Interface.
-func (m API) UpdateVersion(i *fastly.UpdateVersionInput) (*fastly.Version, error) {
-	return m.UpdateVersionFn(i)
+func (m API) UpdateVersion(ctx context.Context, i *fastly.UpdateVersionInput) (*fastly.Version, error) {
+	return m.UpdateVersionFn(ctx, i)
 }
 
 // ActivateVersion implements Interface.
-func (m API) ActivateVersion(i *fastly.ActivateVersionInput) (*fastly.Version, error) {
-	return m.ActivateVersionFn(i)
+func (m API) ActivateVersion(ctx context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+	return m.ActivateVersionFn(ctx, i)
 }
 
 // DeactivateVersion implements Interface.
-func (m API) DeactivateVersion(i *fastly.DeactivateVersionInput) (*fastly.Version, error) {
-	return m.DeactivateVersionFn(i)
+func (m API) DeactivateVersion(ctx context.Context, i *fastly.DeactivateVersionInput) (*fastly.Version, error) {
+	return m.DeactivateVersionFn(ctx, i)
 }
 
 // LockVersion implements Interface.
-func (m API) LockVersion(i *fastly.LockVersionInput) (*fastly.Version, error) {
-	return m.LockVersionFn(i)
+func (m API) LockVersion(ctx context.Context, i *fastly.LockVersionInput) (*fastly.Version, error) {
+	return m.LockVersionFn(ctx, i)
 }
 
 // LatestVersion implements Interface.
-func (m API) LatestVersion(i *fastly.LatestVersionInput) (*fastly.Version, error) {
-	return m.LatestVersionFn(i)
+func (m API) LatestVersion(ctx context.Context, i *fastly.LatestVersionInput) (*fastly.Version, error) {
+	return m.LatestVersionFn(ctx, i)
 }
 
 // CreateDomain implements Interface.
-func (m API) CreateDomain(i *fastly.CreateDomainInput) (*fastly.Domain, error) {
-	return m.CreateDomainFn(i)
+func (m API) CreateDomain(ctx context.Context, i *fastly.CreateDomainInput) (*fastly.Domain, error) {
+	return m.CreateDomainFn(ctx, i)
 }
 
 // ListDomains implements Interface.
-func (m API) ListDomains(i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
-	return m.ListDomainsFn(i)
+func (m API) ListDomains(ctx context.Context, i *fastly.ListDomainsInput) ([]*fastly.Domain, error) {
+	return m.ListDomainsFn(ctx, i)
 }
 
 // GetDomain implements Interface.
-func (m API) GetDomain(i *fastly.GetDomainInput) (*fastly.Domain, error) {
-	return m.GetDomainFn(i)
+func (m API) GetDomain(ctx context.Context, i *fastly.GetDomainInput) (*fastly.Domain, error) {
+	return m.GetDomainFn(ctx, i)
 }
 
 // UpdateDomain implements Interface.
-func (m API) UpdateDomain(i *fastly.UpdateDomainInput) (*fastly.Domain, error) {
-	return m.UpdateDomainFn(i)
+func (m API) UpdateDomain(ctx context.Context, i *fastly.UpdateDomainInput) (*fastly.Domain, error) {
+	return m.UpdateDomainFn(ctx, i)
 }
 
 // DeleteDomain implements Interface.
-func (m API) DeleteDomain(i *fastly.DeleteDomainInput) error {
-	return m.DeleteDomainFn(i)
+func (m API) DeleteDomain(ctx context.Context, i *fastly.DeleteDomainInput) error {
+	return m.DeleteDomainFn(ctx, i)
 }
 
 // ValidateDomain implements Interface.
-func (m API) ValidateDomain(i *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error) {
-	return m.ValidateDomainFn(i)
+func (m API) ValidateDomain(ctx context.Context, i *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error) {
+	return m.ValidateDomainFn(ctx, i)
 }
 
 // ValidateAllDomains implements Interface.
-func (m API) ValidateAllDomains(i *fastly.ValidateAllDomainsInput) (results []*fastly.DomainValidationResult, err error) {
-	return m.ValidateAllDomainsFn(i)
+func (m API) ValidateAllDomains(ctx context.Context, i *fastly.ValidateAllDomainsInput) (results []*fastly.DomainValidationResult, err error) {
+	return m.ValidateAllDomainsFn(ctx, i)
 }
 
 // CreateBackend implements Interface.
-func (m API) CreateBackend(i *fastly.CreateBackendInput) (*fastly.Backend, error) {
-	return m.CreateBackendFn(i)
+func (m API) CreateBackend(ctx context.Context, i *fastly.CreateBackendInput) (*fastly.Backend, error) {
+	return m.CreateBackendFn(ctx, i)
 }
 
 // ListBackends implements Interface.
-func (m API) ListBackends(i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
-	return m.ListBackendsFn(i)
+func (m API) ListBackends(ctx context.Context, i *fastly.ListBackendsInput) ([]*fastly.Backend, error) {
+	return m.ListBackendsFn(ctx, i)
 }
 
 // GetBackend implements Interface.
-func (m API) GetBackend(i *fastly.GetBackendInput) (*fastly.Backend, error) {
-	return m.GetBackendFn(i)
+func (m API) GetBackend(ctx context.Context, i *fastly.GetBackendInput) (*fastly.Backend, error) {
+	return m.GetBackendFn(ctx, i)
 }
 
 // UpdateBackend implements Interface.
-func (m API) UpdateBackend(i *fastly.UpdateBackendInput) (*fastly.Backend, error) {
-	return m.UpdateBackendFn(i)
+func (m API) UpdateBackend(ctx context.Context, i *fastly.UpdateBackendInput) (*fastly.Backend, error) {
+	return m.UpdateBackendFn(ctx, i)
 }
 
 // DeleteBackend implements Interface.
-func (m API) DeleteBackend(i *fastly.DeleteBackendInput) error {
-	return m.DeleteBackendFn(i)
+func (m API) DeleteBackend(ctx context.Context, i *fastly.DeleteBackendInput) error {
+	return m.DeleteBackendFn(ctx, i)
 }
 
 // CreateHealthCheck implements Interface.
-func (m API) CreateHealthCheck(i *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error) {
-	return m.CreateHealthCheckFn(i)
+func (m API) CreateHealthCheck(ctx context.Context, i *fastly.CreateHealthCheckInput) (*fastly.HealthCheck, error) {
+	return m.CreateHealthCheckFn(ctx, i)
 }
 
 // ListHealthChecks implements Interface.
-func (m API) ListHealthChecks(i *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error) {
-	return m.ListHealthChecksFn(i)
+func (m API) ListHealthChecks(ctx context.Context, i *fastly.ListHealthChecksInput) ([]*fastly.HealthCheck, error) {
+	return m.ListHealthChecksFn(ctx, i)
 }
 
 // GetHealthCheck implements Interface.
-func (m API) GetHealthCheck(i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error) {
-	return m.GetHealthCheckFn(i)
+func (m API) GetHealthCheck(ctx context.Context, i *fastly.GetHealthCheckInput) (*fastly.HealthCheck, error) {
+	return m.GetHealthCheckFn(ctx, i)
 }
 
 // UpdateHealthCheck implements Interface.
-func (m API) UpdateHealthCheck(i *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error) {
-	return m.UpdateHealthCheckFn(i)
+func (m API) UpdateHealthCheck(ctx context.Context, i *fastly.UpdateHealthCheckInput) (*fastly.HealthCheck, error) {
+	return m.UpdateHealthCheckFn(ctx, i)
 }
 
 // DeleteHealthCheck implements Interface.
-func (m API) DeleteHealthCheck(i *fastly.DeleteHealthCheckInput) error {
-	return m.DeleteHealthCheckFn(i)
+func (m API) DeleteHealthCheck(ctx context.Context, i *fastly.DeleteHealthCheckInput) error {
+	return m.DeleteHealthCheckFn(ctx, i)
 }
 
 // GetPackage implements Interface.
-func (m API) GetPackage(i *fastly.GetPackageInput) (*fastly.Package, error) {
-	return m.GetPackageFn(i)
+func (m API) GetPackage(ctx context.Context, i *fastly.GetPackageInput) (*fastly.Package, error) {
+	return m.GetPackageFn(ctx, i)
 }
 
 // UpdatePackage implements Interface.
-func (m API) UpdatePackage(i *fastly.UpdatePackageInput) (*fastly.Package, error) {
-	return m.UpdatePackageFn(i)
+func (m API) UpdatePackage(ctx context.Context, i *fastly.UpdatePackageInput) (*fastly.Package, error) {
+	return m.UpdatePackageFn(ctx, i)
 }
 
 // CreateDictionary implements Interface.
-func (m API) CreateDictionary(i *fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
-	return m.CreateDictionaryFn(i)
+func (m API) CreateDictionary(ctx context.Context, i *fastly.CreateDictionaryInput) (*fastly.Dictionary, error) {
+	return m.CreateDictionaryFn(ctx, i)
 }
 
 // GetDictionary implements Interface.
-func (m API) GetDictionary(i *fastly.GetDictionaryInput) (*fastly.Dictionary, error) {
-	return m.GetDictionaryFn(i)
+func (m API) GetDictionary(ctx context.Context, i *fastly.GetDictionaryInput) (*fastly.Dictionary, error) {
+	return m.GetDictionaryFn(ctx, i)
 }
 
 // DeleteDictionary implements Interface.
-func (m API) DeleteDictionary(i *fastly.DeleteDictionaryInput) error {
-	return m.DeleteDictionaryFn(i)
+func (m API) DeleteDictionary(ctx context.Context, i *fastly.DeleteDictionaryInput) error {
+	return m.DeleteDictionaryFn(ctx, i)
 }
 
 // ListDictionaries implements Interface.
-func (m API) ListDictionaries(i *fastly.ListDictionariesInput) ([]*fastly.Dictionary, error) {
-	return m.ListDictionariesFn(i)
+func (m API) ListDictionaries(ctx context.Context, i *fastly.ListDictionariesInput) ([]*fastly.Dictionary, error) {
+	return m.ListDictionariesFn(ctx, i)
 }
 
 // UpdateDictionary implements Interface.
-func (m API) UpdateDictionary(i *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
-	return m.UpdateDictionaryFn(i)
+func (m API) UpdateDictionary(ctx context.Context, i *fastly.UpdateDictionaryInput) (*fastly.Dictionary, error) {
+	return m.UpdateDictionaryFn(ctx, i)
 }
 
 // GetDictionaryItems implements Interface.
-func (m API) GetDictionaryItems(i *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
-	return m.GetDictionaryItemsFn(i)
+func (m API) GetDictionaryItems(ctx context.Context, i *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
+	return m.GetDictionaryItemsFn(ctx, i)
 }
 
 // ListDictionaryItems implements Interface.
-func (m API) ListDictionaryItems(i *fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error) {
-	return m.ListDictionaryItemsFn(i)
+func (m API) ListDictionaryItems(ctx context.Context, i *fastly.ListDictionaryItemsInput) ([]*fastly.DictionaryItem, error) {
+	return m.ListDictionaryItemsFn(ctx, i)
 }
 
 // GetDictionaryItem implements Interface.
-func (m API) GetDictionaryItem(i *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error) {
-	return m.GetDictionaryItemFn(i)
+func (m API) GetDictionaryItem(ctx context.Context, i *fastly.GetDictionaryItemInput) (*fastly.DictionaryItem, error) {
+	return m.GetDictionaryItemFn(ctx, i)
 }
 
 // CreateDictionaryItem implements Interface.
-func (m API) CreateDictionaryItem(i *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error) {
-	return m.CreateDictionaryItemFn(i)
+func (m API) CreateDictionaryItem(ctx context.Context, i *fastly.CreateDictionaryItemInput) (*fastly.DictionaryItem, error) {
+	return m.CreateDictionaryItemFn(ctx, i)
 }
 
 // UpdateDictionaryItem implements Interface.
-func (m API) UpdateDictionaryItem(i *fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error) {
-	return m.UpdateDictionaryItemFn(i)
+func (m API) UpdateDictionaryItem(ctx context.Context, i *fastly.UpdateDictionaryItemInput) (*fastly.DictionaryItem, error) {
+	return m.UpdateDictionaryItemFn(ctx, i)
 }
 
 // DeleteDictionaryItem implements Interface.
-func (m API) DeleteDictionaryItem(i *fastly.DeleteDictionaryItemInput) error {
-	return m.DeleteDictionaryItemFn(i)
+func (m API) DeleteDictionaryItem(ctx context.Context, i *fastly.DeleteDictionaryItemInput) error {
+	return m.DeleteDictionaryItemFn(ctx, i)
 }
 
 // BatchModifyDictionaryItems implements Interface.
-func (m API) BatchModifyDictionaryItems(i *fastly.BatchModifyDictionaryItemsInput) error {
-	return m.BatchModifyDictionaryItemsFn(i)
+func (m API) BatchModifyDictionaryItems(ctx context.Context, i *fastly.BatchModifyDictionaryItemsInput) error {
+	return m.BatchModifyDictionaryItemsFn(ctx, i)
 }
 
 // GetDictionaryInfo implements Interface.
-func (m API) GetDictionaryInfo(i *fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error) {
-	return m.GetDictionaryInfoFn(i)
+func (m API) GetDictionaryInfo(ctx context.Context, i *fastly.GetDictionaryInfoInput) (*fastly.DictionaryInfo, error) {
+	return m.GetDictionaryInfoFn(ctx, i)
 }
 
 // CreateBigQuery implements Interface.
-func (m API) CreateBigQuery(i *fastly.CreateBigQueryInput) (*fastly.BigQuery, error) {
-	return m.CreateBigQueryFn(i)
+func (m API) CreateBigQuery(ctx context.Context, i *fastly.CreateBigQueryInput) (*fastly.BigQuery, error) {
+	return m.CreateBigQueryFn(ctx, i)
 }
 
 // ListBigQueries implements Interface.
-func (m API) ListBigQueries(i *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error) {
-	return m.ListBigQueriesFn(i)
+func (m API) ListBigQueries(ctx context.Context, i *fastly.ListBigQueriesInput) ([]*fastly.BigQuery, error) {
+	return m.ListBigQueriesFn(ctx, i)
 }
 
 // GetBigQuery implements Interface.
-func (m API) GetBigQuery(i *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
-	return m.GetBigQueryFn(i)
+func (m API) GetBigQuery(ctx context.Context, i *fastly.GetBigQueryInput) (*fastly.BigQuery, error) {
+	return m.GetBigQueryFn(ctx, i)
 }
 
 // UpdateBigQuery implements Interface.
-func (m API) UpdateBigQuery(i *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error) {
-	return m.UpdateBigQueryFn(i)
+func (m API) UpdateBigQuery(ctx context.Context, i *fastly.UpdateBigQueryInput) (*fastly.BigQuery, error) {
+	return m.UpdateBigQueryFn(ctx, i)
 }
 
 // DeleteBigQuery implements Interface.
-func (m API) DeleteBigQuery(i *fastly.DeleteBigQueryInput) error {
-	return m.DeleteBigQueryFn(i)
+func (m API) DeleteBigQuery(ctx context.Context, i *fastly.DeleteBigQueryInput) error {
+	return m.DeleteBigQueryFn(ctx, i)
 }
 
 // CreateS3 implements Interface.
-func (m API) CreateS3(i *fastly.CreateS3Input) (*fastly.S3, error) {
-	return m.CreateS3Fn(i)
+func (m API) CreateS3(ctx context.Context, i *fastly.CreateS3Input) (*fastly.S3, error) {
+	return m.CreateS3Fn(ctx, i)
 }
 
 // ListS3s implements Interface.
-func (m API) ListS3s(i *fastly.ListS3sInput) ([]*fastly.S3, error) {
-	return m.ListS3sFn(i)
+func (m API) ListS3s(ctx context.Context, i *fastly.ListS3sInput) ([]*fastly.S3, error) {
+	return m.ListS3sFn(ctx, i)
 }
 
 // GetS3 implements Interface.
-func (m API) GetS3(i *fastly.GetS3Input) (*fastly.S3, error) {
-	return m.GetS3Fn(i)
+func (m API) GetS3(ctx context.Context, i *fastly.GetS3Input) (*fastly.S3, error) {
+	return m.GetS3Fn(ctx, i)
 }
 
 // UpdateS3 implements Interface.
-func (m API) UpdateS3(i *fastly.UpdateS3Input) (*fastly.S3, error) {
-	return m.UpdateS3Fn(i)
+func (m API) UpdateS3(ctx context.Context, i *fastly.UpdateS3Input) (*fastly.S3, error) {
+	return m.UpdateS3Fn(ctx, i)
 }
 
 // DeleteS3 implements Interface.
-func (m API) DeleteS3(i *fastly.DeleteS3Input) error {
-	return m.DeleteS3Fn(i)
+func (m API) DeleteS3(ctx context.Context, i *fastly.DeleteS3Input) error {
+	return m.DeleteS3Fn(ctx, i)
 }
 
 // CreateKinesis implements Interface.
-func (m API) CreateKinesis(i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
-	return m.CreateKinesisFn(i)
+func (m API) CreateKinesis(ctx context.Context, i *fastly.CreateKinesisInput) (*fastly.Kinesis, error) {
+	return m.CreateKinesisFn(ctx, i)
 }
 
 // ListKinesis implements Interface.
-func (m API) ListKinesis(i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
-	return m.ListKinesisFn(i)
+func (m API) ListKinesis(ctx context.Context, i *fastly.ListKinesisInput) ([]*fastly.Kinesis, error) {
+	return m.ListKinesisFn(ctx, i)
 }
 
 // GetKinesis implements Interface.
-func (m API) GetKinesis(i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
-	return m.GetKinesisFn(i)
+func (m API) GetKinesis(ctx context.Context, i *fastly.GetKinesisInput) (*fastly.Kinesis, error) {
+	return m.GetKinesisFn(ctx, i)
 }
 
 // UpdateKinesis implements Interface.
-func (m API) UpdateKinesis(i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
-	return m.UpdateKinesisFn(i)
+func (m API) UpdateKinesis(ctx context.Context, i *fastly.UpdateKinesisInput) (*fastly.Kinesis, error) {
+	return m.UpdateKinesisFn(ctx, i)
 }
 
 // DeleteKinesis implements Interface.
-func (m API) DeleteKinesis(i *fastly.DeleteKinesisInput) error {
-	return m.DeleteKinesisFn(i)
+func (m API) DeleteKinesis(ctx context.Context, i *fastly.DeleteKinesisInput) error {
+	return m.DeleteKinesisFn(ctx, i)
 }
 
 // CreateSyslog implements Interface.
-func (m API) CreateSyslog(i *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
-	return m.CreateSyslogFn(i)
+func (m API) CreateSyslog(ctx context.Context, i *fastly.CreateSyslogInput) (*fastly.Syslog, error) {
+	return m.CreateSyslogFn(ctx, i)
 }
 
 // ListSyslogs implements Interface.
-func (m API) ListSyslogs(i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
-	return m.ListSyslogsFn(i)
+func (m API) ListSyslogs(ctx context.Context, i *fastly.ListSyslogsInput) ([]*fastly.Syslog, error) {
+	return m.ListSyslogsFn(ctx, i)
 }
 
 // GetSyslog implements Interface.
-func (m API) GetSyslog(i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
-	return m.GetSyslogFn(i)
+func (m API) GetSyslog(ctx context.Context, i *fastly.GetSyslogInput) (*fastly.Syslog, error) {
+	return m.GetSyslogFn(ctx, i)
 }
 
 // UpdateSyslog implements Interface.
-func (m API) UpdateSyslog(i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
-	return m.UpdateSyslogFn(i)
+func (m API) UpdateSyslog(ctx context.Context, i *fastly.UpdateSyslogInput) (*fastly.Syslog, error) {
+	return m.UpdateSyslogFn(ctx, i)
 }
 
 // DeleteSyslog implements Interface.
-func (m API) DeleteSyslog(i *fastly.DeleteSyslogInput) error {
-	return m.DeleteSyslogFn(i)
+func (m API) DeleteSyslog(ctx context.Context, i *fastly.DeleteSyslogInput) error {
+	return m.DeleteSyslogFn(ctx, i)
 }
 
 // CreateLogentries implements Interface.
-func (m API) CreateLogentries(i *fastly.CreateLogentriesInput) (*fastly.Logentries, error) {
-	return m.CreateLogentriesFn(i)
+func (m API) CreateLogentries(ctx context.Context, i *fastly.CreateLogentriesInput) (*fastly.Logentries, error) {
+	return m.CreateLogentriesFn(ctx, i)
 }
 
 // ListLogentries implements Interface.
-func (m API) ListLogentries(i *fastly.ListLogentriesInput) ([]*fastly.Logentries, error) {
-	return m.ListLogentriesFn(i)
+func (m API) ListLogentries(ctx context.Context, i *fastly.ListLogentriesInput) ([]*fastly.Logentries, error) {
+	return m.ListLogentriesFn(ctx, i)
 }
 
 // GetLogentries implements Interface.
-func (m API) GetLogentries(i *fastly.GetLogentriesInput) (*fastly.Logentries, error) {
-	return m.GetLogentriesFn(i)
+func (m API) GetLogentries(ctx context.Context, i *fastly.GetLogentriesInput) (*fastly.Logentries, error) {
+	return m.GetLogentriesFn(ctx, i)
 }
 
 // UpdateLogentries implements Interface.
-func (m API) UpdateLogentries(i *fastly.UpdateLogentriesInput) (*fastly.Logentries, error) {
-	return m.UpdateLogentriesFn(i)
+func (m API) UpdateLogentries(ctx context.Context, i *fastly.UpdateLogentriesInput) (*fastly.Logentries, error) {
+	return m.UpdateLogentriesFn(ctx, i)
 }
 
 // DeleteLogentries implements Interface.
-func (m API) DeleteLogentries(i *fastly.DeleteLogentriesInput) error {
-	return m.DeleteLogentriesFn(i)
+func (m API) DeleteLogentries(ctx context.Context, i *fastly.DeleteLogentriesInput) error {
+	return m.DeleteLogentriesFn(ctx, i)
 }
 
 // CreatePapertrail implements Interface.
-func (m API) CreatePapertrail(i *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
-	return m.CreatePapertrailFn(i)
+func (m API) CreatePapertrail(ctx context.Context, i *fastly.CreatePapertrailInput) (*fastly.Papertrail, error) {
+	return m.CreatePapertrailFn(ctx, i)
 }
 
 // ListPapertrails implements Interface.
-func (m API) ListPapertrails(i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
-	return m.ListPapertrailsFn(i)
+func (m API) ListPapertrails(ctx context.Context, i *fastly.ListPapertrailsInput) ([]*fastly.Papertrail, error) {
+	return m.ListPapertrailsFn(ctx, i)
 }
 
 // GetPapertrail implements Interface.
-func (m API) GetPapertrail(i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
-	return m.GetPapertrailFn(i)
+func (m API) GetPapertrail(ctx context.Context, i *fastly.GetPapertrailInput) (*fastly.Papertrail, error) {
+	return m.GetPapertrailFn(ctx, i)
 }
 
 // UpdatePapertrail implements Interface.
-func (m API) UpdatePapertrail(i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
-	return m.UpdatePapertrailFn(i)
+func (m API) UpdatePapertrail(ctx context.Context, i *fastly.UpdatePapertrailInput) (*fastly.Papertrail, error) {
+	return m.UpdatePapertrailFn(ctx, i)
 }
 
 // DeletePapertrail implements Interface.
-func (m API) DeletePapertrail(i *fastly.DeletePapertrailInput) error {
-	return m.DeletePapertrailFn(i)
+func (m API) DeletePapertrail(ctx context.Context, i *fastly.DeletePapertrailInput) error {
+	return m.DeletePapertrailFn(ctx, i)
 }
 
 // CreateSumologic implements Interface.
-func (m API) CreateSumologic(i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
-	return m.CreateSumologicFn(i)
+func (m API) CreateSumologic(ctx context.Context, i *fastly.CreateSumologicInput) (*fastly.Sumologic, error) {
+	return m.CreateSumologicFn(ctx, i)
 }
 
 // ListSumologics implements Interface.
-func (m API) ListSumologics(i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
-	return m.ListSumologicsFn(i)
+func (m API) ListSumologics(ctx context.Context, i *fastly.ListSumologicsInput) ([]*fastly.Sumologic, error) {
+	return m.ListSumologicsFn(ctx, i)
 }
 
 // GetSumologic implements Interface.
-func (m API) GetSumologic(i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
-	return m.GetSumologicFn(i)
+func (m API) GetSumologic(ctx context.Context, i *fastly.GetSumologicInput) (*fastly.Sumologic, error) {
+	return m.GetSumologicFn(ctx, i)
 }
 
 // UpdateSumologic implements Interface.
-func (m API) UpdateSumologic(i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
-	return m.UpdateSumologicFn(i)
+func (m API) UpdateSumologic(ctx context.Context, i *fastly.UpdateSumologicInput) (*fastly.Sumologic, error) {
+	return m.UpdateSumologicFn(ctx, i)
 }
 
 // DeleteSumologic implements Interface.
-func (m API) DeleteSumologic(i *fastly.DeleteSumologicInput) error {
-	return m.DeleteSumologicFn(i)
+func (m API) DeleteSumologic(ctx context.Context, i *fastly.DeleteSumologicInput) error {
+	return m.DeleteSumologicFn(ctx, i)
 }
 
 // CreateGCS implements Interface.
-func (m API) CreateGCS(i *fastly.CreateGCSInput) (*fastly.GCS, error) {
-	return m.CreateGCSFn(i)
+func (m API) CreateGCS(ctx context.Context, i *fastly.CreateGCSInput) (*fastly.GCS, error) {
+	return m.CreateGCSFn(ctx, i)
 }
 
 // ListGCSs implements Interface.
-func (m API) ListGCSs(i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
-	return m.ListGCSsFn(i)
+func (m API) ListGCSs(ctx context.Context, i *fastly.ListGCSsInput) ([]*fastly.GCS, error) {
+	return m.ListGCSsFn(ctx, i)
 }
 
 // GetGCS implements Interface.
-func (m API) GetGCS(i *fastly.GetGCSInput) (*fastly.GCS, error) {
-	return m.GetGCSFn(i)
+func (m API) GetGCS(ctx context.Context, i *fastly.GetGCSInput) (*fastly.GCS, error) {
+	return m.GetGCSFn(ctx, i)
 }
 
 // UpdateGCS implements Interface.
-func (m API) UpdateGCS(i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
-	return m.UpdateGCSFn(i)
+func (m API) UpdateGCS(ctx context.Context, i *fastly.UpdateGCSInput) (*fastly.GCS, error) {
+	return m.UpdateGCSFn(ctx, i)
 }
 
 // DeleteGCS implements Interface.
-func (m API) DeleteGCS(i *fastly.DeleteGCSInput) error {
-	return m.DeleteGCSFn(i)
+func (m API) DeleteGCS(ctx context.Context, i *fastly.DeleteGCSInput) error {
+	return m.DeleteGCSFn(ctx, i)
 }
 
 // CreateGrafanaCloudLogs implements Interface.
-func (m API) CreateGrafanaCloudLogs(i *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
-	return m.CreateGrafanaCloudLogsFn(i)
+func (m API) CreateGrafanaCloudLogs(ctx context.Context, i *fastly.CreateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+	return m.CreateGrafanaCloudLogsFn(ctx, i)
 }
 
 // ListGrafanaCloudLogs implements Interface.
-func (m API) ListGrafanaCloudLogs(i *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error) {
-	return m.ListGrafanaCloudLogsFn(i)
+func (m API) ListGrafanaCloudLogs(ctx context.Context, i *fastly.ListGrafanaCloudLogsInput) ([]*fastly.GrafanaCloudLogs, error) {
+	return m.ListGrafanaCloudLogsFn(ctx, i)
 }
 
 // GetGrafanaCloudLogs implements Interface.
-func (m API) GetGrafanaCloudLogs(i *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
-	return m.GetGrafanaCloudLogsFn(i)
+func (m API) GetGrafanaCloudLogs(ctx context.Context, i *fastly.GetGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+	return m.GetGrafanaCloudLogsFn(ctx, i)
 }
 
 // UpdateGrafanaCloudLogs implements Interface.
-func (m API) UpdateGrafanaCloudLogs(i *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
-	return m.UpdateGrafanaCloudLogsFn(i)
+func (m API) UpdateGrafanaCloudLogs(ctx context.Context, i *fastly.UpdateGrafanaCloudLogsInput) (*fastly.GrafanaCloudLogs, error) {
+	return m.UpdateGrafanaCloudLogsFn(ctx, i)
 }
 
 // DeleteGrafanaCloudLogs implements Interface.
-func (m API) DeleteGrafanaCloudLogs(i *fastly.DeleteGrafanaCloudLogsInput) error {
-	return m.DeleteGrafanaCloudLogsFn(i)
+func (m API) DeleteGrafanaCloudLogs(ctx context.Context, i *fastly.DeleteGrafanaCloudLogsInput) error {
+	return m.DeleteGrafanaCloudLogsFn(ctx, i)
 }
 
 // CreateFTP implements Interface.
-func (m API) CreateFTP(i *fastly.CreateFTPInput) (*fastly.FTP, error) {
-	return m.CreateFTPFn(i)
+func (m API) CreateFTP(ctx context.Context, i *fastly.CreateFTPInput) (*fastly.FTP, error) {
+	return m.CreateFTPFn(ctx, i)
 }
 
 // ListFTPs implements Interface.
-func (m API) ListFTPs(i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
-	return m.ListFTPsFn(i)
+func (m API) ListFTPs(ctx context.Context, i *fastly.ListFTPsInput) ([]*fastly.FTP, error) {
+	return m.ListFTPsFn(ctx, i)
 }
 
 // GetFTP implements Interface.
-func (m API) GetFTP(i *fastly.GetFTPInput) (*fastly.FTP, error) {
-	return m.GetFTPFn(i)
+func (m API) GetFTP(ctx context.Context, i *fastly.GetFTPInput) (*fastly.FTP, error) {
+	return m.GetFTPFn(ctx, i)
 }
 
 // UpdateFTP implements Interface.
-func (m API) UpdateFTP(i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
-	return m.UpdateFTPFn(i)
+func (m API) UpdateFTP(ctx context.Context, i *fastly.UpdateFTPInput) (*fastly.FTP, error) {
+	return m.UpdateFTPFn(ctx, i)
 }
 
 // DeleteFTP implements Interface.
-func (m API) DeleteFTP(i *fastly.DeleteFTPInput) error {
-	return m.DeleteFTPFn(i)
+func (m API) DeleteFTP(ctx context.Context, i *fastly.DeleteFTPInput) error {
+	return m.DeleteFTPFn(ctx, i)
 }
 
 // CreateSplunk implements Interface.
-func (m API) CreateSplunk(i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
-	return m.CreateSplunkFn(i)
+func (m API) CreateSplunk(ctx context.Context, i *fastly.CreateSplunkInput) (*fastly.Splunk, error) {
+	return m.CreateSplunkFn(ctx, i)
 }
 
 // ListSplunks implements Interface.
-func (m API) ListSplunks(i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
-	return m.ListSplunksFn(i)
+func (m API) ListSplunks(ctx context.Context, i *fastly.ListSplunksInput) ([]*fastly.Splunk, error) {
+	return m.ListSplunksFn(ctx, i)
 }
 
 // GetSplunk implements Interface.
-func (m API) GetSplunk(i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
-	return m.GetSplunkFn(i)
+func (m API) GetSplunk(ctx context.Context, i *fastly.GetSplunkInput) (*fastly.Splunk, error) {
+	return m.GetSplunkFn(ctx, i)
 }
 
 // UpdateSplunk implements Interface.
-func (m API) UpdateSplunk(i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
-	return m.UpdateSplunkFn(i)
+func (m API) UpdateSplunk(ctx context.Context, i *fastly.UpdateSplunkInput) (*fastly.Splunk, error) {
+	return m.UpdateSplunkFn(ctx, i)
 }
 
 // DeleteSplunk implements Interface.
-func (m API) DeleteSplunk(i *fastly.DeleteSplunkInput) error {
-	return m.DeleteSplunkFn(i)
+func (m API) DeleteSplunk(ctx context.Context, i *fastly.DeleteSplunkInput) error {
+	return m.DeleteSplunkFn(ctx, i)
 }
 
 // CreateScalyr implements Interface.
-func (m API) CreateScalyr(i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
-	return m.CreateScalyrFn(i)
+func (m API) CreateScalyr(ctx context.Context, i *fastly.CreateScalyrInput) (*fastly.Scalyr, error) {
+	return m.CreateScalyrFn(ctx, i)
 }
 
 // ListScalyrs implements Interface.
-func (m API) ListScalyrs(i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
-	return m.ListScalyrsFn(i)
+func (m API) ListScalyrs(ctx context.Context, i *fastly.ListScalyrsInput) ([]*fastly.Scalyr, error) {
+	return m.ListScalyrsFn(ctx, i)
 }
 
 // GetScalyr implements Interface.
-func (m API) GetScalyr(i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
-	return m.GetScalyrFn(i)
+func (m API) GetScalyr(ctx context.Context, i *fastly.GetScalyrInput) (*fastly.Scalyr, error) {
+	return m.GetScalyrFn(ctx, i)
 }
 
 // UpdateScalyr implements Interface.
-func (m API) UpdateScalyr(i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
-	return m.UpdateScalyrFn(i)
+func (m API) UpdateScalyr(ctx context.Context, i *fastly.UpdateScalyrInput) (*fastly.Scalyr, error) {
+	return m.UpdateScalyrFn(ctx, i)
 }
 
 // DeleteScalyr implements Interface.
-func (m API) DeleteScalyr(i *fastly.DeleteScalyrInput) error {
-	return m.DeleteScalyrFn(i)
+func (m API) DeleteScalyr(ctx context.Context, i *fastly.DeleteScalyrInput) error {
+	return m.DeleteScalyrFn(ctx, i)
 }
 
 // CreateLoggly implements Interface.
-func (m API) CreateLoggly(i *fastly.CreateLogglyInput) (*fastly.Loggly, error) {
-	return m.CreateLogglyFn(i)
+func (m API) CreateLoggly(ctx context.Context, i *fastly.CreateLogglyInput) (*fastly.Loggly, error) {
+	return m.CreateLogglyFn(ctx, i)
 }
 
 // ListLoggly implements Interface.
-func (m API) ListLoggly(i *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
-	return m.ListLogglyFn(i)
+func (m API) ListLoggly(ctx context.Context, i *fastly.ListLogglyInput) ([]*fastly.Loggly, error) {
+	return m.ListLogglyFn(ctx, i)
 }
 
 // GetLoggly implements Interface.
-func (m API) GetLoggly(i *fastly.GetLogglyInput) (*fastly.Loggly, error) {
-	return m.GetLogglyFn(i)
+func (m API) GetLoggly(ctx context.Context, i *fastly.GetLogglyInput) (*fastly.Loggly, error) {
+	return m.GetLogglyFn(ctx, i)
 }
 
 // UpdateLoggly implements Interface.
-func (m API) UpdateLoggly(i *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
-	return m.UpdateLogglyFn(i)
+func (m API) UpdateLoggly(ctx context.Context, i *fastly.UpdateLogglyInput) (*fastly.Loggly, error) {
+	return m.UpdateLogglyFn(ctx, i)
 }
 
 // DeleteLoggly implements Interface.
-func (m API) DeleteLoggly(i *fastly.DeleteLogglyInput) error {
-	return m.DeleteLogglyFn(i)
+func (m API) DeleteLoggly(ctx context.Context, i *fastly.DeleteLogglyInput) error {
+	return m.DeleteLogglyFn(ctx, i)
 }
 
 // CreateHoneycomb implements Interface.
-func (m API) CreateHoneycomb(i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
-	return m.CreateHoneycombFn(i)
+func (m API) CreateHoneycomb(ctx context.Context, i *fastly.CreateHoneycombInput) (*fastly.Honeycomb, error) {
+	return m.CreateHoneycombFn(ctx, i)
 }
 
 // ListHoneycombs implements Interface.
-func (m API) ListHoneycombs(i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
-	return m.ListHoneycombsFn(i)
+func (m API) ListHoneycombs(ctx context.Context, i *fastly.ListHoneycombsInput) ([]*fastly.Honeycomb, error) {
+	return m.ListHoneycombsFn(ctx, i)
 }
 
 // GetHoneycomb implements Interface.
-func (m API) GetHoneycomb(i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
-	return m.GetHoneycombFn(i)
+func (m API) GetHoneycomb(ctx context.Context, i *fastly.GetHoneycombInput) (*fastly.Honeycomb, error) {
+	return m.GetHoneycombFn(ctx, i)
 }
 
 // UpdateHoneycomb implements Interface.
-func (m API) UpdateHoneycomb(i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
-	return m.UpdateHoneycombFn(i)
+func (m API) UpdateHoneycomb(ctx context.Context, i *fastly.UpdateHoneycombInput) (*fastly.Honeycomb, error) {
+	return m.UpdateHoneycombFn(ctx, i)
 }
 
 // DeleteHoneycomb implements Interface.
-func (m API) DeleteHoneycomb(i *fastly.DeleteHoneycombInput) error {
-	return m.DeleteHoneycombFn(i)
+func (m API) DeleteHoneycomb(ctx context.Context, i *fastly.DeleteHoneycombInput) error {
+	return m.DeleteHoneycombFn(ctx, i)
 }
 
 // CreateHeroku implements Interface.
-func (m API) CreateHeroku(i *fastly.CreateHerokuInput) (*fastly.Heroku, error) {
-	return m.CreateHerokuFn(i)
+func (m API) CreateHeroku(ctx context.Context, i *fastly.CreateHerokuInput) (*fastly.Heroku, error) {
+	return m.CreateHerokuFn(ctx, i)
 }
 
 // ListHerokus implements Interface.
-func (m API) ListHerokus(i *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
-	return m.ListHerokusFn(i)
+func (m API) ListHerokus(ctx context.Context, i *fastly.ListHerokusInput) ([]*fastly.Heroku, error) {
+	return m.ListHerokusFn(ctx, i)
 }
 
 // GetHeroku implements Interface.
-func (m API) GetHeroku(i *fastly.GetHerokuInput) (*fastly.Heroku, error) {
-	return m.GetHerokuFn(i)
+func (m API) GetHeroku(ctx context.Context, i *fastly.GetHerokuInput) (*fastly.Heroku, error) {
+	return m.GetHerokuFn(ctx, i)
 }
 
 // UpdateHeroku implements Interface.
-func (m API) UpdateHeroku(i *fastly.UpdateHerokuInput) (*fastly.Heroku, error) {
-	return m.UpdateHerokuFn(i)
+func (m API) UpdateHeroku(ctx context.Context, i *fastly.UpdateHerokuInput) (*fastly.Heroku, error) {
+	return m.UpdateHerokuFn(ctx, i)
 }
 
 // DeleteHeroku implements Interface.
-func (m API) DeleteHeroku(i *fastly.DeleteHerokuInput) error {
-	return m.DeleteHerokuFn(i)
+func (m API) DeleteHeroku(ctx context.Context, i *fastly.DeleteHerokuInput) error {
+	return m.DeleteHerokuFn(ctx, i)
 }
 
 // CreateSFTP implements Interface.
-func (m API) CreateSFTP(i *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
-	return m.CreateSFTPFn(i)
+func (m API) CreateSFTP(ctx context.Context, i *fastly.CreateSFTPInput) (*fastly.SFTP, error) {
+	return m.CreateSFTPFn(ctx, i)
 }
 
 // ListSFTPs implements Interface.
-func (m API) ListSFTPs(i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
-	return m.ListSFTPsFn(i)
+func (m API) ListSFTPs(ctx context.Context, i *fastly.ListSFTPsInput) ([]*fastly.SFTP, error) {
+	return m.ListSFTPsFn(ctx, i)
 }
 
 // GetSFTP implements Interface.
-func (m API) GetSFTP(i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
-	return m.GetSFTPFn(i)
+func (m API) GetSFTP(ctx context.Context, i *fastly.GetSFTPInput) (*fastly.SFTP, error) {
+	return m.GetSFTPFn(ctx, i)
 }
 
 // UpdateSFTP implements Interface.
-func (m API) UpdateSFTP(i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
-	return m.UpdateSFTPFn(i)
+func (m API) UpdateSFTP(ctx context.Context, i *fastly.UpdateSFTPInput) (*fastly.SFTP, error) {
+	return m.UpdateSFTPFn(ctx, i)
 }
 
 // DeleteSFTP implements Interface.
-func (m API) DeleteSFTP(i *fastly.DeleteSFTPInput) error {
-	return m.DeleteSFTPFn(i)
+func (m API) DeleteSFTP(ctx context.Context, i *fastly.DeleteSFTPInput) error {
+	return m.DeleteSFTPFn(ctx, i)
 }
 
 // CreateLogshuttle implements Interface.
-func (m API) CreateLogshuttle(i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
-	return m.CreateLogshuttleFn(i)
+func (m API) CreateLogshuttle(ctx context.Context, i *fastly.CreateLogshuttleInput) (*fastly.Logshuttle, error) {
+	return m.CreateLogshuttleFn(ctx, i)
 }
 
 // ListLogshuttles implements Interface.
-func (m API) ListLogshuttles(i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
-	return m.ListLogshuttlesFn(i)
+func (m API) ListLogshuttles(ctx context.Context, i *fastly.ListLogshuttlesInput) ([]*fastly.Logshuttle, error) {
+	return m.ListLogshuttlesFn(ctx, i)
 }
 
 // GetLogshuttle implements Interface.
-func (m API) GetLogshuttle(i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
-	return m.GetLogshuttleFn(i)
+func (m API) GetLogshuttle(ctx context.Context, i *fastly.GetLogshuttleInput) (*fastly.Logshuttle, error) {
+	return m.GetLogshuttleFn(ctx, i)
 }
 
 // UpdateLogshuttle implements Interface.
-func (m API) UpdateLogshuttle(i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
-	return m.UpdateLogshuttleFn(i)
+func (m API) UpdateLogshuttle(ctx context.Context, i *fastly.UpdateLogshuttleInput) (*fastly.Logshuttle, error) {
+	return m.UpdateLogshuttleFn(ctx, i)
 }
 
 // DeleteLogshuttle implements Interface.
-func (m API) DeleteLogshuttle(i *fastly.DeleteLogshuttleInput) error {
-	return m.DeleteLogshuttleFn(i)
+func (m API) DeleteLogshuttle(ctx context.Context, i *fastly.DeleteLogshuttleInput) error {
+	return m.DeleteLogshuttleFn(ctx, i)
 }
 
 // CreateCloudfiles implements Interface.
-func (m API) CreateCloudfiles(i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
-	return m.CreateCloudfilesFn(i)
+func (m API) CreateCloudfiles(ctx context.Context, i *fastly.CreateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return m.CreateCloudfilesFn(ctx, i)
 }
 
 // ListCloudfiles implements Interface.
-func (m API) ListCloudfiles(i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
-	return m.ListCloudfilesFn(i)
+func (m API) ListCloudfiles(ctx context.Context, i *fastly.ListCloudfilesInput) ([]*fastly.Cloudfiles, error) {
+	return m.ListCloudfilesFn(ctx, i)
 }
 
 // GetCloudfiles implements Interface.
-func (m API) GetCloudfiles(i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
-	return m.GetCloudfilesFn(i)
+func (m API) GetCloudfiles(ctx context.Context, i *fastly.GetCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return m.GetCloudfilesFn(ctx, i)
 }
 
 // UpdateCloudfiles implements Interface.
-func (m API) UpdateCloudfiles(i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
-	return m.UpdateCloudfilesFn(i)
+func (m API) UpdateCloudfiles(ctx context.Context, i *fastly.UpdateCloudfilesInput) (*fastly.Cloudfiles, error) {
+	return m.UpdateCloudfilesFn(ctx, i)
 }
 
 // DeleteCloudfiles implements Interface.
-func (m API) DeleteCloudfiles(i *fastly.DeleteCloudfilesInput) error {
-	return m.DeleteCloudfilesFn(i)
+func (m API) DeleteCloudfiles(ctx context.Context, i *fastly.DeleteCloudfilesInput) error {
+	return m.DeleteCloudfilesFn(ctx, i)
 }
 
 // CreateDigitalOcean implements Interface.
-func (m API) CreateDigitalOcean(i *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error) {
-	return m.CreateDigitalOceanFn(i)
+func (m API) CreateDigitalOcean(ctx context.Context, i *fastly.CreateDigitalOceanInput) (*fastly.DigitalOcean, error) {
+	return m.CreateDigitalOceanFn(ctx, i)
 }
 
 // ListDigitalOceans implements Interface.
-func (m API) ListDigitalOceans(i *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error) {
-	return m.ListDigitalOceansFn(i)
+func (m API) ListDigitalOceans(ctx context.Context, i *fastly.ListDigitalOceansInput) ([]*fastly.DigitalOcean, error) {
+	return m.ListDigitalOceansFn(ctx, i)
 }
 
 // GetDigitalOcean implements Interface.
-func (m API) GetDigitalOcean(i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error) {
-	return m.GetDigitalOceanFn(i)
+func (m API) GetDigitalOcean(ctx context.Context, i *fastly.GetDigitalOceanInput) (*fastly.DigitalOcean, error) {
+	return m.GetDigitalOceanFn(ctx, i)
 }
 
 // UpdateDigitalOcean implements Interface.
-func (m API) UpdateDigitalOcean(i *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error) {
-	return m.UpdateDigitalOceanFn(i)
+func (m API) UpdateDigitalOcean(ctx context.Context, i *fastly.UpdateDigitalOceanInput) (*fastly.DigitalOcean, error) {
+	return m.UpdateDigitalOceanFn(ctx, i)
 }
 
 // DeleteDigitalOcean implements Interface.
-func (m API) DeleteDigitalOcean(i *fastly.DeleteDigitalOceanInput) error {
-	return m.DeleteDigitalOceanFn(i)
+func (m API) DeleteDigitalOcean(ctx context.Context, i *fastly.DeleteDigitalOceanInput) error {
+	return m.DeleteDigitalOceanFn(ctx, i)
 }
 
 // CreateElasticsearch implements Interface.
-func (m API) CreateElasticsearch(i *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
-	return m.CreateElasticsearchFn(i)
+func (m API) CreateElasticsearch(ctx context.Context, i *fastly.CreateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return m.CreateElasticsearchFn(ctx, i)
 }
 
 // ListElasticsearch implements Interface.
-func (m API) ListElasticsearch(i *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
-	return m.ListElasticsearchFn(i)
+func (m API) ListElasticsearch(ctx context.Context, i *fastly.ListElasticsearchInput) ([]*fastly.Elasticsearch, error) {
+	return m.ListElasticsearchFn(ctx, i)
 }
 
 // GetElasticsearch implements Interface.
-func (m API) GetElasticsearch(i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
-	return m.GetElasticsearchFn(i)
+func (m API) GetElasticsearch(ctx context.Context, i *fastly.GetElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return m.GetElasticsearchFn(ctx, i)
 }
 
 // UpdateElasticsearch implements Interface.
-func (m API) UpdateElasticsearch(i *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
-	return m.UpdateElasticsearchFn(i)
+func (m API) UpdateElasticsearch(ctx context.Context, i *fastly.UpdateElasticsearchInput) (*fastly.Elasticsearch, error) {
+	return m.UpdateElasticsearchFn(ctx, i)
 }
 
 // DeleteElasticsearch implements Interface.
-func (m API) DeleteElasticsearch(i *fastly.DeleteElasticsearchInput) error {
-	return m.DeleteElasticsearchFn(i)
+func (m API) DeleteElasticsearch(ctx context.Context, i *fastly.DeleteElasticsearchInput) error {
+	return m.DeleteElasticsearchFn(ctx, i)
 }
 
 // CreateBlobStorage implements Interface.
-func (m API) CreateBlobStorage(i *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error) {
-	return m.CreateBlobStorageFn(i)
+func (m API) CreateBlobStorage(ctx context.Context, i *fastly.CreateBlobStorageInput) (*fastly.BlobStorage, error) {
+	return m.CreateBlobStorageFn(ctx, i)
 }
 
 // ListBlobStorages implements Interface.
-func (m API) ListBlobStorages(i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error) {
-	return m.ListBlobStoragesFn(i)
+func (m API) ListBlobStorages(ctx context.Context, i *fastly.ListBlobStoragesInput) ([]*fastly.BlobStorage, error) {
+	return m.ListBlobStoragesFn(ctx, i)
 }
 
 // GetBlobStorage implements Interface.
-func (m API) GetBlobStorage(i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
-	return m.GetBlobStorageFn(i)
+func (m API) GetBlobStorage(ctx context.Context, i *fastly.GetBlobStorageInput) (*fastly.BlobStorage, error) {
+	return m.GetBlobStorageFn(ctx, i)
 }
 
 // UpdateBlobStorage implements Interface.
-func (m API) UpdateBlobStorage(i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {
-	return m.UpdateBlobStorageFn(i)
+func (m API) UpdateBlobStorage(ctx context.Context, i *fastly.UpdateBlobStorageInput) (*fastly.BlobStorage, error) {
+	return m.UpdateBlobStorageFn(ctx, i)
 }
 
 // DeleteBlobStorage implements Interface.
-func (m API) DeleteBlobStorage(i *fastly.DeleteBlobStorageInput) error {
-	return m.DeleteBlobStorageFn(i)
+func (m API) DeleteBlobStorage(ctx context.Context, i *fastly.DeleteBlobStorageInput) error {
+	return m.DeleteBlobStorageFn(ctx, i)
 }
 
 // CreateDatadog implements Interface.
-func (m API) CreateDatadog(i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
-	return m.CreateDatadogFn(i)
+func (m API) CreateDatadog(ctx context.Context, i *fastly.CreateDatadogInput) (*fastly.Datadog, error) {
+	return m.CreateDatadogFn(ctx, i)
 }
 
 // ListDatadog implements Interface.
-func (m API) ListDatadog(i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
-	return m.ListDatadogFn(i)
+func (m API) ListDatadog(ctx context.Context, i *fastly.ListDatadogInput) ([]*fastly.Datadog, error) {
+	return m.ListDatadogFn(ctx, i)
 }
 
 // GetDatadog implements Interface.
-func (m API) GetDatadog(i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
-	return m.GetDatadogFn(i)
+func (m API) GetDatadog(ctx context.Context, i *fastly.GetDatadogInput) (*fastly.Datadog, error) {
+	return m.GetDatadogFn(ctx, i)
 }
 
 // UpdateDatadog implements Interface.
-func (m API) UpdateDatadog(i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
-	return m.UpdateDatadogFn(i)
+func (m API) UpdateDatadog(ctx context.Context, i *fastly.UpdateDatadogInput) (*fastly.Datadog, error) {
+	return m.UpdateDatadogFn(ctx, i)
 }
 
 // DeleteDatadog implements Interface.
-func (m API) DeleteDatadog(i *fastly.DeleteDatadogInput) error {
-	return m.DeleteDatadogFn(i)
+func (m API) DeleteDatadog(ctx context.Context, i *fastly.DeleteDatadogInput) error {
+	return m.DeleteDatadogFn(ctx, i)
 }
 
 // CreateHTTPS implements Interface.
-func (m API) CreateHTTPS(i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
-	return m.CreateHTTPSFn(i)
+func (m API) CreateHTTPS(ctx context.Context, i *fastly.CreateHTTPSInput) (*fastly.HTTPS, error) {
+	return m.CreateHTTPSFn(ctx, i)
 }
 
 // ListHTTPS implements Interface.
-func (m API) ListHTTPS(i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
-	return m.ListHTTPSFn(i)
+func (m API) ListHTTPS(ctx context.Context, i *fastly.ListHTTPSInput) ([]*fastly.HTTPS, error) {
+	return m.ListHTTPSFn(ctx, i)
 }
 
 // GetHTTPS implements Interface.
-func (m API) GetHTTPS(i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
-	return m.GetHTTPSFn(i)
+func (m API) GetHTTPS(ctx context.Context, i *fastly.GetHTTPSInput) (*fastly.HTTPS, error) {
+	return m.GetHTTPSFn(ctx, i)
 }
 
 // UpdateHTTPS implements Interface.
-func (m API) UpdateHTTPS(i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
-	return m.UpdateHTTPSFn(i)
+func (m API) UpdateHTTPS(ctx context.Context, i *fastly.UpdateHTTPSInput) (*fastly.HTTPS, error) {
+	return m.UpdateHTTPSFn(ctx, i)
 }
 
 // DeleteHTTPS implements Interface.
-func (m API) DeleteHTTPS(i *fastly.DeleteHTTPSInput) error {
-	return m.DeleteHTTPSFn(i)
+func (m API) DeleteHTTPS(ctx context.Context, i *fastly.DeleteHTTPSInput) error {
+	return m.DeleteHTTPSFn(ctx, i)
 }
 
 // CreateKafka implements Interface.
-func (m API) CreateKafka(i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
-	return m.CreateKafkaFn(i)
+func (m API) CreateKafka(ctx context.Context, i *fastly.CreateKafkaInput) (*fastly.Kafka, error) {
+	return m.CreateKafkaFn(ctx, i)
 }
 
 // ListKafkas implements Interface.
-func (m API) ListKafkas(i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
-	return m.ListKafkasFn(i)
+func (m API) ListKafkas(ctx context.Context, i *fastly.ListKafkasInput) ([]*fastly.Kafka, error) {
+	return m.ListKafkasFn(ctx, i)
 }
 
 // GetKafka implements Interface.
-func (m API) GetKafka(i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
-	return m.GetKafkaFn(i)
+func (m API) GetKafka(ctx context.Context, i *fastly.GetKafkaInput) (*fastly.Kafka, error) {
+	return m.GetKafkaFn(ctx, i)
 }
 
 // UpdateKafka implements Interface.
-func (m API) UpdateKafka(i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
-	return m.UpdateKafkaFn(i)
+func (m API) UpdateKafka(ctx context.Context, i *fastly.UpdateKafkaInput) (*fastly.Kafka, error) {
+	return m.UpdateKafkaFn(ctx, i)
 }
 
 // DeleteKafka implements Interface.
-func (m API) DeleteKafka(i *fastly.DeleteKafkaInput) error {
-	return m.DeleteKafkaFn(i)
+func (m API) DeleteKafka(ctx context.Context, i *fastly.DeleteKafkaInput) error {
+	return m.DeleteKafkaFn(ctx, i)
 }
 
 // CreatePubsub implements Interface.
-func (m API) CreatePubsub(i *fastly.CreatePubsubInput) (*fastly.Pubsub, error) {
-	return m.CreatePubsubFn(i)
+func (m API) CreatePubsub(ctx context.Context, i *fastly.CreatePubsubInput) (*fastly.Pubsub, error) {
+	return m.CreatePubsubFn(ctx, i)
 }
 
 // ListPubsubs implements Interface.
-func (m API) ListPubsubs(i *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error) {
-	return m.ListPubsubsFn(i)
+func (m API) ListPubsubs(ctx context.Context, i *fastly.ListPubsubsInput) ([]*fastly.Pubsub, error) {
+	return m.ListPubsubsFn(ctx, i)
 }
 
 // GetPubsub implements Interface.
-func (m API) GetPubsub(i *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
-	return m.GetPubsubFn(i)
+func (m API) GetPubsub(ctx context.Context, i *fastly.GetPubsubInput) (*fastly.Pubsub, error) {
+	return m.GetPubsubFn(ctx, i)
 }
 
 // UpdatePubsub implements Interface.
-func (m API) UpdatePubsub(i *fastly.UpdatePubsubInput) (*fastly.Pubsub, error) {
-	return m.UpdatePubsubFn(i)
+func (m API) UpdatePubsub(ctx context.Context, i *fastly.UpdatePubsubInput) (*fastly.Pubsub, error) {
+	return m.UpdatePubsubFn(ctx, i)
 }
 
 // DeletePubsub implements Interface.
-func (m API) DeletePubsub(i *fastly.DeletePubsubInput) error {
-	return m.DeletePubsubFn(i)
+func (m API) DeletePubsub(ctx context.Context, i *fastly.DeletePubsubInput) error {
+	return m.DeletePubsubFn(ctx, i)
 }
 
 // CreateOpenstack implements Interface.
-func (m API) CreateOpenstack(i *fastly.CreateOpenstackInput) (*fastly.Openstack, error) {
-	return m.CreateOpenstackFn(i)
+func (m API) CreateOpenstack(ctx context.Context, i *fastly.CreateOpenstackInput) (*fastly.Openstack, error) {
+	return m.CreateOpenstackFn(ctx, i)
 }
 
 // ListOpenstack implements Interface.
-func (m API) ListOpenstack(i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error) {
-	return m.ListOpenstacksFn(i)
+func (m API) ListOpenstack(ctx context.Context, i *fastly.ListOpenstackInput) ([]*fastly.Openstack, error) {
+	return m.ListOpenstacksFn(ctx, i)
 }
 
 // GetOpenstack implements Interface.
-func (m API) GetOpenstack(i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
-	return m.GetOpenstackFn(i)
+func (m API) GetOpenstack(ctx context.Context, i *fastly.GetOpenstackInput) (*fastly.Openstack, error) {
+	return m.GetOpenstackFn(ctx, i)
 }
 
 // UpdateOpenstack implements Interface.
-func (m API) UpdateOpenstack(i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error) {
-	return m.UpdateOpenstackFn(i)
+func (m API) UpdateOpenstack(ctx context.Context, i *fastly.UpdateOpenstackInput) (*fastly.Openstack, error) {
+	return m.UpdateOpenstackFn(ctx, i)
 }
 
 // DeleteOpenstack implements Interface.
-func (m API) DeleteOpenstack(i *fastly.DeleteOpenstackInput) error {
-	return m.DeleteOpenstackFn(i)
+func (m API) DeleteOpenstack(ctx context.Context, i *fastly.DeleteOpenstackInput) error {
+	return m.DeleteOpenstackFn(ctx, i)
 }
 
 // GetRegions implements Interface.
-func (m API) GetRegions() (*fastly.RegionsResponse, error) {
-	return m.GetRegionsFn()
+func (m API) GetRegions(ctx context.Context) (*fastly.RegionsResponse, error) {
+	return m.GetRegionsFn(ctx)
 }
 
 // GetStatsJSON implements Interface.
-func (m API) GetStatsJSON(i *fastly.GetStatsInput, dst any) error {
-	return m.GetStatsJSONFn(i, dst)
+func (m API) GetStatsJSON(ctx context.Context, i *fastly.GetStatsInput, dst any) error {
+	return m.GetStatsJSONFn(ctx, i, dst)
 }
 
 // CreateManagedLogging implements Interface.
-func (m API) CreateManagedLogging(i *fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error) {
-	return m.CreateManagedLoggingFn(i)
+func (m API) CreateManagedLogging(ctx context.Context, i *fastly.CreateManagedLoggingInput) (*fastly.ManagedLogging, error) {
+	return m.CreateManagedLoggingFn(ctx, i)
 }
 
 // GetGeneratedVCL implements Interface.
-func (m API) GetGeneratedVCL(i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
-	return m.GetGeneratedVCLFn(i)
+func (m API) GetGeneratedVCL(ctx context.Context, i *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
+	return m.GetGeneratedVCLFn(ctx, i)
 }
 
 // CreateVCL implements Interface.
-func (m API) CreateVCL(i *fastly.CreateVCLInput) (*fastly.VCL, error) {
-	return m.CreateVCLFn(i)
+func (m API) CreateVCL(ctx context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
+	return m.CreateVCLFn(ctx, i)
 }
 
 // ListVCLs implements Interface.
-func (m API) ListVCLs(i *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
-	return m.ListVCLsFn(i)
+func (m API) ListVCLs(ctx context.Context, i *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
+	return m.ListVCLsFn(ctx, i)
 }
 
 // GetVCL implements Interface.
-func (m API) GetVCL(i *fastly.GetVCLInput) (*fastly.VCL, error) {
-	return m.GetVCLFn(i)
+func (m API) GetVCL(ctx context.Context, i *fastly.GetVCLInput) (*fastly.VCL, error) {
+	return m.GetVCLFn(ctx, i)
 }
 
 // UpdateVCL implements Interface.
-func (m API) UpdateVCL(i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
-	return m.UpdateVCLFn(i)
+func (m API) UpdateVCL(ctx context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+	return m.UpdateVCLFn(ctx, i)
 }
 
 // DeleteVCL implements Interface.
-func (m API) DeleteVCL(i *fastly.DeleteVCLInput) error {
-	return m.DeleteVCLFn(i)
+func (m API) DeleteVCL(ctx context.Context, i *fastly.DeleteVCLInput) error {
+	return m.DeleteVCLFn(ctx, i)
 }
 
 // CreateSnippet implements Interface.
-func (m API) CreateSnippet(i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
-	return m.CreateSnippetFn(i)
+func (m API) CreateSnippet(ctx context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
+	return m.CreateSnippetFn(ctx, i)
 }
 
 // ListSnippets implements Interface.
-func (m API) ListSnippets(i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
-	return m.ListSnippetsFn(i)
+func (m API) ListSnippets(ctx context.Context, i *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
+	return m.ListSnippetsFn(ctx, i)
 }
 
 // GetSnippet implements Interface.
-func (m API) GetSnippet(i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
-	return m.GetSnippetFn(i)
+func (m API) GetSnippet(ctx context.Context, i *fastly.GetSnippetInput) (*fastly.Snippet, error) {
+	return m.GetSnippetFn(ctx, i)
 }
 
 // GetDynamicSnippet implements Interface.
-func (m API) GetDynamicSnippet(i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
-	return m.GetDynamicSnippetFn(i)
+func (m API) GetDynamicSnippet(ctx context.Context, i *fastly.GetDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+	return m.GetDynamicSnippetFn(ctx, i)
 }
 
 // UpdateSnippet implements Interface.
-func (m API) UpdateSnippet(i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
-	return m.UpdateSnippetFn(i)
+func (m API) UpdateSnippet(ctx context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+	return m.UpdateSnippetFn(ctx, i)
 }
 
 // UpdateDynamicSnippet implements Interface.
-func (m API) UpdateDynamicSnippet(i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
-	return m.UpdateDynamicSnippetFn(i)
+func (m API) UpdateDynamicSnippet(ctx context.Context, i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
+	return m.UpdateDynamicSnippetFn(ctx, i)
 }
 
 // DeleteSnippet implements Interface.
-func (m API) DeleteSnippet(i *fastly.DeleteSnippetInput) error {
-	return m.DeleteSnippetFn(i)
+func (m API) DeleteSnippet(ctx context.Context, i *fastly.DeleteSnippetInput) error {
+	return m.DeleteSnippetFn(ctx, i)
 }
 
 // Purge implements Interface.
-func (m API) Purge(i *fastly.PurgeInput) (*fastly.Purge, error) {
-	return m.PurgeFn(i)
+func (m API) Purge(ctx context.Context, i *fastly.PurgeInput) (*fastly.Purge, error) {
+	return m.PurgeFn(ctx, i)
 }
 
 // PurgeKey implements Interface.
-func (m API) PurgeKey(i *fastly.PurgeKeyInput) (*fastly.Purge, error) {
-	return m.PurgeKeyFn(i)
+func (m API) PurgeKey(ctx context.Context, i *fastly.PurgeKeyInput) (*fastly.Purge, error) {
+	return m.PurgeKeyFn(ctx, i)
 }
 
 // PurgeKeys implements Interface.
-func (m API) PurgeKeys(i *fastly.PurgeKeysInput) (map[string]string, error) {
-	return m.PurgeKeysFn(i)
+func (m API) PurgeKeys(ctx context.Context, i *fastly.PurgeKeysInput) (map[string]string, error) {
+	return m.PurgeKeysFn(ctx, i)
 }
 
 // PurgeAll implements Interface.
-func (m API) PurgeAll(i *fastly.PurgeAllInput) (*fastly.Purge, error) {
-	return m.PurgeAllFn(i)
+func (m API) PurgeAll(ctx context.Context, i *fastly.PurgeAllInput) (*fastly.Purge, error) {
+	return m.PurgeAllFn(ctx, i)
 }
 
 // CreateACL implements Interface.
-func (m API) CreateACL(i *fastly.CreateACLInput) (*fastly.ACL, error) {
-	return m.CreateACLFn(i)
+func (m API) CreateACL(ctx context.Context, i *fastly.CreateACLInput) (*fastly.ACL, error) {
+	return m.CreateACLFn(ctx, i)
 }
 
 // DeleteACL implements Interface.
-func (m API) DeleteACL(i *fastly.DeleteACLInput) error {
-	return m.DeleteACLFn(i)
+func (m API) DeleteACL(ctx context.Context, i *fastly.DeleteACLInput) error {
+	return m.DeleteACLFn(ctx, i)
 }
 
 // GetACL implements Interface.
-func (m API) GetACL(i *fastly.GetACLInput) (*fastly.ACL, error) {
-	return m.GetACLFn(i)
+func (m API) GetACL(ctx context.Context, i *fastly.GetACLInput) (*fastly.ACL, error) {
+	return m.GetACLFn(ctx, i)
 }
 
 // ListACLs implements Interface.
-func (m API) ListACLs(i *fastly.ListACLsInput) ([]*fastly.ACL, error) {
-	return m.ListACLsFn(i)
+func (m API) ListACLs(ctx context.Context, i *fastly.ListACLsInput) ([]*fastly.ACL, error) {
+	return m.ListACLsFn(ctx, i)
 }
 
 // UpdateACL implements Interface.
-func (m API) UpdateACL(i *fastly.UpdateACLInput) (*fastly.ACL, error) {
-	return m.UpdateACLFn(i)
+func (m API) UpdateACL(ctx context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
+	return m.UpdateACLFn(ctx, i)
 }
 
 // CreateACLEntry implements Interface.
-func (m API) CreateACLEntry(i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
-	return m.CreateACLEntryFn(i)
+func (m API) CreateACLEntry(ctx context.Context, i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
+	return m.CreateACLEntryFn(ctx, i)
 }
 
 // DeleteACLEntry implements Interface.
-func (m API) DeleteACLEntry(i *fastly.DeleteACLEntryInput) error {
-	return m.DeleteACLEntryFn(i)
+func (m API) DeleteACLEntry(ctx context.Context, i *fastly.DeleteACLEntryInput) error {
+	return m.DeleteACLEntryFn(ctx, i)
 }
 
 // GetACLEntry implements Interface.
-func (m API) GetACLEntry(i *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {
-	return m.GetACLEntryFn(i)
+func (m API) GetACLEntry(ctx context.Context, i *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {
+	return m.GetACLEntryFn(ctx, i)
 }
 
 // GetACLEntries implements Interface.
-func (m API) GetACLEntries(i *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
-	return m.GetACLEntriesFn(i)
+func (m API) GetACLEntries(ctx context.Context, i *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
+	return m.GetACLEntriesFn(ctx, i)
 }
 
 // ListACLEntries implements Interface.
-func (m API) ListACLEntries(i *fastly.ListACLEntriesInput) ([]*fastly.ACLEntry, error) {
-	return m.ListACLEntriesFn(i)
+func (m API) ListACLEntries(ctx context.Context, i *fastly.ListACLEntriesInput) ([]*fastly.ACLEntry, error) {
+	return m.ListACLEntriesFn(ctx, i)
 }
 
 // UpdateACLEntry implements Interface.
-func (m API) UpdateACLEntry(i *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error) {
-	return m.UpdateACLEntryFn(i)
+func (m API) UpdateACLEntry(ctx context.Context, i *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error) {
+	return m.UpdateACLEntryFn(ctx, i)
 }
 
 // BatchModifyACLEntries implements Interface.
-func (m API) BatchModifyACLEntries(i *fastly.BatchModifyACLEntriesInput) error {
-	return m.BatchModifyACLEntriesFn(i)
+func (m API) BatchModifyACLEntries(ctx context.Context, i *fastly.BatchModifyACLEntriesInput) error {
+	return m.BatchModifyACLEntriesFn(ctx, i)
 }
 
 // CreateNewRelic implements Interface.
-func (m API) CreateNewRelic(i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
-	return m.CreateNewRelicFn(i)
+func (m API) CreateNewRelic(ctx context.Context, i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
+	return m.CreateNewRelicFn(ctx, i)
 }
 
 // DeleteNewRelic implements Interface.
-func (m API) DeleteNewRelic(i *fastly.DeleteNewRelicInput) error {
-	return m.DeleteNewRelicFn(i)
+func (m API) DeleteNewRelic(ctx context.Context, i *fastly.DeleteNewRelicInput) error {
+	return m.DeleteNewRelicFn(ctx, i)
 }
 
 // GetNewRelic implements Interface.
-func (m API) GetNewRelic(i *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
-	return m.GetNewRelicFn(i)
+func (m API) GetNewRelic(ctx context.Context, i *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
+	return m.GetNewRelicFn(ctx, i)
 }
 
 // ListNewRelic implements Interface.
-func (m API) ListNewRelic(i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error) {
-	return m.ListNewRelicFn(i)
+func (m API) ListNewRelic(ctx context.Context, i *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error) {
+	return m.ListNewRelicFn(ctx, i)
 }
 
 // UpdateNewRelic implements Interface.
-func (m API) UpdateNewRelic(i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
-	return m.UpdateNewRelicFn(i)
+func (m API) UpdateNewRelic(ctx context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+	return m.UpdateNewRelicFn(ctx, i)
 }
 
 // CreateNewRelicOTLP implements Interface.
-func (m API) CreateNewRelicOTLP(i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
-	return m.CreateNewRelicOTLPFn(i)
+func (m API) CreateNewRelicOTLP(ctx context.Context, i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+	return m.CreateNewRelicOTLPFn(ctx, i)
 }
 
 // DeleteNewRelicOTLP implements Interface.
-func (m API) DeleteNewRelicOTLP(i *fastly.DeleteNewRelicOTLPInput) error {
-	return m.DeleteNewRelicOTLPFn(i)
+func (m API) DeleteNewRelicOTLP(ctx context.Context, i *fastly.DeleteNewRelicOTLPInput) error {
+	return m.DeleteNewRelicOTLPFn(ctx, i)
 }
 
 // GetNewRelicOTLP implements Interface.
-func (m API) GetNewRelicOTLP(i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
-	return m.GetNewRelicOTLPFn(i)
+func (m API) GetNewRelicOTLP(ctx context.Context, i *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+	return m.GetNewRelicOTLPFn(ctx, i)
 }
 
 // ListNewRelicOTLP implements Interface.
-func (m API) ListNewRelicOTLP(i *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error) {
-	return m.ListNewRelicOTLPFn(i)
+func (m API) ListNewRelicOTLP(ctx context.Context, i *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error) {
+	return m.ListNewRelicOTLPFn(ctx, i)
 }
 
 // UpdateNewRelicOTLP implements Interface.
-func (m API) UpdateNewRelicOTLP(i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
-	return m.UpdateNewRelicOTLPFn(i)
+func (m API) UpdateNewRelicOTLP(ctx context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+	return m.UpdateNewRelicOTLPFn(ctx, i)
 }
 
 // CreateUser implements Interface.
-func (m API) CreateUser(i *fastly.CreateUserInput) (*fastly.User, error) {
-	return m.CreateUserFn(i)
+func (m API) CreateUser(ctx context.Context, i *fastly.CreateUserInput) (*fastly.User, error) {
+	return m.CreateUserFn(ctx, i)
 }
 
 // DeleteUser implements Interface.
-func (m API) DeleteUser(i *fastly.DeleteUserInput) error {
-	return m.DeleteUserFn(i)
+func (m API) DeleteUser(ctx context.Context, i *fastly.DeleteUserInput) error {
+	return m.DeleteUserFn(ctx, i)
 }
 
 // GetCurrentUser implements Interface.
-func (m API) GetCurrentUser() (*fastly.User, error) {
-	return m.GetCurrentUserFn()
+func (m API) GetCurrentUser(ctx context.Context) (*fastly.User, error) {
+	return m.GetCurrentUserFn(ctx)
 }
 
 // GetUser implements Interface.
-func (m API) GetUser(i *fastly.GetUserInput) (*fastly.User, error) {
-	return m.GetUserFn(i)
+func (m API) GetUser(ctx context.Context, i *fastly.GetUserInput) (*fastly.User, error) {
+	return m.GetUserFn(ctx, i)
 }
 
 // ListCustomerUsers implements Interface.
-func (m API) ListCustomerUsers(i *fastly.ListCustomerUsersInput) ([]*fastly.User, error) {
-	return m.ListCustomerUsersFn(i)
+func (m API) ListCustomerUsers(ctx context.Context, i *fastly.ListCustomerUsersInput) ([]*fastly.User, error) {
+	return m.ListCustomerUsersFn(ctx, i)
 }
 
 // UpdateUser implements Interface.
-func (m API) UpdateUser(i *fastly.UpdateUserInput) (*fastly.User, error) {
-	return m.UpdateUserFn(i)
+func (m API) UpdateUser(ctx context.Context, i *fastly.UpdateUserInput) (*fastly.User, error) {
+	return m.UpdateUserFn(ctx, i)
 }
 
 // ResetUserPassword implements Interface.
-func (m API) ResetUserPassword(i *fastly.ResetUserPasswordInput) error {
-	return m.ResetUserPasswordFn(i)
+func (m API) ResetUserPassword(ctx context.Context, i *fastly.ResetUserPasswordInput) error {
+	return m.ResetUserPasswordFn(ctx, i)
 }
 
 // BatchDeleteTokens implements Interface.
-func (m API) BatchDeleteTokens(i *fastly.BatchDeleteTokensInput) error {
-	return m.BatchDeleteTokensFn(i)
+func (m API) BatchDeleteTokens(ctx context.Context, i *fastly.BatchDeleteTokensInput) error {
+	return m.BatchDeleteTokensFn(ctx, i)
 }
 
 // CreateToken implements Interface.
-func (m API) CreateToken(i *fastly.CreateTokenInput) (*fastly.Token, error) {
-	return m.CreateTokenFn(i)
+func (m API) CreateToken(ctx context.Context, i *fastly.CreateTokenInput) (*fastly.Token, error) {
+	return m.CreateTokenFn(ctx, i)
 }
 
 // DeleteToken implements Interface.
-func (m API) DeleteToken(i *fastly.DeleteTokenInput) error {
-	return m.DeleteTokenFn(i)
+func (m API) DeleteToken(ctx context.Context, i *fastly.DeleteTokenInput) error {
+	return m.DeleteTokenFn(ctx, i)
 }
 
 // DeleteTokenSelf implements Interface.
-func (m API) DeleteTokenSelf() error {
-	return m.DeleteTokenSelfFn()
+func (m API) DeleteTokenSelf(ctx context.Context) error {
+	return m.DeleteTokenSelfFn(ctx)
 }
 
 // GetTokenSelf implements Interface.
-func (m API) GetTokenSelf() (*fastly.Token, error) {
-	return m.GetTokenSelfFn()
+func (m API) GetTokenSelf(ctx context.Context) (*fastly.Token, error) {
+	return m.GetTokenSelfFn(ctx)
 }
 
 // ListCustomerTokens implements Interface.
-func (m API) ListCustomerTokens(i *fastly.ListCustomerTokensInput) ([]*fastly.Token, error) {
-	return m.ListCustomerTokensFn(i)
+func (m API) ListCustomerTokens(ctx context.Context, i *fastly.ListCustomerTokensInput) ([]*fastly.Token, error) {
+	return m.ListCustomerTokensFn(ctx, i)
 }
 
 // ListTokens implements Interface.
-func (m API) ListTokens(i *fastly.ListTokensInput) ([]*fastly.Token, error) {
-	return m.ListTokensFn(i)
+func (m API) ListTokens(ctx context.Context, i *fastly.ListTokensInput) ([]*fastly.Token, error) {
+	return m.ListTokensFn(ctx, i)
 }
 
 // NewListKVStoreKeysPaginator implements Interface.
-func (m API) NewListKVStoreKeysPaginator(i *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
-	return m.NewListKVStoreKeysPaginatorFn(i)
+func (m API) NewListKVStoreKeysPaginator(ctx context.Context, i *fastly.ListKVStoreKeysInput) fastly.PaginatorKVStoreEntries {
+	return m.NewListKVStoreKeysPaginatorFn(ctx, i)
 }
 
 // GetCustomTLSConfiguration implements Interface.
-func (m API) GetCustomTLSConfiguration(i *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
-	return m.GetCustomTLSConfigurationFn(i)
+func (m API) GetCustomTLSConfiguration(ctx context.Context, i *fastly.GetCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
+	return m.GetCustomTLSConfigurationFn(ctx, i)
 }
 
 // ListCustomTLSConfigurations implements Interface.
-func (m API) ListCustomTLSConfigurations(i *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error) {
-	return m.ListCustomTLSConfigurationsFn(i)
+func (m API) ListCustomTLSConfigurations(ctx context.Context, i *fastly.ListCustomTLSConfigurationsInput) ([]*fastly.CustomTLSConfiguration, error) {
+	return m.ListCustomTLSConfigurationsFn(ctx, i)
 }
 
 // UpdateCustomTLSConfiguration implements Interface.
-func (m API) UpdateCustomTLSConfiguration(i *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
-	return m.UpdateCustomTLSConfigurationFn(i)
+func (m API) UpdateCustomTLSConfiguration(ctx context.Context, i *fastly.UpdateCustomTLSConfigurationInput) (*fastly.CustomTLSConfiguration, error) {
+	return m.UpdateCustomTLSConfigurationFn(ctx, i)
 }
 
 // GetTLSActivation implements Interface.
-func (m API) GetTLSActivation(i *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error) {
-	return m.GetTLSActivationFn(i)
+func (m API) GetTLSActivation(ctx context.Context, i *fastly.GetTLSActivationInput) (*fastly.TLSActivation, error) {
+	return m.GetTLSActivationFn(ctx, i)
 }
 
 // ListTLSActivations implements Interface.
-func (m API) ListTLSActivations(i *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error) {
-	return m.ListTLSActivationsFn(i)
+func (m API) ListTLSActivations(ctx context.Context, i *fastly.ListTLSActivationsInput) ([]*fastly.TLSActivation, error) {
+	return m.ListTLSActivationsFn(ctx, i)
 }
 
 // UpdateTLSActivation implements Interface.
-func (m API) UpdateTLSActivation(i *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error) {
-	return m.UpdateTLSActivationFn(i)
+func (m API) UpdateTLSActivation(ctx context.Context, i *fastly.UpdateTLSActivationInput) (*fastly.TLSActivation, error) {
+	return m.UpdateTLSActivationFn(ctx, i)
 }
 
 // CreateTLSActivation implements Interface.
-func (m API) CreateTLSActivation(i *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error) {
-	return m.CreateTLSActivationFn(i)
+func (m API) CreateTLSActivation(ctx context.Context, i *fastly.CreateTLSActivationInput) (*fastly.TLSActivation, error) {
+	return m.CreateTLSActivationFn(ctx, i)
 }
 
 // DeleteTLSActivation implements Interface.
-func (m API) DeleteTLSActivation(i *fastly.DeleteTLSActivationInput) error {
-	return m.DeleteTLSActivationFn(i)
+func (m API) DeleteTLSActivation(ctx context.Context, i *fastly.DeleteTLSActivationInput) error {
+	return m.DeleteTLSActivationFn(ctx, i)
 }
 
 // CreateCustomTLSCertificate implements Interface.
-func (m API) CreateCustomTLSCertificate(i *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
-	return m.CreateCustomTLSCertificateFn(i)
+func (m API) CreateCustomTLSCertificate(ctx context.Context, i *fastly.CreateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+	return m.CreateCustomTLSCertificateFn(ctx, i)
 }
 
 // DeleteCustomTLSCertificate implements Interface.
-func (m API) DeleteCustomTLSCertificate(i *fastly.DeleteCustomTLSCertificateInput) error {
-	return m.DeleteCustomTLSCertificateFn(i)
+func (m API) DeleteCustomTLSCertificate(ctx context.Context, i *fastly.DeleteCustomTLSCertificateInput) error {
+	return m.DeleteCustomTLSCertificateFn(ctx, i)
 }
 
 // GetCustomTLSCertificate implements Interface.
-func (m API) GetCustomTLSCertificate(i *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
-	return m.GetCustomTLSCertificateFn(i)
+func (m API) GetCustomTLSCertificate(ctx context.Context, i *fastly.GetCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+	return m.GetCustomTLSCertificateFn(ctx, i)
 }
 
 // ListCustomTLSCertificates implements Interface.
-func (m API) ListCustomTLSCertificates(i *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error) {
-	return m.ListCustomTLSCertificatesFn(i)
+func (m API) ListCustomTLSCertificates(ctx context.Context, i *fastly.ListCustomTLSCertificatesInput) ([]*fastly.CustomTLSCertificate, error) {
+	return m.ListCustomTLSCertificatesFn(ctx, i)
 }
 
 // UpdateCustomTLSCertificate implements Interface.
-func (m API) UpdateCustomTLSCertificate(i *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
-	return m.UpdateCustomTLSCertificateFn(i)
+func (m API) UpdateCustomTLSCertificate(ctx context.Context, i *fastly.UpdateCustomTLSCertificateInput) (*fastly.CustomTLSCertificate, error) {
+	return m.UpdateCustomTLSCertificateFn(ctx, i)
 }
 
 // ListTLSDomains implements Interface.
-func (m API) ListTLSDomains(i *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error) {
-	return m.ListTLSDomainsFn(i)
+func (m API) ListTLSDomains(ctx context.Context, i *fastly.ListTLSDomainsInput) ([]*fastly.TLSDomain, error) {
+	return m.ListTLSDomainsFn(ctx, i)
 }
 
 // CreatePrivateKey implements Interface.
-func (m API) CreatePrivateKey(i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
-	return m.CreatePrivateKeyFn(i)
+func (m API) CreatePrivateKey(ctx context.Context, i *fastly.CreatePrivateKeyInput) (*fastly.PrivateKey, error) {
+	return m.CreatePrivateKeyFn(ctx, i)
 }
 
 // DeletePrivateKey implements Interface.
-func (m API) DeletePrivateKey(i *fastly.DeletePrivateKeyInput) error {
-	return m.DeletePrivateKeyFn(i)
+func (m API) DeletePrivateKey(ctx context.Context, i *fastly.DeletePrivateKeyInput) error {
+	return m.DeletePrivateKeyFn(ctx, i)
 }
 
 // GetPrivateKey implements Interface.
-func (m API) GetPrivateKey(i *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error) {
-	return m.GetPrivateKeyFn(i)
+func (m API) GetPrivateKey(ctx context.Context, i *fastly.GetPrivateKeyInput) (*fastly.PrivateKey, error) {
+	return m.GetPrivateKeyFn(ctx, i)
 }
 
 // ListPrivateKeys implements Interface.
-func (m API) ListPrivateKeys(i *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error) {
-	return m.ListPrivateKeysFn(i)
+func (m API) ListPrivateKeys(ctx context.Context, i *fastly.ListPrivateKeysInput) ([]*fastly.PrivateKey, error) {
+	return m.ListPrivateKeysFn(ctx, i)
 }
 
 // CreateBulkCertificate implements Interface.
-func (m API) CreateBulkCertificate(i *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error) {
-	return m.CreateBulkCertificateFn(i)
+func (m API) CreateBulkCertificate(ctx context.Context, i *fastly.CreateBulkCertificateInput) (*fastly.BulkCertificate, error) {
+	return m.CreateBulkCertificateFn(ctx, i)
 }
 
 // DeleteBulkCertificate implements Interface.
-func (m API) DeleteBulkCertificate(i *fastly.DeleteBulkCertificateInput) error {
-	return m.DeleteBulkCertificateFn(i)
+func (m API) DeleteBulkCertificate(ctx context.Context, i *fastly.DeleteBulkCertificateInput) error {
+	return m.DeleteBulkCertificateFn(ctx, i)
 }
 
 // GetBulkCertificate implements Interface.
-func (m API) GetBulkCertificate(i *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error) {
-	return m.GetBulkCertificateFn(i)
+func (m API) GetBulkCertificate(ctx context.Context, i *fastly.GetBulkCertificateInput) (*fastly.BulkCertificate, error) {
+	return m.GetBulkCertificateFn(ctx, i)
 }
 
 // ListBulkCertificates implements Interface.
-func (m API) ListBulkCertificates(i *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error) {
-	return m.ListBulkCertificatesFn(i)
+func (m API) ListBulkCertificates(ctx context.Context, i *fastly.ListBulkCertificatesInput) ([]*fastly.BulkCertificate, error) {
+	return m.ListBulkCertificatesFn(ctx, i)
 }
 
 // UpdateBulkCertificate implements Interface.
-func (m API) UpdateBulkCertificate(i *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error) {
-	return m.UpdateBulkCertificateFn(i)
+func (m API) UpdateBulkCertificate(ctx context.Context, i *fastly.UpdateBulkCertificateInput) (*fastly.BulkCertificate, error) {
+	return m.UpdateBulkCertificateFn(ctx, i)
 }
 
 // CreateTLSSubscription implements Interface.
-func (m API) CreateTLSSubscription(i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
-	return m.CreateTLSSubscriptionFn(i)
+func (m API) CreateTLSSubscription(ctx context.Context, i *fastly.CreateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+	return m.CreateTLSSubscriptionFn(ctx, i)
 }
 
 // DeleteTLSSubscription implements Interface.
-func (m API) DeleteTLSSubscription(i *fastly.DeleteTLSSubscriptionInput) error {
-	return m.DeleteTLSSubscriptionFn(i)
+func (m API) DeleteTLSSubscription(ctx context.Context, i *fastly.DeleteTLSSubscriptionInput) error {
+	return m.DeleteTLSSubscriptionFn(ctx, i)
 }
 
 // GetTLSSubscription implements Interface.
-func (m API) GetTLSSubscription(i *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
-	return m.GetTLSSubscriptionFn(i)
+func (m API) GetTLSSubscription(ctx context.Context, i *fastly.GetTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+	return m.GetTLSSubscriptionFn(ctx, i)
 }
 
 // ListTLSSubscriptions implements Interface.
-func (m API) ListTLSSubscriptions(i *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error) {
-	return m.ListTLSSubscriptionsFn(i)
+func (m API) ListTLSSubscriptions(ctx context.Context, i *fastly.ListTLSSubscriptionsInput) ([]*fastly.TLSSubscription, error) {
+	return m.ListTLSSubscriptionsFn(ctx, i)
 }
 
 // UpdateTLSSubscription implements Interface.
-func (m API) UpdateTLSSubscription(i *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
-	return m.UpdateTLSSubscriptionFn(i)
+func (m API) UpdateTLSSubscription(ctx context.Context, i *fastly.UpdateTLSSubscriptionInput) (*fastly.TLSSubscription, error) {
+	return m.UpdateTLSSubscriptionFn(ctx, i)
 }
 
 // ListServiceAuthorizations implements Interface.
-func (m API) ListServiceAuthorizations(i *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error) {
-	return m.ListServiceAuthorizationsFn(i)
+func (m API) ListServiceAuthorizations(ctx context.Context, i *fastly.ListServiceAuthorizationsInput) (*fastly.ServiceAuthorizations, error) {
+	return m.ListServiceAuthorizationsFn(ctx, i)
 }
 
 // GetServiceAuthorization implements Interface.
-func (m API) GetServiceAuthorization(i *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
-	return m.GetServiceAuthorizationFn(i)
+func (m API) GetServiceAuthorization(ctx context.Context, i *fastly.GetServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+	return m.GetServiceAuthorizationFn(ctx, i)
 }
 
 // CreateServiceAuthorization implements Interface.
-func (m API) CreateServiceAuthorization(i *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
-	return m.CreateServiceAuthorizationFn(i)
+func (m API) CreateServiceAuthorization(ctx context.Context, i *fastly.CreateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+	return m.CreateServiceAuthorizationFn(ctx, i)
 }
 
 // UpdateServiceAuthorization implements Interface.
-func (m API) UpdateServiceAuthorization(i *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
-	return m.UpdateServiceAuthorizationFn(i)
+func (m API) UpdateServiceAuthorization(ctx context.Context, i *fastly.UpdateServiceAuthorizationInput) (*fastly.ServiceAuthorization, error) {
+	return m.UpdateServiceAuthorizationFn(ctx, i)
 }
 
 // DeleteServiceAuthorization implements Interface.
-func (m API) DeleteServiceAuthorization(i *fastly.DeleteServiceAuthorizationInput) error {
-	return m.DeleteServiceAuthorizationFn(i)
+func (m API) DeleteServiceAuthorization(ctx context.Context, i *fastly.DeleteServiceAuthorizationInput) error {
+	return m.DeleteServiceAuthorizationFn(ctx, i)
 }
 
 // CreateConfigStore implements Interface.
-func (m API) CreateConfigStore(i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
-	return m.CreateConfigStoreFn(i)
+func (m API) CreateConfigStore(ctx context.Context, i *fastly.CreateConfigStoreInput) (*fastly.ConfigStore, error) {
+	return m.CreateConfigStoreFn(ctx, i)
 }
 
 // DeleteConfigStore implements Interface.
-func (m API) DeleteConfigStore(i *fastly.DeleteConfigStoreInput) error {
-	return m.DeleteConfigStoreFn(i)
+func (m API) DeleteConfigStore(ctx context.Context, i *fastly.DeleteConfigStoreInput) error {
+	return m.DeleteConfigStoreFn(ctx, i)
 }
 
 // GetConfigStore implements Interface.
-func (m API) GetConfigStore(i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
-	return m.GetConfigStoreFn(i)
+func (m API) GetConfigStore(ctx context.Context, i *fastly.GetConfigStoreInput) (*fastly.ConfigStore, error) {
+	return m.GetConfigStoreFn(ctx, i)
 }
 
 // GetConfigStoreMetadata implements Interface.
-func (m API) GetConfigStoreMetadata(i *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error) {
-	return m.GetConfigStoreMetadataFn(i)
+func (m API) GetConfigStoreMetadata(ctx context.Context, i *fastly.GetConfigStoreMetadataInput) (*fastly.ConfigStoreMetadata, error) {
+	return m.GetConfigStoreMetadataFn(ctx, i)
 }
 
 // ListConfigStores implements Interface.
-func (m API) ListConfigStores(i *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
-	return m.ListConfigStoresFn(i)
+func (m API) ListConfigStores(ctx context.Context, i *fastly.ListConfigStoresInput) ([]*fastly.ConfigStore, error) {
+	return m.ListConfigStoresFn(ctx, i)
 }
 
 // ListConfigStoreServices implements Interface.
-func (m API) ListConfigStoreServices(i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
-	return m.ListConfigStoreServicesFn(i)
+func (m API) ListConfigStoreServices(ctx context.Context, i *fastly.ListConfigStoreServicesInput) ([]*fastly.Service, error) {
+	return m.ListConfigStoreServicesFn(ctx, i)
 }
 
 // UpdateConfigStore implements Interface.
-func (m API) UpdateConfigStore(i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
-	return m.UpdateConfigStoreFn(i)
+func (m API) UpdateConfigStore(ctx context.Context, i *fastly.UpdateConfigStoreInput) (*fastly.ConfigStore, error) {
+	return m.UpdateConfigStoreFn(ctx, i)
 }
 
 // CreateConfigStoreItem implements Interface.
-func (m API) CreateConfigStoreItem(i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
-	return m.CreateConfigStoreItemFn(i)
+func (m API) CreateConfigStoreItem(ctx context.Context, i *fastly.CreateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+	return m.CreateConfigStoreItemFn(ctx, i)
 }
 
 // DeleteConfigStoreItem implements Interface.
-func (m API) DeleteConfigStoreItem(i *fastly.DeleteConfigStoreItemInput) error {
-	return m.DeleteConfigStoreItemFn(i)
+func (m API) DeleteConfigStoreItem(ctx context.Context, i *fastly.DeleteConfigStoreItemInput) error {
+	return m.DeleteConfigStoreItemFn(ctx, i)
 }
 
 // GetConfigStoreItem implements Interface.
-func (m API) GetConfigStoreItem(i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
-	return m.GetConfigStoreItemFn(i)
+func (m API) GetConfigStoreItem(ctx context.Context, i *fastly.GetConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+	return m.GetConfigStoreItemFn(ctx, i)
 }
 
 // ListConfigStoreItems implements Interface.
-func (m API) ListConfigStoreItems(i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
-	return m.ListConfigStoreItemsFn(i)
+func (m API) ListConfigStoreItems(ctx context.Context, i *fastly.ListConfigStoreItemsInput) ([]*fastly.ConfigStoreItem, error) {
+	return m.ListConfigStoreItemsFn(ctx, i)
 }
 
 // UpdateConfigStoreItem implements Interface.
-func (m API) UpdateConfigStoreItem(i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
-	return m.UpdateConfigStoreItemFn(i)
+func (m API) UpdateConfigStoreItem(ctx context.Context, i *fastly.UpdateConfigStoreItemInput) (*fastly.ConfigStoreItem, error) {
+	return m.UpdateConfigStoreItemFn(ctx, i)
 }
 
 // CreateKVStore implements Interface.
-func (m API) CreateKVStore(i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
-	return m.CreateKVStoreFn(i)
+func (m API) CreateKVStore(ctx context.Context, i *fastly.CreateKVStoreInput) (*fastly.KVStore, error) {
+	return m.CreateKVStoreFn(ctx, i)
 }
 
 // GetKVStore implements Interface.
-func (m API) GetKVStore(i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
-	return m.GetKVStoreFn(i)
+func (m API) GetKVStore(ctx context.Context, i *fastly.GetKVStoreInput) (*fastly.KVStore, error) {
+	return m.GetKVStoreFn(ctx, i)
 }
 
 // ListKVStores implements Interface.
-func (m API) ListKVStores(i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
-	return m.ListKVStoresFn(i)
+func (m API) ListKVStores(ctx context.Context, i *fastly.ListKVStoresInput) (*fastly.ListKVStoresResponse, error) {
+	return m.ListKVStoresFn(ctx, i)
 }
 
 // DeleteKVStore implements Interface.
-func (m API) DeleteKVStore(i *fastly.DeleteKVStoreInput) error {
-	return m.DeleteKVStoreFn(i)
+func (m API) DeleteKVStore(ctx context.Context, i *fastly.DeleteKVStoreInput) error {
+	return m.DeleteKVStoreFn(ctx, i)
 }
 
 // ListKVStoreKeys implements Interface.
-func (m API) ListKVStoreKeys(i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
-	return m.ListKVStoreKeysFn(i)
+func (m API) ListKVStoreKeys(ctx context.Context, i *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+	return m.ListKVStoreKeysFn(ctx, i)
 }
 
 // GetKVStoreKey implements Interface.
-func (m API) GetKVStoreKey(i *fastly.GetKVStoreKeyInput) (string, error) {
-	return m.GetKVStoreKeyFn(i)
+func (m API) GetKVStoreKey(ctx context.Context, i *fastly.GetKVStoreKeyInput) (string, error) {
+	return m.GetKVStoreKeyFn(ctx, i)
 }
 
 // InsertKVStoreKey implements Interface.
-func (m API) InsertKVStoreKey(i *fastly.InsertKVStoreKeyInput) error {
-	return m.InsertKVStoreKeyFn(i)
+func (m API) InsertKVStoreKey(ctx context.Context, i *fastly.InsertKVStoreKeyInput) error {
+	return m.InsertKVStoreKeyFn(ctx, i)
 }
 
 // DeleteKVStoreKey implements Interface.
-func (m API) DeleteKVStoreKey(i *fastly.DeleteKVStoreKeyInput) error {
-	return m.DeleteKVStoreKeyFn(i)
+func (m API) DeleteKVStoreKey(ctx context.Context, i *fastly.DeleteKVStoreKeyInput) error {
+	return m.DeleteKVStoreKeyFn(ctx, i)
 }
 
 // BatchModifyKVStoreKey implements Interface.
-func (m API) BatchModifyKVStoreKey(i *fastly.BatchModifyKVStoreKeyInput) error {
-	return m.BatchModifyKVStoreKeyFn(i)
+func (m API) BatchModifyKVStoreKey(ctx context.Context, i *fastly.BatchModifyKVStoreKeyInput) error {
+	return m.BatchModifyKVStoreKeyFn(ctx, i)
 }
 
 // CreateSecretStore implements Interface.
-func (m API) CreateSecretStore(i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
-	return m.CreateSecretStoreFn(i)
+func (m API) CreateSecretStore(ctx context.Context, i *fastly.CreateSecretStoreInput) (*fastly.SecretStore, error) {
+	return m.CreateSecretStoreFn(ctx, i)
 }
 
 // GetSecretStore implements Interface.
-func (m API) GetSecretStore(i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
-	return m.GetSecretStoreFn(i)
+func (m API) GetSecretStore(ctx context.Context, i *fastly.GetSecretStoreInput) (*fastly.SecretStore, error) {
+	return m.GetSecretStoreFn(ctx, i)
 }
 
 // DeleteSecretStore implements Interface.
-func (m API) DeleteSecretStore(i *fastly.DeleteSecretStoreInput) error {
-	return m.DeleteSecretStoreFn(i)
+func (m API) DeleteSecretStore(ctx context.Context, i *fastly.DeleteSecretStoreInput) error {
+	return m.DeleteSecretStoreFn(ctx, i)
 }
 
 // ListSecretStores implements Interface.
-func (m API) ListSecretStores(i *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
-	return m.ListSecretStoresFn(i)
+func (m API) ListSecretStores(ctx context.Context, i *fastly.ListSecretStoresInput) (*fastly.SecretStores, error) {
+	return m.ListSecretStoresFn(ctx, i)
 }
 
 // CreateSecret implements Interface.
-func (m API) CreateSecret(i *fastly.CreateSecretInput) (*fastly.Secret, error) {
-	return m.CreateSecretFn(i)
+func (m API) CreateSecret(ctx context.Context, i *fastly.CreateSecretInput) (*fastly.Secret, error) {
+	return m.CreateSecretFn(ctx, i)
 }
 
 // GetSecret implements Interface.
-func (m API) GetSecret(i *fastly.GetSecretInput) (*fastly.Secret, error) {
-	return m.GetSecretFn(i)
+func (m API) GetSecret(ctx context.Context, i *fastly.GetSecretInput) (*fastly.Secret, error) {
+	return m.GetSecretFn(ctx, i)
 }
 
 // DeleteSecret implements Interface.
-func (m API) DeleteSecret(i *fastly.DeleteSecretInput) error {
-	return m.DeleteSecretFn(i)
+func (m API) DeleteSecret(ctx context.Context, i *fastly.DeleteSecretInput) error {
+	return m.DeleteSecretFn(ctx, i)
 }
 
 // ListSecrets implements Interface.
-func (m API) ListSecrets(i *fastly.ListSecretsInput) (*fastly.Secrets, error) {
-	return m.ListSecretsFn(i)
+func (m API) ListSecrets(ctx context.Context, i *fastly.ListSecretsInput) (*fastly.Secrets, error) {
+	return m.ListSecretsFn(ctx, i)
 }
 
 // CreateClientKey implements Interface.
-func (m API) CreateClientKey() (*fastly.ClientKey, error) {
-	return m.CreateClientKeyFn()
+func (m API) CreateClientKey(ctx context.Context) (*fastly.ClientKey, error) {
+	return m.CreateClientKeyFn(ctx)
 }
 
 // GetSigningKey implements Interface.
-func (m API) GetSigningKey() (ed25519.PublicKey, error) {
-	return m.GetSigningKeyFn()
+func (m API) GetSigningKey(ctx context.Context) (ed25519.PublicKey, error) {
+	return m.GetSigningKeyFn(ctx)
 }
 
 // CreateResource implements Interface.
-func (m API) CreateResource(i *fastly.CreateResourceInput) (*fastly.Resource, error) {
-	return m.CreateResourceFn(i)
+func (m API) CreateResource(ctx context.Context, i *fastly.CreateResourceInput) (*fastly.Resource, error) {
+	return m.CreateResourceFn(ctx, i)
 }
 
 // DeleteResource implements Interface.
-func (m API) DeleteResource(i *fastly.DeleteResourceInput) error {
-	return m.DeleteResourceFn(i)
+func (m API) DeleteResource(ctx context.Context, i *fastly.DeleteResourceInput) error {
+	return m.DeleteResourceFn(ctx, i)
 }
 
 // GetResource implements Interface.
-func (m API) GetResource(i *fastly.GetResourceInput) (*fastly.Resource, error) {
-	return m.GetResourceFn(i)
+func (m API) GetResource(ctx context.Context, i *fastly.GetResourceInput) (*fastly.Resource, error) {
+	return m.GetResourceFn(ctx, i)
 }
 
 // ListResources implements Interface.
-func (m API) ListResources(i *fastly.ListResourcesInput) ([]*fastly.Resource, error) {
-	return m.ListResourcesFn(i)
+func (m API) ListResources(ctx context.Context, i *fastly.ListResourcesInput) ([]*fastly.Resource, error) {
+	return m.ListResourcesFn(ctx, i)
 }
 
 // UpdateResource implements Interface.
-func (m API) UpdateResource(i *fastly.UpdateResourceInput) (*fastly.Resource, error) {
-	return m.UpdateResourceFn(i)
+func (m API) UpdateResource(ctx context.Context, i *fastly.UpdateResourceInput) (*fastly.Resource, error) {
+	return m.UpdateResourceFn(ctx, i)
 }
 
 // CreateERL implements Interface.
-func (m API) CreateERL(i *fastly.CreateERLInput) (*fastly.ERL, error) {
-	return m.CreateERLFn(i)
+func (m API) CreateERL(ctx context.Context, i *fastly.CreateERLInput) (*fastly.ERL, error) {
+	return m.CreateERLFn(ctx, i)
 }
 
 // DeleteERL implements Interface.
-func (m API) DeleteERL(i *fastly.DeleteERLInput) error {
-	return m.DeleteERLFn(i)
+func (m API) DeleteERL(ctx context.Context, i *fastly.DeleteERLInput) error {
+	return m.DeleteERLFn(ctx, i)
 }
 
 // GetERL implements Interface.
-func (m API) GetERL(i *fastly.GetERLInput) (*fastly.ERL, error) {
-	return m.GetERLFn(i)
+func (m API) GetERL(ctx context.Context, i *fastly.GetERLInput) (*fastly.ERL, error) {
+	return m.GetERLFn(ctx, i)
 }
 
 // ListERLs implements Interface.
-func (m API) ListERLs(i *fastly.ListERLsInput) ([]*fastly.ERL, error) {
-	return m.ListERLsFn(i)
+func (m API) ListERLs(ctx context.Context, i *fastly.ListERLsInput) ([]*fastly.ERL, error) {
+	return m.ListERLsFn(ctx, i)
 }
 
 // UpdateERL implements Interface.
-func (m API) UpdateERL(i *fastly.UpdateERLInput) (*fastly.ERL, error) {
-	return m.UpdateERLFn(i)
+func (m API) UpdateERL(ctx context.Context, i *fastly.UpdateERLInput) (*fastly.ERL, error) {
+	return m.UpdateERLFn(ctx, i)
 }
 
 // CreateCondition implements Interface.
-func (m API) CreateCondition(i *fastly.CreateConditionInput) (*fastly.Condition, error) {
-	return m.CreateConditionFn(i)
+func (m API) CreateCondition(ctx context.Context, i *fastly.CreateConditionInput) (*fastly.Condition, error) {
+	return m.CreateConditionFn(ctx, i)
 }
 
 // DeleteCondition implements Interface.
-func (m API) DeleteCondition(i *fastly.DeleteConditionInput) error {
-	return m.DeleteConditionFn(i)
+func (m API) DeleteCondition(ctx context.Context, i *fastly.DeleteConditionInput) error {
+	return m.DeleteConditionFn(ctx, i)
 }
 
 // GetCondition implements Interface.
-func (m API) GetCondition(i *fastly.GetConditionInput) (*fastly.Condition, error) {
-	return m.GetConditionFn(i)
+func (m API) GetCondition(ctx context.Context, i *fastly.GetConditionInput) (*fastly.Condition, error) {
+	return m.GetConditionFn(ctx, i)
 }
 
 // ListConditions implements Interface.
-func (m API) ListConditions(i *fastly.ListConditionsInput) ([]*fastly.Condition, error) {
-	return m.ListConditionsFn(i)
+func (m API) ListConditions(ctx context.Context, i *fastly.ListConditionsInput) ([]*fastly.Condition, error) {
+	return m.ListConditionsFn(ctx, i)
 }
 
 // UpdateCondition implements Interface.
-func (m API) UpdateCondition(i *fastly.UpdateConditionInput) (*fastly.Condition, error) {
-	return m.UpdateConditionFn(i)
-}
-
-// GetProduct implements Interface.
-func (m API) GetProduct(i *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error) {
-	return m.GetProductFn(i)
-}
-
-// EnableProduct implements Interface.
-func (m API) EnableProduct(i *fastly.ProductEnablementInput) (*fastly.ProductEnablement, error) {
-	return m.EnableProductFn(i)
-}
-
-// DisableProduct implements Interface.
-func (m API) DisableProduct(i *fastly.ProductEnablementInput) error {
-	return m.DisableProductFn(i)
+func (m API) UpdateCondition(ctx context.Context, i *fastly.UpdateConditionInput) (*fastly.Condition, error) {
+	return m.UpdateConditionFn(ctx, i)
 }
 
 // ListAlertDefinitions implements Interface.
-func (m API) ListAlertDefinitions(i *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error) {
-	return m.ListAlertDefinitionsFn(i)
+func (m API) ListAlertDefinitions(ctx context.Context, i *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error) {
+	return m.ListAlertDefinitionsFn(ctx, i)
 }
 
 // CreateAlertDefinition implements Interface.
-func (m API) CreateAlertDefinition(i *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
-	return m.CreateAlertDefinitionFn(i)
+func (m API) CreateAlertDefinition(ctx context.Context, i *fastly.CreateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
+	return m.CreateAlertDefinitionFn(ctx, i)
 }
 
 // GetAlertDefinition implements Interface.
-func (m API) GetAlertDefinition(i *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error) {
-	return m.GetAlertDefinitionFn(i)
+func (m API) GetAlertDefinition(ctx context.Context, i *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error) {
+	return m.GetAlertDefinitionFn(ctx, i)
 }
 
 // UpdateAlertDefinition implements Interface.
-func (m API) UpdateAlertDefinition(i *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
-	return m.UpdateAlertDefinitionFn(i)
+func (m API) UpdateAlertDefinition(ctx context.Context, i *fastly.UpdateAlertDefinitionInput) (*fastly.AlertDefinition, error) {
+	return m.UpdateAlertDefinitionFn(ctx, i)
 }
 
 // DeleteAlertDefinition implements Interface.
-func (m API) DeleteAlertDefinition(i *fastly.DeleteAlertDefinitionInput) error {
-	return m.DeleteAlertDefinitionFn(i)
+func (m API) DeleteAlertDefinition(ctx context.Context, i *fastly.DeleteAlertDefinitionInput) error {
+	return m.DeleteAlertDefinitionFn(ctx, i)
 }
 
 // TestAlertDefinition implements Interface.
-func (m API) TestAlertDefinition(i *fastly.TestAlertDefinitionInput) error {
-	return m.TestAlertDefinitionFn(i)
+func (m API) TestAlertDefinition(ctx context.Context, i *fastly.TestAlertDefinitionInput) error {
+	return m.TestAlertDefinitionFn(ctx, i)
 }
 
 // ListAlertHistory implements Interface.
-func (m API) ListAlertHistory(i *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error) {
-	return m.ListAlertHistoryFn(i)
+func (m API) ListAlertHistory(ctx context.Context, i *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error) {
+	return m.ListAlertHistoryFn(ctx, i)
 }
 
 // CreateObservabilityCustomDashboard implements Interface.
-func (m API) CreateObservabilityCustomDashboard(i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
-	return m.CreateObservabilityCustomDashboardFn(i)
+func (m API) CreateObservabilityCustomDashboard(ctx context.Context, i *fastly.CreateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+	return m.CreateObservabilityCustomDashboardFn(ctx, i)
 }
 
 // DeleteObservabilityCustomDashboard implements Interface.
-func (m API) DeleteObservabilityCustomDashboard(i *fastly.DeleteObservabilityCustomDashboardInput) error {
-	return m.DeleteObservabilityCustomDashboardFn(i)
+func (m API) DeleteObservabilityCustomDashboard(ctx context.Context, i *fastly.DeleteObservabilityCustomDashboardInput) error {
+	return m.DeleteObservabilityCustomDashboardFn(ctx, i)
 }
 
 // GetObservabilityCustomDashboard implements Interface.
-func (m API) GetObservabilityCustomDashboard(i *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
-	return m.GetObservabilityCustomDashboardFn(i)
+func (m API) GetObservabilityCustomDashboard(ctx context.Context, i *fastly.GetObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+	return m.GetObservabilityCustomDashboardFn(ctx, i)
 }
 
 // ListObservabilityCustomDashboards implements Interface.
-func (m API) ListObservabilityCustomDashboards(i *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error) {
-	return m.ListObservabilityCustomDashboardsFn(i)
+func (m API) ListObservabilityCustomDashboards(ctx context.Context, i *fastly.ListObservabilityCustomDashboardsInput) (*fastly.ListDashboardsResponse, error) {
+	return m.ListObservabilityCustomDashboardsFn(ctx, i)
 }
 
 // UpdateObservabilityCustomDashboard implements Interface.
-func (m API) UpdateObservabilityCustomDashboard(i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
-	return m.UpdateObservabilityCustomDashboardFn(i)
+func (m API) UpdateObservabilityCustomDashboard(ctx context.Context, i *fastly.UpdateObservabilityCustomDashboardInput) (*fastly.ObservabilityCustomDashboard, error) {
+	return m.UpdateObservabilityCustomDashboardFn(ctx, i)
 }

--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 )
@@ -39,7 +39,7 @@ type HTTPClient struct {
 }
 
 // Get mocks a HTTP Client Get request.
-func (c *HTTPClient) Get(p string, _ fastly.RequestOptions) (*http.Response, error) {
+func (c *HTTPClient) Get(_ context.Context, p string, _ fastly.RequestOptions) (*http.Response, error) {
 	fmt.Printf("p: %#v\n", p)
 	// IMPORTANT: Have to increment on defer as index is already 0 by this point.
 	// This is opposite to the Do() method which is -1 at the time it's called.

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -1,12 +1,13 @@
 package testutil
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/commands/sso"
 	"github.com/fastly/cli/pkg/commands/whoami"
@@ -23,7 +24,7 @@ var Err = errors.New("test error")
 // NOTE: consult the entire test suite before adding any new entries to the
 // returned type as the tests currently use testutil.CloneVersionResult() as a
 // way of making the test output and expectations as accurate as possible.
-func ListVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+func ListVersions(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
@@ -53,13 +54,13 @@ func ListVersions(i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 
 // ListVersionsError returns a generic error message when attempting to list
 // service versions.
-func ListVersionsError(_ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+func ListVersionsError(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return nil, Err
 }
 
 // CloneVersionResult returns a function which returns a specific cloned version.
-func CloneVersionResult(version int) func(i *fastly.CloneVersionInput) (*fastly.Version, error) {
-	return func(i *fastly.CloneVersionInput) (*fastly.Version, error) {
+func CloneVersionResult(version int) func(_ context.Context, i *fastly.CloneVersionInput) (*fastly.Version, error) {
+	return func(_ context.Context, i *fastly.CloneVersionInput) (*fastly.Version, error) {
 		return &fastly.Version{
 			ServiceID: fastly.ToPointer(i.ServiceID),
 			Number:    fastly.ToPointer(version),
@@ -69,7 +70,7 @@ func CloneVersionResult(version int) func(i *fastly.CloneVersionInput) (*fastly.
 
 // CloneVersionError returns a generic error message when attempting to clone a
 // service version.
-func CloneVersionError(_ *fastly.CloneVersionInput) (*fastly.Version, error) {
+func CloneVersionError(_ context.Context, _ *fastly.CloneVersionInput) (*fastly.Version, error) {
 	return nil, Err
 }
 

--- a/pkg/testutil/paginator.go
+++ b/pkg/testutil/paginator.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // ServicesPaginator mocks the behaviour of a paginator for services.

--- a/pkg/testutil/scenarios.go
+++ b/pkg/testutil/scenarios.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/app"

--- a/pkg/text/accesskey.go
+++ b/pkg/text/accesskey.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v10/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
 )
 
 // PrintAccessKey displays an access key.

--- a/pkg/text/backend.go
+++ b/pkg/text/backend.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // PrintBackend pretty prints a fastly.Backend structure in verbose format

--- a/pkg/text/computeacl.go
+++ b/pkg/text/computeacl.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly/computeacls"
+	"github.com/fastly/go-fastly/v11/fastly/computeacls"
 )
 
 // PrintComputeACL displays a compute ACL.

--- a/pkg/text/configstore.go
+++ b/pkg/text/configstore.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	fsttime "github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/dictionary.go
+++ b/pkg/text/dictionary.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/dictionaryitem.go
+++ b/pkg/text/dictionaryitem.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/dictionaryitem_test.go
+++ b/pkg/text/dictionaryitem_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 func TestPrintDictionaryItem(t *testing.T) {

--- a/pkg/text/healthcheck.go
+++ b/pkg/text/healthcheck.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // PrintHealthCheck pretty prints a fastly.HealthCheck structure in verbose

--- a/pkg/text/kvstore.go
+++ b/pkg/text/kvstore.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/resource.go
+++ b/pkg/text/resource.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/secretstore.go
+++ b/pkg/text/secretstore.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 )
 
 // PrintSecretStoresTbl displays store data in a table format.

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/service_test.go
+++ b/pkg/text/service_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v10/fastly"
+	"github.com/fastly/go-fastly/v11/fastly"
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"


### PR DESCRIPTION
go-fastly version 11 requires a context.Context object to be passed as the first argument in all of the API functions it exports. This commit modifies all of the code in the CLI to pass context.TODO() in that case, since the CLI does not use context objects for any other purpose.

The CLI also has an internal 'interface' which maps to the complete set of API functions in the 'fastly' namespace exported by go-fastly, and hundreds of 'mock' functions used in the CLI test suite. Those have also been updated, and along the way many inconsistencies in those function signatures were corrected.

go-fastly version 11 removed a deprecated set of product enablement API functions, so the `fastly products` command has been updated to use the new API functions. The tests for the `fastly products` command no longer mock the API calls as they no longer exist, and the new `fastly product` command which will appear in the next release will provide full test coverage of the CLI's use of the new product enablement API functions.

There are no functional changes in this commit, and the entire test suite still passes.

At least 80% of the changes in this commit were produced using [comby](https://comby.dev/).

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?