### PR TITLE
feat(setup): Add interactive setup wizard for CLI configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - breaking(domain) - service-version oriented `domain` commands have been moved under the `service domain` command. Versionless `domain-v1` commands have been moved to the `domain` command ([#1615](https://github.com/fastly/cli/pull/1615))
 
 ### Enhancements:
+- feat(setup): Add interactive setup wizard for CLI configuration with API token and SSO authentication options
 - feat(rust): Allow testing with prerelease Rust versions ([#1604](https://github.com/fastly/cli/pull/1604))
 - feat(compute/hashfiles): remove hashsum subcommand ([#1608](https://github.com/fastly/cli/pull/1608))
 - feat(ngwaf/rules): add support for CRUD operations for NGWAF rules ([#1605](https://github.com/fastly/cli/pull/1605))

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -60,6 +60,7 @@ complete -F _fastly_bash_autocomplete fastly
 			Args: "--completion-bash",
 			WantOutput: `help
 sso
+setup
 auth-token
 compute
 config

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -115,6 +115,7 @@ import (
 	servicevclsnippet "github.com/fastly/cli/pkg/commands/service/vcl/snippet"
 	serviceversion "github.com/fastly/cli/pkg/commands/service/version"
 	"github.com/fastly/cli/pkg/commands/serviceauth"
+	"github.com/fastly/cli/pkg/commands/setup"
 	"github.com/fastly/cli/pkg/commands/shellcomplete"
 	"github.com/fastly/cli/pkg/commands/sso"
 	"github.com/fastly/cli/pkg/commands/stats"
@@ -149,6 +150,7 @@ func Define( // nolint:revive // function-length
 	// placement of the `sso` subcommand not look too odd we place it at the
 	// beginning of the list of commands.
 	ssoCmdRoot := sso.NewRootCommand(app, data)
+	setupCmdRoot := setup.NewRootCommand(app, data, ssoCmdRoot)
 
 	authtokenCmdRoot := authtoken.NewRootCommand(app, data)
 	authtokenCreate := authtoken.NewCreateCommand(authtokenCmdRoot.CmdClause, data)
@@ -1329,6 +1331,7 @@ func Define( // nolint:revive // function-length
 		serviceVersionStage,
 		serviceVersionUnstage,
 		serviceVersionUpdate,
+		setupCmdRoot,
 		ssoCmdRoot,
 		statsCmdRoot,
 		statsHistorical,

--- a/pkg/commands/setup/root.go
+++ b/pkg/commands/setup/root.go
@@ -1,0 +1,316 @@
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/fastly/cli/pkg/api/undocumented"
+	"github.com/fastly/cli/pkg/argparser"
+	"github.com/fastly/cli/pkg/commands/sso"
+	fsterr "github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/profile"
+	"github.com/fastly/cli/pkg/text"
+	"github.com/fastly/cli/pkg/useragent"
+)
+
+// RootCommand is the setup command.
+type RootCommand struct {
+	argparser.Base
+	ssoCmd *sso.RootCommand
+
+	profileName string
+	setDefault  argparser.OptionalBool
+}
+
+// NewRootCommand creates a new setup command.
+func NewRootCommand(parent argparser.Registerer, g *global.Data, ssoCmd *sso.RootCommand) *RootCommand {
+	var c RootCommand
+	c.Globals = g
+	c.ssoCmd = ssoCmd
+	c.CmdClause = parent.Command("setup", "Interactive setup wizard for configuring the Fastly CLI")
+	c.CmdClause.Flag("name", "Profile name to create").Default(profile.DefaultName).StringVar(&c.profileName)
+	c.CmdClause.Flag("set-default", "Set as default profile").Action(c.setDefault.Set).BoolVar(&c.setDefault.Value)
+	return &c
+}
+
+// Exec implements the command interface.
+func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
+	token := c.Globals.Flags.Token
+	nonInteractive := c.Globals.Flags.NonInteractive
+	autoYes := c.Globals.Flags.AutoYes
+
+	if nonInteractive && token == "" {
+		return fsterr.RemediationError{
+			Inner:       errors.New("--token is required when using --non-interactive"),
+			Remediation: "Provide an API token: fastly setup --non-interactive --token $FASTLY_API_TOKEN",
+		}
+	}
+
+	if profile.Exist(c.profileName, c.Globals.Config.Profiles) {
+		if nonInteractive {
+			return fsterr.RemediationError{
+				Inner:       fmt.Errorf("profile '%s' already exists", c.profileName),
+				Remediation: "Use 'fastly profile update' to modify, or specify a different --name.",
+			}
+		}
+
+		if autoYes {
+			return fsterr.RemediationError{
+				Inner:       fmt.Errorf("profile '%s' already exists", c.profileName),
+				Remediation: "Specify a different profile name: fastly setup -y --name <new-name>",
+			}
+		}
+
+		text.Warning(out, "A profile named '%s' already exists.", c.profileName)
+		cont, err := text.AskYesNo(out, "Would you like to create a profile with a different name? [y/N] ", in)
+		if err != nil {
+			return err
+		}
+		if !cont {
+			text.Info(out, "Setup cancelled.")
+			return nil
+		}
+	}
+
+	if nonInteractive {
+		return c.runNonInteractive(out, token, nonInteractive)
+	}
+	return c.runInteractive(in, out, autoYes)
+}
+
+// verifyResponse models the /verify endpoint response.
+type verifyResponse struct {
+	Customer struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"customer"`
+	User struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Login string `json:"login"`
+	} `json:"user"`
+	Token struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		Scope     string `json:"scope"`
+		CreatedAt string `json:"created_at"`
+		ExpiresAt string `json:"expires_at"`
+	} `json:"token"`
+}
+
+func (c *RootCommand) validateToken(token string) (*verifyResponse, error) {
+	endpoint, _ := c.Globals.APIEndpoint()
+	data, err := undocumented.Call(undocumented.CallOptions{
+		APIEndpoint: endpoint,
+		HTTPClient:  c.Globals.HTTPClient,
+		HTTPHeaders: []undocumented.HTTPHeader{
+			{Key: "Accept", Value: "application/json"},
+			{Key: "User-Agent", Value: useragent.Name},
+		},
+		Method: http.MethodGet,
+		Path:   "/verify",
+		Token:  token,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error validating token: %w", err)
+	}
+
+	var resp verifyResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("error decoding API response: %w", err)
+	}
+	return &resp, nil
+}
+
+func (c *RootCommand) runNonInteractive(out io.Writer, token string, _ bool) error {
+	resp, err := c.validateToken(token)
+	if err != nil {
+		return err
+	}
+
+	makeDefault := c.setDefault.Value
+	if !c.setDefault.WasSet {
+		_, defaultProfile := profile.Default(c.Globals.Config.Profiles)
+		makeDefault = (defaultProfile == nil)
+	}
+
+	if err := c.createProfile(c.profileName, token, resp, makeDefault); err != nil {
+		return err
+	}
+
+	if makeDefault {
+		text.Success(out, "Profile '%s' created and set as default.", c.profileName)
+	} else {
+		text.Success(out, "Profile '%s' created.", c.profileName)
+	}
+	return nil
+}
+
+func (c *RootCommand) runInteractive(in io.Reader, out io.Writer, autoYes bool) error {
+	text.Output(out, "Welcome to Fastly CLI Setup!")
+	text.Break(out)
+	text.Output(out, "This wizard will help you configure authentication and create a profile.")
+	text.Break(out)
+
+	useSSO := false
+	if !autoYes {
+		text.Output(out, "How would you like to authenticate?")
+		text.Break(out)
+		text.Output(out, "  1. API Token (recommended for automation)")
+		text.Output(out, "  2. SSO/Browser Login (recommended for interactive use)")
+		text.Break(out)
+		choice, err := text.Input(out, "Choice [1]: ", in)
+		if err != nil {
+			return err
+		}
+		useSSO = (choice == "2")
+	}
+
+	profileName := c.profileName
+	needsNewName := profile.Exist(c.profileName, c.Globals.Config.Profiles)
+
+	if !autoYes {
+		prompt := fmt.Sprintf("Profile name [%s]: ", c.profileName)
+		if needsNewName {
+			prompt = "Enter a new profile name: "
+		}
+
+		for {
+			input, err := text.Input(out, prompt, in)
+			if err != nil {
+				return err
+			}
+			input = strings.TrimSpace(input)
+
+			if input == "" && !needsNewName {
+				break
+			}
+
+			if input == "" {
+				text.Warning(out, "Profile name cannot be empty.")
+				continue
+			}
+
+			if profile.Exist(input, c.Globals.Config.Profiles) {
+				text.Warning(out, "Profile '%s' already exists. Please choose a different name.", input)
+				needsNewName = true
+				prompt = "Enter a new profile name: "
+				continue
+			}
+
+			profileName = input
+			break
+		}
+	} else if needsNewName {
+		return fmt.Errorf("profile '%s' already exists", c.profileName)
+	}
+
+	_, defaultProfile := profile.Default(c.Globals.Config.Profiles)
+	hasExistingDefault := (defaultProfile != nil)
+
+	makeDefault := true
+	if c.setDefault.WasSet {
+		makeDefault = c.setDefault.Value
+	} else if hasExistingDefault {
+		if autoYes {
+			makeDefault = false
+		} else {
+			var err error
+			makeDefault, err = text.AskYesNo(out, "Set this profile as your default? [y/N] ", in)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if useSSO {
+		return c.runSSOFlow(in, out, profileName, makeDefault)
+	}
+	return c.runAPITokenFlow(in, out, profileName, makeDefault)
+}
+
+func (c *RootCommand) runSSOFlow(in io.Reader, out io.Writer, profileName string, makeDefault bool) error {
+	c.ssoCmd.InvokedFromProfileCreate = true
+	c.ssoCmd.ProfileCreateName = profileName
+	c.ssoCmd.ProfileDefault = makeDefault
+
+	if err := c.ssoCmd.Exec(in, out); err != nil {
+		return fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	c.displaySummary(out, profileName, makeDefault)
+	return nil
+}
+
+func (c *RootCommand) runAPITokenFlow(in io.Reader, out io.Writer, profileName string, makeDefault bool) error {
+	text.Break(out)
+	text.Output(out, "You can create an API token at: https://manage.fastly.com/account/personal/tokens")
+	text.Break(out)
+	token, err := text.InputSecure(out, "Fastly API token: ", in, profile.ValidateTokenNotEmpty)
+	if err != nil {
+		return err
+	}
+	if token == "" {
+		return fsterr.RemediationError{
+			Inner:       errors.New("API token cannot be empty"),
+			Remediation: "Enter a valid API token, or create one at https://manage.fastly.com/account/personal/tokens",
+		}
+	}
+
+	spinner, err := text.NewSpinner(out)
+	if err != nil {
+		return err
+	}
+
+	var resp *verifyResponse
+	err = spinner.Process("Validating token", func(_ *text.SpinnerWrapper) error {
+		resp, err = c.validateToken(token)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	text.Break(out)
+	text.Success(out, "Token validated successfully!")
+	fmt.Fprintf(out, "\n  Email: %s\n", resp.User.Login)
+	fmt.Fprintf(out, "  Customer: %s (%s)\n", resp.Customer.Name, resp.Customer.ID)
+
+	if err := c.createProfile(profileName, token, resp, makeDefault); err != nil {
+		return err
+	}
+
+	c.displaySummary(out, profileName, makeDefault)
+	return nil
+}
+
+func (c *RootCommand) createProfile(name, token string, resp *verifyResponse, makeDefault bool) error {
+	c.Globals.Config.Profiles = profile.Create(
+		name,
+		c.Globals.Config.Profiles,
+		resp.User.Login,
+		token,
+		makeDefault,
+	)
+	return c.Globals.Config.Write(c.Globals.ConfigPath)
+}
+
+func (c *RootCommand) displaySummary(out io.Writer, profileName string, isDefault bool) {
+	text.Break(out)
+	if isDefault {
+		text.Success(out, "Setup complete! Profile '%s' created and set as default.", profileName)
+	} else {
+		text.Success(out, "Setup complete! Profile '%s' created.", profileName)
+	}
+	text.Description(out, "Your configuration has been saved to", c.Globals.ConfigPath)
+	text.Break(out)
+	text.Output(out, "Next steps:")
+	text.Output(out, "  - Run 'fastly whoami' to verify your identity")
+	text.Output(out, "  - Run 'fastly service list' to see your services")
+	text.Output(out, "  - Run 'fastly compute init' to start a new Compute project")
+}

--- a/pkg/commands/setup/root_test.go
+++ b/pkg/commands/setup/root_test.go
@@ -1,0 +1,88 @@
+package setup_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/testutil"
+)
+
+func TestSetupNonInteractive(t *testing.T) {
+	scenarios := []testutil.CLIScenario{
+		{
+			Name: "non-interactive requires token",
+			Args: "--non-interactive",
+			Env: &testutil.EnvConfig{
+				Opts: &testutil.EnvOpts{
+					Copy: []testutil.FileIO{
+						{
+							Src: filepath.Join("testdata", "config.toml"),
+							Dst: "config.toml",
+						},
+					},
+				},
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
+					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
+				},
+			},
+			WantError: "--token is required when using --non-interactive",
+		},
+		{
+			Name: "non-interactive profile already exists",
+			Args: "--non-interactive --token test_token_123 --name user",
+			Env: &testutil.EnvConfig{
+				Opts: &testutil.EnvOpts{
+					Copy: []testutil.FileIO{
+						{
+							Src: filepath.Join("testdata", "config.toml"),
+							Dst: "config.toml",
+						},
+					},
+				},
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
+					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
+				},
+			},
+			ConfigFile: &config.File{
+				Profiles: config.Profiles{
+					"user": &config.Profile{
+						Default: true,
+						Email:   "existing@example.com",
+						Token:   "existing_token",
+					},
+				},
+			},
+			WantError: "profile 'user' already exists",
+		},
+		{
+			Name: "auto-yes profile already exists",
+			Args: "--auto-yes --name user",
+			Env: &testutil.EnvConfig{
+				Opts: &testutil.EnvOpts{
+					Copy: []testutil.FileIO{
+						{
+							Src: filepath.Join("testdata", "config.toml"),
+							Dst: "config.toml",
+						},
+					},
+				},
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
+					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
+				},
+			},
+			ConfigFile: &config.File{
+				Profiles: config.Profiles{
+					"user": &config.Profile{
+						Default: true,
+						Email:   "existing@example.com",
+						Token:   "existing_token",
+					},
+				},
+			},
+			WantError: "profile 'user' already exists",
+		},
+	}
+
+	testutil.RunCLIScenarios(t, []string{"setup"}, scenarios)
+}

--- a/pkg/commands/setup/testdata/config.toml
+++ b/pkg/commands/setup/testdata/config.toml
@@ -1,0 +1,4 @@
+config_version = 2
+
+[fastly]
+  api_endpoint = "https://api.fastly.com"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -421,6 +421,10 @@ func (f *File) UseStatic(path string) error {
 
 // Write encodes in-memory data to disk.
 func (f *File) Write(path string) error {
+	if err := ensureConfigDirExists(path); err != nil {
+		return err
+	}
+
 	// gosec flagged this:
 	// G304 (CWE-22): Potential file inclusion via variable
 	//

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,8 +1,22 @@
 package profile
 
 import (
+	"errors"
+
 	"github.com/fastly/cli/pkg/config"
 )
+
+// ErrEmptyToken is returned when a user tries to supply an empty string as a
+// token in the terminal prompt.
+var ErrEmptyToken = errors.New("token cannot be empty")
+
+// ValidateTokenNotEmpty validates that a token string is not empty.
+func ValidateTokenNotEmpty(s string) error {
+	if s == "" {
+		return ErrEmptyToken
+	}
+	return nil
+}
 
 // DefaultName is the default profile name.
 const DefaultName = "user"
@@ -92,6 +106,25 @@ func Delete(name string, p config.Profiles) bool {
 		}
 	}
 	return ok
+}
+
+// Create adds a new profile to the configuration.
+// Returns the updated profiles.
+func Create(name string, p config.Profiles, email, token string, makeDefault bool) config.Profiles {
+	if p == nil {
+		p = make(config.Profiles)
+	}
+
+	p[name] = &config.Profile{
+		Default: makeDefault,
+		Email:   email,
+		Token:   token,
+	}
+
+	if makeDefault {
+		p, _ = SetDefault(name, p)
+	}
+	return p
 }
 
 // EditOption lets callers of Edit specify profile fields to update.


### PR DESCRIPTION
Add a new `fastly setup` command providing an interactive wizard for configuring the Fastly CLI with API token or SSO authentication.

### Change summary

 <!--
Briefly describe the changes introduced in this pull request. Include context or
reasoning behind the changes, even if they seem minor. If relevant, link to any
related discussions (e.g. Slack threads, tickets, documents).
-->

After installing the CLI for the first time, it’s not obvious how to set it up or register a profile.

Running `fastly sso` is not necessarily what users would try first. When they do, it fails and tells them to use `fastly profile create`. However, `fastly profile create` asks for a token, while SSO is usually what users expect to use when setting up the CLI initially.

We’ve received feedback from customers who wanted to use the MCP server but struggled to configure the CLI on their first attempt, and I experienced the same confusion myself.

This PR introduces a simple command designed to immediately catch the attention of new users right after installation, before they even need to consult the online documentation.

```text
setup               Interactive setup wizard for configuring the Fastly CLI
```

It checks whether a default profile already exists, lets users register a new profile either with an API token or via SSO, and gracefully handles conflicts with existing profile names.

It also prints a small set of suggested commands that users can run to try out the tool, along with the path where the configuration is stored. This information is especially helpful for first-time users.

The command name is intentionally generic ("setup"), allowing it to be extended in the future to support additional CLI setup tasks, such as enabling or configuring optional components.

While this command doesn’t introduce any new capabilities, it improves the onboarding experience.
It can also be run in non-interactive mode.

This is meant as a proposal. The setup command may feel redundant, and if the consensus is that it doesn’t add enough value, closing the pull request is completely fine :)

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [X] Does your submission pass tests?

### Changes to Core Features:

* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### User Impact

Improved onboarding experience.

<!-- What is the user impact of this change? -->

### Are there any considerations that need to be addressed for release?

A short documentation page needs to be written for this new command. I’d be happy to do it.

<!-- Any breaking changes, etc -->

No breaking changes expected.

But this also addresses an old `TODO` item in `profile/create.go` about consolidating the directory check logic that was duplicated in multiple places (and would have had to be duplicated one more time).