### PR TITLE
Bump PR Tests to use Go 1.25

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: "Install dependencies"
         run: make mod-download
         shell: bash
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         tinygo-version: [0.31.2]
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         node-version: [18]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
@@ -146,7 +146,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Run golangci-lint@latest
         id: lint
         uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
### Change summary

Bumping the supported Go version to 1.25x to support the dependency changes in PR #1648. 
