### PR TITLE
Set up workflow permissions for trusted publishing

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+permissions:
+  id-token: write
+  contents: read
 jobs:
   npm_release:
     runs-on: ubuntu-latest
@@ -25,8 +28,6 @@ jobs:
         run: npm install && npm version "${{ github.ref_name }}" --allow-same-version
       - name: Publish packages to npmjs.org
         working-directory: ./npm/@fastly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for dir in *; do
             (


### PR DESCRIPTION
### Change summary

This PR updates the `publish_release.yml` workflow file:

1. enables the permission `id-token: write` for OpenID Connect (OIDC) authentication for use with [Trusted Publishing with npmjs](https://docs.npmjs.com/trusted-publishers)
2. removes the auth token as it's no longer used when Trusted Publishing is used

 <!--
Briefly describe the changes introduced in this pull request. Include context or
reasoning behind the changes, even if they seem minor. If relevant, link to any
related discussions (e.g. Slack threads, tickets, documents).
-->

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
N/A

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
N/A

### User Impact

None
<!-- What is the user impact of this change? -->

### Are there any considerations that need to be addressed for release?

None
<!-- Any breaking changes, etc -->
