### PR TITLE
Ensure that alias root.go files are using argparser.Base

### DIFF
--- a/pkg/commands/alias/backend/root.go
+++ b/pkg/commands/alias/backend/root.go
@@ -3,25 +3,29 @@ package backend
 import (
 	"io"
 
-	servicebackend "github.com/fastly/cli/pkg/commands/service/backend"
-
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
 )
 
-// RootCommand wraps the RootCommand from the servicebackend package.
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
 type RootCommand struct {
-	*servicebackend.RootCommand
+	argparser.Base
+	// no flags
 }
 
-// NewRootCommand returns a usable command registered under the parent.
+// CommandName is the string to be used to invoke this command.
+const CommandName = "backend"
+
+// NewRootCommand returns a new command registered in the parent.
 func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
-	c := RootCommand{servicebackend.NewRootCommand(parent, g)}
-	c.CmdClause.Hidden()
+	var c RootCommand
+	c.Globals = g
+	c.CmdClause = parent.Command(CommandName, "Manipulate Fastly service version backends").Hidden()
 	return &c
 }
 
 // Exec implements the command interface.
-func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
-	return c.RootCommand.Exec(in, out)
+func (c *RootCommand) Exec(_ io.Reader, _ io.Writer) error {
+	panic("unreachable")
 }

--- a/pkg/commands/alias/healthcheck/root.go
+++ b/pkg/commands/alias/healthcheck/root.go
@@ -3,25 +3,29 @@ package healthcheck
 import (
 	"io"
 
-	servicehealthcheck "github.com/fastly/cli/pkg/commands/service/healthcheck"
-
 	"github.com/fastly/cli/pkg/argparser"
 	"github.com/fastly/cli/pkg/global"
 )
 
-// RootCommand wraps the RootCommand from the servicehealthcheck package.
+// RootCommand is the parent command for all subcommands in this package.
+// It should be installed under the primary root command.
 type RootCommand struct {
-	*servicehealthcheck.RootCommand
+	argparser.Base
+	// no flags
 }
 
-// NewRootCommand returns a usable command registered under the parent.
+// CommandName is the string to be used to invoke this command.
+const CommandName = "healthcheck"
+
+// NewRootCommand returns a new command registered in the parent.
 func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
-	c := RootCommand{servicehealthcheck.NewRootCommand(parent, g)}
-	c.CmdClause.Hidden()
+	var c RootCommand
+	c.Globals = g
+	c.CmdClause = parent.Command(CommandName, "Manipulate Fastly service version healthchecks").Hidden()
 	return &c
 }
 
 // Exec implements the command interface.
-func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
-	return c.RootCommand.Exec(in, out)
+func (c *RootCommand) Exec(_ io.Reader, _ io.Writer) error {
+	panic("unreachable")
 }


### PR DESCRIPTION
### Change summary

This PR fixes alias root commands to use standalone pattern instead of wrapping service commands. The `healthcheck` and `backend` alias root files were incorrectly wrapping the service command. 
Ref: #1622 & #1621.  

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?


### User Impact

None. 