### PR TITLE
Dockerfile-rust: use base image toolchain instead of reinstalling stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes:
+
+- fix(docker): Use base image toolchain instead of reinstalling stable, which could pull in an unvalidated Rust version.
+
 ### Breaking:
 
 - breaking(domain) - service-version oriented `domain` commands have been moved under the `service domain` command. Versionless `domain-v1` commands have been moved to the `domain` command ([#1615](https://github.com/fastly/cli/pull/1615))

--- a/Dockerfile-rust
+++ b/Dockerfile-rust
@@ -1,9 +1,8 @@
 FROM rust:latest
 LABEL maintainer="Fastly OSS <oss@fastly.com>"
 
-ENV RUST_TOOLCHAIN=stable
-RUN rustup toolchain install ${RUST_TOOLCHAIN} \
-  && rustup target add wasm32-wasip1 --toolchain ${RUST_TOOLCHAIN} \
+ENV RUSTUP_TOOLCHAIN=$RUST_VERSION
+RUN rustup target add wasm32-wasip1 \
   && apt-get update && apt-get install -y curl jq && apt-get -y clean && rm -rf /var/lib/apt/lists/* \
   && cargo install wasm-tools --locked \
   && export FASTLY_CLI_VERSION=$(curl -s https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \


### PR DESCRIPTION
### Change summary

`rustup toolchain install stable` re-downloads the latest stable toolchain,
which may differ from the pinned `rust:` base image version. This seems
redundant and is somewhat non-obvious if you want to pin the Rust version.
(e.g. when pinning Rust 1.92 since the current latest CLI panics with stable:
"version '1.93.1' of Rust has not been validated for use with Fastly Compute.").

Since the base image already ships with the correct toolchain, just add
the wasm target directly.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the
same update/change?

### User Impact

None — only affects the Docker build image, not the CLI itself.

### Are there any considerations that need to be addressed for release?

No. Technically this Dockerfile still fails to run CLI v13.3.0 unless you pin the Rust version. This at least centralizes the latter.