### PR TITLE
Enable loading Secret Store configuration through environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking:
 
 ### Enhancements:
+- fix(manifest): Enable loading Secret Store configuration through environment variables ([#1540](https://github.com/fastly/cli/pull/1540))
 
 ### Bug fixes:
 

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -127,6 +127,9 @@ func (f *File) MarshalTOML() ([]byte, error) {
 					if e.Data != "" {
 						obj["data"] = e.Data
 					}
+					if e.Env != "" {
+						obj["env"] = e.Env
+					}
 					items = append(items, obj)
 				}
 				secretStores[key] = items

--- a/pkg/manifest/local_server.go
+++ b/pkg/manifest/local_server.go
@@ -119,6 +119,7 @@ type SecretStoreArrayEntry struct {
 	Key  string `toml:"key"`
 	File string `toml:"file,omitempty"`
 	Data string `toml:"data,omitempty"`
+	Env  string `toml:"env,omitempty"`
 }
 
 // SecretStoreExternalFile represents the external key/value store,

--- a/pkg/manifest/testdata/fastly-viceroy-update.toml
+++ b/pkg/manifest/testdata/fastly-viceroy-update.toml
@@ -71,3 +71,7 @@ data = "This is also some secret data"
 [[local_server.secret_stores.store_two]]
 key = "second"
 file = "/path/to/other/secret.json"
+
+[[local_server.secret_stores.store_two]]
+key = "fourth"
+env = "ENV_FOURTH"


### PR DESCRIPTION
### Change summary

This PR complements https://github.com/fastly/Viceroy/pull/527 enabling the CLI's manifest schema to recognize the env field in Secret Stores.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
The test fixture `fastly-viceroy-update.toml` has been updated to make sure that manifest updates persist the field.

* [x] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?

This relates to https://github.com/fastly/Viceroy/pull/527 but doesn't have to wait for it before releasing this.
