### PR TITLE
Bump go-fastly to v12.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 )
 
 require (
-	github.com/fastly/go-fastly/v11 v11.3.1
 	github.com/hashicorp/cap v0.10.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/otiai10/copy v1.14.1
@@ -82,5 +81,6 @@ require (
 
 require (
 	4d63.com/optional v0.2.0
+	github.com/fastly/go-fastly/v12 v12.0.0
 	github.com/mitchellh/go-ps v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:aYo8nnk3ojoQkP5iErif5Xxv0Mo0Ga/FR5+ffl/7+Nk=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v11 v11.3.1 h1:GiBDf9k1Xh5yT1hAD64EC8WDiBScDETNh1gfDP0gCaA=
-github.com/fastly/go-fastly/v11 v11.3.1/go.mod h1:sphV7DVAKUZT30O1h9m9Lw9DbB0kC3CnQUOhVI3gaeo=
+github.com/fastly/go-fastly/v12 v12.0.0 h1:jfL+AtA4OBrSpx4S/HZCYhcS65T+6zeG+9rvOTJXzhg=
+github.com/fastly/go-fastly/v12 v12.0.0/go.mod h1:9An7aQ1PaZcMb4jnot+lWEBNnHBMl9t4U0OUV8XVoMA=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -5,7 +5,7 @@ import (
 	"crypto/ed25519"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // HTTPClient models a concrete http.Client. It's a consumer contract for some

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/cap/oidc"
 	"github.com/skratchdot/open-golang/open"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/kingpin"
 

--- a/pkg/argparser/cmd.go
+++ b/pkg/argparser/cmd.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/kingpin"
 

--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/kingpin"
 

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/manifest"

--- a/pkg/commands/acl/acl_test.go
+++ b/pkg/commands/acl/acl_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/acl"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/acl/create.go
+++ b/pkg/commands/acl/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/acl/delete.go
+++ b/pkg/commands/acl/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/acl/describe.go
+++ b/pkg/commands/acl/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/acl/list.go
+++ b/pkg/commands/acl/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/acl/update.go
+++ b/pkg/commands/acl/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/aclentry/aclentry_test.go
+++ b/pkg/commands/aclentry/aclentry_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/aclentry"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/aclentry/create.go
+++ b/pkg/commands/aclentry/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/aclentry/delete.go
+++ b/pkg/commands/aclentry/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/aclentry/describe.go
+++ b/pkg/commands/aclentry/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/aclentry/list.go
+++ b/pkg/commands/aclentry/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/aclentry/update.go
+++ b/pkg/commands/aclentry/update.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/alerts/alerts_test.go
+++ b/pkg/commands/alerts/alerts_test.go
@@ -9,7 +9,7 @@ import (
 	root "github.com/fastly/cli/pkg/commands/alerts"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 func TestAlertsCreate(t *testing.T) {

--- a/pkg/commands/alerts/common.go
+++ b/pkg/commands/alerts/common.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // evaluationType is a list of supported evaluation types.

--- a/pkg/commands/alerts/create.go
+++ b/pkg/commands/alerts/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // NewCreateCommand returns a usable command registered under the parent.

--- a/pkg/commands/alerts/delete.go
+++ b/pkg/commands/alerts/delete.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/alerts/describe.go
+++ b/pkg/commands/alerts/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/alerts/list.go
+++ b/pkg/commands/alerts/list.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/alerts/list_history.go
+++ b/pkg/commands/alerts/list_history.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/alerts/update.go
+++ b/pkg/commands/alerts/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/authtoken"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/authtoken/create.go
+++ b/pkg/commands/authtoken/create.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/kingpin"
 

--- a/pkg/commands/authtoken/delete.go
+++ b/pkg/commands/authtoken/delete.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/authtoken/describe.go
+++ b/pkg/commands/authtoken/describe.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/authtoken/list.go
+++ b/pkg/commands/authtoken/list.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/backend/backend_test.go
+++ b/pkg/commands/backend/backend_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/backend"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/backend/create.go
+++ b/pkg/commands/backend/create.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/backend/delete.go
+++ b/pkg/commands/backend/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/backend/describe.go
+++ b/pkg/commands/backend/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/backend/list.go
+++ b/pkg/commands/backend/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/backend/update.go
+++ b/pkg/commands/backend/update.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -7,7 +7,7 @@ package compute_test
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/testutil"
 )

--- a/pkg/commands/compute/computeacl/computeacl_test.go
+++ b/pkg/commands/compute/computeacl/computeacl_test.go
@@ -12,7 +12,7 @@ import (
 	sub "github.com/fastly/cli/pkg/commands/compute/computeacl"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 )
 
 func TestComputeACLCreate(t *testing.T) {

--- a/pkg/commands/compute/computeacl/create.go
+++ b/pkg/commands/compute/computeacl/create.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/computeacl/delete.go
+++ b/pkg/commands/compute/computeacl/delete.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/computeacl/describe.go
+++ b/pkg/commands/compute/computeacl/describe.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/computeacl/listacls.go
+++ b/pkg/commands/compute/computeacl/listacls.go
@@ -9,9 +9,9 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 )
 
 // ListCommand calls the Fastly API to list all compute ACLs.

--- a/pkg/commands/compute/computeacl/listentries.go
+++ b/pkg/commands/compute/computeacl/listentries.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/computeacl/lookup.go
+++ b/pkg/commands/compute/computeacl/lookup.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/computeacl/update.go
+++ b/pkg/commands/compute/computeacl/update.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/deploy.go
+++ b/pkg/commands/compute/deploy.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kennygrant/sanitize"
 	"github.com/mholt/archiver/v3"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/api/undocumented"

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/commands/compute"

--- a/pkg/commands/compute/init.go
+++ b/pkg/commands/compute/init.go
@@ -19,7 +19,7 @@ import (
 
 	cp "github.com/otiai10/copy"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/config"

--- a/pkg/commands/compute/init_test.go
+++ b/pkg/commands/compute/init_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/config"

--- a/pkg/commands/compute/setup/backend.go
+++ b/pkg/commands/compute/setup/backend.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/commands/backend"

--- a/pkg/commands/compute/setup/config_store.go
+++ b/pkg/commands/compute/setup/config_store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/setup/domain.go
+++ b/pkg/commands/compute/setup/domain.go
@@ -10,7 +10,7 @@ import (
 
 	petname "github.com/dustinkirkland/golang-petname"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/setup/kv_store.go
+++ b/pkg/commands/compute/setup/kv_store.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/setup/secret_store.go
+++ b/pkg/commands/compute/setup/secret_store.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	fsterrors "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/compute/update.go
+++ b/pkg/commands/compute/update.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kennygrant/sanitize"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstore/configstore_test.go
+++ b/pkg/commands/configstore/configstore_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/configstore"
 	fstfmt "github.com/fastly/cli/pkg/fmt"

--- a/pkg/commands/configstore/create.go
+++ b/pkg/commands/configstore/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstore/delete.go
+++ b/pkg/commands/configstore/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstore/describe.go
+++ b/pkg/commands/configstore/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstore/helper_test.go
+++ b/pkg/commands/configstore/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 func fmtStore(cs *fastly.ConfigStore, csm *fastly.ConfigStoreMetadata) string {

--- a/pkg/commands/configstore/list.go
+++ b/pkg/commands/configstore/list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstore/list_services.go
+++ b/pkg/commands/configstore/list_services.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstore/update.go
+++ b/pkg/commands/configstore/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstoreentry/configstoreentry_test.go
+++ b/pkg/commands/configstoreentry/configstoreentry_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/configstoreentry"
 	fstfmt "github.com/fastly/cli/pkg/fmt"

--- a/pkg/commands/configstoreentry/create.go
+++ b/pkg/commands/configstoreentry/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstoreentry/delete.go
+++ b/pkg/commands/configstoreentry/delete.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstoreentry/describe.go
+++ b/pkg/commands/configstoreentry/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstoreentry/list.go
+++ b/pkg/commands/configstoreentry/list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/configstoreentry/update.go
+++ b/pkg/commands/configstoreentry/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dashboard/create.go
+++ b/pkg/commands/dashboard/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dashboard/dashboard_test.go
+++ b/pkg/commands/dashboard/dashboard_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/dashboard"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/dashboard/delete.go
+++ b/pkg/commands/dashboard/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dashboard/describe.go
+++ b/pkg/commands/dashboard/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/printer"

--- a/pkg/commands/dashboard/item/create.go
+++ b/pkg/commands/dashboard/item/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/printer"

--- a/pkg/commands/dashboard/item/delete.go
+++ b/pkg/commands/dashboard/item/delete.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"slices"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dashboard/item/describe.go
+++ b/pkg/commands/dashboard/item/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/printer"

--- a/pkg/commands/dashboard/item/item_test.go
+++ b/pkg/commands/dashboard/item/item_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/dashboard"
 	sub "github.com/fastly/cli/pkg/commands/dashboard/item"

--- a/pkg/commands/dashboard/item/update.go
+++ b/pkg/commands/dashboard/item/update.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"slices"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dashboard/list.go
+++ b/pkg/commands/dashboard/list.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/dashboard/printer"

--- a/pkg/commands/dashboard/printer/print.go
+++ b/pkg/commands/dashboard/printer/print.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/text"
 )

--- a/pkg/commands/dashboard/update.go
+++ b/pkg/commands/dashboard/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dictionary/create.go
+++ b/pkg/commands/dictionary/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/dictionary/delete.go
+++ b/pkg/commands/dictionary/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/dictionary/describe.go
+++ b/pkg/commands/dictionary/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dictionary/dictionary_test.go
+++ b/pkg/commands/dictionary/dictionary_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/dictionary"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/dictionary/list.go
+++ b/pkg/commands/dictionary/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dictionary/update.go
+++ b/pkg/commands/dictionary/update.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/dictionaryentry/create.go
+++ b/pkg/commands/dictionaryentry/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/dictionaryentry/delete.go
+++ b/pkg/commands/dictionaryentry/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/dictionaryentry/describe.go
+++ b/pkg/commands/dictionaryentry/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dictionaryentry/dictionaryitem_test.go
+++ b/pkg/commands/dictionaryentry/dictionaryitem_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/dictionaryentry/list.go
+++ b/pkg/commands/dictionaryentry/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/dictionaryentry/update.go
+++ b/pkg/commands/dictionaryentry/update.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/domain/create.go
+++ b/pkg/commands/domain/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/domain/delete.go
+++ b/pkg/commands/domain/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/domain/describe.go
+++ b/pkg/commands/domain/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/domain/domain_test.go
+++ b/pkg/commands/domain/domain_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/domain"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/domain/list.go
+++ b/pkg/commands/domain/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/domain/update.go
+++ b/pkg/commands/domain/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/domain/validate.go
+++ b/pkg/commands/domain/validate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/domainv1/common.go
+++ b/pkg/commands/domainv1/common.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/text"
 )

--- a/pkg/commands/domainv1/create.go
+++ b/pkg/commands/domainv1/create.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/domainv1/delete.go
+++ b/pkg/commands/domainv1/delete.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/domainv1/describe.go
+++ b/pkg/commands/domainv1/describe.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/domainv1/domain_test.go
+++ b/pkg/commands/domainv1/domain_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/domains"
 
 	root "github.com/fastly/cli/pkg/commands/domainv1"
 	"github.com/fastly/cli/pkg/testutil"

--- a/pkg/commands/domainv1/list.go
+++ b/pkg/commands/domainv1/list.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/domainv1/update.go
+++ b/pkg/commands/domainv1/update.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/domains"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/domains"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/healthcheck/create.go
+++ b/pkg/commands/healthcheck/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/healthcheck/delete.go
+++ b/pkg/commands/healthcheck/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/healthcheck/describe.go
+++ b/pkg/commands/healthcheck/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/healthcheck/healthcheck_test.go
+++ b/pkg/commands/healthcheck/healthcheck_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/healthcheck/list.go
+++ b/pkg/commands/healthcheck/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/healthcheck/update.go
+++ b/pkg/commands/healthcheck/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/imageoptimizerdefaults/get.go
+++ b/pkg/commands/imageoptimizerdefaults/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/imageoptimizerdefaults/imageoptimizer_test.go
+++ b/pkg/commands/imageoptimizerdefaults/imageoptimizer_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/imageoptimizerdefaults"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/imageoptimizerdefaults/update.go
+++ b/pkg/commands/imageoptimizerdefaults/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/ip/ip_test.go
+++ b/pkg/commands/ip/ip_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/ip"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/kvstore/create.go
+++ b/pkg/commands/kvstore/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/kvstore/delete.go
+++ b/pkg/commands/kvstore/delete.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/kvstoreentry"

--- a/pkg/commands/kvstore/describe.go
+++ b/pkg/commands/kvstore/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/kvstore/kvstore_test.go
+++ b/pkg/commands/kvstore/kvstore_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/kvstore"
 	fstfmt "github.com/fastly/cli/pkg/fmt"

--- a/pkg/commands/kvstore/list.go
+++ b/pkg/commands/kvstore/list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/kvstoreentry/create.go
+++ b/pkg/commands/kvstoreentry/create.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"

--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/kvstoreentry/describe.go
+++ b/pkg/commands/kvstoreentry/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/kvstoreentry/get.go
+++ b/pkg/commands/kvstoreentry/get.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/kvstoreentry/kvstoreentry_test.go
+++ b/pkg/commands/kvstoreentry/kvstoreentry_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/kvstoreentry"
 	fstfmt "github.com/fastly/cli/pkg/fmt"

--- a/pkg/commands/kvstoreentry/list.go
+++ b/pkg/commands/kvstoreentry/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/azureblob/azureblob_test.go
+++ b/pkg/commands/logging/azureblob/azureblob_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/azureblob"

--- a/pkg/commands/logging/azureblob/create.go
+++ b/pkg/commands/logging/azureblob/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/azureblob/delete.go
+++ b/pkg/commands/logging/azureblob/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/azureblob/describe.go
+++ b/pkg/commands/logging/azureblob/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/azureblob/list.go
+++ b/pkg/commands/logging/azureblob/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/azureblob/update.go
+++ b/pkg/commands/logging/azureblob/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/bigquery/bigquery_test.go
+++ b/pkg/commands/logging/bigquery/bigquery_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/bigquery"

--- a/pkg/commands/logging/bigquery/create.go
+++ b/pkg/commands/logging/bigquery/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/bigquery/delete.go
+++ b/pkg/commands/logging/bigquery/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/bigquery/describe.go
+++ b/pkg/commands/logging/bigquery/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/bigquery/list.go
+++ b/pkg/commands/logging/bigquery/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/bigquery/update.go
+++ b/pkg/commands/logging/bigquery/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/commands/logging/cloudfiles/cloudfiles_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/cloudfiles"

--- a/pkg/commands/logging/cloudfiles/create.go
+++ b/pkg/commands/logging/cloudfiles/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/cloudfiles/delete.go
+++ b/pkg/commands/logging/cloudfiles/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/cloudfiles/describe.go
+++ b/pkg/commands/logging/cloudfiles/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/cloudfiles/list.go
+++ b/pkg/commands/logging/cloudfiles/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/cloudfiles/update.go
+++ b/pkg/commands/logging/cloudfiles/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/datadog/create.go
+++ b/pkg/commands/logging/datadog/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/logging/datadog/datadog_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/datadog/datadog_test.go
+++ b/pkg/commands/logging/datadog/datadog_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/datadog"

--- a/pkg/commands/logging/datadog/delete.go
+++ b/pkg/commands/logging/datadog/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/datadog/describe.go
+++ b/pkg/commands/logging/datadog/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/datadog/list.go
+++ b/pkg/commands/logging/datadog/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/datadog/update.go
+++ b/pkg/commands/logging/datadog/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/digitalocean/create.go
+++ b/pkg/commands/logging/digitalocean/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/digitalocean/delete.go
+++ b/pkg/commands/logging/digitalocean/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/digitalocean/describe.go
+++ b/pkg/commands/logging/digitalocean/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/digitalocean/digitalocean_test.go
+++ b/pkg/commands/logging/digitalocean/digitalocean_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/digitalocean"

--- a/pkg/commands/logging/digitalocean/list.go
+++ b/pkg/commands/logging/digitalocean/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/digitalocean/update.go
+++ b/pkg/commands/logging/digitalocean/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/elasticsearch/create.go
+++ b/pkg/commands/logging/elasticsearch/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/elasticsearch/delete.go
+++ b/pkg/commands/logging/elasticsearch/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/elasticsearch/describe.go
+++ b/pkg/commands/logging/elasticsearch/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/commands/logging/elasticsearch/elasticsearch_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/elasticsearch"

--- a/pkg/commands/logging/elasticsearch/list.go
+++ b/pkg/commands/logging/elasticsearch/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/elasticsearch/update.go
+++ b/pkg/commands/logging/elasticsearch/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/ftp/create.go
+++ b/pkg/commands/logging/ftp/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/ftp/delete.go
+++ b/pkg/commands/logging/ftp/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/ftp/describe.go
+++ b/pkg/commands/logging/ftp/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/logging/ftp/ftp_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/ftp/ftp_test.go
+++ b/pkg/commands/logging/ftp/ftp_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/ftp"

--- a/pkg/commands/logging/ftp/list.go
+++ b/pkg/commands/logging/ftp/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/ftp/update.go
+++ b/pkg/commands/logging/ftp/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/gcs/create.go
+++ b/pkg/commands/logging/gcs/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/gcs/delete.go
+++ b/pkg/commands/logging/gcs/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/gcs/describe.go
+++ b/pkg/commands/logging/gcs/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/logging/gcs/gcs_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/gcs/gcs_test.go
+++ b/pkg/commands/logging/gcs/gcs_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/gcs"

--- a/pkg/commands/logging/gcs/list.go
+++ b/pkg/commands/logging/gcs/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/gcs/update.go
+++ b/pkg/commands/logging/gcs/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/googlepubsub/create.go
+++ b/pkg/commands/logging/googlepubsub/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/googlepubsub/delete.go
+++ b/pkg/commands/logging/googlepubsub/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/googlepubsub/describe.go
+++ b/pkg/commands/logging/googlepubsub/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/commands/logging/googlepubsub/googlepubsub_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/googlepubsub"

--- a/pkg/commands/logging/googlepubsub/list.go
+++ b/pkg/commands/logging/googlepubsub/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/googlepubsub/update.go
+++ b/pkg/commands/logging/googlepubsub/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/grafanacloudlogs/create.go
+++ b/pkg/commands/logging/grafanacloudlogs/create.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/manifest"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // CreateCommand calls the Fastly API to create a GrafanaCloudLogs logging endpoint.

--- a/pkg/commands/logging/grafanacloudlogs/delete.go
+++ b/pkg/commands/logging/grafanacloudlogs/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/grafanacloudlogs/describe.go
+++ b/pkg/commands/logging/grafanacloudlogs/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/grafanacloudlogs/grafanacloud_logs_integration_test.go
+++ b/pkg/commands/logging/grafanacloudlogs/grafanacloud_logs_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 func TestGrafanaCloudLogsCreate(t *testing.T) {

--- a/pkg/commands/logging/grafanacloudlogs/grafanacloudlogs_test.go
+++ b/pkg/commands/logging/grafanacloudlogs/grafanacloudlogs_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/grafanacloudlogs"

--- a/pkg/commands/logging/grafanacloudlogs/list.go
+++ b/pkg/commands/logging/grafanacloudlogs/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/grafanacloudlogs/update.go
+++ b/pkg/commands/logging/grafanacloudlogs/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/heroku/create.go
+++ b/pkg/commands/logging/heroku/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/heroku/delete.go
+++ b/pkg/commands/logging/heroku/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/heroku/describe.go
+++ b/pkg/commands/logging/heroku/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/logging/heroku/heroku_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/heroku/heroku_test.go
+++ b/pkg/commands/logging/heroku/heroku_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/heroku"

--- a/pkg/commands/logging/heroku/list.go
+++ b/pkg/commands/logging/heroku/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/heroku/update.go
+++ b/pkg/commands/logging/heroku/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/honeycomb/create.go
+++ b/pkg/commands/logging/honeycomb/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/honeycomb/delete.go
+++ b/pkg/commands/logging/honeycomb/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/honeycomb/describe.go
+++ b/pkg/commands/logging/honeycomb/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/honeycomb/honeycomb_test.go
+++ b/pkg/commands/logging/honeycomb/honeycomb_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/honeycomb"

--- a/pkg/commands/logging/honeycomb/list.go
+++ b/pkg/commands/logging/honeycomb/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/honeycomb/update.go
+++ b/pkg/commands/logging/honeycomb/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/https/create.go
+++ b/pkg/commands/logging/https/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/https/delete.go
+++ b/pkg/commands/logging/https/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/https/describe.go
+++ b/pkg/commands/logging/https/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/https/https_integration_test.go
+++ b/pkg/commands/logging/https/https_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/https/https_test.go
+++ b/pkg/commands/logging/https/https_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/https"

--- a/pkg/commands/logging/https/list.go
+++ b/pkg/commands/logging/https/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/https/update.go
+++ b/pkg/commands/logging/https/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/kafka/create.go
+++ b/pkg/commands/logging/kafka/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/kafka/delete.go
+++ b/pkg/commands/logging/kafka/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/kafka/describe.go
+++ b/pkg/commands/logging/kafka/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/logging/kafka/kafka_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/kafka/kafka_test.go
+++ b/pkg/commands/logging/kafka/kafka_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/kafka"

--- a/pkg/commands/logging/kafka/list.go
+++ b/pkg/commands/logging/kafka/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/kafka/update.go
+++ b/pkg/commands/logging/kafka/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/kinesis/create.go
+++ b/pkg/commands/logging/kinesis/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/kinesis/delete.go
+++ b/pkg/commands/logging/kinesis/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/kinesis/describe.go
+++ b/pkg/commands/logging/kinesis/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/kinesis/kinesis_test.go
+++ b/pkg/commands/logging/kinesis/kinesis_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/kinesis"

--- a/pkg/commands/logging/kinesis/list.go
+++ b/pkg/commands/logging/kinesis/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/kinesis/update.go
+++ b/pkg/commands/logging/kinesis/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/loggly/create.go
+++ b/pkg/commands/logging/loggly/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/loggly/delete.go
+++ b/pkg/commands/logging/loggly/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/loggly/describe.go
+++ b/pkg/commands/logging/loggly/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/loggly/list.go
+++ b/pkg/commands/logging/loggly/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/logging/loggly/loggly_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/loggly/loggly_test.go
+++ b/pkg/commands/logging/loggly/loggly_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/loggly"

--- a/pkg/commands/logging/loggly/update.go
+++ b/pkg/commands/logging/loggly/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/logshuttle/create.go
+++ b/pkg/commands/logging/logshuttle/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/logshuttle/delete.go
+++ b/pkg/commands/logging/logshuttle/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/logshuttle/describe.go
+++ b/pkg/commands/logging/logshuttle/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/logshuttle/list.go
+++ b/pkg/commands/logging/logshuttle/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/logshuttle/logshuttle_test.go
+++ b/pkg/commands/logging/logshuttle/logshuttle_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/logshuttle"

--- a/pkg/commands/logging/logshuttle/update.go
+++ b/pkg/commands/logging/logshuttle/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/newrelic/create.go
+++ b/pkg/commands/logging/newrelic/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/newrelic/delete.go
+++ b/pkg/commands/logging/newrelic/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/newrelic/describe.go
+++ b/pkg/commands/logging/newrelic/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/newrelic/list.go
+++ b/pkg/commands/logging/newrelic/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/logging/newrelic/newrelic_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/logging"
 	sub "github.com/fastly/cli/pkg/commands/logging/newrelic"

--- a/pkg/commands/logging/newrelic/update.go
+++ b/pkg/commands/logging/newrelic/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/newrelicotlp/create.go
+++ b/pkg/commands/logging/newrelicotlp/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/newrelicotlp/delete.go
+++ b/pkg/commands/logging/newrelicotlp/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/newrelicotlp/describe.go
+++ b/pkg/commands/logging/newrelicotlp/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/newrelicotlp/list.go
+++ b/pkg/commands/logging/newrelicotlp/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/newrelicotlp/newrelicotlp_test.go
+++ b/pkg/commands/logging/newrelicotlp/newrelicotlp_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/logging"
 	sub "github.com/fastly/cli/pkg/commands/logging/newrelicotlp"

--- a/pkg/commands/logging/newrelicotlp/update.go
+++ b/pkg/commands/logging/newrelicotlp/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/openstack/create.go
+++ b/pkg/commands/logging/openstack/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/openstack/delete.go
+++ b/pkg/commands/logging/openstack/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/openstack/describe.go
+++ b/pkg/commands/logging/openstack/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/openstack/list.go
+++ b/pkg/commands/logging/openstack/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/logging/openstack/openstack_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/openstack/openstack_test.go
+++ b/pkg/commands/logging/openstack/openstack_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/openstack"

--- a/pkg/commands/logging/openstack/update.go
+++ b/pkg/commands/logging/openstack/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/papertrail/create.go
+++ b/pkg/commands/logging/papertrail/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/papertrail/delete.go
+++ b/pkg/commands/logging/papertrail/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/papertrail/describe.go
+++ b/pkg/commands/logging/papertrail/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/papertrail/list.go
+++ b/pkg/commands/logging/papertrail/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/papertrail/papertrail_test.go
+++ b/pkg/commands/logging/papertrail/papertrail_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/papertrail"

--- a/pkg/commands/logging/papertrail/update.go
+++ b/pkg/commands/logging/papertrail/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/s3/create.go
+++ b/pkg/commands/logging/s3/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/s3/delete.go
+++ b/pkg/commands/logging/s3/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/s3/describe.go
+++ b/pkg/commands/logging/s3/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/s3/list.go
+++ b/pkg/commands/logging/s3/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/s3/s3_integration_test.go
+++ b/pkg/commands/logging/s3/s3_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/s3/s3_test.go
+++ b/pkg/commands/logging/s3/s3_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/s3"

--- a/pkg/commands/logging/s3/update.go
+++ b/pkg/commands/logging/s3/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/scalyr/create.go
+++ b/pkg/commands/logging/scalyr/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/scalyr/delete.go
+++ b/pkg/commands/logging/scalyr/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/scalyr/describe.go
+++ b/pkg/commands/logging/scalyr/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/scalyr/list.go
+++ b/pkg/commands/logging/scalyr/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	fsterrs "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/scalyr/scalyr_test.go
+++ b/pkg/commands/logging/scalyr/scalyr_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/scalyr"

--- a/pkg/commands/logging/scalyr/update.go
+++ b/pkg/commands/logging/scalyr/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/sftp/create.go
+++ b/pkg/commands/logging/sftp/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/sftp/delete.go
+++ b/pkg/commands/logging/sftp/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/sftp/describe.go
+++ b/pkg/commands/logging/sftp/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/sftp/list.go
+++ b/pkg/commands/logging/sftp/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/logging/sftp/sftp_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/sftp/sftp_test.go
+++ b/pkg/commands/logging/sftp/sftp_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/sftp"

--- a/pkg/commands/logging/sftp/update.go
+++ b/pkg/commands/logging/sftp/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/splunk/create.go
+++ b/pkg/commands/logging/splunk/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/splunk/delete.go
+++ b/pkg/commands/logging/splunk/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/splunk/describe.go
+++ b/pkg/commands/logging/splunk/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/splunk/list.go
+++ b/pkg/commands/logging/splunk/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/logging/splunk/splunk_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/splunk/splunk_test.go
+++ b/pkg/commands/logging/splunk/splunk_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/splunk"

--- a/pkg/commands/logging/splunk/update.go
+++ b/pkg/commands/logging/splunk/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/sumologic/create.go
+++ b/pkg/commands/logging/sumologic/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/sumologic/delete.go
+++ b/pkg/commands/logging/sumologic/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/sumologic/describe.go
+++ b/pkg/commands/logging/sumologic/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/sumologic/list.go
+++ b/pkg/commands/logging/sumologic/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/sumologic/sumologic_test.go
+++ b/pkg/commands/logging/sumologic/sumologic_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/sumologic"

--- a/pkg/commands/logging/sumologic/update.go
+++ b/pkg/commands/logging/sumologic/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/syslog/create.go
+++ b/pkg/commands/logging/syslog/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/syslog/delete.go
+++ b/pkg/commands/logging/syslog/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logging/syslog/describe.go
+++ b/pkg/commands/logging/syslog/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/syslog/list.go
+++ b/pkg/commands/logging/syslog/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/logging/syslog/syslog_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/logging/syslog/syslog_test.go
+++ b/pkg/commands/logging/syslog/syslog_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/commands/logging/syslog"

--- a/pkg/commands/logging/syslog/update.go
+++ b/pkg/commands/logging/syslog/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/logtail/root.go
+++ b/pkg/commands/logtail/root.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/tomnomnom/linkheader"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/debug"

--- a/pkg/commands/objectstorage/accesskeys/accesskeys_test.go
+++ b/pkg/commands/objectstorage/accesskeys/accesskeys_test.go
@@ -12,7 +12,7 @@ import (
 	sub "github.com/fastly/cli/pkg/commands/objectstorage/accesskeys"
 	fstfmt "github.com/fastly/cli/pkg/fmt"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v12/fastly/objectstorage/accesskeys"
 )
 
 const (

--- a/pkg/commands/objectstorage/accesskeys/create.go
+++ b/pkg/commands/objectstorage/accesskeys/create.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v12/fastly/objectstorage/accesskeys"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/objectstorage/accesskeys/delete.go
+++ b/pkg/commands/objectstorage/accesskeys/delete.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v12/fastly/objectstorage/accesskeys"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/objectstorage/accesskeys/get.go
+++ b/pkg/commands/objectstorage/accesskeys/get.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v12/fastly/objectstorage/accesskeys"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/objectstorage/accesskeys/list.go
+++ b/pkg/commands/objectstorage/accesskeys/list.go
@@ -9,9 +9,9 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
-	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v12/fastly/objectstorage/accesskeys"
 )
 
 // ListCommand calls the Fastly API to list all access keys.

--- a/pkg/commands/pop/pop_test.go
+++ b/pkg/commands/pop/pop_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/pop/root.go
+++ b/pkg/commands/pop/root.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/products/root.go
+++ b/pkg/commands/products/root.go
@@ -6,20 +6,20 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly/products/botmanagement"
-	"github.com/fastly/go-fastly/v11/fastly/products/brotlicompression"
-	"github.com/fastly/go-fastly/v11/fastly/products/domaininspector"
-	"github.com/fastly/go-fastly/v11/fastly/products/fanout"
-	"github.com/fastly/go-fastly/v11/fastly/products/imageoptimizer"
-	"github.com/fastly/go-fastly/v11/fastly/products/logexplorerinsights"
-	"github.com/fastly/go-fastly/v11/fastly/products/origininspector"
-	"github.com/fastly/go-fastly/v11/fastly/products/websockets"
+	"github.com/fastly/go-fastly/v12/fastly/products/botmanagement"
+	"github.com/fastly/go-fastly/v12/fastly/products/brotlicompression"
+	"github.com/fastly/go-fastly/v12/fastly/products/domaininspector"
+	"github.com/fastly/go-fastly/v12/fastly/products/fanout"
+	"github.com/fastly/go-fastly/v12/fastly/products/imageoptimizer"
+	"github.com/fastly/go-fastly/v12/fastly/products/logexplorerinsights"
+	"github.com/fastly/go-fastly/v12/fastly/products/origininspector"
+	"github.com/fastly/go-fastly/v12/fastly/products/websockets"
 )
 
 // RootCommand is the parent command for all subcommands in this package.

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/profile"
 	"github.com/fastly/cli/pkg/config"

--- a/pkg/commands/profile/update.go
+++ b/pkg/commands/profile/update.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"

--- a/pkg/commands/purge/purge_test.go
+++ b/pkg/commands/purge/purge_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/purge"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/purge/root.go
+++ b/pkg/commands/purge/root.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/ratelimit/create.go
+++ b/pkg/commands/ratelimit/create.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/ratelimit/delete.go
+++ b/pkg/commands/ratelimit/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/ratelimit/describe.go
+++ b/pkg/commands/ratelimit/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/ratelimit/list.go
+++ b/pkg/commands/ratelimit/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/ratelimit/ratelimit_test.go
+++ b/pkg/commands/ratelimit/ratelimit_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/ratelimit"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/ratelimit/update.go
+++ b/pkg/commands/ratelimit/update.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/resourcelink/create.go
+++ b/pkg/commands/resourcelink/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/resourcelink/delete.go
+++ b/pkg/commands/resourcelink/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/resourcelink/describe.go
+++ b/pkg/commands/resourcelink/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/resourcelink/list.go
+++ b/pkg/commands/resourcelink/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/resourcelink/resourcelink_test.go
+++ b/pkg/commands/resourcelink/resourcelink_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/commands/resourcelink"

--- a/pkg/commands/resourcelink/update.go
+++ b/pkg/commands/resourcelink/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/secretstore/create.go
+++ b/pkg/commands/secretstore/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstore/delete.go
+++ b/pkg/commands/secretstore/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstore/describe.go
+++ b/pkg/commands/secretstore/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstore/helper_test.go
+++ b/pkg/commands/secretstore/helper_test.go
@@ -3,7 +3,7 @@ package secretstore_test
 import (
 	"bytes"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/text"
 )

--- a/pkg/commands/secretstore/list.go
+++ b/pkg/commands/secretstore/list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstore/secretstore_test.go
+++ b/pkg/commands/secretstore/secretstore_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/commands/secretstore"

--- a/pkg/commands/secretstoreentry/create.go
+++ b/pkg/commands/secretstoreentry/create.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstoreentry/delete.go
+++ b/pkg/commands/secretstoreentry/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstoreentry/describe.go
+++ b/pkg/commands/secretstoreentry/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstoreentry/helper_test.go
+++ b/pkg/commands/secretstoreentry/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 func fmtSecret(s *fastly.Secret) string {

--- a/pkg/commands/secretstoreentry/list.go
+++ b/pkg/commands/secretstoreentry/list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/secretstoreentry/secretstoreentry_test.go
+++ b/pkg/commands/secretstoreentry/secretstoreentry_test.go
@@ -18,7 +18,7 @@ import (
 
 	"golang.org/x/crypto/nacl/box"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/commands/secretstoreentry"

--- a/pkg/commands/service/create.go
+++ b/pkg/commands/service/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/service/delete.go
+++ b/pkg/commands/service/delete.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/service/describe.go
+++ b/pkg/commands/service/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/service/list.go
+++ b/pkg/commands/service/list.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/service/search.go
+++ b/pkg/commands/service/search.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/service/update.go
+++ b/pkg/commands/service/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/serviceauth/create.go
+++ b/pkg/commands/serviceauth/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/serviceauth/delete.go
+++ b/pkg/commands/serviceauth/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/serviceauth/describe.go
+++ b/pkg/commands/serviceauth/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/serviceauth/list.go
+++ b/pkg/commands/serviceauth/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // ListCommand calls the Fastly API to list service authorizations.

--- a/pkg/commands/serviceauth/service_test.go
+++ b/pkg/commands/serviceauth/service_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/serviceauth/update.go
+++ b/pkg/commands/serviceauth/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/serviceversion/activate.go
+++ b/pkg/commands/serviceversion/activate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/serviceversion/clone.go
+++ b/pkg/commands/serviceversion/clone.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/serviceversion/deactivate.go
+++ b/pkg/commands/serviceversion/deactivate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/serviceversion/list.go
+++ b/pkg/commands/serviceversion/list.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/serviceversion/lock.go
+++ b/pkg/commands/serviceversion/lock.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/serviceversion/serviceversion_test.go
+++ b/pkg/commands/serviceversion/serviceversion_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/serviceversion"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/serviceversion/stage.go
+++ b/pkg/commands/serviceversion/stage.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/serviceversion/unstage.go
+++ b/pkg/commands/serviceversion/unstage.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/serviceversion/update.go
+++ b/pkg/commands/serviceversion/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/sso/sso_test.go
+++ b/pkg/commands/sso/sso_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/auth"
 	"github.com/fastly/cli/pkg/config"

--- a/pkg/commands/stats/historical.go
+++ b/pkg/commands/stats/historical.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/stats/historical_test.go
+++ b/pkg/commands/stats/historical_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/stats/realtime.go
+++ b/pkg/commands/stats/realtime.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/argparser"

--- a/pkg/commands/stats/regions_test.go
+++ b/pkg/commands/stats/regions_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/app"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/stats/template.go
+++ b/pkg/commands/stats/template.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 var blockTemplate = template.Must(template.New("stats_block").Parse(

--- a/pkg/commands/tls/config/config_test.go
+++ b/pkg/commands/tls/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/config"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/tls/config/describe.go
+++ b/pkg/commands/tls/config/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/config/list.go
+++ b/pkg/commands/tls/config/list.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/config/update.go
+++ b/pkg/commands/tls/config/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/activation/activation_test.go
+++ b/pkg/commands/tls/custom/activation/activation_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/activation"

--- a/pkg/commands/tls/custom/activation/create.go
+++ b/pkg/commands/tls/custom/activation/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/activation/delete.go
+++ b/pkg/commands/tls/custom/activation/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/activation/describe.go
+++ b/pkg/commands/tls/custom/activation/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/custom/activation/list.go
+++ b/pkg/commands/tls/custom/activation/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/custom/activation/update.go
+++ b/pkg/commands/tls/custom/activation/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/certificate/certificate_test.go
+++ b/pkg/commands/tls/custom/certificate/certificate_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/certificate"

--- a/pkg/commands/tls/custom/certificate/create.go
+++ b/pkg/commands/tls/custom/certificate/create.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/certificate/delete.go
+++ b/pkg/commands/tls/custom/certificate/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/certificate/describe.go
+++ b/pkg/commands/tls/custom/certificate/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/custom/certificate/list.go
+++ b/pkg/commands/tls/custom/certificate/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/custom/certificate/update.go
+++ b/pkg/commands/tls/custom/certificate/update.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/domain/domain_test.go
+++ b/pkg/commands/tls/custom/domain/domain_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/domain"

--- a/pkg/commands/tls/custom/domain/list.go
+++ b/pkg/commands/tls/custom/domain/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/custom/privatekey/create.go
+++ b/pkg/commands/tls/custom/privatekey/create.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/privatekey/delete.go
+++ b/pkg/commands/tls/custom/privatekey/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/custom/privatekey/describe.go
+++ b/pkg/commands/tls/custom/privatekey/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/custom/privatekey/list.go
+++ b/pkg/commands/tls/custom/privatekey/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/custom/privatekey/privatekey_test.go
+++ b/pkg/commands/tls/custom/privatekey/privatekey_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/custom"
 	sub "github.com/fastly/cli/pkg/commands/tls/custom/privatekey"

--- a/pkg/commands/tls/platform/create.go
+++ b/pkg/commands/tls/platform/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/platform/delete.go
+++ b/pkg/commands/tls/platform/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/platform/describe.go
+++ b/pkg/commands/tls/platform/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/platform/list.go
+++ b/pkg/commands/tls/platform/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/platform/platform_test.go
+++ b/pkg/commands/tls/platform/platform_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/platform"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/tls/platform/update.go
+++ b/pkg/commands/tls/platform/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/subscription/create.go
+++ b/pkg/commands/tls/subscription/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/subscription/delete.go
+++ b/pkg/commands/tls/subscription/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tls/subscription/describe.go
+++ b/pkg/commands/tls/subscription/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/subscription/list.go
+++ b/pkg/commands/tls/subscription/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tls/subscription/subscription_test.go
+++ b/pkg/commands/tls/subscription/subscription_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/tls/subscription"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/tls/subscription/update.go
+++ b/pkg/commands/tls/subscription/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/tools/domain/status.go
+++ b/pkg/commands/tools/domain/status.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/status"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/tools/status"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tools/domain/status_test.go
+++ b/pkg/commands/tools/domain/status_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/status"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/tools/status"
 
 	"github.com/fastly/cli/pkg/commands/tools"
 	"github.com/fastly/cli/pkg/commands/tools/domain"

--- a/pkg/commands/tools/domain/suggest.go
+++ b/pkg/commands/tools/domain/suggest.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/suggest"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/tools/suggest"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/tools/domain/suggest_test.go
+++ b/pkg/commands/tools/domain/suggest_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/domainmanagement/v1/tools/suggest"
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/domainmanagement/v1/tools/suggest"
 
 	"github.com/fastly/cli/pkg/commands/tools"
 	"github.com/fastly/cli/pkg/commands/tools/domain"

--- a/pkg/commands/user/create.go
+++ b/pkg/commands/user/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/user/delete.go
+++ b/pkg/commands/user/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/user/describe.go
+++ b/pkg/commands/user/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/user/list.go
+++ b/pkg/commands/user/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/user/update.go
+++ b/pkg/commands/user/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"

--- a/pkg/commands/user/user_test.go
+++ b/pkg/commands/user/user_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/user"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/commands/vcl/condition/condition_test.go
+++ b/pkg/commands/vcl/condition/condition_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	sub "github.com/fastly/cli/pkg/commands/vcl/condition"

--- a/pkg/commands/vcl/condition/create.go
+++ b/pkg/commands/vcl/condition/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/condition/delete.go
+++ b/pkg/commands/vcl/condition/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/condition/describe.go
+++ b/pkg/commands/vcl/condition/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/vcl/condition/list.go
+++ b/pkg/commands/vcl/condition/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/vcl/condition/update.go
+++ b/pkg/commands/vcl/condition/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/custom/create.go
+++ b/pkg/commands/vcl/custom/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/custom/custom_test.go
+++ b/pkg/commands/vcl/custom/custom_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	sub "github.com/fastly/cli/pkg/commands/vcl/custom"

--- a/pkg/commands/vcl/custom/delete.go
+++ b/pkg/commands/vcl/custom/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/custom/describe.go
+++ b/pkg/commands/vcl/custom/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/vcl/custom/list.go
+++ b/pkg/commands/vcl/custom/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/vcl/custom/update.go
+++ b/pkg/commands/vcl/custom/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/describe.go
+++ b/pkg/commands/vcl/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/vcl/snippet/create.go
+++ b/pkg/commands/vcl/snippet/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/snippet/delete.go
+++ b/pkg/commands/vcl/snippet/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/snippet/describe.go
+++ b/pkg/commands/vcl/snippet/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/vcl/snippet/list.go
+++ b/pkg/commands/vcl/snippet/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/argparser"
 	fsterr "github.com/fastly/cli/pkg/errors"

--- a/pkg/commands/vcl/snippet/snippet_test.go
+++ b/pkg/commands/vcl/snippet/snippet_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	sub "github.com/fastly/cli/pkg/commands/vcl/snippet"

--- a/pkg/commands/vcl/snippet/update.go
+++ b/pkg/commands/vcl/snippet/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"4d63.com/optional"
 

--- a/pkg/commands/vcl/vcl_test.go
+++ b/pkg/commands/vcl/vcl_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	root "github.com/fastly/cli/pkg/commands/vcl"
 	"github.com/fastly/cli/pkg/mock"

--- a/pkg/errors/deduce.go
+++ b/pkg/errors/deduce.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // Deduce attempts to deduce a RemediationError from a plain error. If the error

--- a/pkg/errors/deduce_test.go
+++ b/pkg/errors/deduce_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/testutil"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 func TestDeduce(t *testing.T) {

--- a/pkg/errors/log.go
+++ b/pkg/errors/log.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // LogPath is the location of the fastly CLI error log.

--- a/pkg/mock/api.go
+++ b/pkg/mock/api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // API is a mock implementation of api.Interface that's used for testing.

--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 )

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/commands/sso"
 	"github.com/fastly/cli/pkg/commands/whoami"

--- a/pkg/testutil/paginator.go
+++ b/pkg/testutil/paginator.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // ServicesPaginator mocks the behaviour of a paginator for services.

--- a/pkg/testutil/scenarios.go
+++ b/pkg/testutil/scenarios.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/api"
 	"github.com/fastly/cli/pkg/app"

--- a/pkg/text/accesskey.go
+++ b/pkg/text/accesskey.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/fastly/cli/pkg/time"
-	"github.com/fastly/go-fastly/v11/fastly/objectstorage/accesskeys"
+	"github.com/fastly/go-fastly/v12/fastly/objectstorage/accesskeys"
 )
 
 // PrintAccessKey displays an access key.

--- a/pkg/text/backend.go
+++ b/pkg/text/backend.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // PrintBackend pretty prints a fastly.Backend structure in verbose format

--- a/pkg/text/computeacl.go
+++ b/pkg/text/computeacl.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly/computeacls"
+	"github.com/fastly/go-fastly/v12/fastly/computeacls"
 )
 
 // PrintComputeACL displays a compute ACL.

--- a/pkg/text/configstore.go
+++ b/pkg/text/configstore.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	fsttime "github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/dictionary.go
+++ b/pkg/text/dictionary.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/dictionaryitem.go
+++ b/pkg/text/dictionaryitem.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/dictionaryitem_test.go
+++ b/pkg/text/dictionaryitem_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 func TestPrintDictionaryItem(t *testing.T) {

--- a/pkg/text/healthcheck.go
+++ b/pkg/text/healthcheck.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // PrintHealthCheck pretty prints a fastly.HealthCheck structure in verbose

--- a/pkg/text/kvstore.go
+++ b/pkg/text/kvstore.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/resource.go
+++ b/pkg/text/resource.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/secretstore.go
+++ b/pkg/text/secretstore.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 )
 
 // PrintSecretStoresTbl displays store data in a table format.

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/segmentio/textio"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/time"
 )

--- a/pkg/text/service_test.go
+++ b/pkg/text/service_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fastly/go-fastly/v11/fastly"
+	"github.com/fastly/go-fastly/v12/fastly"
 
 	"github.com/fastly/cli/pkg/testutil"
 	"github.com/fastly/cli/pkg/text"


### PR DESCRIPTION
### Change summary

Bump `go-fastly` to v12.0.0.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/terraform-provider-fastly/pulls) for the same update/change?