### PR TITLE
refactor(domainv1,tools): use updated go-fastly domainmanagement imports and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - feat(vcl): Allow showing of generated VCL for a service version [#1498](https://github.com/fastly/cli/pull/1498)
 - Add experimental "enable Pushpin" mode ([#1509](https://github.com/fastly/cli/pull/1509))
 - feat(object-storage): improve access-keys list output ([#1513](https://github.com/fastly/cli/pull/1513))
+- refactor(domainv1,tools): use updated go-fastly domainmanagement imports and types ([#1517](https://github.com/fastly/cli/pull/1517))
 
 ### Bug fixes:
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v11 v11.2.0
+	github.com/fastly/go-fastly/v11 v11.3.0
 	github.com/hashicorp/cap v0.10.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/otiai10/copy v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:aYo8nnk3ojoQkP5iErif5Xxv0Mo0Ga/FR5+ffl/7+Nk=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v11 v11.2.0 h1:4gFhs6dZ0HzNGpZ6XiCi1dwESCMD4je3+OENIcD7wJk=
-github.com/fastly/go-fastly/v11 v11.2.0/go.mod h1:yv1Tvz457kNCxyNaPi3J8Z3xUxeU8m1XN7O4a8OFLgc=
+github.com/fastly/go-fastly/v11 v11.3.0 h1:S0Md/3Tkja+H1X+hBnlQUiCet0N9XB2YzSVtVcNjwPc=
+github.com/fastly/go-fastly/v11 v11.3.0/go.mod h1:yv1Tvz457kNCxyNaPi3J8Z3xUxeU8m1XN7O4a8OFLgc=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/commands/domainv1/common.go
+++ b/pkg/commands/domainv1/common.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"io"
 
-	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/text"
 )
 
 // printSummary displays the information returned from the API in a summarised
 // format.
-func printSummary(out io.Writer, data []v1.Data) {
+func printSummary(out io.Writer, data []domains.Data) {
 	t := text.NewTable(out)
 	t.AddHeader("FQDN", "DOMAIN ID", "SERVICE ID", "CREATED AT", "UPDATED AT", "DESCRIPTION")
 	for _, d := range data {
@@ -26,7 +26,7 @@ func printSummary(out io.Writer, data []v1.Data) {
 
 // printSummary displays the information returned from the API in a verbose
 // format.
-func printVerbose(out io.Writer, data []v1.Data) {
+func printVerbose(out io.Writer, data []domains.Data) {
 	for _, d := range data {
 		fmt.Fprintf(out, "FQDN: %s\n", d.FQDN)
 		fmt.Fprintf(out, "Domain ID: %s\n", d.DomainID)

--- a/pkg/commands/domainv1/create.go
+++ b/pkg/commands/domainv1/create.go
@@ -7,8 +7,7 @@ import (
 	"io"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-
-	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -50,7 +49,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec invokes the application logic for the command.
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
-	input := &v1.CreateInput{
+	input := &domains.CreateInput{
 		FQDN: &c.fqdn,
 	}
 	if c.serviceID != "" {
@@ -66,7 +65,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	d, err := v1.Create(context.TODO(), fc, input)
+	d, err := domains.Create(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"FQDN":       c.fqdn,

--- a/pkg/commands/domainv1/delete.go
+++ b/pkg/commands/domainv1/delete.go
@@ -6,8 +6,7 @@ import (
 	"io"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-
-	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -42,11 +41,11 @@ func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	input := &v1.DeleteInput{
+	input := &domains.DeleteInput{
 		DomainID: &c.domainID,
 	}
 
-	err := v1.Delete(context.TODO(), fc, input)
+	err := domains.Delete(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Domain ID": c.domainID,

--- a/pkg/commands/domainv1/describe.go
+++ b/pkg/commands/domainv1/describe.go
@@ -6,8 +6,7 @@ import (
 	"io"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-
-	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -49,11 +48,11 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	input := &v1.GetInput{
+	input := &domains.GetInput{
 		DomainID: &c.domainID,
 	}
 
-	d, err := v1.Get(context.TODO(), fc, input)
+	d, err := domains.Get(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Domain ID": c.domainID,
@@ -66,7 +65,7 @@ func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	if d != nil {
-		cl := []v1.Data{*d}
+		cl := []domains.Data{*d}
 		if c.Globals.Verbose() {
 			printVerbose(out, cl)
 		} else {

--- a/pkg/commands/domainv1/domain_test.go
+++ b/pkg/commands/domainv1/domain_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
 
 	root "github.com/fastly/cli/pkg/commands/domainv1"
 	"github.com/fastly/cli/pkg/testutil"
@@ -31,7 +31,7 @@ func TestDomainV1Create(t *testing.T) {
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     http.StatusText(http.StatusOK),
-						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(v1.Data{
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(domains.Data{
 							DomainID:  did,
 							FQDN:      fqdn,
 							ServiceID: &sid,
@@ -48,7 +48,7 @@ func TestDomainV1Create(t *testing.T) {
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     http.StatusText(http.StatusOK),
-						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(v1.Data{
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(domains.Data{
 							DomainID: did,
 							FQDN:     fqdn,
 						}))),
@@ -89,8 +89,8 @@ func TestDomainV1List(t *testing.T) {
 	did := "domain-id"
 	description := "domain description"
 
-	resp := testutil.GenJSON(v1.Collection{
-		Data: []v1.Data{
+	resp := testutil.GenJSON(domains.Collection{
+		Data: []domains.Data{
 			{
 				DomainID:    did,
 				FQDN:        fqdn,
@@ -141,7 +141,7 @@ func TestDomainV1Describe(t *testing.T) {
 	did := "domain-id"
 	description := "domain description"
 
-	resp := testutil.GenJSON(v1.Data{
+	resp := testutil.GenJSON(domains.Data{
 		DomainID:    did,
 		FQDN:        fqdn,
 		ServiceID:   &sid,
@@ -200,7 +200,7 @@ func TestDomainV1Update(t *testing.T) {
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     http.StatusText(http.StatusOK),
-						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(v1.Data{
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(domains.Data{
 							DomainID:  did,
 							FQDN:      fqdn,
 							ServiceID: &sid,
@@ -217,7 +217,7 @@ func TestDomainV1Update(t *testing.T) {
 					Response: &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     http.StatusText(http.StatusOK),
-						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(v1.Data{
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(domains.Data{
 							DomainID: did,
 							FQDN:     fqdn,
 						}))),

--- a/pkg/commands/domainv1/list.go
+++ b/pkg/commands/domainv1/list.go
@@ -6,8 +6,7 @@ import (
 	"io"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-
-	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
@@ -58,7 +57,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 		return fsterr.ErrInvalidVerboseJSONCombo
 	}
 
-	input := &v1.ListInput{}
+	input := &domains.ListInput{}
 
 	if c.serviceID.WasSet {
 		input.ServiceID = &c.serviceID.Value
@@ -82,7 +81,7 @@ func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	}
 
 	for {
-		cl, err := v1.List(context.TODO(), fc, input)
+		cl, err := domains.List(context.TODO(), fc, input)
 		if err != nil {
 			c.Globals.ErrLog.AddWithContext(err, map[string]any{
 				"Cursor":     c.cursor.Value,

--- a/pkg/commands/domainv1/update.go
+++ b/pkg/commands/domainv1/update.go
@@ -7,8 +7,7 @@ import (
 	"io"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-
-	v1 "github.com/fastly/go-fastly/v11/fastly/domains/v1"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
@@ -44,7 +43,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec invokes the application logic for the command.
 func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
-	input := &v1.UpdateInput{
+	input := &domains.UpdateInput{
 		DomainID: &c.domainID,
 	}
 	if c.serviceID != "" {
@@ -60,7 +59,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return errors.New("failed to convert interface to a fastly client")
 	}
 
-	d, err := v1.Update(context.TODO(), fc, input)
+	d, err := domains.Update(context.TODO(), fc, input)
 	if err != nil {
 		c.Globals.ErrLog.AddWithContext(err, map[string]any{
 			"Domain ID":  c.domainID,

--- a/pkg/commands/tools/domain/status.go
+++ b/pkg/commands/tools/domain/status.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/status"
+
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
-	"github.com/fastly/go-fastly/v11/fastly"
-
-	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/status"
 )
 
 // GetDomainStatusCommand calls the Fastly API to check the availability of a domain name.

--- a/pkg/commands/tools/domain/status_test.go
+++ b/pkg/commands/tools/domain/status_test.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/status"
+
 	"github.com/fastly/cli/pkg/commands/tools"
 	"github.com/fastly/cli/pkg/commands/tools/domain"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v11/fastly"
-
-	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/status"
 )
 
 func TestNewDomainsV1ToolsStatusCommand(t *testing.T) {

--- a/pkg/commands/tools/domain/suggest.go
+++ b/pkg/commands/tools/domain/suggest.go
@@ -7,13 +7,13 @@ import (
 	"io"
 	"strings"
 
+	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/suggest"
+
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
-
-	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/suggest"
 )
 
 // GetDomainSuggestionsCommand calls the Fastly API and results domain search results for a given query.

--- a/pkg/commands/tools/domain/suggest_test.go
+++ b/pkg/commands/tools/domain/suggest_test.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/suggest"
+
 	"github.com/fastly/cli/pkg/commands/tools"
 	"github.com/fastly/cli/pkg/commands/tools/domain"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v11/fastly"
-
-	"github.com/fastly/go-fastly/v11/fastly/domains/v1/tools/suggest"
 )
 
 func TestNewDomainsV1ToolsSuggestCommand(t *testing.T) {


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

* [x] What is the user impact of this change?

There is no impact to the user. The changes as described in this PR are internal only. No package paths have changed, nor have any package names changed, nor have any CLI commands/subcommands changed. The only change has been to the go-fastly calls to match the latest go-fastly interface.

### Are there any considerations that need to be addressed for release?

I have an internal conversation going to ascertain if this PR should be doing more (e.g. renaming command from domains-v1 to domain-management, as well as renaming the package path from domainv1 to domainmanagement). But even if we do want to go ahead with those changes we'll likely want to do that in a follow-up PR.