### PR TITLE
Apply packages permission for publish to GitHub packages

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  packages: write
 jobs:
   npm_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Change summary

This PR updates the publish workflow to give `packages:write` which is needed for publishing to GitHub packages.

This is needed because GitHub worker permissions are replaced, not merged, so when we added `id-token:write`, the implied `packages:write` was lost.