### PR TITLE
Apply contents permission for goreleaser

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -6,7 +6,7 @@ on:
       - published
 permissions:
   id-token: write
-  contents: read
+  contents: write
   packages: write
 jobs:
   npm_release:


### PR DESCRIPTION
### Change summary

This PR adds the permission `contents:write` to the release workflow.

This is needed because GitHub worker permissions are replaced, not merged, so when we added `id-token:write` I needed to provide a value of `contents`, for which I had used `read`.
