### PR TITLE
Add Tools `go-releaser` CI Job

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -127,6 +127,19 @@ jobs:
       - name: Build docker images
         run: |
           for dockerFile in Dockerfile*; do docker build -f $dockerFile . ; done
+  tools-build:
+    name: "Test goreleaser tools build"
+    if: contains(github.event.pull_request.labels.*.name, 'tools')
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v6
+      - name: "Install Go"
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/go.mod
+      - name: "Test goreleaser tools build"
+        run: go tool -modfile=tools/go.mod goreleaser build --single-target --skip=post-hooks --skip=validate
   golangci-latest:
     name: lint-latest (informational)
     needs: [config]

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -128,8 +128,9 @@ jobs:
         run: |
           for dockerFile in Dockerfile*; do docker build -f $dockerFile . ; done
   tools-build:
-    name: "Test goreleaser tools build"
+    name: "goreleaser tools build"
     if: contains(github.event.pull_request.labels.*.name, 'tools')
+    needs: [config]
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
@@ -138,6 +139,12 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: tools/go.mod
+      - name: "Config Artifact"
+        uses: actions/download-artifact@v8
+        with:
+          name: config-artifact-${{ github.sha }}
+      - name: "Move Config"
+        run: mv config.toml pkg/config/config.toml
       - name: "Test goreleaser tools build"
         run: go tool -modfile=tools/go.mod goreleaser build --single-target --snapshot --skip=post-hooks --skip=validate
   golangci-latest:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           go-version-file: tools/go.mod
       - name: "Test goreleaser tools build"
-        run: go tool -modfile=tools/go.mod goreleaser build --single-target --skip=post-hooks --skip=validate
+        run: go tool -modfile=tools/go.mod goreleaser build --single-target --snapshot --skip=post-hooks --skip=validate
   golangci-latest:
     name: lint-latest (informational)
     needs: [config]


### PR DESCRIPTION
### Change summary

Since we skip any release steps for all PRs that aren't tagged as a release, we need to add a CI job to test `goreleaser` tools builds against Dependabot PRs. This ensures that future dependency PRs opened will validate that they do not conflict with the current version of `goreleaser` to prevent scenarios like #1762.  

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Notes:

We are only testing against `ubuntu-latest` as we are just looking for collision errors, which should be available on any architecture. So this should be sufficient for this use case. 