### PR TITLE
Restore permission for trusted publishing

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,6 +5,7 @@ on:
     types:
       - published
 permissions:
+  id-token: write
   contents: read
   packages: write
 jobs:


### PR DESCRIPTION
### Change summary

This PR restores a permission in the workflow that had been removed in #1718 that is needed for publishing to NPM.

Publishing to NPM using trusted publishing requires `id-token: write` as added in #1644.

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?

A new point release (14.3.1) would be needed to get this version into NPM.