### PR TITLE
feat(kvstoreentry): Support for the `prefix` parameter  for List operations

### DIFF
--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -265,6 +265,16 @@ func TestListCommand(t *testing.T) {
 			WantOutput: strings.Join(testItems, "\n") + "\n",
 		},
 		{
+			Name: "validate --prefix=foo",
+			Args: fmt.Sprintf("--store-id %s --prefix=foo", storeID),
+			API: mock.API{
+				ListKVStoreKeysFn: func(_ context.Context, _ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {
+					return &fastly.ListKVStoreKeysResponse{Data: []string{"foo-key1", "foo-key2"}}, nil
+				},
+			},
+			WantOutput: "✓ Getting data\nfoo-key1\nfoo-key2\n",
+		},
+		{
 			Args: fmt.Sprintf("--store-id %s --json", storeID),
 			API: mock.API{
 				ListKVStoreKeysFn: func(_ context.Context, _ *fastly.ListKVStoreKeysInput) (*fastly.ListKVStoreKeysResponse, error) {

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -19,6 +19,7 @@ type ListCommand struct {
 	argparser.JSONOutput
 
 	consistency string
+	prefix      string
 	Input       fastly.ListKVStoreKeysInput
 }
 
@@ -43,6 +44,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 
 	// Optional.
 	c.CmdClause.Flag("consistency", "Determines accuracy of results. i.e. 'eventual' uses caching to improve performance").Default("strong").HintOptions(ConsistencyOptions...).EnumVar(&c.consistency, ConsistencyOptions...)
+	c.CmdClause.Flag("prefix", "Restrict results to items whose keys match this prefix").StringVar(&c.prefix)
 	c.RegisterFlagBool(c.JSONFlag()) // --json
 	return &c
 }
@@ -82,6 +84,8 @@ func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	case "strong":
 		c.Input.Consistency = fastly.ConsistencyStrong
 	}
+
+	c.Input.Prefix = c.prefix
 
 	for {
 		o, err := c.Globals.APIClient.ListKVStoreKeys(context.TODO(), &c.Input)


### PR DESCRIPTION
 All Submissions:

### New Feature Submissions:

* [ ] Does your submission pass tests?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

Testing:
```
 make test TEST_ARGS="-run TestListCommand ./pkg/commands/kvstoreentry"
ok      github.com/fastly/cli/pkg/commands/kvstoreentry 1.053s
```