### PR TITLE
[CDTOOL-1137] feat(products): Add enable/disable support for API Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Enhancements:
 
 - feat(manifest): Enable loading Secret Store configuration through environment variables ([#1540](https://github.com/fastly/cli/pull/1540))
-- feat(products): Add enable/disable support for API Discovery ([#XXX](https://github.com/fastly/go-fastly/pull/XXX))
+- feat(products): Add enable/disable support for API Discovery ([#1543](https://github.com/fastly/go-fastly/pull/1543))
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Breaking:
 
 ### Enhancements:
-- fix(manifest): Enable loading Secret Store configuration through environment variables ([#1540](https://github.com/fastly/cli/pull/1540))
+
+- feat(manifest): Enable loading Secret Store configuration through environment variables ([#1540](https://github.com/fastly/cli/pull/1540))
+- feat(products): Add enable/disable support for API Discovery ([#XXX](https://github.com/fastly/go-fastly/pull/XXX))
 
 ### Bug fixes:
 

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,6 @@ require (
 
 require (
 	4d63.com/optional v0.2.0
-	github.com/fastly/go-fastly/v12 v12.0.0
+	github.com/fastly/go-fastly/v12 v12.1.0
 	github.com/mitchellh/go-ps v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:aYo8nnk3ojoQkP5iErif5Xxv0Mo0Ga/FR5+ffl/7+Nk=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v12 v12.0.0 h1:jfL+AtA4OBrSpx4S/HZCYhcS65T+6zeG+9rvOTJXzhg=
-github.com/fastly/go-fastly/v12 v12.0.0/go.mod h1:9An7aQ1PaZcMb4jnot+lWEBNnHBMl9t4U0OUV8XVoMA=
+github.com/fastly/go-fastly/v12 v12.1.0 h1:AONgwSHg/XEjSaMePpXV9RsHVojgG6kIp2rpOZ0uN38=
+github.com/fastly/go-fastly/v12 v12.1.0/go.mod h1:9An7aQ1PaZcMb4jnot+lWEBNnHBMl9t4U0OUV8XVoMA=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/pkg/commands/products/products_test.go
+++ b/pkg/commands/products/products_test.go
@@ -21,12 +21,12 @@ func TestProductEnablement(t *testing.T) {
 		{
 			Name:      "validate flag parsing error for enabling product",
 			Args:      "--service-id 123 --enable foo",
-			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
+			WantError: "error parsing arguments: enum value must be one of api_discovery,bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
 		},
 		{
 			Name:      "validate flag parsing error for disabling product",
 			Args:      "--service-id 123 --disable foo",
-			WantError: "error parsing arguments: enum value must be one of bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
+			WantError: "error parsing arguments: enum value must be one of api_discovery,bot_management,brotli_compression,domain_inspector,fanout,image_optimizer,log_explorer_insights,origin_inspector,websockets, got 'foo'",
 		},
 		{
 			Name:      "validate invalid json/verbose flag combo",

--- a/pkg/commands/products/root.go
+++ b/pkg/commands/products/root.go
@@ -12,6 +12,7 @@ import (
 	fsterr "github.com/fastly/cli/pkg/errors"
 	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v12/fastly/products/apidiscovery"
 	"github.com/fastly/go-fastly/v12/fastly/products/botmanagement"
 	"github.com/fastly/go-fastly/v12/fastly/products/brotlicompression"
 	"github.com/fastly/go-fastly/v12/fastly/products/domaininspector"
@@ -35,6 +36,7 @@ type RootCommand struct {
 
 // ProductEnablementOptions is a list of products that can be enabled/disabled.
 var ProductEnablementOptions = []string{
+	"api_discovery",
 	"bot_management",
 	"brotli_compression",
 	"domain_inspector",
@@ -47,6 +49,7 @@ var ProductEnablementOptions = []string{
 
 // ProductStatus indicates the status for each product.
 type ProductStatus struct {
+	APIDiscovery        bool `json:"api_discovery"`
 	BotManagement       bool `json:"bot_management"`
 	BrotliCompression   bool `json:"brotli_compression"`
 	DomainInspector     bool `json:"domain_inspector"`
@@ -107,6 +110,8 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	if c.enableProduct != "" {
 		switch c.enableProduct {
+		case "api_discovery":
+			_, err = apidiscovery.Enable(context.TODO(), ac, serviceID)
 		case "bot_management":
 			_, err = botmanagement.Enable(context.TODO(), ac, serviceID)
 		case "brotli_compression":
@@ -135,6 +140,8 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	if c.disableProduct != "" {
 		switch c.disableProduct {
+		case "api_discovery":
+			err = apidiscovery.Disable(context.TODO(), ac, serviceID)
 		case "bot_management":
 			err = botmanagement.Disable(context.TODO(), ac, serviceID)
 		case "brotli_compression":
@@ -163,6 +170,9 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	ps := ProductStatus{}
 
+	if _, err = apidiscovery.Get(context.TODO(), ac, serviceID); err == nil {
+		ps.APIDiscovery = true
+	}
 	if _, err = botmanagement.Get(context.TODO(), ac, serviceID); err == nil {
 		ps.BotManagement = true
 	}
@@ -194,6 +204,7 @@ func (c *RootCommand) Exec(_ io.Reader, out io.Writer) error {
 
 	t := text.NewTable(out)
 	t.AddHeader("PRODUCT", "ENABLED")
+	t.AddLine("API Discovery", ps.APIDiscovery)
 	t.AddLine("Bot Management", ps.BotManagement)
 	t.AddLine("Brotli Compression", ps.BrotliCompression)
 	t.AddLine("Domain Inspector", ps.DomainInspector)


### PR DESCRIPTION
### Change summary

Adds the ability to enable and disable the API Discovery product on services.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [X] Does your submission pass tests?

```
=== RUN   TestProductEnablement
=== RUN   TestProductEnablement/validate_missing_Service_ID
token: mock-token
endpoint: https://api.fastly.com
debugMode: false
=== RUN   TestProductEnablement/validate_invalid_enable/disable_flag_combo
token: mock-token
endpoint: https://api.fastly.com
debugMode: false
=== RUN   TestProductEnablement/validate_flag_parsing_error_for_enabling_product
=== RUN   TestProductEnablement/validate_flag_parsing_error_for_disabling_product
=== RUN   TestProductEnablement/validate_invalid_json/verbose_flag_combo
token: mock-token
endpoint: https://api.fastly.com
debugMode: false
--- PASS: TestProductEnablement (0.03s)
    --- PASS: TestProductEnablement/validate_missing_Service_ID (0.01s)
    --- PASS: TestProductEnablement/validate_invalid_enable/disable_flag_combo (0.01s)
    --- PASS: TestProductEnablement/validate_flag_parsing_error_for_enabling_product (0.01s)
    --- PASS: TestProductEnablement/validate_flag_parsing_error_for_disabling_product (0.01s)
    --- PASS: TestProductEnablement/validate_invalid_json/verbose_flag_combo (0.00s)
PASS
ok  	github.com/fastly/cli/pkg/commands/products	1.059s
```