### PR TITLE
CDTOOL-1217 add CRUD operations for ngwaf custom signals at the account and workspace levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements:
 - feat(commands/ngwaf/workspaces): add support for update operation for NGWAF workspaces ([#1578](https://github.com/fastly/cli/pull/1578))
 - feat(commands/ngwaf/lists): add support for CRUD operations for NGWAF Lists ([#1582](https://github.com/fastly/cli/pull/1582))
+- feat(commands/ngwaf/customsignals): add support for CRUD operations for NGWAF Custom Signals ([#1592](https://github.com/fastly/cli/pull/1592))
 
 ### Bug fixes:
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -57,12 +57,14 @@ import (
 	"github.com/fastly/cli/pkg/commands/logtail"
 	"github.com/fastly/cli/pkg/commands/ngwaf"
 	"github.com/fastly/cli/pkg/commands/ngwaf/countrylist"
+	"github.com/fastly/cli/pkg/commands/ngwaf/customsignal"
 	"github.com/fastly/cli/pkg/commands/ngwaf/iplist"
 	"github.com/fastly/cli/pkg/commands/ngwaf/signallist"
 	"github.com/fastly/cli/pkg/commands/ngwaf/stringlist"
 	"github.com/fastly/cli/pkg/commands/ngwaf/wildcardlist"
 	"github.com/fastly/cli/pkg/commands/ngwaf/workspace"
 	wscountrylist "github.com/fastly/cli/pkg/commands/ngwaf/workspace/countrylist"
+	wscustomsignal "github.com/fastly/cli/pkg/commands/ngwaf/workspace/customsignal"
 	wsiplist "github.com/fastly/cli/pkg/commands/ngwaf/workspace/iplist"
 	"github.com/fastly/cli/pkg/commands/ngwaf/workspace/redaction"
 	wssignallistlist "github.com/fastly/cli/pkg/commands/ngwaf/workspace/signallist"
@@ -426,6 +428,12 @@ func Define( // nolint:revive // function-length
 	ngwafCountryListGet := countrylist.NewGetCommand(ngwafCountryListRoot.CmdClause, data)
 	ngwafCountryListList := countrylist.NewListCommand(ngwafCountryListRoot.CmdClause, data)
 	ngwafCountryListUpdate := countrylist.NewUpdateCommand(ngwafCountryListRoot.CmdClause, data)
+	ngwafCustomSignalRoot := customsignal.NewRootCommand(ngwafRoot.CmdClause, data)
+	ngwafCustomSignalCreate := customsignal.NewCreateCommand(ngwafCustomSignalRoot.CmdClause, data)
+	ngwafCustomSignalDelete := customsignal.NewDeleteCommand(ngwafCustomSignalRoot.CmdClause, data)
+	ngwafCustomSignalGet := customsignal.NewGetCommand(ngwafCustomSignalRoot.CmdClause, data)
+	ngwafCustomSignalList := customsignal.NewListCommand(ngwafCustomSignalRoot.CmdClause, data)
+	ngwafCustomSignalUpdate := customsignal.NewUpdateCommand(ngwafCustomSignalRoot.CmdClause, data)
 	ngwafIPListRoot := iplist.NewRootCommand(ngwafRoot.CmdClause, data)
 	ngwafIPListCreate := iplist.NewCreateCommand(ngwafIPListRoot.CmdClause, data)
 	ngwafIPListDelete := iplist.NewDeleteCommand(ngwafIPListRoot.CmdClause, data)
@@ -456,6 +464,12 @@ func Define( // nolint:revive // function-length
 	ngwafWorkspaceCountryListGet := wscountrylist.NewGetCommand(ngwafWorkspaceCountryListRoot.CmdClause, data)
 	ngwafWorkspaceCountryListList := wscountrylist.NewListCommand(ngwafWorkspaceCountryListRoot.CmdClause, data)
 	ngwafWorkspaceCountryListUpdate := wscountrylist.NewUpdateCommand(ngwafWorkspaceCountryListRoot.CmdClause, data)
+	ngwafWorkspaceCustomSignalRoot := wscustomsignal.NewRootCommand(ngwafWorkspaceRoot.CmdClause, data)
+	ngwafWorkspaceCustomSignalCreate := wscustomsignal.NewCreateCommand(ngwafWorkspaceCustomSignalRoot.CmdClause, data)
+	ngwafWorkspaceCustomSignalDelete := wscustomsignal.NewDeleteCommand(ngwafWorkspaceCustomSignalRoot.CmdClause, data)
+	ngwafWorkspaceCustomSignalGet := wscustomsignal.NewGetCommand(ngwafWorkspaceCustomSignalRoot.CmdClause, data)
+	ngwafWorkspaceCustomSignalList := wscustomsignal.NewListCommand(ngwafWorkspaceCustomSignalRoot.CmdClause, data)
+	ngwafWorkspaceCustomSignalUpdate := wscustomsignal.NewUpdateCommand(ngwafWorkspaceCustomSignalRoot.CmdClause, data)
 	ngwafWorkspaceIPListRoot := wsiplist.NewRootCommand(ngwafWorkspaceRoot.CmdClause, data)
 	ngwafWorkspaceIPListCreate := wsiplist.NewCreateCommand(ngwafWorkspaceIPListRoot.CmdClause, data)
 	ngwafWorkspaceIPListDelete := wsiplist.NewDeleteCommand(ngwafWorkspaceIPListRoot.CmdClause, data)
@@ -916,6 +930,12 @@ func Define( // nolint:revive // function-length
 		ngwafCountryListGet,
 		ngwafCountryListList,
 		ngwafCountryListUpdate,
+		ngwafCustomSignalRoot,
+		ngwafCustomSignalCreate,
+		ngwafCustomSignalDelete,
+		ngwafCustomSignalGet,
+		ngwafCustomSignalList,
+		ngwafCustomSignalUpdate,
 		ngwafIPListRoot,
 		ngwafIPListCreate,
 		ngwafIPListDelete,
@@ -945,6 +965,12 @@ func Define( // nolint:revive // function-length
 		ngwafWorkspaceCountryListGet,
 		ngwafWorkspaceCountryListList,
 		ngwafWorkspaceCountryListUpdate,
+		ngwafWorkspaceCustomSignalRoot,
+		ngwafWorkspaceCustomSignalCreate,
+		ngwafWorkspaceCustomSignalDelete,
+		ngwafWorkspaceCustomSignalGet,
+		ngwafWorkspaceCustomSignalList,
+		ngwafWorkspaceCustomSignalUpdate,
 		ngwafWorkspaceIPListRoot,
 		ngwafWorkspaceIPListCreate,
 		ngwafWorkspaceIPListDelete,

--- a/pkg/commands/ngwaf/customsignal/create.go
+++ b/pkg/commands/ngwaf/customsignal/create.go
@@ -1,0 +1,82 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// CreateCommand calls the Fastly API to create account-level custom signals.
+type CreateCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	name string
+
+	// Optional.
+	description argparser.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateCommand {
+	c := CreateCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+	c.CmdClause = parent.Command("create", "Create an account-level custom signal").Alias("add")
+
+	// Required.
+	c.CmdClause.Flag("name", "User submitted display name of a custom signal. Is immutable and must be between 3 and 25 characters").Required().StringVar(&c.name)
+
+	// Optional.
+	c.CmdClause.Flag("description", "User submitted description of a custom signal.").Action(c.description.Set).StringVar(&c.description.Value)
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+	var err error
+	input := &signals.CreateInput{
+		Name: &c.name,
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeAccount,
+			AppliesTo: []string{"*"},
+		},
+	}
+	if c.description.WasSet {
+		input.Description = &c.description.Value
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	data, err := signals.Create(context.TODO(), fc, input)
+	if err != nil {
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, data); ok {
+		return err
+	}
+
+	text.Success(out, "Created account-level custom signal '%s' (signal-id: %s)", data.Name, data.SignalID)
+	return nil
+}

--- a/pkg/commands/ngwaf/customsignal/customsignal_test.go
+++ b/pkg/commands/ngwaf/customsignal/customsignal_test.go
@@ -1,0 +1,364 @@
+package customsignal_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	root "github.com/fastly/cli/pkg/commands/ngwaf"
+	sub "github.com/fastly/cli/pkg/commands/ngwaf/customsignal"
+	fstfmt "github.com/fastly/cli/pkg/fmt"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+)
+
+const (
+	customSignalDescription = "NGWAFCLICustomSignal"
+	customSignalID          = "someID"
+	customSignalName        = "CLICustomSignalName"
+)
+
+var customSignal = signals.Signal{
+	CreatedAt:   testutil.Date,
+	Description: customSignalDescription,
+	Name:        customSignalName,
+	SignalID:    customSignalID,
+	Scope: signals.Scope{
+		Type:      string(scope.ScopeTypeAccount),
+		AppliesTo: []string{"*"},
+	},
+}
+
+func TestCustomSignalCreate(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --name flag",
+			Args:      fmt.Sprintf("--description %s", customSignalDescription),
+			WantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			Name: "validate internal server error",
+			Args: fmt.Sprintf("--description %s --name %s", customSignalDescription, customSignalName),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Status:     http.StatusText(http.StatusInternalServerError),
+					},
+				},
+			},
+			WantError: "500 - Internal Server Error",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--description %s --name %s", customSignalDescription, customSignalName),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader((testutil.GenJSON(customSignal)))),
+					},
+				},
+			},
+			WantOutput: fstfmt.Success("Created account-level custom signal '%s' (signal-id: %s)", customSignalName, customSignalID),
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--description %s --name %s --json", customSignalDescription, customSignalName),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignal))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignal),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "create"}, scenarios)
+}
+
+func TestCustomSignalDelete(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --signal-id flag",
+			Args:      "",
+			WantError: "error parsing arguments: required flag --signal-id not provided",
+		},
+		{
+			Name: "validate bad request",
+			Args: "--signal-id bar",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Status:     http.StatusText(http.StatusBadRequest),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(`
+							{
+    							"title": "invalid signal ID",
+    							"status": 400
+							}
+						`))),
+					},
+				},
+			},
+			WantError: "400 - Bad Request",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--signal-id %s", customSignalID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusNoContent,
+						Status:     http.StatusText(http.StatusNoContent),
+					},
+				},
+			},
+			WantOutput: fstfmt.Success("Deleted account-level custom signal (id: %s)", customSignalID),
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--signal-id %s --json", customSignalID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusNoContent,
+						Status:     http.StatusText(http.StatusNoContent),
+					},
+				},
+			},
+			WantOutput: fstfmt.JSON(`{"id": %q, "deleted": true}`, customSignalID),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "delete"}, scenarios)
+}
+
+func TestCustomSignalGet(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --signal-id flag",
+			Args:      "",
+			WantError: "error parsing arguments: required flag --signal-id not provided",
+		},
+		{
+			Name: "validate bad request",
+			Args: "--signal-id baz",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Status:     http.StatusText(http.StatusBadRequest),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(`
+							{
+    							"title": "invalid Custom Signal ID",
+    							"status": 400
+							}
+						`))),
+					},
+				},
+			},
+			WantError: "400 - Bad Request",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--signal-id %s", customSignalID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader((testutil.GenJSON(customSignal)))),
+					},
+				},
+			},
+			WantOutput: customSignalString,
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--signal-id %s --json", customSignalID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader((testutil.GenJSON(customSignal)))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignal),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "get"}, scenarios)
+}
+
+func TestCustomSignalList(t *testing.T) {
+	customSignalsObject := signals.Signals{
+		Data: []signals.Signal{
+			{
+				CreatedAt:   testutil.Date,
+				Description: customSignalDescription,
+				Name:        customSignalName,
+				SignalID:    customSignalID,
+				Scope: signals.Scope{
+					Type:      string(scope.ScopeTypeAccount),
+					AppliesTo: []string{"*"},
+				},
+			},
+			{
+				CreatedAt:   testutil.Date,
+				Description: customSignalDescription,
+				Name:        customSignalName + "2",
+				SignalID:    customSignalID + "2",
+				Scope: signals.Scope{
+					Type:      string(scope.ScopeTypeAccount),
+					AppliesTo: []string{"*"},
+				},
+			},
+		},
+		Meta: signals.MetaSignals{},
+	}
+
+	scenarios := []testutil.CLIScenario{
+		{
+			Name: "validate internal server error",
+			Args: "",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Status:     http.StatusText(http.StatusInternalServerError),
+					},
+				},
+			},
+			WantError: "500 - Internal Server Error",
+		},
+		{
+			Name: "validate API success (zero account-level custom signals)",
+			Args: "",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(signals.Signals{
+							Data: []signals.Signal{},
+							Meta: signals.MetaSignals{},
+						}))),
+					},
+				},
+			},
+			WantOutput: zeroListCustomSignalsString,
+		},
+		{
+			Name: "validate API success",
+			Args: "",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignalsObject))),
+					},
+				},
+			},
+			WantOutput: listCustomSignalsString,
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: "--json",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignalsObject))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignalsObject),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "list"}, scenarios)
+}
+
+func TestCustomSignalUpdate(t *testing.T) {
+	customSignalObject := signals.Signal{
+		CreatedAt:   testutil.Date,
+		Description: customSignalDescription,
+		Name:        customSignalName,
+		SignalID:    customSignalID,
+	}
+
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --signal-id flag",
+			Args:      fmt.Sprintf("--description %s", customSignalDescription),
+			WantError: "error parsing arguments: required flag --signal-id not provided",
+		},
+		{
+			Name:      "validate missing --description flag",
+			Args:      fmt.Sprintf("--signal-id %s", customSignalID),
+			WantError: "error parsing arguments: required flag --description not provided",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--signal-id %s --description %s", customSignalID, customSignalDescription),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignalObject))),
+					},
+				},
+			},
+			WantOutput: fstfmt.Success("Updated account-level signal '%s' (signal-id: %s)", customSignalName, customSignalID),
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--signal-id %s --description %s --json", customSignalID, customSignalDescription),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignal))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignal),
+		},
+	}
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
+}
+
+var listCustomSignalsString = strings.TrimSpace(`
+ID       Name                  Description           Scope    Updated At                     Created At
+someID   CLICustomSignalName   NGWAFCLICustomSignal  account  0001-01-01 00:00:00 +0000 UTC  2021-06-15 23:00:00 +0000 UTC
+someID2  CLICustomSignalName2  NGWAFCLICustomSignal  account  0001-01-01 00:00:00 +0000 UTC  2021-06-15 23:00:00 +0000 UTC
+`) + "\n"
+
+var zeroListCustomSignalsString = strings.TrimSpace(`
+ID  Name  Description  Scope  Updated At  Created At
+`) + "\n"
+
+var customSignalString = strings.TrimSpace(`
+ID: someID
+Name: CLICustomSignalName
+Description: NGWAFCLICustomSignal
+Scope: account
+Updated (UTC): 0001-01-01 00:00
+Created (UTC): 2021-06-15 23:00
+`)

--- a/pkg/commands/ngwaf/customsignal/delete.go
+++ b/pkg/commands/ngwaf/customsignal/delete.go
@@ -1,0 +1,84 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// DeleteCommand calls the Fastly API to delete an account-level custom signal.
+type DeleteCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	signalID string
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteCommand {
+	c := DeleteCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	c.CmdClause = parent.Command("delete", "Delete an account-level custom signal")
+
+	// Required.
+	c.CmdClause.Flag("signal-id", "Custom Signal ID").Required().StringVar(&c.signalID)
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	err := signals.Delete(context.TODO(), fc, &signals.DeleteInput{
+		SignalID: &c.signalID,
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeAccount,
+			AppliesTo: []string{"*"},
+		},
+	})
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if c.JSONOutput.Enabled {
+		o := struct {
+			ID      string `json:"id"`
+			Deleted bool   `json:"deleted"`
+		}{
+			c.signalID,
+			true,
+		}
+		_, err := c.WriteJSON(out, o)
+		return err
+	}
+
+	text.Success(out, "Deleted account-level custom signal (id: %s)", c.signalID)
+	return nil
+}

--- a/pkg/commands/ngwaf/customsignal/doc.go
+++ b/pkg/commands/ngwaf/customsignal/doc.go
@@ -1,0 +1,2 @@
+// Package customsignal contains commands to inspect and manipulate NGWAF account-level custom signals.
+package customsignal

--- a/pkg/commands/ngwaf/customsignal/get.go
+++ b/pkg/commands/ngwaf/customsignal/get.go
@@ -1,0 +1,76 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// GetCommand calls the Fastly API to get an account-level custom signal.
+type GetCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	signalID string
+}
+
+// NewGetCommand returns a usable command registered under the parent.
+func NewGetCommand(parent argparser.Registerer, g *global.Data) *GetCommand {
+	c := GetCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	c.CmdClause = parent.Command("get", "Get a custom signal")
+
+	// Required.
+	c.CmdClause.Flag("signal-id", "Custom Signal ID").Required().StringVar(&c.signalID)
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *GetCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	data, err := signals.Get(context.TODO(), fc, &signals.GetInput{
+		SignalID: &c.signalID,
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeAccount,
+			AppliesTo: []string{"*"},
+		},
+	})
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, data); ok {
+		return err
+	}
+
+	text.PrintCustomSignal(out, data)
+	return nil
+}

--- a/pkg/commands/ngwaf/customsignal/list.go
+++ b/pkg/commands/ngwaf/customsignal/list.go
@@ -1,0 +1,68 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v12/fastly"
+
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+)
+
+// ListCommand calls the Fastly API to list all account-level custom signals for your API token.
+type ListCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
+	c := ListCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	c.CmdClause = parent.Command("list", "List all account-level custom signals")
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	signals, err := signals.List(context.TODO(), fc, &signals.ListInput{
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeAccount,
+			AppliesTo: []string{"*"},
+		},
+	})
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, signals); ok {
+		return err
+	}
+
+	text.PrintCustomSignalTbl(out, signals.Data)
+	return nil
+}

--- a/pkg/commands/ngwaf/customsignal/root.go
+++ b/pkg/commands/ngwaf/customsignal/root.go
@@ -1,0 +1,31 @@
+package customsignal
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/argparser"
+	"github.com/fastly/cli/pkg/global"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	argparser.Base
+	// no flags
+}
+
+// CommandName is the string to be used to invoke this command.
+const CommandName = "customsignal"
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = g
+	c.CmdClause = parent.Command(CommandName, "Manage NGWAF Account-Level Custom Signals")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(_ io.Reader, _ io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/commands/ngwaf/customsignal/update.go
+++ b/pkg/commands/ngwaf/customsignal/update.go
@@ -1,0 +1,78 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// UpdateCommand calls the Fastly API to update account-level custom signals.
+type UpdateCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	signalID    string
+	description string
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateCommand {
+	c := UpdateCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+	c.CmdClause = parent.Command("update", "Update a workspace")
+
+	// Required.
+	c.CmdClause.Flag("signal-id", "Custom Signal ID").Required().StringVar(&c.signalID)
+	c.CmdClause.Flag("description", "User submitted description of a custom signal.").Required().StringVar(&c.description)
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+	var err error
+	input := &signals.UpdateInput{
+		SignalID:    &c.signalID,
+		Description: &c.description,
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeAccount,
+			AppliesTo: []string{"*"},
+		},
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	data, err := signals.Update(context.TODO(), fc, input)
+	if err != nil {
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, data); ok {
+		return err
+	}
+
+	text.Success(out, "Updated account-level signal '%s' (signal-id: %s)", data.Name, data.SignalID)
+	return nil
+}

--- a/pkg/commands/ngwaf/workspace/customsignal/create.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/create.go
@@ -1,0 +1,95 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// CreateCommand calls the Fastly API to create workspace-level custom signals.
+type CreateCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	name        string
+	workspaceID argparser.OptionalWorkspaceID
+
+	// Optional.
+	description argparser.OptionalString
+}
+
+// NewCreateCommand returns a usable command registered under the parent.
+func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateCommand {
+	c := CreateCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+	c.CmdClause = parent.Command("create", "Create an workspace-level custom signal").Alias("add")
+
+	// Required.
+	c.CmdClause.Flag("name", "User submitted display name of a custom signal. Is immutable and must be between 3 and 25 characters").Required().StringVar(&c.name)
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagNGWAFWorkspaceID,
+		Description: argparser.FlagNGWAFWorkspaceIDDesc,
+		Dst:         &c.workspaceID.Value,
+		Action:      c.workspaceID.Set,
+		Required:    true,
+	})
+
+	// Optional.
+	c.CmdClause.Flag("description", "User submitted description of a custom signal.").Action(c.description.Set).StringVar(&c.description.Value)
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+	var err error
+	input := &signals.CreateInput{
+		Name: &c.name,
+		Scope: &scope.Scope{
+			Type: scope.ScopeTypeWorkspace,
+		},
+	}
+
+	if err := c.workspaceID.Parse(); err != nil {
+		return err
+	}
+	input.Scope.AppliesTo = []string{c.workspaceID.Value}
+
+	if c.description.WasSet {
+		input.Description = &c.description.Value
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	data, err := signals.Create(context.TODO(), fc, input)
+	if err != nil {
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, data); ok {
+		return err
+	}
+
+	text.Success(out, "Created workspace-level custom signal '%s' (signal-id: %s)", data.Name, data.SignalID)
+	return nil
+}

--- a/pkg/commands/ngwaf/workspace/customsignal/customsignal_test.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/customsignal_test.go
@@ -1,0 +1,391 @@
+package customsignal_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	root "github.com/fastly/cli/pkg/commands/ngwaf"
+	sub "github.com/fastly/cli/pkg/commands/ngwaf/workspace"
+	sub2 "github.com/fastly/cli/pkg/commands/ngwaf/workspace/customsignal"
+	fstfmt "github.com/fastly/cli/pkg/fmt"
+	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+)
+
+const (
+	customSignalDescription = "NGWAFCLICustomSignal"
+	customSignalID          = "someID"
+	customSignalName        = "CLICustomSignalName"
+	workspaceID             = "WorkspaceID"
+)
+
+var customSignal = signals.Signal{
+	CreatedAt:   testutil.Date,
+	Description: customSignalDescription,
+	Name:        customSignalName,
+	SignalID:    customSignalID,
+	Scope: signals.Scope{
+		Type:      string(scope.ScopeTypeWorkspace),
+		AppliesTo: []string{workspaceID},
+	},
+}
+
+func TestCustomSignalCreate(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --name flag",
+			Args:      fmt.Sprintf("--description %s --workspace-id %s", customSignalDescription, workspaceID),
+			WantError: "error parsing arguments: required flag --name not provided",
+		},
+		{
+			Name:      "validate missing --workspace-id flag",
+			Args:      fmt.Sprintf("--description %s --name %s", customSignalDescription, customSignalName),
+			WantError: "error parsing arguments: required flag --workspace-id not provided",
+		},
+		{
+			Name: "validate internal server error",
+			Args: fmt.Sprintf("--description %s --name %s --workspace-id %s", customSignalDescription, customSignalName, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Status:     http.StatusText(http.StatusInternalServerError),
+					},
+				},
+			},
+			WantError: "500 - Internal Server Error",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--description %s --name %s --workspace-id %s", customSignalDescription, customSignalName, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader((testutil.GenJSON(customSignal)))),
+					},
+				},
+			},
+			WantOutput: fstfmt.Success("Created workspace-level custom signal '%s' (signal-id: %s)", customSignalName, customSignalID),
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--description %s --name %s --workspace-id %s --json", customSignalDescription, customSignalName, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignal))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignal),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, sub2.CommandName, "create"}, scenarios)
+}
+
+func TestCustomSignalDelete(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --signal-id flag",
+			Args:      fmt.Sprintf("--workspace-id %s", workspaceID),
+			WantError: "error parsing arguments: required flag --signal-id not provided",
+		},
+		{
+			Name:      "validate missing --workspace-id flag",
+			Args:      fmt.Sprintf("--signal-id %s", customSignalID),
+			WantError: "error parsing arguments: required flag --workspace-id not provided",
+		},
+		{
+			Name: "validate bad request",
+			Args: "--signal-id bar --workspace-id baz",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Status:     http.StatusText(http.StatusBadRequest),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(`
+							{
+    							"title": "invalid signal ID",
+    							"status": 400
+							}
+						`))),
+					},
+				},
+			},
+			WantError: "400 - Bad Request",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--signal-id %s --workspace-id %s", customSignalID, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusNoContent,
+						Status:     http.StatusText(http.StatusNoContent),
+					},
+				},
+			},
+			WantOutput: fstfmt.Success("Deleted workspace-level custom signal (id: %s)", customSignalID),
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--signal-id %s --workspace-id %s --json", customSignalID, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusNoContent,
+						Status:     http.StatusText(http.StatusNoContent),
+					},
+				},
+			},
+			WantOutput: fstfmt.JSON(`{"id": %q, "deleted": true}`, customSignalID),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, sub2.CommandName, "delete"}, scenarios)
+}
+
+func TestCustomSignalGet(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --signal-id flag",
+			Args:      fmt.Sprintf("--workspace-id %s", workspaceID),
+			WantError: "error parsing arguments: required flag --signal-id not provided",
+		},
+		{
+			Name:      "validate missing --workspace-id flag",
+			Args:      fmt.Sprintf("--signal-id %s", customSignalID),
+			WantError: "error parsing arguments: required flag --workspace-id not provided",
+		},
+		{
+			Name: "validate bad request",
+			Args: "--signal-id baz --workspace-id bar",
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Status:     http.StatusText(http.StatusBadRequest),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(`
+							{
+    							"title": "invalid Custom Signal ID",
+    							"status": 400
+							}
+						`))),
+					},
+				},
+			},
+			WantError: "400 - Bad Request",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--signal-id %s --workspace-id %s", customSignalID, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader((testutil.GenJSON(customSignal)))),
+					},
+				},
+			},
+			WantOutput: customSignalString,
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--signal-id %s --workspace-id %s --json", customSignalID, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader((testutil.GenJSON(customSignal)))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignal),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, sub2.CommandName, "get"}, scenarios)
+}
+
+func TestCustomSignalList(t *testing.T) {
+	customSignalsObject := signals.Signals{
+		Data: []signals.Signal{
+			{
+				CreatedAt:   testutil.Date,
+				Description: customSignalDescription,
+				Name:        customSignalName,
+				SignalID:    customSignalID,
+				Scope: signals.Scope{
+					Type:      string(scope.ScopeTypeWorkspace),
+					AppliesTo: []string{workspaceID},
+				},
+			},
+			{
+				CreatedAt:   testutil.Date,
+				Description: customSignalDescription,
+				Name:        customSignalName + "2",
+				SignalID:    customSignalID + "2",
+				Scope: signals.Scope{
+					Type:      string(scope.ScopeTypeWorkspace),
+					AppliesTo: []string{workspaceID},
+				},
+			},
+		},
+		Meta: signals.MetaSignals{},
+	}
+
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --workspace-id flag",
+			Args:      "",
+			WantError: "error parsing arguments: required flag --workspace-id not provided",
+		},
+		{
+			Name: "validate internal server error",
+			Args: fmt.Sprintf("--workspace-id %s", workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Status:     http.StatusText(http.StatusInternalServerError),
+					},
+				},
+			},
+			WantError: "500 - Internal Server Error",
+		},
+		{
+			Name: "validate API success (zero workspace-level custom signals)",
+			Args: fmt.Sprintf("--workspace-id %s", workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body: io.NopCloser(bytes.NewReader(testutil.GenJSON(signals.Signals{
+							Data: []signals.Signal{},
+							Meta: signals.MetaSignals{},
+						}))),
+					},
+				},
+			},
+			WantOutput: zeroListCustomSignalsString,
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--workspace-id %s", workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignalsObject))),
+					},
+				},
+			},
+			WantOutput: listCustomSignalsString,
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--workspace-id %s --json", workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignalsObject))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignalsObject),
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, sub2.CommandName, "list"}, scenarios)
+}
+
+func TestCustomSignalUpdate(t *testing.T) {
+	customSignalObject := signals.Signal{
+		CreatedAt:   testutil.Date,
+		Description: customSignalDescription,
+		Name:        customSignalName,
+		SignalID:    customSignalID,
+	}
+
+	scenarios := []testutil.CLIScenario{
+		{
+			Name:      "validate missing --signal-id flag",
+			Args:      fmt.Sprintf("--description %s --workspace-id %s", customSignalDescription+"2", workspaceID),
+			WantError: "error parsing arguments: required flag --signal-id not provided",
+		},
+		{
+			Name:      "validate missing --workspace-id flag",
+			Args:      fmt.Sprintf("--description %s --signal-id %s", customSignalDescription+"2", customSignalID),
+			WantError: "error parsing arguments: required flag --workspace-id not provided",
+		},
+		{
+			Name:      "validate missing --description flag",
+			Args:      fmt.Sprintf("--workspace-id %s --signal-id %s", workspaceID, customSignalID),
+			WantError: "error parsing arguments: required flag --description not provided",
+		},
+		{
+			Name: "validate API success",
+			Args: fmt.Sprintf("--signal-id %s --description %s --workspace-id %s", customSignalID, customSignalDescription, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignalObject))),
+					},
+				},
+			},
+			WantOutput: fstfmt.Success("Updated workspace-level signal '%s' (signal-id: %s)", customSignalName, customSignalID),
+		},
+		{
+			Name: "validate optional --json flag",
+			Args: fmt.Sprintf("--signal-id %s --description %s --workspace-id %s --json", customSignalID, customSignalDescription, workspaceID),
+			Client: &http.Client{
+				Transport: &testutil.MockRoundTripper{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Body:       io.NopCloser(bytes.NewReader(testutil.GenJSON(customSignal))),
+					},
+				},
+			},
+			WantOutput: fstfmt.EncodeJSON(customSignal),
+		},
+	}
+	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, sub2.CommandName, "update"}, scenarios)
+}
+
+var listCustomSignalsString = strings.TrimSpace(`
+ID       Name                  Description           Scope      Updated At                     Created At
+someID   CLICustomSignalName   NGWAFCLICustomSignal  workspace  0001-01-01 00:00:00 +0000 UTC  2021-06-15 23:00:00 +0000 UTC
+someID2  CLICustomSignalName2  NGWAFCLICustomSignal  workspace  0001-01-01 00:00:00 +0000 UTC  2021-06-15 23:00:00 +0000 UTC
+`) + "\n"
+
+var zeroListCustomSignalsString = strings.TrimSpace(`
+ID  Name  Description  Scope  Updated At  Created At
+`) + "\n"
+
+var customSignalString = strings.TrimSpace(`
+ID: someID
+Name: CLICustomSignalName
+Description: NGWAFCLICustomSignal
+Scope: workspace
+Updated (UTC): 0001-01-01 00:00
+Created (UTC): 2021-06-15 23:00
+`)

--- a/pkg/commands/ngwaf/workspace/customsignal/delete.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/delete.go
@@ -1,0 +1,97 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// DeleteCommand calls the Fastly API to delete an workspace-level custom signal.
+type DeleteCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	signalID    string
+	workspaceID argparser.OptionalWorkspaceID
+}
+
+// NewDeleteCommand returns a usable command registered under the parent.
+func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteCommand {
+	c := DeleteCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	c.CmdClause = parent.Command("delete", "Delete an workspace-level custom signal")
+
+	// Required.
+	c.CmdClause.Flag("signal-id", "Custom Signal ID").Required().StringVar(&c.signalID)
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagNGWAFWorkspaceID,
+		Description: argparser.FlagNGWAFWorkspaceIDDesc,
+		Dst:         &c.workspaceID.Value,
+		Action:      c.workspaceID.Set,
+		Required:    true,
+	})
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	input := &signals.DeleteInput{
+		SignalID: &c.signalID,
+		Scope: &scope.Scope{
+			Type: scope.ScopeTypeWorkspace,
+		},
+	}
+	if err := c.workspaceID.Parse(); err != nil {
+		return err
+	}
+	input.Scope.AppliesTo = []string{c.workspaceID.Value}
+
+	err := signals.Delete(context.TODO(), fc, input)
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if c.JSONOutput.Enabled {
+		o := struct {
+			ID      string `json:"id"`
+			Deleted bool   `json:"deleted"`
+		}{
+			c.signalID,
+			true,
+		}
+		_, err := c.WriteJSON(out, o)
+		return err
+	}
+
+	text.Success(out, "Deleted workspace-level custom signal (id: %s)", c.signalID)
+	return nil
+}

--- a/pkg/commands/ngwaf/workspace/customsignal/doc.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/doc.go
@@ -1,0 +1,2 @@
+// Package customsignal contains commands to inspect and manipulate NGWAF workspace-level custom signals.
+package customsignal

--- a/pkg/commands/ngwaf/workspace/customsignal/get.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/get.go
@@ -1,0 +1,90 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// GetCommand calls the Fastly API to get an workspace-level custom signal.
+type GetCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	signalID    string
+	workspaceID argparser.OptionalWorkspaceID
+}
+
+// NewGetCommand returns a usable command registered under the parent.
+func NewGetCommand(parent argparser.Registerer, g *global.Data) *GetCommand {
+	c := GetCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	c.CmdClause = parent.Command("get", "Get a custom signal")
+
+	// Required.
+	c.CmdClause.Flag("signal-id", "Custom Signal ID").Required().StringVar(&c.signalID)
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagNGWAFWorkspaceID,
+		Description: argparser.FlagNGWAFWorkspaceIDDesc,
+		Dst:         &c.workspaceID.Value,
+		Action:      c.workspaceID.Set,
+		Required:    true,
+	})
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *GetCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	input := &signals.GetInput{
+		SignalID: &c.signalID,
+		Scope: &scope.Scope{
+			Type: scope.ScopeTypeWorkspace,
+		},
+	}
+
+	if err := c.workspaceID.Parse(); err != nil {
+		return err
+	}
+	input.Scope.AppliesTo = []string{c.workspaceID.Value}
+
+	data, err := signals.Get(context.TODO(), fc, input)
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, data); ok {
+		return err
+	}
+
+	text.PrintCustomSignal(out, data)
+	return nil
+}

--- a/pkg/commands/ngwaf/workspace/customsignal/list.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/list.go
@@ -1,0 +1,86 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/go-fastly/v12/fastly"
+
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+)
+
+// ListCommand calls the Fastly API to list all workspace-level custom signals for your API token.
+type ListCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	workspaceID argparser.OptionalWorkspaceID
+}
+
+// NewListCommand returns a usable command registered under the parent.
+func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
+	c := ListCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+
+	c.CmdClause = parent.Command("list", "List all workspace-level custom signals")
+
+	// Required.
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagNGWAFWorkspaceID,
+		Description: argparser.FlagNGWAFWorkspaceIDDesc,
+		Dst:         &c.workspaceID.Value,
+		Action:      c.workspaceID.Set,
+		Required:    true,
+	})
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	input := &signals.ListInput{
+		Scope: &scope.Scope{
+			Type: scope.ScopeTypeWorkspace,
+		},
+	}
+
+	if err := c.workspaceID.Parse(); err != nil {
+		return err
+	}
+	input.Scope.AppliesTo = []string{c.workspaceID.Value}
+
+	signals, err := signals.List(context.TODO(), fc, input)
+	if err != nil {
+		c.Globals.ErrLog.Add(err)
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, signals); ok {
+		return err
+	}
+
+	text.PrintCustomSignalTbl(out, signals.Data)
+	return nil
+}

--- a/pkg/commands/ngwaf/workspace/customsignal/root.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/root.go
@@ -1,0 +1,31 @@
+package customsignal
+
+import (
+	"io"
+
+	"github.com/fastly/cli/pkg/argparser"
+	"github.com/fastly/cli/pkg/global"
+)
+
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
+type RootCommand struct {
+	argparser.Base
+	// no flags
+}
+
+// CommandName is the string to be used to invoke this command.
+const CommandName = "customsignal"
+
+// NewRootCommand returns a new command registered in the parent.
+func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
+	var c RootCommand
+	c.Globals = g
+	c.CmdClause = parent.Command(CommandName, "Manage NGWAF Workspace-Level Custom Signals")
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(_ io.Reader, _ io.Writer) error {
+	panic("unreachable")
+}

--- a/pkg/commands/ngwaf/workspace/customsignal/update.go
+++ b/pkg/commands/ngwaf/workspace/customsignal/update.go
@@ -1,0 +1,90 @@
+package customsignal
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/fastly/go-fastly/v12/fastly"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+
+	"github.com/fastly/cli/pkg/argparser"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/text"
+)
+
+// UpdateCommand calls the Fastly API to update workspace-level custom signals.
+type UpdateCommand struct {
+	argparser.Base
+	argparser.JSONOutput
+
+	// Required.
+	signalID    string
+	description string
+	workspaceID argparser.OptionalWorkspaceID
+}
+
+// NewUpdateCommand returns a usable command registered under the parent.
+func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateCommand {
+	c := UpdateCommand{
+		Base: argparser.Base{
+			Globals: g,
+		},
+	}
+	c.CmdClause = parent.Command("update", "Update a workspace")
+
+	// Required.
+	c.CmdClause.Flag("signal-id", "Custom Signal ID").Required().StringVar(&c.signalID)
+	c.CmdClause.Flag("description", "User submitted description of a custom signal.").Required().StringVar(&c.description)
+	c.RegisterFlag(argparser.StringFlagOpts{
+		Name:        argparser.FlagNGWAFWorkspaceID,
+		Description: argparser.FlagNGWAFWorkspaceIDDesc,
+		Dst:         &c.workspaceID.Value,
+		Action:      c.workspaceID.Set,
+		Required:    true,
+	})
+
+	// Optional.
+	c.RegisterFlagBool(c.JSONFlag())
+
+	return &c
+}
+
+// Exec invokes the application logic for the command.
+func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
+	if c.Globals.Verbose() && c.JSONOutput.Enabled {
+		return fsterr.ErrInvalidVerboseJSONCombo
+	}
+	var err error
+	input := &signals.UpdateInput{
+		SignalID:    &c.signalID,
+		Description: &c.description,
+		Scope: &scope.Scope{
+			Type: scope.ScopeTypeWorkspace,
+		},
+	}
+
+	if err := c.workspaceID.Parse(); err != nil {
+		return err
+	}
+	input.Scope.AppliesTo = []string{c.workspaceID.Value}
+
+	fc, ok := c.Globals.APIClient.(*fastly.Client)
+	if !ok {
+		return errors.New("failed to convert interface to a fastly client")
+	}
+
+	data, err := signals.Update(context.TODO(), fc, input)
+	if err != nil {
+		return err
+	}
+
+	if ok, err := c.WriteJSON(out, data); ok {
+		return err
+	}
+
+	text.Success(out, "Updated workspace-level signal '%s' (signal-id: %s)", data.Name, data.SignalID)
+	return nil
+}

--- a/pkg/commands/ngwaf/workspace/update.go
+++ b/pkg/commands/ngwaf/workspace/update.go
@@ -16,7 +16,7 @@ import (
 	"github.com/fastly/cli/pkg/text"
 )
 
-// UpdateCommand calls the Fastly API to create domains.
+// UpdateCommand calls the Fastly API to update workspaces.
 type UpdateCommand struct {
 	argparser.Base
 	argparser.JSONOutput

--- a/pkg/text/customsignal.go
+++ b/pkg/text/customsignal.go
@@ -1,0 +1,42 @@
+package text
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fastly/cli/pkg/time"
+	"github.com/fastly/go-fastly/v12/fastly/ngwaf/v1/signals"
+)
+
+// PrintCustomSignal displays an NGWAF custom signal.
+func PrintCustomSignal(out io.Writer, customSignalToPrint *signals.Signal) {
+	fmt.Fprintf(out, "ID: %s\n", customSignalToPrint.SignalID)
+	fmt.Fprintf(out, "Name: %s\n", customSignalToPrint.Name)
+	fmt.Fprintf(out, "Description: %s\n", customSignalToPrint.Description)
+	fmt.Fprintf(out, "Scope: %s\n", customSignalToPrint.Scope.Type)
+	fmt.Fprintf(out, "Updated (UTC): %s\n", customSignalToPrint.UpdatedAt.UTC().Format(time.Format))
+	fmt.Fprintf(out, "Created (UTC): %s\n", customSignalToPrint.CreatedAt.UTC().Format(time.Format))
+}
+
+// PrintCustomSignalTbl displays custom signals in a table format.
+func PrintCustomSignalTbl(out io.Writer, customSignalsToPrint []signals.Signal) {
+	tbl := NewTable(out)
+	tbl.AddHeader("ID", "Name", "Description", "Scope", "Updated At", "Created At")
+
+	if customSignalsToPrint == nil {
+		tbl.Print()
+		return
+	}
+
+	for _, listToPrint := range customSignalsToPrint {
+		tbl.AddLine(
+			listToPrint.SignalID,
+			listToPrint.Name,
+			listToPrint.Description,
+			listToPrint.Scope.Type,
+			listToPrint.UpdatedAt,
+			listToPrint.CreatedAt,
+		)
+	}
+	tbl.Print()
+}


### PR DESCRIPTION
### Change summary

Add CRUD operations for account and workspace level custom signals

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
