### PR TITLE
CDTOOL-1328 list version refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - fix(compute/deploy): remove compute trial activation code because trials no longer exist ([#1730](https://github.com/fastly/cli/pull/1730))
 - fix(auth): SSO token expiration status now reflects the actual API token lifetime (~12 hours) instead of the internal JWT refresh token (~30 minutes), preventing spurious warnings and premature re-authentication [#1728](https://github.com/fastly/cli/pull/1728)
+- fix(argparser): skip ListVersions API call for numeric versions [#1774](https://github.com/fastly/cli/pull/1774)
 
 ### Enhancements:
 

--- a/pkg/argparser/common.go
+++ b/pkg/argparser/common.go
@@ -28,7 +28,7 @@ var (
 	// FlagVersionName is the flag name.
 	FlagVersionName = "version"
 	// FlagVersionDesc is the flag description.
-	FlagVersionDesc = "'latest', 'active', or the number of a specific Fastly service version"
+	FlagVersionDesc = "'latest', 'active', 'staged', or the number of a specific Fastly service version"
 )
 
 // PaginationDirection is a list of directions the page results can be displayed.

--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -166,8 +166,22 @@ func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fast
 			return fastly.ToValue(vs[i].Number) > fastly.ToValue(vs[j].Number)
 		})
 		return vs[0], nil
+	case "staged":
+		serviceDetails, err := client.GetServiceDetails(context.TODO(), &fastly.GetServiceDetailsInput{
+			ServiceID: sid,
+			Filters: []fastly.ServiceDetailsFilter{
+				{Key: "versions.staged", Value: true},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error getting service details: %w", err)
+		}
+		if serviceDetails.Version == nil {
+			return nil, fmt.Errorf("no staged service version found")
+		}
+		return serviceDetails.Version, nil
 	default:
-		return nil, fmt.Errorf("invalid version value %q: must be a version number, \"latest\", or \"active\"", sv.Value)
+		return nil, fmt.Errorf("invalid version value %q: must be a version number, \"latest\", \"active\", or \"staged\"", sv.Value)
 	}
 }
 

--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -115,6 +115,13 @@ type OptionalServiceVersion struct {
 }
 
 // Parse returns a service version based on the given user input.
+//
+// Supported values:
+//   - Numeric version (e.g., "1", "2", "42"): Returns the specified version
+//   - "active": Returns the currently active version
+//   - "staged": Returns the currently staged version
+//   - "latest": Returns the highest version number (latest version)
+//   - Omitted (no flag provided): Returns active version, falls back to latest if no active version exists
 func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fastly.Version, error) {
 	// When no --version flag is provided (WasSet=false), default to "active" to preserve
 	// the original behavior of trying active version first, with fallback to latest.

--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -116,10 +116,10 @@ type OptionalServiceVersion struct {
 
 // Parse returns a service version based on the given user input.
 func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fastly.Version, error) {
-	// When no --version flag is provided (WasSet=false), treat it as "latest".
-	// This is the default behavior for commands that don't require an explicit version.
+	// When no --version flag is provided (WasSet=false), default to "active" to preserve
+	// the original behavior of trying active version first, with fallback to latest.
 	if sv.Value == "" && !sv.WasSet {
-		sv.Value = "latest"
+		sv.Value = "active"
 	}
 
 	// When a specific numeric version is provided, use it directly.
@@ -131,6 +131,26 @@ func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fast
 	}
 
 	switch strings.ToLower(sv.Value) {
+	case "active":
+		serviceDetails, err := client.GetServiceDetails(context.TODO(), &fastly.GetServiceDetailsInput{
+			ServiceID: sid,
+			Filters: []fastly.ServiceDetailsFilter{
+				{Key: "versions.active", Value: true},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error getting service details: %w", err)
+		}
+		// If active version exists, return it
+		if serviceDetails.ActiveVersion != nil {
+			return serviceDetails.ActiveVersion, nil
+		}
+		// If flag was explicitly set to "active" but no active version exists, return error
+		if sv.WasSet {
+			return nil, fmt.Errorf("no active service version found")
+		}
+		// If flag was not explicitly set and there's no active version, fall through to latest
+		fallthrough
 	case "latest":
 		vs, err := client.ListVersions(context.TODO(), &fastly.ListVersionsInput{
 			ServiceID: sid,
@@ -146,20 +166,6 @@ func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fast
 			return fastly.ToValue(vs[i].Number) > fastly.ToValue(vs[j].Number)
 		})
 		return vs[0], nil
-	case "active":
-		serviceDetails, err := client.GetServiceDetails(context.TODO(), &fastly.GetServiceDetailsInput{
-			ServiceID: sid,
-			Filters: []fastly.ServiceDetailsFilter{
-				{Key: "versions.active", Value: true},
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error getting service details: %w", err)
-		}
-		if serviceDetails.ActiveVersion == nil {
-			return nil, fmt.Errorf("no active service version found")
-		}
-		return serviceDetails.ActiveVersion, nil
 	default:
 		return nil, fmt.Errorf("invalid version value %q: must be a version number, \"latest\", or \"active\"", sv.Value)
 	}

--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -116,41 +116,53 @@ type OptionalServiceVersion struct {
 
 // Parse returns a service version based on the given user input.
 func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fastly.Version, error) {
-	vs, err := client.ListVersions(context.TODO(), &fastly.ListVersionsInput{
-		ServiceID: sid,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error listing service versions: %w", err)
-	}
-	if len(vs) == 0 {
-		return nil, errors.New("error listing service versions: no versions available")
+	// When no --version flag is provided (WasSet=false), treat it as "latest".
+	// This is the default behavior for commands that don't require an explicit version.
+	if sv.Value == "" && !sv.WasSet {
+		sv.Value = "latest"
 	}
 
-	// Sort versions into descending order.
-	sort.Slice(vs, func(i, j int) bool {
-		return fastly.ToValue(vs[i].Number) > fastly.ToValue(vs[j].Number)
-	})
-
-	var v *fastly.Version
+	// When a specific numeric version is provided, use it directly.
+	if n, err := strconv.Atoi(sv.Value); err == nil {
+		return client.GetVersion(context.TODO(), &fastly.GetVersionInput{
+			ServiceID:      sid,
+			ServiceVersion: n,
+		})
+	}
 
 	switch strings.ToLower(sv.Value) {
 	case "latest":
+		vs, err := client.ListVersions(context.TODO(), &fastly.ListVersionsInput{
+			ServiceID: sid,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error listing service versions: %w", err)
+		}
+		if len(vs) == 0 {
+			return nil, errors.New("no service versions available")
+		}
+		// Sort versions into descending order to ensure we get the latest
+		sort.Slice(vs, func(i, j int) bool {
+			return fastly.ToValue(vs[i].Number) > fastly.ToValue(vs[j].Number)
+		})
 		return vs[0], nil
 	case "active":
-		v, err = GetActiveVersion(vs)
-	case "": // no --version flag provided
-		v, err = GetActiveVersion(vs)
+		serviceDetails, err := client.GetServiceDetails(context.TODO(), &fastly.GetServiceDetailsInput{
+			ServiceID: sid,
+			Filters: []fastly.ServiceDetailsFilter{
+				{Key: "versions.active", Value: true},
+			},
+		})
 		if err != nil {
-			return vs[0], nil //lint:ignore nilerr if no active version, return latest version
+			return nil, fmt.Errorf("error getting service details: %w", err)
 		}
+		if serviceDetails.ActiveVersion == nil {
+			return nil, fmt.Errorf("no active service version found")
+		}
+		return serviceDetails.ActiveVersion, nil
 	default:
-		v, err = GetSpecifiedVersion(vs, sv.Value)
+		return nil, fmt.Errorf("invalid version value %q: must be a version number, \"latest\", or \"active\"", sv.Value)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	return v, nil
 }
 
 // OptionalServiceNameID represents a mapping between a Fastly service name and
@@ -249,7 +261,8 @@ func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, verbose bool, 
 			Remediation: fsterr.AutoCloneRemediation,
 		}
 	}
-	if ac.Value && (v.Active != nil && *v.Active || v.Locked != nil && *v.Locked) {
+	stateUnknown := v.Active == nil && v.Locked == nil
+	if ac.Value && (stateUnknown || v.Active != nil && *v.Active || v.Locked != nil && *v.Locked) {
 		version, err := client.CloneVersion(context.TODO(), &fastly.CloneVersionInput{
 			ServiceID:      sid,
 			ServiceVersion: fastly.ToValue(v.Number),
@@ -267,32 +280,6 @@ func (ac *OptionalAutoClone) Parse(v *fastly.Version, sid string, verbose bool, 
 
 	// Treat the function as a no-op if the version is editable.
 	return v, nil
-}
-
-// GetActiveVersion returns the active service version.
-func GetActiveVersion(vs []*fastly.Version) (*fastly.Version, error) {
-	for _, v := range vs {
-		if fastly.ToValue(v.Active) {
-			return v, nil
-		}
-	}
-	return nil, fmt.Errorf("no active service version found")
-}
-
-// GetSpecifiedVersion returns the specified service version.
-func GetSpecifiedVersion(vs []*fastly.Version, version string) (*fastly.Version, error) {
-	i, err := strconv.Atoi(version)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, v := range vs {
-		if fastly.ToValue(v.Number) == i {
-			return v, nil
-		}
-	}
-
-	return nil, fmt.Errorf("specified service version not found: %s", version)
 }
 
 // Content determines if the given flag value is a file path, and if so read

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -34,23 +32,21 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 			flagValue:   "active",
 			wantVersion: 1,
 		},
-		// NOTE: Default behaviour for an empty flag value (or no flag at all) is to
-		// get the active version, and if no active version return the latest.
-		"empty": {
+		"empty with WasSet": {
 			flagValue:   "",
-			wantVersion: 1,
+			errExpected: true,
 		},
 		"omitted": {
 			flagOmitted: true,
-			wantVersion: 1,
+			wantVersion: 4, // Returns latest version when flag not provided
 		},
-		"specific version OK": {
+		"specific version": {
 			flagValue:   "2",
 			wantVersion: 2,
 		},
-		"specific version ERR": {
-			flagValue:   "5",
-			errExpected: true, // there is no version 5
+		"specific version not found": {
+			flagValue:   "999",
+			errExpected: true,
 		},
 	}
 
@@ -60,12 +56,15 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 
 			if !c.flagOmitted {
 				sv.OptionalString = argparser.OptionalString{
-					Value: c.flagValue,
+					Optional: argparser.Optional{WasSet: true},
+					Value:    c.flagValue,
 				}
 			}
 
 			v, err := sv.Parse("123", mock.API{
-				ListVersionsFn: listVersions,
+				GetVersionFn:        testutil.GetVersion,
+				ListVersionsFn:      listVersions,
+				GetServiceDetailsFn: getServiceDetails,
 			})
 			if err != nil {
 				if c.errExpected {
@@ -90,15 +89,21 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 
 // listVersions returns a list of service versions in different states.
 //
-// The first element is active, the second is locked, the third is
-// editable, the fourth is staged.
+// Versions are returned in descending order by version number (highest first),
+// matching the real Fastly API behavior.
+// Version 4 (staged), Version 3 (editable), Version 2 (locked), Version 1 (active).
 func listVersions(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
-			Number:    fastly.ToPointer(1),
-			Active:    fastly.ToPointer(true),
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+			Number:    fastly.ToPointer(4),
+			Staging:   fastly.ToPointer(true),
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
+		},
+		{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(3),
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
 		},
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
@@ -108,125 +113,56 @@ func listVersions(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Ver
 		},
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
-			Number:    fastly.ToPointer(3),
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
-		},
-		{
-			ServiceID: fastly.ToPointer(i.ServiceID),
-			Number:    fastly.ToPointer(4),
-			Staging:   fastly.ToPointer(true),
-			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
+			Number:    fastly.ToPointer(1),
+			Active:    fastly.ToPointer(true),
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
 		},
 	}, nil
 }
 
-func TestGetLatestActiveVersion(t *testing.T) {
-	for _, testcase := range []struct {
-		name          string
-		inputVersions []*fastly.Version
-		wantVersion   int
-		wantError     string
-	}{
-		{
-			name: "active",
-			inputVersions: []*fastly.Version{
-				{Number: fastly.ToPointer(1), Active: fastly.ToPointer(false), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: fastly.ToPointer(2), Active: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 2,
-		},
-		{
-			name: "draft",
-			inputVersions: []*fastly.Version{
-				{Number: fastly.ToPointer(1), Active: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: fastly.ToPointer(2), Active: fastly.ToPointer(false), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 1,
-		},
-		{
-			name: "locked",
-			inputVersions: []*fastly.Version{
-				{Number: fastly.ToPointer(1), Active: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: fastly.ToPointer(2), Active: fastly.ToPointer(false), Locked: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 1,
-		},
-		{
-			name: "no active",
-			inputVersions: []*fastly.Version{
-				{Number: fastly.ToPointer(1), Active: fastly.ToPointer(false), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: fastly.ToPointer(2), Active: fastly.ToPointer(false), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-				{Number: fastly.ToPointer(3), Active: fastly.ToPointer(false), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-03T01:00:00Z")},
-			},
-			wantError: "no active service version found",
-		},
-	} {
-		t.Run(testcase.name, func(t *testing.T) {
-			// NOTE: this is a duplicate of the sorting algorithm in
-			// cmd/command.go to make the test as realistic as possible
-			sort.Slice(testcase.inputVersions, func(i, j int) bool {
-				return fastly.ToValue(testcase.inputVersions[i].Number) > fastly.ToValue(testcase.inputVersions[j].Number)
-			})
-
-			v, err := argparser.GetActiveVersion(testcase.inputVersions)
-			if err != nil {
-				if testcase.wantError != "" {
-					testutil.AssertString(t, testcase.wantError, err.Error())
-				} else {
-					t.Errorf("unexpected error returned: %v", err)
-				}
-			} else if fastly.ToValue(v.Number) != testcase.wantVersion {
-				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
-			}
-		})
+// getServiceDetails returns service details with active and latest version info.
+func getServiceDetails(_ context.Context, i *fastly.GetServiceDetailsInput) (*fastly.ServiceDetail, error) {
+	result := &fastly.ServiceDetail{
+		ServiceID: fastly.ToPointer(i.ServiceID),
 	}
-}
 
-func TestGetSpecifiedVersion(t *testing.T) {
-	for _, testcase := range []struct {
-		name          string
-		inputVersions []*fastly.Version
-		wantVersion   int
-		wantError     string
-	}{
-		{
-			name: "success",
-			inputVersions: []*fastly.Version{
-				{Number: fastly.ToPointer(1), Active: fastly.ToPointer(false), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: fastly.ToPointer(2), Active: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-02T01:00:00Z")},
-			},
-			wantVersion: 1,
-		},
-		{
-			name: "no version available",
-			inputVersions: []*fastly.Version{
-				{Number: fastly.ToPointer(1), Active: fastly.ToPointer(false), Locked: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z")},
-				{Number: fastly.ToPointer(2), Active: fastly.ToPointer(false), Locked: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-02-02T01:00:00Z")},
-				{Number: fastly.ToPointer(3), Active: fastly.ToPointer(true), UpdatedAt: testutil.MustParseTimeRFC3339("2000-03-03T01:00:00Z")},
-			},
-			wantVersion: 4,
-			wantError:   "specified service version not found: 4",
-		},
-	} {
-		t.Run(testcase.name, func(t *testing.T) {
-			// NOTE: this is a duplicate of the sorting algorithm in
-			// cmd/command.go to make the test as realistic as possible
-			sort.Slice(testcase.inputVersions, func(i, j int) bool {
-				return fastly.ToValue(testcase.inputVersions[i].Number) > fastly.ToValue(testcase.inputVersions[j].Number)
-			})
-
-			v, err := argparser.GetSpecifiedVersion(testcase.inputVersions, strconv.Itoa(testcase.wantVersion))
-			if err != nil {
-				if testcase.wantError != "" {
-					testutil.AssertString(t, testcase.wantError, err.Error())
-				} else {
-					t.Errorf("unexpected error returned: %v", err)
-				}
-			} else if fastly.ToValue(v.Number) != testcase.wantVersion {
-				t.Errorf("wanted version %d, got %d", testcase.wantVersion, v.Number)
-			}
-		})
+	// Check if specific version is requested
+	if i.Version != nil {
+		result.Version = &fastly.Version{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    i.Version,
+			UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		}
+		return result, nil
 	}
+
+	// Check filters
+	for _, filter := range i.Filters {
+		if filter.Key == "versions.active" && filter.Value {
+			result.ActiveVersion = &fastly.Version{
+				ServiceID: fastly.ToPointer(i.ServiceID),
+				Number:    fastly.ToPointer(1),
+				Active:    fastly.ToPointer(true),
+				UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+			}
+			return result, nil
+		}
+	}
+
+	// Default: return both active and latest
+	result.ActiveVersion = &fastly.Version{
+		ServiceID: fastly.ToPointer(i.ServiceID),
+		Number:    fastly.ToPointer(1),
+		Active:    fastly.ToPointer(true),
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+	}
+	result.Version = &fastly.Version{
+		ServiceID: fastly.ToPointer(i.ServiceID),
+		Number:    fastly.ToPointer(4),
+		Staging:   fastly.ToPointer(true),
+		UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
+	}
+	return result, nil
 }
 
 func TestOptionalAutoCloneParse(t *testing.T) {
@@ -240,6 +176,8 @@ func TestOptionalAutoCloneParse(t *testing.T) {
 		"version is editable": {
 			version: &fastly.Version{
 				Number: fastly.ToPointer(1),
+				Active: fastly.ToPointer(false),
+				Locked: fastly.ToPointer(false),
 			},
 			wantVersion:    1,
 			expectEditable: true,
@@ -336,6 +274,7 @@ func TestServiceID(t *testing.T) {
 		WantError     string
 		WantSource    manifest.Source
 		WantFlag      string
+		EnvVars       map[string]string
 	}{
 		"service-id flag": {
 			Data: manifest.Data{
@@ -351,6 +290,7 @@ func TestServiceID(t *testing.T) {
 			},
 			WantServiceID: "456",
 			WantSource:    manifest.SourceFile,
+			EnvVars:       map[string]string{"FASTLY_SERVICE_ID": ""},
 		},
 		"service-name flag with service-id flag": {
 			ServiceName: argparser.OptionalServiceNameID{argparser.OptionalString{Optional: argparser.Optional{WasSet: true}, Value: "bar"}},
@@ -400,11 +340,16 @@ func TestServiceID(t *testing.T) {
 		"no information provided": {
 			Data:      manifest.Data{},
 			WantError: "error reading service: no service ID found",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			// Set environment variables for this test case
+			for k, v := range c.EnvVars {
+				t.Setenv(k, v)
+			}
 			serviceID, source, flag, err := argparser.ServiceID(c.ServiceName, c.Data, c.API, nil)
 			testutil.AssertErrorContains(t, err, c.WantError)
 			if err == nil {

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -38,7 +38,7 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 		},
 		"omitted": {
 			flagOmitted: true,
-			wantVersion: 4, // Returns latest version when flag not provided
+			wantVersion: 1, // Returns active version when flag not provided (falls back to latest if no active)
 		},
 		"specific version": {
 			flagValue:   "2",

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -32,6 +32,10 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 			flagValue:   "active",
 			wantVersion: 1,
 		},
+		"staged": {
+			flagValue:   "staged",
+			wantVersion: 4,
+		},
 		"empty with WasSet": {
 			flagValue:   "",
 			errExpected: true,
@@ -142,6 +146,15 @@ func getServiceDetails(_ context.Context, i *fastly.GetServiceDetailsInput) (*fa
 				Number:    fastly.ToPointer(1),
 				Active:    fastly.ToPointer(true),
 				UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+			}
+			return result, nil
+		}
+		if filter.Key == "versions.staged" && filter.Value {
+			result.Version = &fastly.Version{
+				ServiceID: fastly.ToPointer(i.ServiceID),
+				Number:    fastly.ToPointer(4),
+				Staging:   fastly.ToPointer(true),
+				UpdatedAt: testutil.MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
 			}
 			return result, nil
 		}

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -72,10 +72,8 @@ func TestOptionalServiceVersionParse(t *testing.T) {
 				}
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if err == nil {
-				if c.errExpected {
-					t.Fatalf("expected error, have %v", v)
-				}
+			if c.errExpected {
+				t.Fatalf("expected error, have %v", v)
 			}
 
 			want := c.wantVersion
@@ -212,6 +210,14 @@ func TestOptionalAutoCloneParse(t *testing.T) {
 			flagOmitted: true,
 			errExpected: true,
 		},
+		"version state unknown with autoclone": {
+			version: &fastly.Version{
+				Number: fastly.ToPointer(1),
+				Active: nil,
+				Locked: nil,
+			},
+			wantVersion: 2,
+		},
 	}
 
 	for name, c := range cases {
@@ -242,10 +248,8 @@ func TestOptionalAutoCloneParse(t *testing.T) {
 				}
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if err == nil {
-				if c.errExpected {
-					t.Fatalf("expected error, have %v", v)
-				}
+			if c.errExpected {
+				t.Fatalf("expected error, have %v", v)
 			}
 
 			want := c.wantVersion

--- a/pkg/commands/apisecurity/tags/tags_test.go
+++ b/pkg/commands/apisecurity/tags/tags_test.go
@@ -38,6 +38,7 @@ func TestTagsCreate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      fmt.Sprintf("--name %s", tagName),
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -110,6 +111,7 @@ func TestTagsDelete(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      fmt.Sprintf("--tag-id %s", tagID),
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -172,6 +174,7 @@ func TestTagsGet(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      fmt.Sprintf("--tag-id %s", tagID),
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -261,6 +264,7 @@ func TestTagsList(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -357,6 +361,7 @@ func TestTagsUpdate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      fmt.Sprintf("--tag-id %s --name %s --description %s", tagID, updatedTagName, updatedTagDesc),
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -196,8 +196,23 @@ func getConfigStoreOk(_ context.Context, _ *fastly.GetConfigStoreInput) (*fastly
 	}, nil
 }
 
-func getServiceDetailsWasm(_ context.Context, _ *fastly.GetServiceDetailsInput) (*fastly.ServiceDetail, error) {
-	return &fastly.ServiceDetail{
+func getServiceDetailsWasm(_ context.Context, i *fastly.GetServiceDetailsInput) (*fastly.ServiceDetail, error) {
+	detail := &fastly.ServiceDetail{
 		Type: fastly.ToPointer("wasm"),
-	}, nil
+		Version: &fastly.Version{
+			Number: fastly.ToPointer(1),
+		},
+	}
+
+	// If filtering for active version, also set ActiveVersion field
+	for _, filter := range i.Filters {
+		if filter.Key == "versions.active" && filter.Value {
+			detail.ActiveVersion = &fastly.Version{
+				Number: fastly.ToPointer(1),
+				Active: fastly.ToPointer(true),
+			}
+		}
+	}
+
+	return detail, nil
 }

--- a/pkg/commands/compute/compute_mocks_test.go
+++ b/pkg/commands/compute/compute_mocks_test.go
@@ -216,3 +216,13 @@ func getServiceDetailsWasm(_ context.Context, i *fastly.GetServiceDetailsInput) 
 
 	return detail, nil
 }
+
+func getServiceDetailsWasmNoActive(_ context.Context, _ *fastly.GetServiceDetailsInput) (*fastly.ServiceDetail, error) {
+	// Returns service details with no active version, forcing fallback to latest
+	return &fastly.ServiceDetail{
+		Type: fastly.ToPointer("wasm"),
+		Version: &fastly.Version{
+			Number: fastly.ToPointer(1),
+		},
+	}, nil
+}

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -176,8 +176,9 @@ func TestDeploy(t *testing.T) {
 			name: "list versions error",
 			args: args("compute deploy --service-id 123 --token 123"),
 			api: mock.API{
-				GetServiceFn:   getServiceOK,
-				ListVersionsFn: testutil.ListVersionsError,
+				GetServiceFn:        getServiceOK,
+				GetServiceDetailsFn: getServiceDetailsWasmNoActive,
+				ListVersionsFn:      testutil.ListVersionsError,
 			},
 			wantError: fmt.Sprintf("error listing service versions: %s", testutil.Err.Error()),
 		},

--- a/pkg/commands/compute/deploy_test.go
+++ b/pkg/commands/compute/deploy_test.go
@@ -188,7 +188,8 @@ func TestDeploy(t *testing.T) {
 				CloneVersionFn:      testutil.CloneVersionError,
 				GetPackageFn:        getPackageOk,
 				GetServiceDetailsFn: getServiceDetailsWasm,
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
+				ListDomainsFn:       listDomainsOk,
 			},
 			wantError: fmt.Sprintf("error cloning service version: %s", testutil.Err.Error()),
 		},
@@ -199,7 +200,8 @@ func TestDeploy(t *testing.T) {
 				CloneVersionFn:      testutil.CloneVersionError,
 				GetPackageFn:        getPackageOk,
 				GetServiceDetailsFn: getServiceDetailsWasm,
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
+				ListDomainsFn:       listDomainsOk,
 			},
 			wantError: fmt.Sprintf("error cloning service version: %s", testutil.Err.Error()),
 		},
@@ -446,8 +448,8 @@ func TestDeploy(t *testing.T) {
 				GetPackageFn:        getPackageOk,
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
+				GetVersionFn:        testutil.GetVersion,
 				ListDomainsFn:       listDomainsOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -477,11 +479,11 @@ func TestDeploy(t *testing.T) {
 			args: args("compute deploy --service-id 123 --token 123 --package pkg/package.tar.gz --version 3 --verbose"),
 			api: mock.API{
 				ActivateVersionFn:   activateVersionOk,
+				GetVersionFn:        testutil.GetVersion,
 				GetPackageFn:        getPackageOk,
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
 				ListDomainsFn:       listDomainsOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -512,8 +514,8 @@ func TestDeploy(t *testing.T) {
 				GetPackageFn:        getPackageOk,
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
+				GetVersionFn:        testutil.GetVersion,
 				ListDomainsFn:       listDomainsOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -539,8 +541,8 @@ func TestDeploy(t *testing.T) {
 				GetPackageFn:        getPackageOk,
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
+				GetVersionFn:        testutil.GetVersion,
 				ListDomainsFn:       listDomainsOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -567,7 +569,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
 				ListDomainsFn:       listDomainsOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -593,8 +594,8 @@ func TestDeploy(t *testing.T) {
 				GetPackageFn:        getPackageOk,
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
+				GetVersionFn:        testutil.GetVersion,
 				ListDomainsFn:       listDomainsOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 				UpdateVersionFn:     updateVersionOk,
 			},
@@ -1055,7 +1056,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceDetailsFn: getServiceDetailsWasm,
 				GetServiceFn:        getServiceOK,
 				ListDomainsFn:       listDomainsOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1194,7 +1194,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceFn:            getServiceOK,
 				ListConfigStoresFn:      listConfigStoresEmpty,
 				ListDomainsFn:           listDomainsOk,
-				ListVersionsFn:          testutil.ListVersions,
 				UpdateConfigStoreItemFn: updateConfigStoreItemOK,
 				UpdatePackageFn:         updatePackageOk,
 			},
@@ -1254,7 +1253,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceFn:            getServiceOK,
 				ListConfigStoresFn:      listConfigStoresOk,
 				ListDomainsFn:           listDomainsOk,
-				ListVersionsFn:          testutil.ListVersions,
 				UpdateConfigStoreItemFn: updateConfigStoreItemOK,
 				UpdatePackageFn:         updatePackageOk,
 			},
@@ -1314,7 +1312,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceFn:            getServiceOK,
 				ListConfigStoresFn:      listConfigStoresEmpty,
 				ListDomainsFn:           listDomainsOk,
-				ListVersionsFn:          testutil.ListVersions,
 				UpdateConfigStoreItemFn: updateConfigStoreItemOK,
 				UpdatePackageFn:         updatePackageOk,
 			},
@@ -1367,7 +1364,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceFn:            getServiceOK,
 				ListConfigStoresFn:      listConfigStoresEmpty,
 				ListDomainsFn:           listDomainsOk,
-				ListVersionsFn:          testutil.ListVersions,
 				UpdateConfigStoreItemFn: updateConfigStoreItemOK,
 				UpdatePackageFn:         updatePackageOk,
 			},
@@ -1469,7 +1465,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceDetailsFn:    getServiceDetailsWasm,
 				GetServiceFn:           getServiceOK,
 				ListDomainsFn:          listDomainsOk,
-				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1516,7 +1511,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceDetailsFn:    getServiceDetailsWasm,
 				GetServiceFn:           getServiceOK,
 				ListDomainsFn:          listDomainsOk,
-				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1564,7 +1558,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceDetailsFn:    getServiceDetailsWasm,
 				GetServiceFn:           getServiceOK,
 				ListDomainsFn:          listDomainsOk,
-				ListVersionsFn:         testutil.ListVersions,
 				UpdatePackageFn:        updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1664,7 +1657,6 @@ func TestDeploy(t *testing.T) {
 				InsertKVStoreKeyFn:  createKVStoreItemOK,
 				ListDomainsFn:       listDomainsOk,
 				ListKVStoresFn:      listKVStoresOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1725,7 +1717,6 @@ func TestDeploy(t *testing.T) {
 				InsertKVStoreKeyFn:  createKVStoreItemOK,
 				ListDomainsFn:       listDomainsOk,
 				ListKVStoresFn:      listKVStoresEmpty,
-				ListVersionsFn:      testutil.ListVersions,
 			},
 			httpClientRes: []*http.Response{
 				mock.NewHTTPResponse(http.StatusNoContent, nil, nil),
@@ -1771,7 +1762,6 @@ func TestDeploy(t *testing.T) {
 				InsertKVStoreKeyFn:  createKVStoreItemOK,
 				ListDomainsFn:       listDomainsOk,
 				ListKVStoresFn:      listKVStoresEmpty,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1824,7 +1814,6 @@ func TestDeploy(t *testing.T) {
 				InsertKVStoreKeyFn:  createKVStoreItemOK,
 				ListDomainsFn:       listDomainsOk,
 				ListKVStoresFn:      listKVStoresEmpty,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1933,7 +1922,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceFn:        getServiceOK,
 				ListDomainsFn:       listDomainsOk,
 				ListSecretStoresFn:  listSecretStoresOk,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -1997,7 +1985,6 @@ func TestDeploy(t *testing.T) {
 				GetServiceFn:        getServiceOK,
 				ListDomainsFn:       listDomainsOk,
 				ListSecretStoresFn:  listSecretStoresEmpty,
-				ListVersionsFn:      testutil.ListVersions,
 				UpdatePackageFn:     updatePackageOk,
 			},
 			httpClientRes: []*http.Response{
@@ -2049,6 +2036,10 @@ func TestDeploy(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			// Clear FASTLY_SERVICE_ID for tests that create a new service
+			if testcase.api.CreateServiceFn != nil {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			// Because the manifest can be mutated on each test scenario, we recreate
 			// the file each time.
 			manifestContent := `manifest_version = 2
@@ -2238,6 +2229,7 @@ func TestDeploy_ActivateBeacon(t *testing.T) {
 		GetPackageFn:        getPackageOk,
 		GetServiceDetailsFn: getServiceDetailsWasm,
 		GetServiceFn:        getServiceOK,
+		GetVersionFn:        testutil.GetVersion,
 		ListDomainsFn:       listDomainsOk,
 		ListVersionsFn:      testutil.ListVersions,
 		UpdatePackageFn:     updatePackageOk,

--- a/pkg/commands/compute/update_test.go
+++ b/pkg/commands/compute/update_test.go
@@ -16,7 +16,7 @@ func TestUpdate(t *testing.T) {
 			Name: "package API error",
 			Args: "-s 123 --version 1 --package pkg/package.tar.gz --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdatePackageFn: updatePackageError,
 			},
@@ -39,7 +39,7 @@ func TestUpdate(t *testing.T) {
 			Name: "success",
 			Args: "-s 123 --version 2 --package pkg/package.tar.gz --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdatePackageFn: updatePackageOk,
 			},

--- a/pkg/commands/products/products_test.go
+++ b/pkg/commands/products/products_test.go
@@ -11,6 +11,7 @@ func TestProductEnablement(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Name:      "validate missing Service ID",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "failed to identify Service ID: error reading service: no service ID found",
 		},
 		{

--- a/pkg/commands/service/acl/acl_test.go
+++ b/pkg/commands/service/acl/acl_test.go
@@ -2,6 +2,7 @@ package acl_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -17,6 +18,7 @@ func TestACLCreate(t *testing.T) {
 		{
 			Name:      "validate missing --name flag",
 			Args:      "--version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -27,28 +29,13 @@ func TestACLCreate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foo --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foo --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foo --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate CreateACL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateACLFn: func(_ context.Context, _ *fastly.CreateACLInput) (*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
@@ -59,7 +46,7 @@ func TestACLCreate(t *testing.T) {
 		{
 			Name: "validate CreateACL API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateACLFn: func(_ context.Context, i *fastly.CreateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
 						ACLID:          fastly.ToPointer("456"),
@@ -75,7 +62,7 @@ func TestACLCreate(t *testing.T) {
 		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateACLFn: func(_ context.Context, i *fastly.CreateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
@@ -99,6 +86,7 @@ func TestACLDelete(t *testing.T) {
 		{
 			Name:      "validate missing --name flag",
 			Args:      "--version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error parsing arguments: required flag --name not provided",
 		},
 		{
@@ -109,28 +97,13 @@ func TestACLDelete(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foo --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate DeleteACL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteACLFn: func(_ context.Context, _ *fastly.DeleteACLInput) error {
 					return testutil.Err
 				},
@@ -141,7 +114,7 @@ func TestACLDelete(t *testing.T) {
 		{
 			Name: "validate DeleteACL API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteACLFn: func(_ context.Context, _ *fastly.DeleteACLInput) error {
 					return nil
 				},
@@ -150,15 +123,69 @@ func TestACLDelete(t *testing.T) {
 			WantOutput: "Deleted ACL 'foobar' (service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteACLFn: func(_ context.Context, i *fastly.DeleteACLInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteACLFn: func(_ context.Context, i *fastly.DeleteACLInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteACLFn: func(_ context.Context, _ *fastly.DeleteACLInput) error {
 					return nil
 				},
 			},
 			Args:       "--autoclone --name foo --service-id 123 --version 1",
+			WantOutput: "Deleted ACL 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteACLFn: func(_ context.Context, i *fastly.DeleteACLInput) error {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 2",
+			WantOutput: "Deleted ACL 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteACLFn: func(_ context.Context, i *fastly.DeleteACLInput) error {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 3",
 			WantOutput: "Deleted ACL 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -181,12 +208,13 @@ func TestACLDescribe(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate GetACL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				GetACLFn: func(_ context.Context, _ *fastly.GetACLInput) (*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
@@ -197,8 +225,8 @@ func TestACLDescribe(t *testing.T) {
 		{
 			Name: "validate GetACL API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetACLFn:       getACL,
+				GetVersionFn: testutil.GetVersion,
+				GetACLFn:     getACL,
 			},
 			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -206,8 +234,8 @@ func TestACLDescribe(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetACLFn:       getACL,
+				GetVersionFn: testutil.GetVersion,
+				GetACLFn:     getACL,
 			},
 			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -226,12 +254,13 @@ func TestACLList(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate ListACLs API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				ListACLsFn: func(_ context.Context, _ *fastly.ListACLsInput) ([]*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
@@ -242,8 +271,8 @@ func TestACLList(t *testing.T) {
 		{
 			Name: "validate ListACLs API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListACLsFn:     listACLs,
+				GetVersionFn: testutil.GetVersion,
+				ListACLsFn:   listACLs,
 			},
 			Args:       "--service-id 123 --version 3",
 			WantOutput: "SERVICE ID  VERSION  NAME  ID\n123         3        foo   456\n123         3        bar   789\n",
@@ -251,8 +280,8 @@ func TestACLList(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListACLsFn:     listACLs,
+				GetVersionFn: testutil.GetVersion,
+				ListACLsFn:   listACLs,
 			},
 			Args:       "--service-id 123 --version 1",
 			WantOutput: "SERVICE ID  VERSION  NAME  ID\n123         1        foo   456\n123         1        bar   789\n",
@@ -260,8 +289,8 @@ func TestACLList(t *testing.T) {
 		{
 			Name: "validate --verbose flag",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListACLsFn:     listACLs,
+				GetVersionFn: testutil.GetVersion,
+				ListACLsFn:   listACLs,
 			},
 			Args:       "--service-id 123 --verbose --version 1",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (auth: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nID: 456\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nID: 789\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\n",
@@ -291,28 +320,13 @@ func TestACLUpdate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --new-name beepboop --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foo --new-name beepboop --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foo --new-name beepboop --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate UpdateACL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateACLFn: func(_ context.Context, _ *fastly.UpdateACLInput) (*fastly.ACL, error) {
 					return nil, testutil.Err
 				},
@@ -323,7 +337,7 @@ func TestACLUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateACL API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
 						ACLID:          fastly.ToPointer("456"),
@@ -337,9 +351,31 @@ func TestACLUpdate(t *testing.T) {
 			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
 					return &fastly.ACL{
@@ -351,6 +387,48 @@ func TestACLUpdate(t *testing.T) {
 				},
 			},
 			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
+			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.ACL{
+						ACLID:          fastly.ToPointer("456"),
+						Name:           i.NewName,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 2",
+			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateACLFn: func(_ context.Context, i *fastly.UpdateACLInput) (*fastly.ACL, error) {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.ACL{
+						ACLID:          fastly.ToPointer("456"),
+						Name:           i.NewName,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 3",
 			WantOutput: "Updated ACL 'beepboop' (previously: 'foobar', service: 123, version: 4)",
 		},
 	}

--- a/pkg/commands/service/aclentry/aclentry_test.go
+++ b/pkg/commands/service/aclentry/aclentry_test.go
@@ -25,16 +25,19 @@ func TestACLEntryCreate(t *testing.T) {
 		{
 			Name:      "validate missing --ip flag",
 			Args:      "--acl-id 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--acl-id 123 --ip 127.0.0.1",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate CreateACLEntry API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				CreateACLEntryFn: func(_ context.Context, _ *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
 					return nil, testutil.Err
 				},
@@ -45,6 +48,7 @@ func TestACLEntryCreate(t *testing.T) {
 		{
 			Name: "validate CreateACLEntry API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				CreateACLEntryFn: func(_ context.Context, i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
 					return &fastly.ACLEntry{
 						ACLID:     fastly.ToPointer(i.ACLID),
@@ -60,6 +64,7 @@ func TestACLEntryCreate(t *testing.T) {
 		{
 			Name: "validate CreateACLEntry API success with negated IP",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				CreateACLEntryFn: func(_ context.Context, i *fastly.CreateACLEntryInput) (*fastly.ACLEntry, error) {
 					return &fastly.ACLEntry{
 						ACLID:     fastly.ToPointer(i.ACLID),
@@ -93,11 +98,13 @@ func TestACLEntryDelete(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--acl-id 123 --id 456",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate DeleteACL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				DeleteACLEntryFn: func(_ context.Context, _ *fastly.DeleteACLEntryInput) error {
 					return testutil.Err
 				},
@@ -108,6 +115,7 @@ func TestACLEntryDelete(t *testing.T) {
 		{
 			Name: "validate DeleteACL API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				DeleteACLEntryFn: func(_ context.Context, _ *fastly.DeleteACLEntryInput) error {
 					return nil
 				},
@@ -135,11 +143,13 @@ func TestACLEntryDescribe(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--acl-id 123 --id 456",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate GetACL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetACLEntryFn: func(_ context.Context, _ *fastly.GetACLEntryInput) (*fastly.ACLEntry, error) {
 					return nil, testutil.Err
 				},
@@ -150,6 +160,7 @@ func TestACLEntryDescribe(t *testing.T) {
 		{
 			Name: "validate GetACL API success",
 			API: &mock.API{
+				GetVersionFn:  testutil.GetVersion,
 				GetACLEntryFn: getACLEntry,
 			},
 			Args:       "--acl-id 123 --id 456 --service-id 123",
@@ -169,11 +180,13 @@ func TestACLEntryList(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--acl-id 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate ListACLEntries API error (via GetNext() call)",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetACLEntriesFn: func(ctx context.Context, _ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
 					return fastly.NewPaginator[fastly.ACLEntry](ctx, &mock.HTTPClient{
 						Errors: []error{
@@ -189,6 +202,7 @@ func TestACLEntryList(t *testing.T) {
 		{
 			Name: "validate ListACLEntries API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetACLEntriesFn: func(ctx context.Context, _ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
 					return fastly.NewPaginator[fastly.ACLEntry](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
@@ -231,6 +245,7 @@ func TestACLEntryList(t *testing.T) {
 		{
 			Name: "validate --verbose flag",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetACLEntriesFn: func(ctx context.Context, _ *fastly.GetACLEntriesInput) *fastly.ListPaginator[fastly.ACLEntry] {
 					return fastly.NewPaginator[fastly.ACLEntry](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
@@ -318,6 +333,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--acl-id 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -328,6 +344,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateACL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				UpdateACLEntryFn: func(_ context.Context, _ *fastly.UpdateACLEntryInput) (*fastly.ACLEntry, error) {
 					return nil, testutil.Err
 				},
@@ -338,6 +355,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate error from --file set with invalid json",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},
@@ -348,6 +366,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate error from --file set with zero json entries",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},
@@ -358,6 +377,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate success with --file",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},
@@ -372,6 +392,7 @@ func TestACLEntryUpdate(t *testing.T) {
 		{
 			Name: "validate success with --file as inline json",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				BatchModifyACLEntriesFn: func(_ context.Context, _ *fastly.BatchModifyACLEntriesInput) error {
 					return nil
 				},

--- a/pkg/commands/service/alert/alert_test.go
+++ b/pkg/commands/service/alert/alert_test.go
@@ -200,6 +200,7 @@ func TestAlertsDelete(t *testing.T) {
 			Name: "ok",
 			Args: "--id ABC",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				DeleteAlertDefinitionFn: func(_ context.Context, _ *fastly.DeleteAlertDefinitionInput) error {
 					return nil
 				},
@@ -220,6 +221,7 @@ func TestAlertsDescribe(t *testing.T) {
 			Name: "ok",
 			Args: "--id ABC",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetAlertDefinitionFn: func(_ context.Context, _ *fastly.GetAlertDefinitionInput) (*fastly.AlertDefinition, error) {
 					response := &mockDefinition
 					return response, nil
@@ -292,6 +294,7 @@ func TestAlertsList(t *testing.T) {
 		{
 			Name: "validate ListAlerts API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListAlertDefinitionsFn: func(_ context.Context, _ *fastly.ListAlertDefinitionsInput) (*fastly.AlertDefinitionsResponse, error) {
 					response := &fastly.AlertDefinitionsResponse{
 						Data: []fastly.AlertDefinition{mockDefinition},
@@ -372,6 +375,7 @@ func TestAlertsHistoryList(t *testing.T) {
 		{
 			Name: "validate ListAlerts API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListAlertHistoryFn: func(_ context.Context, _ *fastly.ListAlertHistoryInput) (*fastly.AlertHistoryResponse, error) {
 					response := &fastly.AlertHistoryResponse{
 						Data: []fastly.AlertHistory{mockHistory},

--- a/pkg/commands/service/backend/backend_test.go
+++ b/pkg/commands/service/backend/backend_test.go
@@ -3,6 +3,7 @@ package backend_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -21,36 +22,15 @@ func TestBackendCreate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--version 1",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
-		// The following test specifies a service version that's 'active', and
-		// subsequently we expect it to not be cloned as we don't provide the
-		// --autoclone flag and trying to add a backend to an activated service
-		// should cause an error.
-		{
-			Args: "--service-id 123 --version 1 --address example.com --name www.test.com",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			WantError: "service version 1 is active",
-		},
-		// The following test specifies a service version that's 'locked', and
-		// subsequently we expect it to not be cloned as we don't provide the
-		// --autoclone flag and trying to add a backend to a locked service
-		// should cause an error.
-		{
-			Args: "--service-id 123 --version 2 --address example.com --name www.test.com",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			WantError: "service version 2 is locked",
-		},
-		// The following test is the same as the 'active' test above but it appends --autoclone
+		// The following test appends --autoclone
 		// so we can be sure the backend creation error still occurs.
 		{
 			Args: "--service-id 123 --version 1 --address example.com --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateBackendFn: createBackendError,
 			},
@@ -61,7 +41,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --address example.com --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateBackendFn: createBackendError,
 			},
@@ -72,7 +52,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateBackendFn: createBackendError,
 			},
@@ -86,7 +66,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --port 8080",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateBackendFn: createBackendWithPort(8080),
 			},
@@ -96,7 +76,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --address 127.0.0.1 --override-host invalid-host-override --name www.test.com --autoclone --port 8080",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateBackendFn: createBackendWithPort(8080),
 			},
@@ -106,7 +86,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-name test-service --version 1 --address 127.0.0.1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
 					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
@@ -128,7 +108,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --use-ssl --verbose",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateBackendFn: createBackendWithPort(443),
 			},
@@ -140,7 +120,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --address 127.0.0.1 --name www.test.com --autoclone --port 8443 --use-ssl --verbose",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateBackendFn: createBackendWithPort(8443),
 			},
@@ -151,7 +131,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CreateBackendFn: createBackendOK,
 			},
 			WantOutput: "Created backend www.test.com (service 123 version 3)",
@@ -160,7 +140,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=true",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CreateBackendFn: createBackendOK,
 			},
 			WantOutput: "Created backend www.test.com (service 123 version 3)",
@@ -168,7 +148,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=false",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CreateBackendFn: createBackendOK,
 			},
 			WantOutput: "Created backend www.test.com (service 123 version 3)",
@@ -176,7 +156,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --tcp-ka-enabled=invalid",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CreateBackendFn: createBackendOK,
 			},
 			WantError: "'tcp-ka-enabled' flag must be one of the following [true, false]",
@@ -185,7 +165,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --prefer-ipv6=true",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CreateBackendFn: createBackendOK,
 			},
 			WantOutput: "Created backend www.test.com (service 123 version 3)",
@@ -193,7 +173,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --prefer-ipv6=false",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CreateBackendFn: createBackendOK,
 			},
 			WantOutput: "Created backend www.test.com (service 123 version 3)",
@@ -201,7 +181,7 @@ func TestBackendCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3 --address 127.0.0.1 --name www.test.com --prefer-ipv6=invalid",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CreateBackendFn: createBackendOK,
 			},
 			WantError: "'prefer-ipv6' flag must be one of the following [true, false]",
@@ -215,7 +195,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --json",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsOK,
 			},
 			WantOutput: listBackendsJSONOutput,
@@ -223,7 +203,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --json --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsOK,
 			},
 			WantError: fsterr.ErrInvalidVerboseJSONCombo.Error(),
@@ -231,7 +211,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsOK,
 			},
 			WantOutput: listBackendsShortOutput,
@@ -239,7 +219,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsOK,
 			},
 			WantOutput: listBackendsVerboseOutput,
@@ -247,7 +227,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsOK,
 			},
 			WantOutput: listBackendsVerboseOutput,
@@ -255,7 +235,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "--verbose --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsOK,
 			},
 			WantOutput: listBackendsVerboseOutput,
@@ -263,7 +243,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "-v --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsOK,
 			},
 			WantOutput: listBackendsVerboseOutput,
@@ -271,7 +251,7 @@ func TestBackendList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListBackendsFn: listBackendsError,
 			},
 			WantError: errTest.Error(),
@@ -289,16 +269,16 @@ func TestBackendDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetBackendFn:   getBackendError,
+				GetVersionFn: testutil.GetVersion,
+				GetBackendFn: getBackendError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetBackendFn:   getBackendOK,
+				GetVersionFn: testutil.GetVersion,
+				GetBackendFn: getBackendOK,
 			},
 			WantOutput: describeBackendOutput,
 		},
@@ -315,7 +295,7 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendError,
@@ -325,18 +305,42 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --comment  --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
 			},
 			WantOutput: "Updated backend www.example.com (service 123 version 4)",
 		},
+		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				GetBackendFn: getBackendOK,
+				UpdateBackendFn: func(_ context.Context, i *fastly.UpdateBackendInput) (*fastly.Backend, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name www.test.com --new-name www.example.com --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				GetBackendFn: getBackendOK,
+				UpdateBackendFn: func(_ context.Context, i *fastly.UpdateBackendInput) (*fastly.Backend, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name www.test.com --new-name www.example.com --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
 		// The following tests verify parsing of the --tcp-ka-enable flag.
 		{
-			Args: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=true --autoclone",
+			Args: "--service-id 123 --version 3 --name www.test.com --tcp-ka-enabled=true --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
@@ -346,7 +350,7 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=false --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
@@ -356,7 +360,7 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --tcp-ka-enabled=invalid --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
@@ -367,7 +371,7 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --prefer-ipv6=true --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
@@ -377,7 +381,7 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --prefer-ipv6=false --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
@@ -387,12 +391,67 @@ func TestBackendUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --prefer-ipv6=invalid --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetBackendFn:    getBackendOK,
 				UpdateBackendFn: updateBackendOK,
 			},
 			WantError: "'prefer-ipv6' flag must be one of the following [true, false]",
+		},
+		{
+			Name: "validate --autoclone results in cloned service version",
+			API: &mock.API{
+				GetVersionFn:    testutil.GetVersion,
+				CloneVersionFn:  testutil.CloneVersionResult(4),
+				GetBackendFn:    getBackendOK,
+				UpdateBackendFn: updateBackendOK,
+			},
+			Args:       "--autoclone --name www.test.com --new-name www.example.com --service-id 123 --version 1",
+			WantOutput: "Updated backend www.example.com (service 123 version 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				GetBackendFn:   getBackendOK,
+				UpdateBackendFn: func(_ context.Context, i *fastly.UpdateBackendInput) (*fastly.Backend, error) {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.Backend{
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+						Name:           i.NewName,
+						Comment:        i.Comment,
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name www.test.com --new-name www.example.com --service-id 123 --version 2",
+			WantOutput: "Updated backend www.example.com (service 123 version 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				GetBackendFn:   getBackendOK,
+				UpdateBackendFn: func(_ context.Context, i *fastly.UpdateBackendInput) (*fastly.Backend, error) {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.Backend{
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+						Name:           i.NewName,
+						Comment:        i.Comment,
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name www.test.com --new-name www.example.com --service-id 123 --version 3",
+			WantOutput: "Updated backend www.example.com (service 123 version 4)",
 		},
 	}
 	testutil.RunCLIScenarios(t, []string{root.CommandName, sub.CommandName, "update"}, scenarios)
@@ -407,7 +466,7 @@ func TestBackendDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteBackendFn: deleteBackendError,
 			},
@@ -416,10 +475,74 @@ func TestBackendDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteBackendFn: deleteBackendOK,
 			},
+			WantOutput: "Deleted backend www.test.com (service 123 version 4)",
+		},
+		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteBackendFn: func(_ context.Context, i *fastly.DeleteBackendInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name www.test.com --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteBackendFn: func(_ context.Context, i *fastly.DeleteBackendInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name www.test.com --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
+			Name: "validate --autoclone results in cloned service version",
+			API: &mock.API{
+				GetVersionFn:    testutil.GetVersion,
+				CloneVersionFn:  testutil.CloneVersionResult(4),
+				DeleteBackendFn: deleteBackendOK,
+			},
+			Args:       "--autoclone --name www.test.com --service-id 123 --version 1",
+			WantOutput: "Deleted backend www.test.com (service 123 version 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteBackendFn: func(_ context.Context, i *fastly.DeleteBackendInput) error {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name www.test.com --service-id 123 --version 2",
+			WantOutput: "Deleted backend www.test.com (service 123 version 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteBackendFn: func(_ context.Context, i *fastly.DeleteBackendInput) error {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name www.test.com --service-id 123 --version 3",
 			WantOutput: "Deleted backend www.test.com (service 123 version 4)",
 		},
 	}

--- a/pkg/commands/service/dictionary/dictionary_test.go
+++ b/pkg/commands/service/dictionary/dictionary_test.go
@@ -23,7 +23,7 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			Args: "--version 1 --service-id 123 --name dict-1",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetDictionaryFn: describeDictionaryOK,
 			},
 			WantOutput: describeDictionaryOutput,
@@ -31,7 +31,7 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			Args: "--version 1 --service-id 123 --name dict-1",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetDictionaryFn: describeDictionaryOKDeleted,
 			},
 			WantOutput: describeDictionaryOutputDeleted,
@@ -39,7 +39,7 @@ func TestDictionaryDescribe(t *testing.T) {
 		{
 			Args: "--version 1 --service-id 123 --name dict-1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				GetDictionaryFn:       describeDictionaryOK,
 				GetDictionaryInfoFn:   getDictionaryInfoOK,
 				ListDictionaryItemsFn: listDictionaryItemsOK,
@@ -54,12 +54,13 @@ func TestDictionaryCreate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--version 1",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Args: "--version 1 --service-id 123 --name denylist --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateDictionaryFn: createDictionaryOK,
 			},
@@ -68,7 +69,7 @@ func TestDictionaryCreate(t *testing.T) {
 		{
 			Args: "--version 1 --service-id 123 --name denylist --write-only --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateDictionaryFn: createDictionaryOK,
 			},
@@ -77,7 +78,7 @@ func TestDictionaryCreate(t *testing.T) {
 		{
 			Args: "--version 1 --service-id 123 --name denylist --write-only fish --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: unexpected 'fish'",
@@ -85,7 +86,7 @@ func TestDictionaryCreate(t *testing.T) {
 		{
 			Args: "--version 1 --service-id 123 --name denylist --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateDictionaryFn: createDictionaryDuplicate,
 			},
@@ -104,7 +105,7 @@ func TestDeleteDictionary(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name allowlist --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteDictionaryFn: deleteDictionaryOK,
 			},
@@ -113,7 +114,7 @@ func TestDeleteDictionary(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name allowlist --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteDictionaryFn: deleteDictionaryError,
 			},
@@ -128,9 +129,10 @@ func TestListDictionary(t *testing.T) {
 		{
 			Args: "--version 1",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListDictionariesFn: listDictionariesOk,
 			},
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -140,7 +142,7 @@ func TestListDictionary(t *testing.T) {
 		{
 			Args: "--version 1 --service-id 123",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListDictionariesFn: listDictionariesOk,
 			},
 			WantOutput: listDictionariesOutput,
@@ -153,6 +155,7 @@ func TestUpdateDictionary(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--version 1 --name oldname --new-name newname",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -166,7 +169,7 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name oldname --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: required flag --new-name or --write-only not provided",
@@ -174,7 +177,7 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
@@ -183,7 +186,7 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name oldname --new-name dict-1 --write-only true --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
@@ -192,7 +195,7 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name oldname --write-only true --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryWriteOnlyOK,
 			},
@@ -201,7 +204,7 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			Args: "-v --service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryNameOK,
 			},
@@ -210,7 +213,7 @@ func TestUpdateDictionary(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name oldname --new-name dict-1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateDictionaryFn: updateDictionaryError,
 			},

--- a/pkg/commands/service/dictionaryentry/dictionaryitem_test.go
+++ b/pkg/commands/service/dictionaryentry/dictionaryitem_test.go
@@ -50,10 +50,12 @@ func TestDictionaryItemsList(t *testing.T) {
 		},
 		{
 			Args:      "--dictionary-id 456",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetDictionaryItemsFn: func(ctx context.Context, _ *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
 					return fastly.NewPaginator[fastly.DictionaryItem](ctx, &mock.HTTPClient{
 						Errors: []error{
@@ -68,6 +70,7 @@ func TestDictionaryItemsList(t *testing.T) {
 		},
 		{
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetDictionaryItemsFn: func(ctx context.Context, _ *fastly.GetDictionaryItemsInput) *fastly.ListPaginator[fastly.DictionaryItem] {
 					return fastly.NewPaginator[fastly.DictionaryItem](ctx, &mock.HTTPClient{
 						Errors: []error{nil},

--- a/pkg/commands/service/domain/domain_test.go
+++ b/pkg/commands/service/domain/domain_test.go
@@ -19,12 +19,13 @@ func TestDomainCreate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--version 1",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateDomainFn: createDomainOK,
 			},
@@ -33,7 +34,7 @@ func TestDomainCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateDomainFn: createDomainError,
 			},
@@ -48,48 +49,48 @@ func TestDomainList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDomainsFn:  listDomainsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDomainsFn: listDomainsOK,
 			},
 			WantOutput: listDomainsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDomainsFn:  listDomainsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDomainsFn: listDomainsOK,
 			},
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDomainsFn:  listDomainsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDomainsFn: listDomainsOK,
 			},
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
 			Args: "--verbose --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDomainsFn:  listDomainsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDomainsFn: listDomainsOK,
 			},
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
 			Args: "-v --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDomainsFn:  listDomainsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDomainsFn: listDomainsOK,
 			},
 			WantOutput: listDomainsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDomainsFn:  listDomainsError,
+				GetVersionFn:  testutil.GetVersion,
+				ListDomainsFn: listDomainsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -106,16 +107,16 @@ func TestDomainDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetDomainFn:    getDomainError,
+				GetVersionFn: testutil.GetVersion,
+				GetDomainFn:  getDomainError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetDomainFn:    getDomainOK,
+				GetVersionFn: testutil.GetVersion,
+				GetDomainFn:  getDomainOK,
 			},
 			WantOutput: describeDomainOutput,
 		},
@@ -132,7 +133,7 @@ func TestDomainUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateDomainFn: updateDomainOK,
 			},
@@ -141,7 +142,7 @@ func TestDomainUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateDomainFn: updateDomainError,
 			},
@@ -150,7 +151,7 @@ func TestDomainUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateDomainFn: updateDomainOK,
 			},
@@ -169,7 +170,7 @@ func TestDomainDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteDomainFn: deleteDomainError,
 			},
@@ -178,7 +179,7 @@ func TestDomainDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteDomainFn: deleteDomainOK,
 			},
@@ -197,12 +198,13 @@ func TestDomainValidate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate missing --name flag",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --name flag",
@@ -210,7 +212,7 @@ func TestDomainValidate(t *testing.T) {
 		{
 			Name: "validate ValidateDomain API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				ValidateDomainFn: func(_ context.Context, _ *fastly.ValidateDomainInput) (*fastly.DomainValidationResult, error) {
 					return nil, testutil.Err
 				},
@@ -221,7 +223,7 @@ func TestDomainValidate(t *testing.T) {
 		{
 			Name: "validate ValidateAllDomains API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				ValidateAllDomainsFn: func(_ context.Context, _ *fastly.ValidateAllDomainsInput) ([]*fastly.DomainValidationResult, error) {
 					return nil, testutil.Err
 				},
@@ -232,7 +234,7 @@ func TestDomainValidate(t *testing.T) {
 		{
 			Name: "validate ValidateDomain API success",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ValidateDomainFn: validateDomain,
 			},
 			Args:       "--name foo.example.com --service-id 123 --version 3",
@@ -241,7 +243,7 @@ func TestDomainValidate(t *testing.T) {
 		{
 			Name: "validate ValidateAllDomains API success",
 			API: &mock.API{
-				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetVersion,
 				ValidateAllDomainsFn: validateAllDomains,
 			},
 			Args:       "--all --service-id 123 --version 3",
@@ -250,7 +252,7 @@ func TestDomainValidate(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ValidateDomainFn: validateDomain,
 			},
 			Args:       "--name foo.example.com --service-id 123 --version 1",

--- a/pkg/commands/service/healthcheck/healthcheck_test.go
+++ b/pkg/commands/service/healthcheck/healthcheck_test.go
@@ -19,12 +19,13 @@ func TestHealthCheckCreate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--version 1",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateHealthCheckFn: createHealthCheckError,
 			},
@@ -35,7 +36,7 @@ func TestHealthCheckCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone --timeout 10",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateHealthCheckFn: createHealthCheckOK,
 			},
@@ -50,7 +51,7 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			WantOutput: listHealthChecksShortOutput,
@@ -58,7 +59,7 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			WantOutput: listHealthChecksVerboseOutput,
@@ -66,7 +67,7 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			WantOutput: listHealthChecksVerboseOutput,
@@ -74,7 +75,7 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			Args: "--verbose --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			WantOutput: listHealthChecksVerboseOutput,
@@ -82,7 +83,7 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			Args: "-v --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListHealthChecksFn: listHealthChecksOK,
 			},
 			WantOutput: listHealthChecksVerboseOutput,
@@ -90,7 +91,7 @@ func TestHealthCheckList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListHealthChecksFn: listHealthChecksError,
 			},
 			WantError: errTest.Error(),
@@ -108,7 +109,7 @@ func TestHealthCheckDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				GetHealthCheckFn: getHealthCheckError,
 			},
 			WantError: errTest.Error(),
@@ -116,7 +117,7 @@ func TestHealthCheckDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				GetHealthCheckFn: getHealthCheckOK,
 			},
 			WantOutput: describeHealthCheckOutput,
@@ -134,7 +135,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateHealthCheckFn: updateHealthCheckOK,
 			},
@@ -142,7 +143,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateHealthCheckFn: updateHealthCheckError,
 			},
@@ -151,7 +152,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --new-name www.example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateHealthCheckFn: updateHealthCheckOK,
 			},
@@ -170,7 +171,7 @@ func TestHealthCheckDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteHealthCheckFn: deleteHealthCheckError,
 			},
@@ -179,7 +180,7 @@ func TestHealthCheckDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name www.test.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteHealthCheckFn: deleteHealthCheckOK,
 			},

--- a/pkg/commands/service/imageoptimizerdefaults/imageoptimizer_test.go
+++ b/pkg/commands/service/imageoptimizerdefaults/imageoptimizer_test.go
@@ -29,7 +29,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate missing optional flags",
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsValidationError,
 			},
 			// For future clarity, this order is coming from Go-Fastly. We should fix that at some point.
@@ -39,7 +39,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate successful boolean updates of webp, upscale and allow-video",
 			Args: "--service-id 123 --version 1 --webp=true --upscale=false --allow-video=true",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsWithBoolsOK,
 			},
 			WantOutput: "Updated Image Optimizer default settings for service 123 (version 1)\n\nAllow Video: true\nJPEG Quality: 85\nJPEG Type: auto\nResize Filter: lanczos3\nUpscale: false\nWebP: true\nWebP Quality: 85\n",
@@ -48,7 +48,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate successful update of the --resize, --webp-quality and --jpeg-quality flags",
 			Args: "--service-id 123 --version 1 --resize-filter bicubic --webp-quality 90 --jpeg-quality 80",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsWithOptionsOK,
 			},
 			WantOutput: "Updated Image Optimizer default settings for service 123 (version 1)\n\nAllow Video: false\nJPEG Quality: 80\nJPEG Type: auto\nResize Filter: bicubic\nUpscale: false\nWebP: false\nWebP Quality: 90\n",
@@ -57,7 +57,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate incorrect input for the --webp flag",
 			Args: "--service-id 123 --version 1 --webp invalid",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsOK,
 			},
 			WantError: "'webp' flag must be one of the following [true, false]",
@@ -66,7 +66,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate incorrect input for the --upscale flag",
 			Args: "--service-id 123 --version 1 --upscale invalid",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsOK,
 			},
 			WantError: "'upscale' flag must be one of the following [true, false]",
@@ -75,7 +75,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate incorrect input for the --allow-video flag",
 			Args: "--service-id 123 --version 1 --allow-video invalid",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsOK,
 			},
 			WantError: "'allow-video' flag must be one of the following [true, false]",
@@ -84,7 +84,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate incorrect input for the --resize-filter flag",
 			Args: "--service-id 123 --version 1 --resize-filter invalid",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsOK,
 			},
 			WantError: "invalid resize filter: invalid. Valid options: lanczos3, lanczos2, bicubic, bilinear, nearest",
@@ -93,7 +93,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate incorrect input for the --jpeg-type flag",
 			Args: "--service-id 123 --version 1 --jpeg-type invalid",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsOK,
 			},
 			WantError: "invalid jpeg type: invalid. Valid options: auto, baseline, progressive",
@@ -102,7 +102,7 @@ func TestImageOptimizerDefaultsUpdate(t *testing.T) {
 			Name: "validate API error handling",
 			Args: "--service-id 123 --version 1 --webp true",
 			API: &mock.API{
-				ListVersionsFn:                        testutil.ListVersions,
+				GetVersionFn:                          testutil.GetVersion,
 				UpdateImageOptimizerDefaultSettingsFn: updateImageOptimizerDefaultsError,
 			},
 			WantError: errTest.Error(),
@@ -197,7 +197,7 @@ func TestImageOptimizerDefaultsGet(t *testing.T) {
 			Name: "validate successful get with no flags",
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:                     testutil.ListVersions,
+				GetVersionFn:                       testutil.GetVersion,
 				GetImageOptimizerDefaultSettingsFn: getImageOptimizerDefaultsOK,
 			},
 			WantOutput: "Allow Video: false\nJPEG Quality: 85\nJPEG Type: auto\nResize Filter: lanczos3\nUpscale: false\nWebP: false\nWebP Quality: 85\n",
@@ -206,7 +206,7 @@ func TestImageOptimizerDefaultsGet(t *testing.T) {
 			Name: "validate successful get with --json flag",
 			Args: "--service-id 123 --version 1 --json",
 			API: &mock.API{
-				ListVersionsFn:                     testutil.ListVersions,
+				GetVersionFn:                       testutil.GetVersion,
 				GetImageOptimizerDefaultSettingsFn: getImageOptimizerDefaultsOK,
 			},
 			WantOutput: "{\n  \"resize_filter\": \"lanczos3\",\n  \"webp\": false,\n  \"webp_quality\": 85,\n  \"jpeg_type\": \"auto\",\n  \"jpeg_quality\": 85,\n  \"upscale\": false,\n  \"allow_video\": false\n}\n",
@@ -215,7 +215,7 @@ func TestImageOptimizerDefaultsGet(t *testing.T) {
 			Name: "validate API error handling",
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:                     testutil.ListVersions,
+				GetVersionFn:                       testutil.GetVersion,
 				GetImageOptimizerDefaultSettingsFn: getImageOptimizerDefaultsError,
 			},
 			WantError: errTest.Error(),

--- a/pkg/commands/service/logging/azureblob/azureblob_integration_test.go
+++ b/pkg/commands/service/logging/azureblob/azureblob_integration_test.go
@@ -21,7 +21,7 @@ func TestBlobStorageCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBlobStorageFn: createBlobStorageOK,
 			},
@@ -30,7 +30,7 @@ func TestBlobStorageCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBlobStorageFn: createBlobStorageError,
 			},
@@ -39,7 +39,7 @@ func TestBlobStorageCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --account-name account --container log --sas-token abc --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				CreateBlobStorageFn: createBlobStorageError,
 			},
@@ -54,7 +54,7 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			WantOutput: listBlobStoragesShortOutput,
@@ -62,7 +62,7 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			WantOutput: listBlobStoragesVerboseOutput,
@@ -70,7 +70,7 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListBlobStoragesFn: listBlobStoragesOK,
 			},
 			WantOutput: listBlobStoragesVerboseOutput,
@@ -78,7 +78,7 @@ func TestBlobStorageList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListBlobStoragesFn: listBlobStoragesError,
 			},
 			WantError: errTest.Error(),
@@ -96,7 +96,7 @@ func TestBlobStorageDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				GetBlobStorageFn: getBlobStorageError,
 			},
 			WantError: errTest.Error(),
@@ -104,7 +104,7 @@ func TestBlobStorageDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				GetBlobStorageFn: getBlobStorageOK,
 			},
 			WantOutput: describeBlobStorageOutput,
@@ -122,7 +122,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateBlobStorageFn: updateBlobStorageError,
 			},
@@ -131,7 +131,7 @@ func TestBlobStorageUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				UpdateBlobStorageFn: updateBlobStorageOK,
 			},
@@ -150,7 +150,7 @@ func TestBlobStorageDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteBlobStorageFn: deleteBlobStorageError,
 			},
@@ -159,7 +159,7 @@ func TestBlobStorageDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				CloneVersionFn:      testutil.CloneVersionResult(4),
 				DeleteBlobStorageFn: deleteBlobStorageOK,
 			},

--- a/pkg/commands/service/logging/azureblob/azureblob_test.go
+++ b/pkg/commands/service/logging/azureblob/azureblob_test.go
@@ -210,8 +210,7 @@ func createCommandRequired() *azureblob.CreateCommand {
 	// uses a testcase.api field to assign the mock API to the global client.
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &azureblob.CreateCommand{
@@ -251,8 +250,7 @@ func createCommandAll() *azureblob.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &azureblob.CreateCommand{

--- a/pkg/commands/service/logging/azureblob/azureblob_test.go
+++ b/pkg/commands/service/logging/azureblob/azureblob_test.go
@@ -210,7 +210,7 @@ func createCommandRequired() *azureblob.CreateCommand {
 	// uses a testcase.api field to assign the mock API to the global client.
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &azureblob.CreateCommand{
@@ -250,7 +250,7 @@ func createCommandAll() *azureblob.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &azureblob.CreateCommand{

--- a/pkg/commands/service/logging/azureblob/azureblob_test.go
+++ b/pkg/commands/service/logging/azureblob/azureblob_test.go
@@ -66,6 +66,9 @@ func TestCreateBlobStorageInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -109,7 +112,7 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				GetBlobStorageFn: getBlobStorageOK,
 			},
@@ -139,7 +142,7 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				GetBlobStorageFn: getBlobStorageOK,
 			},
@@ -159,6 +162,9 @@ func TestUpdateBlobStorageInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -203,6 +209,7 @@ func createCommandRequired() *azureblob.CreateCommand {
 	// TODO: make consistent (in all other logging files) with syslog_test which
 	// uses a testcase.api field to assign the mock API to the global client.
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -243,6 +250,7 @@ func createCommandAll() *azureblob.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -288,6 +296,7 @@ func createCommandAll() *azureblob.CreateCommand {
 func createCommandMissingServiceID() *azureblob.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -376,5 +385,6 @@ func updateCommandAll() *azureblob.UpdateCommand {
 func updateCommandMissingServiceID() *azureblob.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/azureblob/create.go
+++ b/pkg/commands/service/logging/azureblob/create.go
@@ -209,7 +209,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Azure Blob Storage logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/azureblob/update.go
+++ b/pkg/commands/service/logging/azureblob/update.go
@@ -207,7 +207,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Azure Blob Storage logging endpoint %s (service %s version %d)",
 		fastly.ToValue(azureblob.Name),
 		fastly.ToValue(azureblob.ServiceID),

--- a/pkg/commands/service/logging/bigquery/bigquery_integration_test.go
+++ b/pkg/commands/service/logging/bigquery/bigquery_integration_test.go
@@ -21,7 +21,7 @@ func TestBigQueryCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"` --autoclone",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				CreateBigQueryFn: createBigQueryOK,
 			},
@@ -30,7 +30,7 @@ func TestBigQueryCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --project-id project123 --dataset logs --table logs --user user@domain.com --secret-key `\"-----BEGIN RSA PRIVATE KEY-----MIIEogIBAAKCA\"` --autoclone",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				CreateBigQueryFn: createBigQueryError,
 			},
@@ -45,7 +45,7 @@ func TestBigQueryList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			WantOutput: listBigQueriesShortOutput,
@@ -53,7 +53,7 @@ func TestBigQueryList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			WantOutput: listBigQueriesVerboseOutput,
@@ -61,7 +61,7 @@ func TestBigQueryList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListBigQueriesFn: listBigQueriesOK,
 			},
 			WantOutput: listBigQueriesVerboseOutput,
@@ -69,7 +69,7 @@ func TestBigQueryList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListBigQueriesFn: listBigQueriesError,
 			},
 			WantError: errTest.Error(),
@@ -87,16 +87,16 @@ func TestBigQueryDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetBigQueryFn:  getBigQueryError,
+				GetVersionFn:  testutil.GetVersion,
+				GetBigQueryFn: getBigQueryError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetBigQueryFn:  getBigQueryOK,
+				GetVersionFn:  testutil.GetVersion,
+				GetBigQueryFn: getBigQueryOK,
 			},
 			WantOutput: describeBigQueryOutput,
 		},
@@ -113,7 +113,7 @@ func TestBigQueryUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				UpdateBigQueryFn: updateBigQueryError,
 			},
@@ -122,7 +122,7 @@ func TestBigQueryUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				UpdateBigQueryFn: updateBigQueryOK,
 			},
@@ -141,7 +141,7 @@ func TestBigQueryDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				DeleteBigQueryFn: deleteBigQueryError,
 			},
@@ -150,7 +150,7 @@ func TestBigQueryDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				CloneVersionFn:   testutil.CloneVersionResult(4),
 				DeleteBigQueryFn: deleteBigQueryOK,
 			},

--- a/pkg/commands/service/logging/bigquery/bigquery_test.go
+++ b/pkg/commands/service/logging/bigquery/bigquery_test.go
@@ -65,6 +65,9 @@ func TestCreateBigQueryInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -108,7 +111,7 @@ func TestUpdateBigQueryInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetBigQueryFn:  getBigQueryOK,
 			},
@@ -122,7 +125,7 @@ func TestUpdateBigQueryInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetBigQueryFn:  getBigQueryOK,
 			},
@@ -154,6 +157,9 @@ func TestUpdateBigQueryInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -196,6 +202,7 @@ func createCommandRequired() *bigquery.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -238,6 +245,7 @@ func createCommandAll() *bigquery.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -280,6 +288,7 @@ func createCommandAll() *bigquery.CreateCommand {
 func createCommandMissingServiceID() *bigquery.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -364,5 +373,6 @@ func updateCommandAll() *bigquery.UpdateCommand {
 func updateCommandMissingServiceID() *bigquery.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/bigquery/bigquery_test.go
+++ b/pkg/commands/service/logging/bigquery/bigquery_test.go
@@ -203,7 +203,7 @@ func createCommandRequired() *bigquery.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &bigquery.CreateCommand{
@@ -245,7 +245,7 @@ func createCommandAll() *bigquery.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &bigquery.CreateCommand{

--- a/pkg/commands/service/logging/bigquery/bigquery_test.go
+++ b/pkg/commands/service/logging/bigquery/bigquery_test.go
@@ -203,8 +203,7 @@ func createCommandRequired() *bigquery.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &bigquery.CreateCommand{
@@ -246,8 +245,7 @@ func createCommandAll() *bigquery.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &bigquery.CreateCommand{

--- a/pkg/commands/service/logging/bigquery/create.go
+++ b/pkg/commands/service/logging/bigquery/create.go
@@ -181,7 +181,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created BigQuery logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/bigquery/update.go
+++ b/pkg/commands/service/logging/bigquery/update.go
@@ -184,7 +184,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated BigQuery logging endpoint %s (service %s version %d)",
 		fastly.ToValue(bq.Name),
 		fastly.ToValue(bq.ServiceID),

--- a/pkg/commands/service/logging/cloudfiles/cloudfiles_integration_test.go
+++ b/pkg/commands/service/logging/cloudfiles/cloudfiles_integration_test.go
@@ -21,7 +21,7 @@ func TestCloudfilesCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --user username --bucket log --access-key foo --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateCloudfilesFn: createCloudfilesOK,
 			},
@@ -30,7 +30,7 @@ func TestCloudfilesCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --user username --bucket log --access-key foo --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateCloudfilesFn: createCloudfilesError,
 			},
@@ -39,7 +39,7 @@ func TestCloudfilesCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --user username --bucket log --access-key foo --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -53,7 +53,7 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			WantOutput: listCloudfilesShortOutput,
@@ -61,7 +61,7 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			WantOutput: listCloudfilesVerboseOutput,
@@ -69,7 +69,7 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListCloudfilesFn: listCloudfilesOK,
 			},
 			WantOutput: listCloudfilesVerboseOutput,
@@ -77,7 +77,7 @@ func TestCloudfilesList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListCloudfilesFn: listCloudfilesError,
 			},
 			WantError: errTest.Error(),
@@ -95,7 +95,7 @@ func TestCloudfilesDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetCloudfilesFn: getCloudfilesError,
 			},
 			WantError: errTest.Error(),
@@ -103,7 +103,7 @@ func TestCloudfilesDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetCloudfilesFn: getCloudfilesOK,
 			},
 			WantOutput: describeCloudfilesOutput,
@@ -121,7 +121,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateCloudfilesFn: updateCloudfilesError,
 			},
@@ -130,7 +130,7 @@ func TestCloudfilesUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateCloudfilesFn: updateCloudfilesOK,
 			},
@@ -149,7 +149,7 @@ func TestCloudfilesDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteCloudfilesFn: deleteCloudfilesError,
 			},
@@ -158,7 +158,7 @@ func TestCloudfilesDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteCloudfilesFn: deleteCloudfilesOK,
 			},

--- a/pkg/commands/service/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/commands/service/logging/cloudfiles/cloudfiles_test.go
@@ -67,6 +67,9 @@ func TestCreateCloudfilesInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -110,7 +113,7 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 			name: "no update",
 			cmd:  updateCommandNoUpdate(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetCloudfilesFn: getCloudfilesOK,
 			},
@@ -124,7 +127,7 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetCloudfilesFn: getCloudfilesOK,
 			},
@@ -161,6 +164,9 @@ func TestUpdateCloudfilesInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -203,6 +209,7 @@ func createCommandRequired() *cloudfiles.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -243,6 +250,7 @@ func createCommandAll() *cloudfiles.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -289,6 +297,7 @@ func createCommandAll() *cloudfiles.CreateCommand {
 func createCommandMissingServiceID() *cloudfiles.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -378,5 +387,6 @@ func updateCommandAll() *cloudfiles.UpdateCommand {
 func updateCommandMissingServiceID() *cloudfiles.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/commands/service/logging/cloudfiles/cloudfiles_test.go
@@ -210,8 +210,7 @@ func createCommandRequired() *cloudfiles.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &cloudfiles.CreateCommand{
@@ -251,8 +250,7 @@ func createCommandAll() *cloudfiles.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &cloudfiles.CreateCommand{

--- a/pkg/commands/service/logging/cloudfiles/cloudfiles_test.go
+++ b/pkg/commands/service/logging/cloudfiles/cloudfiles_test.go
@@ -210,7 +210,7 @@ func createCommandRequired() *cloudfiles.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &cloudfiles.CreateCommand{
@@ -250,7 +250,7 @@ func createCommandAll() *cloudfiles.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &cloudfiles.CreateCommand{

--- a/pkg/commands/service/logging/cloudfiles/create.go
+++ b/pkg/commands/service/logging/cloudfiles/create.go
@@ -209,7 +209,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Cloudfiles logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/cloudfiles/update.go
+++ b/pkg/commands/service/logging/cloudfiles/update.go
@@ -221,7 +221,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Cloudfiles logging endpoint %s (service %s version %d)",
 		fastly.ToValue(cloudfiles.Name),
 		fastly.ToValue(cloudfiles.ServiceID),

--- a/pkg/commands/service/logging/datadog/create.go
+++ b/pkg/commands/service/logging/datadog/create.go
@@ -155,7 +155,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Datadog logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/datadog/datadog_integration_test.go
+++ b/pkg/commands/service/logging/datadog/datadog_integration_test.go
@@ -20,7 +20,7 @@ func TestDatadogCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateDatadogFn: createDatadogOK,
 			},
@@ -29,7 +29,7 @@ func TestDatadogCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateDatadogFn: createDatadogError,
 			},
@@ -44,32 +44,32 @@ func TestDatadogList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDatadogFn:  listDatadogsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDatadogFn: listDatadogsOK,
 			},
 			WantOutput: listDatadogsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDatadogFn:  listDatadogsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDatadogFn: listDatadogsOK,
 			},
 			WantOutput: listDatadogsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDatadogFn:  listDatadogsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListDatadogFn: listDatadogsOK,
 			},
 			WantOutput: listDatadogsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListDatadogFn:  listDatadogsError,
+				GetVersionFn:  testutil.GetVersion,
+				ListDatadogFn: listDatadogsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -86,16 +86,16 @@ func TestDatadogDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetDatadogFn:   getDatadogError,
+				GetVersionFn: testutil.GetVersion,
+				GetDatadogFn: getDatadogError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetDatadogFn:   getDatadogOK,
+				GetVersionFn: testutil.GetVersion,
+				GetDatadogFn: getDatadogOK,
 			},
 			WantOutput: describeDatadogOutput,
 		},
@@ -112,7 +112,7 @@ func TestDatadogUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateDatadogFn: updateDatadogError,
 			},
@@ -121,7 +121,7 @@ func TestDatadogUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateDatadogFn: updateDatadogOK,
 			},
@@ -140,7 +140,7 @@ func TestDatadogDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteDatadogFn: deleteDatadogError,
 			},
@@ -149,7 +149,7 @@ func TestDatadogDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteDatadogFn: deleteDatadogOK,
 			},

--- a/pkg/commands/service/logging/datadog/datadog_test.go
+++ b/pkg/commands/service/logging/datadog/datadog_test.go
@@ -191,8 +191,7 @@ func createCommandOK() *datadog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &datadog.CreateCommand{
@@ -236,8 +235,7 @@ func createCommandRequired() *datadog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &datadog.CreateCommand{

--- a/pkg/commands/service/logging/datadog/datadog_test.go
+++ b/pkg/commands/service/logging/datadog/datadog_test.go
@@ -57,6 +57,9 @@ func TestCreateDatadogInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -100,7 +103,7 @@ func TestUpdateDatadogInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetDatadogFn:   getDatadogOK,
 			},
@@ -114,7 +117,7 @@ func TestUpdateDatadogInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetDatadogFn:   getDatadogOK,
 			},
@@ -142,6 +145,9 @@ func TestUpdateDatadogInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -184,6 +190,7 @@ func createCommandOK() *datadog.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -228,6 +235,7 @@ func createCommandRequired() *datadog.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -260,6 +268,7 @@ func createCommandRequired() *datadog.CreateCommand {
 func createCommandMissingServiceID() *datadog.CreateCommand {
 	res := createCommandOK()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -340,5 +349,6 @@ func updateCommandAll() *datadog.UpdateCommand {
 func updateCommandMissingServiceID() *datadog.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/datadog/datadog_test.go
+++ b/pkg/commands/service/logging/datadog/datadog_test.go
@@ -191,7 +191,7 @@ func createCommandOK() *datadog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &datadog.CreateCommand{
@@ -235,7 +235,7 @@ func createCommandRequired() *datadog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &datadog.CreateCommand{

--- a/pkg/commands/service/logging/datadog/update.go
+++ b/pkg/commands/service/logging/datadog/update.go
@@ -160,7 +160,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Datadog logging endpoint %s (service %s version %d)",
 		fastly.ToValue(datadog.Name),
 		fastly.ToValue(datadog.ServiceID),

--- a/pkg/commands/service/logging/digitalocean/create.go
+++ b/pkg/commands/service/logging/digitalocean/create.go
@@ -214,7 +214,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created DigitalOcean Spaces logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/digitalocean/digitalocean_integration_test.go
+++ b/pkg/commands/service/logging/digitalocean/digitalocean_integration_test.go
@@ -21,7 +21,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetVersion,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
 				CreateDigitalOceanFn: createDigitalOceanOK,
 			},
@@ -30,7 +30,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetVersion,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
 				CreateDigitalOceanFn: createDigitalOceanError,
 			},
@@ -39,7 +39,7 @@ func TestDigitalOceanCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key abc --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -53,7 +53,7 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			WantOutput: listDigitalOceansShortOutput,
@@ -61,7 +61,7 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			WantOutput: listDigitalOceansVerboseOutput,
@@ -69,7 +69,7 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListDigitalOceansFn: listDigitalOceansOK,
 			},
 			WantOutput: listDigitalOceansVerboseOutput,
@@ -77,7 +77,7 @@ func TestDigitalOceanList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListDigitalOceansFn: listDigitalOceansError,
 			},
 			WantError: errTest.Error(),
@@ -95,7 +95,7 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				GetDigitalOceanFn: getDigitalOceanError,
 			},
 			WantError: errTest.Error(),
@@ -103,7 +103,7 @@ func TestDigitalOceanDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
 			WantOutput: describeDigitalOceanOutput,
@@ -121,7 +121,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetVersion,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
 				UpdateDigitalOceanFn: updateDigitalOceanError,
 			},
@@ -130,7 +130,7 @@ func TestDigitalOceanUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetVersion,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
 				UpdateDigitalOceanFn: updateDigitalOceanOK,
 			},
@@ -149,7 +149,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetVersion,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
 				DeleteDigitalOceanFn: deleteDigitalOceanError,
 			},
@@ -158,7 +158,7 @@ func TestDigitalOceanDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:       testutil.ListVersions,
+				GetVersionFn:         testutil.GetVersion,
 				CloneVersionFn:       testutil.CloneVersionResult(4),
 				DeleteDigitalOceanFn: deleteDigitalOceanOK,
 			},

--- a/pkg/commands/service/logging/digitalocean/digitalocean_test.go
+++ b/pkg/commands/service/logging/digitalocean/digitalocean_test.go
@@ -208,8 +208,7 @@ func createCommandRequired() *digitalocean.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &digitalocean.CreateCommand{
@@ -249,8 +248,7 @@ func createCommandAll() *digitalocean.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &digitalocean.CreateCommand{

--- a/pkg/commands/service/logging/digitalocean/digitalocean_test.go
+++ b/pkg/commands/service/logging/digitalocean/digitalocean_test.go
@@ -66,6 +66,9 @@ func TestCreateDigitalOceanInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -109,7 +112,7 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
@@ -139,7 +142,7 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				GetDigitalOceanFn: getDigitalOceanOK,
 			},
@@ -159,6 +162,9 @@ func TestUpdateDigitalOceanInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -201,6 +207,7 @@ func createCommandRequired() *digitalocean.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -241,6 +248,7 @@ func createCommandAll() *digitalocean.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -286,6 +294,7 @@ func createCommandAll() *digitalocean.CreateCommand {
 func createCommandMissingServiceID() *digitalocean.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -374,5 +383,6 @@ func updateCommandAll() *digitalocean.UpdateCommand {
 func updateCommandMissingServiceID() *digitalocean.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/digitalocean/digitalocean_test.go
+++ b/pkg/commands/service/logging/digitalocean/digitalocean_test.go
@@ -208,7 +208,7 @@ func createCommandRequired() *digitalocean.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &digitalocean.CreateCommand{
@@ -248,7 +248,7 @@ func createCommandAll() *digitalocean.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &digitalocean.CreateCommand{

--- a/pkg/commands/service/logging/digitalocean/update.go
+++ b/pkg/commands/service/logging/digitalocean/update.go
@@ -215,7 +215,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated DigitalOcean Spaces logging endpoint %s (service %s version %d)",
 		fastly.ToValue(digitalocean.Name),
 		fastly.ToValue(digitalocean.ServiceID),

--- a/pkg/commands/service/logging/elasticsearch/create.go
+++ b/pkg/commands/service/logging/elasticsearch/create.go
@@ -206,7 +206,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Elasticsearch logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/commands/service/logging/elasticsearch/elasticsearch_integration_test.go
@@ -21,7 +21,7 @@ func TestElasticsearchCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --index logs --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				CreateElasticsearchFn: createElasticsearchOK,
 			},
@@ -30,7 +30,7 @@ func TestElasticsearchCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --index logs --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				CreateElasticsearchFn: createElasticsearchError,
 			},
@@ -45,7 +45,7 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			WantOutput: listElasticsearchsShortOutput,
@@ -53,7 +53,7 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			WantOutput: listElasticsearchsVerboseOutput,
@@ -61,7 +61,7 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListElasticsearchFn: listElasticsearchsOK,
 			},
 			WantOutput: listElasticsearchsVerboseOutput,
@@ -69,7 +69,7 @@ func TestElasticsearchList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				ListElasticsearchFn: listElasticsearchsError,
 			},
 			WantError: errTest.Error(),
@@ -87,7 +87,7 @@ func TestElasticsearchDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				GetElasticsearchFn: getElasticsearchError,
 			},
 			WantError: errTest.Error(),
@@ -95,7 +95,7 @@ func TestElasticsearchDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				GetElasticsearchFn: getElasticsearchOK,
 			},
 			WantOutput: describeElasticsearchOutput,
@@ -113,7 +113,7 @@ func TestElasticsearchUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				UpdateElasticsearchFn: updateElasticsearchError,
 			},
@@ -122,7 +122,7 @@ func TestElasticsearchUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				UpdateElasticsearchFn: updateElasticsearchOK,
 			},
@@ -141,7 +141,7 @@ func TestElasticsearchDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				DeleteElasticsearchFn: deleteElasticsearchError,
 			},
@@ -150,7 +150,7 @@ func TestElasticsearchDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				DeleteElasticsearchFn: deleteElasticsearchOK,
 			},

--- a/pkg/commands/service/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/commands/service/logging/elasticsearch/elasticsearch_test.go
@@ -67,6 +67,9 @@ func TestCreateElasticsearchInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -110,7 +113,7 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				GetElasticsearchFn: getElasticsearchOK,
 			},
@@ -141,7 +144,7 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				GetElasticsearchFn: getElasticsearchOK,
 			},
@@ -161,6 +164,9 @@ func TestUpdateElasticsearchInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -203,6 +209,7 @@ func createCommandRequired() *elasticsearch.CreateCommand {
 		Output: &b,
 	}
 	globals.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -242,6 +249,7 @@ func createCommandAll() *elasticsearch.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -289,6 +297,7 @@ func createCommandAll() *elasticsearch.CreateCommand {
 func createCommandMissingServiceID() *elasticsearch.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -378,5 +387,6 @@ func updateCommandAll() *elasticsearch.UpdateCommand {
 func updateCommandMissingServiceID() *elasticsearch.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/commands/service/logging/elasticsearch/elasticsearch_test.go
@@ -210,8 +210,7 @@ func createCommandRequired() *elasticsearch.CreateCommand {
 	}
 	globals.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &elasticsearch.CreateCommand{
@@ -250,8 +249,7 @@ func createCommandAll() *elasticsearch.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &elasticsearch.CreateCommand{

--- a/pkg/commands/service/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/commands/service/logging/elasticsearch/elasticsearch_test.go
@@ -210,7 +210,7 @@ func createCommandRequired() *elasticsearch.CreateCommand {
 	}
 	globals.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &elasticsearch.CreateCommand{
@@ -249,7 +249,7 @@ func createCommandAll() *elasticsearch.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &elasticsearch.CreateCommand{

--- a/pkg/commands/service/logging/elasticsearch/update.go
+++ b/pkg/commands/service/logging/elasticsearch/update.go
@@ -212,7 +212,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Elasticsearch logging endpoint %s (service %s version %d)",
 		fastly.ToValue(elasticsearch.Name),
 		fastly.ToValue(elasticsearch.ServiceID),

--- a/pkg/commands/service/logging/ftp/create.go
+++ b/pkg/commands/service/logging/ftp/create.go
@@ -202,7 +202,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created FTP logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/ftp/ftp_integration_test.go
+++ b/pkg/commands/service/logging/ftp/ftp_integration_test.go
@@ -21,7 +21,7 @@ func TestFTPCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --compression-codec zstd --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateFTPFn:    createFTPOK,
 			},
@@ -30,7 +30,7 @@ func TestFTPCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateFTPFn:    createFTPError,
 			},
@@ -39,7 +39,7 @@ func TestFTPCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com --user anonymous --password foo@example.com --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -53,32 +53,32 @@ func TestFTPList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListFTPsFn:     listFTPsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListFTPsFn:   listFTPsOK,
 			},
 			WantOutput: listFTPsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListFTPsFn:     listFTPsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListFTPsFn:   listFTPsOK,
 			},
 			WantOutput: listFTPsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListFTPsFn:     listFTPsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListFTPsFn:   listFTPsOK,
 			},
 			WantOutput: listFTPsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListFTPsFn:     listFTPsError,
+				GetVersionFn: testutil.GetVersion,
+				ListFTPsFn:   listFTPsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -95,16 +95,16 @@ func TestFTPDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetFTPFn:       getFTPError,
+				GetVersionFn: testutil.GetVersion,
+				GetFTPFn:     getFTPError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetFTPFn:       getFTPOK,
+				GetVersionFn: testutil.GetVersion,
+				GetFTPFn:     getFTPOK,
 			},
 			WantOutput: describeFTPOutput,
 		},
@@ -121,7 +121,7 @@ func TestFTPUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateFTPFn:    updateFTPError,
 			},
@@ -130,7 +130,7 @@ func TestFTPUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateFTPFn:    updateFTPOK,
 			},
@@ -149,7 +149,7 @@ func TestFTPDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteFTPFn:    deleteFTPError,
 			},
@@ -158,7 +158,7 @@ func TestFTPDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteFTPFn:    deleteFTPOK,
 			},

--- a/pkg/commands/service/logging/ftp/ftp_test.go
+++ b/pkg/commands/service/logging/ftp/ftp_test.go
@@ -207,8 +207,7 @@ func createCommandRequired() *ftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &ftp.CreateCommand{
@@ -248,8 +247,7 @@ func createCommandAll() *ftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &ftp.CreateCommand{

--- a/pkg/commands/service/logging/ftp/ftp_test.go
+++ b/pkg/commands/service/logging/ftp/ftp_test.go
@@ -207,7 +207,7 @@ func createCommandRequired() *ftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &ftp.CreateCommand{
@@ -247,7 +247,7 @@ func createCommandAll() *ftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &ftp.CreateCommand{

--- a/pkg/commands/service/logging/ftp/ftp_test.go
+++ b/pkg/commands/service/logging/ftp/ftp_test.go
@@ -65,6 +65,9 @@ func TestCreateFTPInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -108,7 +111,7 @@ func TestUpdateFTPInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetFTPFn:       getFTPOK,
 			},
@@ -122,7 +125,7 @@ func TestUpdateFTPInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetFTPFn:       getFTPOK,
 			},
@@ -158,6 +161,9 @@ func TestUpdateFTPInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -200,6 +206,7 @@ func createCommandRequired() *ftp.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -240,6 +247,7 @@ func createCommandAll() *ftp.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -284,6 +292,7 @@ func createCommandAll() *ftp.CreateCommand {
 func createCommandMissingServiceID() *ftp.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -372,5 +381,6 @@ func updateCommandAll() *ftp.UpdateCommand {
 func updateCommandMissingServiceID() *ftp.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/ftp/update.go
+++ b/pkg/commands/service/logging/ftp/update.go
@@ -209,7 +209,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated FTP logging endpoint %s (service %s version %d)",
 		fastly.ToValue(ftp.Name),
 		fastly.ToValue(ftp.ServiceID),

--- a/pkg/commands/service/logging/gcs/create.go
+++ b/pkg/commands/service/logging/gcs/create.go
@@ -202,7 +202,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created GCS logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/gcs/gcs_integration_test.go
+++ b/pkg/commands/service/logging/gcs/gcs_integration_test.go
@@ -21,7 +21,7 @@ func TestGCSCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateGCSFn:    createGCSOK,
 			},
@@ -30,7 +30,7 @@ func TestGCSCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --account-name service-account-id --project-id gcp-prj-id --period 86400 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateGCSFn:    createGCSOK,
 			},
@@ -39,7 +39,7 @@ func TestGCSCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateGCSFn:    createGCSError,
 			},
@@ -48,7 +48,7 @@ func TestGCSCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --user foo@example.com --secret-key foo --period 86400 --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -62,32 +62,32 @@ func TestGCSList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListGCSsFn:     listGCSsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListGCSsFn:   listGCSsOK,
 			},
 			WantOutput: listGCSsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListGCSsFn:     listGCSsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListGCSsFn:   listGCSsOK,
 			},
 			WantOutput: listGCSsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListGCSsFn:     listGCSsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListGCSsFn:   listGCSsOK,
 			},
 			WantOutput: listGCSsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListGCSsFn:     listGCSsError,
+				GetVersionFn: testutil.GetVersion,
+				ListGCSsFn:   listGCSsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -104,16 +104,16 @@ func TestGCSDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetGCSFn:       getGCSError,
+				GetVersionFn: testutil.GetVersion,
+				GetGCSFn:     getGCSError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetGCSFn:       getGCSOK,
+				GetVersionFn: testutil.GetVersion,
+				GetGCSFn:     getGCSOK,
 			},
 			WantOutput: describeGCSOutput,
 		},
@@ -130,7 +130,7 @@ func TestGCSUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateGCSFn:    updateGCSError,
 			},
@@ -139,7 +139,7 @@ func TestGCSUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateGCSFn:    updateGCSOK,
 			},
@@ -158,7 +158,7 @@ func TestGCSDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteGCSFn:    deleteGCSError,
 			},
@@ -167,7 +167,7 @@ func TestGCSDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteGCSFn:    deleteGCSOK,
 			},

--- a/pkg/commands/service/logging/gcs/gcs_test.go
+++ b/pkg/commands/service/logging/gcs/gcs_test.go
@@ -206,7 +206,7 @@ func createCommandRequired() *gcs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &gcs.CreateCommand{
@@ -246,7 +246,7 @@ func createCommandAll() *gcs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &gcs.CreateCommand{

--- a/pkg/commands/service/logging/gcs/gcs_test.go
+++ b/pkg/commands/service/logging/gcs/gcs_test.go
@@ -206,8 +206,7 @@ func createCommandRequired() *gcs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &gcs.CreateCommand{
@@ -247,8 +246,7 @@ func createCommandAll() *gcs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &gcs.CreateCommand{

--- a/pkg/commands/service/logging/gcs/gcs_test.go
+++ b/pkg/commands/service/logging/gcs/gcs_test.go
@@ -65,6 +65,9 @@ func TestCreateGCSInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -108,7 +111,7 @@ func TestUpdateGCSInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetGCSFn:       getGCSOK,
 			},
@@ -122,7 +125,7 @@ func TestUpdateGCSInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetGCSFn:       getGCSOK,
 			},
@@ -157,6 +160,9 @@ func TestUpdateGCSInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -199,6 +205,7 @@ func createCommandRequired() *gcs.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -239,6 +246,7 @@ func createCommandAll() *gcs.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -283,6 +291,7 @@ func createCommandAll() *gcs.CreateCommand {
 func createCommandMissingServiceID() *gcs.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -370,5 +379,6 @@ func updateCommandAll() *gcs.UpdateCommand {
 func updateCommandMissingServiceID() *gcs.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/gcs/update.go
+++ b/pkg/commands/service/logging/gcs/update.go
@@ -198,7 +198,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated GCS logging endpoint %s (service %s version %d)",
 		fastly.ToValue(gcs.Name),
 		fastly.ToValue(gcs.ServiceID),

--- a/pkg/commands/service/logging/googlepubsub/create.go
+++ b/pkg/commands/service/logging/googlepubsub/create.go
@@ -165,7 +165,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Google Cloud Pub/Sub logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/googlepubsub/googlepubsub_integration_test.go
+++ b/pkg/commands/service/logging/googlepubsub/googlepubsub_integration_test.go
@@ -21,7 +21,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --topic topic --account-name=me@fastly.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreatePubsubFn: createGooglePubSubOK,
 			},
@@ -30,7 +30,7 @@ func TestGooglePubSubCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --user user@example.com --secret-key secret --project-id project --topic topic --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreatePubsubFn: createGooglePubSubError,
 			},
@@ -45,32 +45,32 @@ func TestGooglePubSubList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListPubsubsFn:  listGooglePubSubsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListPubsubsFn: listGooglePubSubsOK,
 			},
 			WantOutput: listGooglePubSubsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListPubsubsFn:  listGooglePubSubsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListPubsubsFn: listGooglePubSubsOK,
 			},
 			WantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListPubsubsFn:  listGooglePubSubsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListPubsubsFn: listGooglePubSubsOK,
 			},
 			WantOutput: listGooglePubSubsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListPubsubsFn:  listGooglePubSubsError,
+				GetVersionFn:  testutil.GetVersion,
+				ListPubsubsFn: listGooglePubSubsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -87,16 +87,16 @@ func TestGooglePubSubDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetPubsubFn:    getGooglePubSubError,
+				GetVersionFn: testutil.GetVersion,
+				GetPubsubFn:  getGooglePubSubError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetPubsubFn:    getGooglePubSubOK,
+				GetVersionFn: testutil.GetVersion,
+				GetPubsubFn:  getGooglePubSubOK,
 			},
 			WantOutput: describeGooglePubSubOutput,
 		},
@@ -113,7 +113,7 @@ func TestGooglePubSubUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdatePubsubFn: updateGooglePubSubError,
 			},
@@ -122,7 +122,7 @@ func TestGooglePubSubUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdatePubsubFn: updateGooglePubSubOK,
 			},
@@ -141,7 +141,7 @@ func TestGooglePubSubDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeletePubsubFn: deleteGooglePubSubError,
 			},
@@ -150,7 +150,7 @@ func TestGooglePubSubDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeletePubsubFn: deleteGooglePubSubOK,
 			},

--- a/pkg/commands/service/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/commands/service/logging/googlepubsub/googlepubsub_test.go
@@ -198,7 +198,7 @@ func createCommandRequired() *googlepubsub.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &googlepubsub.CreateCommand{
@@ -239,7 +239,7 @@ func createCommandAll() *googlepubsub.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &googlepubsub.CreateCommand{

--- a/pkg/commands/service/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/commands/service/logging/googlepubsub/googlepubsub_test.go
@@ -62,6 +62,9 @@ func TestCreateGooglePubSubInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -105,7 +108,7 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetPubsubFn:    getGooglePubSubOK,
 			},
@@ -129,7 +132,7 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetPubsubFn:    getGooglePubSubOK,
 			},
@@ -149,6 +152,9 @@ func TestUpdateGooglePubSubInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -191,6 +197,7 @@ func createCommandRequired() *googlepubsub.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -232,6 +239,7 @@ func createCommandAll() *googlepubsub.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -272,6 +280,7 @@ func createCommandAll() *googlepubsub.CreateCommand {
 func createCommandMissingServiceID() *googlepubsub.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -354,5 +363,6 @@ func updateCommandAll() *googlepubsub.UpdateCommand {
 func updateCommandMissingServiceID() *googlepubsub.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/googlepubsub/googlepubsub_test.go
+++ b/pkg/commands/service/logging/googlepubsub/googlepubsub_test.go
@@ -198,8 +198,7 @@ func createCommandRequired() *googlepubsub.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &googlepubsub.CreateCommand{
@@ -240,8 +239,7 @@ func createCommandAll() *googlepubsub.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &googlepubsub.CreateCommand{

--- a/pkg/commands/service/logging/googlepubsub/update.go
+++ b/pkg/commands/service/logging/googlepubsub/update.go
@@ -168,7 +168,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Google Cloud Pub/Sub logging endpoint %s (service %s version %d)",
 		fastly.ToValue(googlepubsub.Name),
 		fastly.ToValue(googlepubsub.ServiceID),

--- a/pkg/commands/service/logging/grafanacloudlogs/create.go
+++ b/pkg/commands/service/logging/grafanacloudlogs/create.go
@@ -166,7 +166,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Grafana Cloud Logs logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/grafanacloudlogs/grafanacloud_logs_integration_test.go
+++ b/pkg/commands/service/logging/grafanacloudlogs/grafanacloud_logs_integration_test.go
@@ -20,7 +20,7 @@ func TestGrafanaCloudLogsCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --user 123456 --url https://test123.grafana.net --auth-token testtoken --index `{\"label\": \"value\" }` --autoclone",
 			API: &mock.API{
-				ListVersionsFn:           testutil.ListVersions,
+				GetVersionFn:             testutil.GetVersion,
 				CloneVersionFn:           testutil.CloneVersionResult(4),
 				CreateGrafanaCloudLogsFn: createGrafanaCloudLogsOK,
 			},
@@ -29,7 +29,7 @@ func TestGrafanaCloudLogsCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url https://test123.grafana.net --auth-token testtoken --index `{\"label\": \"value\" }` --autoclone",
 			API: &mock.API{
-				ListVersionsFn:           testutil.ListVersions,
+				GetVersionFn:             testutil.GetVersion,
 				CloneVersionFn:           testutil.CloneVersionResult(4),
 				CreateGrafanaCloudLogsFn: createGrafanaCloudLogsError,
 			},
@@ -44,7 +44,7 @@ func TestGrafanaCloudLogsList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:         testutil.ListVersions,
+				GetVersionFn:           testutil.GetVersion,
 				ListGrafanaCloudLogsFn: listGrafanaCloudLogsOK,
 			},
 			WantOutput: listGrafanaCloudLogsShortOutput,
@@ -52,7 +52,7 @@ func TestGrafanaCloudLogsList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:         testutil.ListVersions,
+				GetVersionFn:           testutil.GetVersion,
 				ListGrafanaCloudLogsFn: listGrafanaCloudLogsOK,
 			},
 			WantOutput: listGrafanaCloudLogsVerboseOutput,
@@ -60,7 +60,7 @@ func TestGrafanaCloudLogsList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:         testutil.ListVersions,
+				GetVersionFn:           testutil.GetVersion,
 				ListGrafanaCloudLogsFn: listGrafanaCloudLogsOK,
 			},
 			WantOutput: listGrafanaCloudLogsVerboseOutput,
@@ -68,7 +68,7 @@ func TestGrafanaCloudLogsList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:         testutil.ListVersions,
+				GetVersionFn:           testutil.GetVersion,
 				ListGrafanaCloudLogsFn: listGrafanaCloudLogsError,
 			},
 			WantError: errTest.Error(),
@@ -86,7 +86,7 @@ func TestGrafanaCloudLogsDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				GetGrafanaCloudLogsFn: getGrafanaCloudLogsError,
 			},
 			WantError: errTest.Error(),
@@ -94,7 +94,7 @@ func TestGrafanaCloudLogsDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				GetGrafanaCloudLogsFn: getGrafanaCloudLogsOK,
 			},
 			WantOutput: describeGrafanaCloudLogsOutput,
@@ -112,7 +112,7 @@ func TestGrafanaCloudLogsUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:           testutil.ListVersions,
+				GetVersionFn:             testutil.GetVersion,
 				CloneVersionFn:           testutil.CloneVersionResult(4),
 				UpdateGrafanaCloudLogsFn: updateGrafanaCloudLogsError,
 			},
@@ -121,7 +121,7 @@ func TestGrafanaCloudLogsUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:           testutil.ListVersions,
+				GetVersionFn:             testutil.GetVersion,
 				CloneVersionFn:           testutil.CloneVersionResult(4),
 				UpdateGrafanaCloudLogsFn: updateGrafanaCloudLogsOK,
 			},
@@ -140,7 +140,7 @@ func TestGrafanaCloudLogsDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:           testutil.ListVersions,
+				GetVersionFn:             testutil.GetVersion,
 				CloneVersionFn:           testutil.CloneVersionResult(4),
 				DeleteGrafanaCloudLogsFn: deleteGrafanaCloudLogsError,
 			},
@@ -149,7 +149,7 @@ func TestGrafanaCloudLogsDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:           testutil.ListVersions,
+				GetVersionFn:             testutil.GetVersion,
 				CloneVersionFn:           testutil.CloneVersionResult(4),
 				DeleteGrafanaCloudLogsFn: deleteGrafanaCloudLogsOK,
 			},

--- a/pkg/commands/service/logging/grafanacloudlogs/grafanacloudlogs_test.go
+++ b/pkg/commands/service/logging/grafanacloudlogs/grafanacloudlogs_test.go
@@ -61,6 +61,9 @@ func TestCreateGrafanaCloudLogsInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -104,7 +107,7 @@ func TestUpdateGrafanaCloudLogsInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				GetGrafanaCloudLogsFn: getGrafanaCloudLogsOK,
 			},
@@ -118,7 +121,7 @@ func TestUpdateGrafanaCloudLogsInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:        testutil.ListVersions,
+				GetVersionFn:          testutil.GetVersion,
 				CloneVersionFn:        testutil.CloneVersionResult(4),
 				GetGrafanaCloudLogsFn: getGrafanaCloudLogsOK,
 			},
@@ -146,6 +149,9 @@ func TestUpdateGrafanaCloudLogsInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -188,6 +194,7 @@ func createCommandRequired() *grafanacloudlogs.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -228,6 +235,7 @@ func createCommandAll() *grafanacloudlogs.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -269,6 +277,7 @@ func createCommandAll() *grafanacloudlogs.CreateCommand {
 func createCommandMissingServiceID() *grafanacloudlogs.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -349,5 +358,6 @@ func updateCommandAll() *grafanacloudlogs.UpdateCommand {
 func updateCommandMissingServiceID() *grafanacloudlogs.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/grafanacloudlogs/grafanacloudlogs_test.go
+++ b/pkg/commands/service/logging/grafanacloudlogs/grafanacloudlogs_test.go
@@ -195,8 +195,7 @@ func createCommandRequired() *grafanacloudlogs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &grafanacloudlogs.CreateCommand{
@@ -236,8 +235,7 @@ func createCommandAll() *grafanacloudlogs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &grafanacloudlogs.CreateCommand{

--- a/pkg/commands/service/logging/grafanacloudlogs/grafanacloudlogs_test.go
+++ b/pkg/commands/service/logging/grafanacloudlogs/grafanacloudlogs_test.go
@@ -195,7 +195,7 @@ func createCommandRequired() *grafanacloudlogs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &grafanacloudlogs.CreateCommand{
@@ -235,7 +235,7 @@ func createCommandAll() *grafanacloudlogs.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &grafanacloudlogs.CreateCommand{

--- a/pkg/commands/service/logging/grafanacloudlogs/update.go
+++ b/pkg/commands/service/logging/grafanacloudlogs/update.go
@@ -168,7 +168,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Grafana Cloud Logs logging endpoint %s (service %s version %d)",
 		fastly.ToValue(grafanacloudlogs.Name),
 		fastly.ToValue(grafanacloudlogs.ServiceID),

--- a/pkg/commands/service/logging/heroku/create.go
+++ b/pkg/commands/service/logging/heroku/create.go
@@ -154,7 +154,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Heroku logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/heroku/heroku_integration_test.go
+++ b/pkg/commands/service/logging/heroku/heroku_integration_test.go
@@ -21,7 +21,7 @@ func TestHerokuCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHerokuFn: createHerokuOK,
 			},
@@ -30,7 +30,7 @@ func TestHerokuCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHerokuFn: createHerokuError,
 			},
@@ -45,32 +45,32 @@ func TestHerokuList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHerokusFn:  listHerokusOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListHerokusFn: listHerokusOK,
 			},
 			WantOutput: listHerokusShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHerokusFn:  listHerokusOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListHerokusFn: listHerokusOK,
 			},
 			WantOutput: listHerokusVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHerokusFn:  listHerokusOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListHerokusFn: listHerokusOK,
 			},
 			WantOutput: listHerokusVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHerokusFn:  listHerokusError,
+				GetVersionFn:  testutil.GetVersion,
+				ListHerokusFn: listHerokusError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -87,16 +87,16 @@ func TestHerokuDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetHerokuFn:    getHerokuError,
+				GetVersionFn: testutil.GetVersion,
+				GetHerokuFn:  getHerokuError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetHerokuFn:    getHerokuOK,
+				GetVersionFn: testutil.GetVersion,
+				GetHerokuFn:  getHerokuOK,
 			},
 			WantOutput: describeHerokuOutput,
 		},
@@ -113,7 +113,7 @@ func TestHerokuUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHerokuFn: updateHerokuError,
 			},
@@ -122,7 +122,7 @@ func TestHerokuUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHerokuFn: updateHerokuOK,
 			},
@@ -141,7 +141,7 @@ func TestHerokuDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHerokuFn: deleteHerokuError,
 			},
@@ -150,7 +150,7 @@ func TestHerokuDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHerokuFn: deleteHerokuOK,
 			},

--- a/pkg/commands/service/logging/heroku/heroku_test.go
+++ b/pkg/commands/service/logging/heroku/heroku_test.go
@@ -58,6 +58,9 @@ func TestCreateHerokuInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -101,7 +104,7 @@ func TestUpdateHerokuInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHerokuFn:    getHerokuOK,
 			},
@@ -115,7 +118,7 @@ func TestUpdateHerokuInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHerokuFn:    getHerokuOK,
 			},
@@ -143,6 +146,9 @@ func TestUpdateHerokuInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -185,6 +191,7 @@ func createCommandRequired() *heroku.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -224,6 +231,7 @@ func createCommandAll() *heroku.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -262,6 +270,7 @@ func createCommandAll() *heroku.CreateCommand {
 func createCommandMissingServiceID() *heroku.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -342,5 +351,6 @@ func updateCommandAll() *heroku.UpdateCommand {
 func updateCommandMissingServiceID() *heroku.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/heroku/heroku_test.go
+++ b/pkg/commands/service/logging/heroku/heroku_test.go
@@ -192,7 +192,7 @@ func createCommandRequired() *heroku.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &heroku.CreateCommand{
@@ -231,7 +231,7 @@ func createCommandAll() *heroku.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &heroku.CreateCommand{

--- a/pkg/commands/service/logging/heroku/heroku_test.go
+++ b/pkg/commands/service/logging/heroku/heroku_test.go
@@ -192,8 +192,7 @@ func createCommandRequired() *heroku.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &heroku.CreateCommand{
@@ -232,8 +231,7 @@ func createCommandAll() *heroku.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &heroku.CreateCommand{

--- a/pkg/commands/service/logging/heroku/update.go
+++ b/pkg/commands/service/logging/heroku/update.go
@@ -160,7 +160,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Heroku logging endpoint %s (service %s version %d)",
 		fastly.ToValue(heroku.Name),
 		fastly.ToValue(heroku.ServiceID),

--- a/pkg/commands/service/logging/honeycomb/create.go
+++ b/pkg/commands/service/logging/honeycomb/create.go
@@ -154,7 +154,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Honeycomb logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/honeycomb/honeycomb_integration_test.go
+++ b/pkg/commands/service/logging/honeycomb/honeycomb_integration_test.go
@@ -20,7 +20,7 @@ func TestHoneycombCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --dataset log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateHoneycombFn: createHoneycombOK,
 			},
@@ -29,7 +29,7 @@ func TestHoneycombCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --dataset log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateHoneycombFn: createHoneycombError,
 			},
@@ -44,7 +44,7 @@ func TestHoneycombList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			WantOutput: listHoneycombsShortOutput,
@@ -52,7 +52,7 @@ func TestHoneycombList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			WantOutput: listHoneycombsVerboseOutput,
@@ -60,7 +60,7 @@ func TestHoneycombList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListHoneycombsFn: listHoneycombsOK,
 			},
 			WantOutput: listHoneycombsVerboseOutput,
@@ -68,7 +68,7 @@ func TestHoneycombList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListHoneycombsFn: listHoneycombsError,
 			},
 			WantError: errTest.Error(),
@@ -86,7 +86,7 @@ func TestHoneycombDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetHoneycombFn: getHoneycombError,
 			},
 			WantError: errTest.Error(),
@@ -94,7 +94,7 @@ func TestHoneycombDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetHoneycombFn: getHoneycombOK,
 			},
 			WantOutput: describeHoneycombOutput,
@@ -112,7 +112,7 @@ func TestHoneycombUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateHoneycombFn: updateHoneycombError,
 			},
@@ -121,7 +121,7 @@ func TestHoneycombUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateHoneycombFn: updateHoneycombOK,
 			},
@@ -140,7 +140,7 @@ func TestHoneycombDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteHoneycombFn: deleteHoneycombError,
 			},
@@ -149,7 +149,7 @@ func TestHoneycombDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteHoneycombFn: deleteHoneycombOK,
 			},

--- a/pkg/commands/service/logging/honeycomb/honeycomb_test.go
+++ b/pkg/commands/service/logging/honeycomb/honeycomb_test.go
@@ -192,7 +192,7 @@ func createCommandRequired() *honeycomb.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &honeycomb.CreateCommand{
@@ -231,7 +231,7 @@ func createCommandAll() *honeycomb.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &honeycomb.CreateCommand{

--- a/pkg/commands/service/logging/honeycomb/honeycomb_test.go
+++ b/pkg/commands/service/logging/honeycomb/honeycomb_test.go
@@ -58,6 +58,9 @@ func TestCreateHoneycombInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -101,7 +104,7 @@ func TestUpdateHoneycombInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHoneycombFn: getHoneycombOK,
 			},
@@ -115,7 +118,7 @@ func TestUpdateHoneycombInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHoneycombFn: getHoneycombOK,
 			},
@@ -143,6 +146,9 @@ func TestUpdateHoneycombInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -185,6 +191,7 @@ func createCommandRequired() *honeycomb.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -224,6 +231,7 @@ func createCommandAll() *honeycomb.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -262,6 +270,7 @@ func createCommandAll() *honeycomb.CreateCommand {
 func createCommandMissingServiceID() *honeycomb.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -342,5 +351,6 @@ func updateCommandAll() *honeycomb.UpdateCommand {
 func updateCommandMissingServiceID() *honeycomb.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/honeycomb/honeycomb_test.go
+++ b/pkg/commands/service/logging/honeycomb/honeycomb_test.go
@@ -192,8 +192,7 @@ func createCommandRequired() *honeycomb.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &honeycomb.CreateCommand{
@@ -232,8 +231,7 @@ func createCommandAll() *honeycomb.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &honeycomb.CreateCommand{

--- a/pkg/commands/service/logging/honeycomb/update.go
+++ b/pkg/commands/service/logging/honeycomb/update.go
@@ -160,7 +160,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Honeycomb logging endpoint %s (service %s version %d)",
 		fastly.ToValue(honeycomb.Name),
 		fastly.ToValue(honeycomb.ServiceID),

--- a/pkg/commands/service/logging/https/create.go
+++ b/pkg/commands/service/logging/https/create.go
@@ -244,7 +244,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created HTTPS logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/https/https_integration_test.go
+++ b/pkg/commands/service/logging/https/https_integration_test.go
@@ -22,7 +22,7 @@ func TestHTTPSCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHTTPSFn:  createHTTPSOK,
 			},
@@ -31,7 +31,7 @@ func TestHTTPSCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateHTTPSFn:  createHTTPSError,
 			},
@@ -40,7 +40,7 @@ func TestHTTPSCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -54,32 +54,32 @@ func TestHTTPSList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHTTPSFn:    listHTTPSsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListHTTPSFn:  listHTTPSsOK,
 			},
 			WantOutput: listHTTPSsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHTTPSFn:    listHTTPSsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListHTTPSFn:  listHTTPSsOK,
 			},
 			WantOutput: listHTTPSsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHTTPSFn:    listHTTPSsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListHTTPSFn:  listHTTPSsOK,
 			},
 			WantOutput: listHTTPSsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListHTTPSFn:    listHTTPSsError,
+				GetVersionFn: testutil.GetVersion,
+				ListHTTPSFn:  listHTTPSsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -96,16 +96,16 @@ func TestHTTPSDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetHTTPSFn:     getHTTPSError,
+				GetVersionFn: testutil.GetVersion,
+				GetHTTPSFn:   getHTTPSError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetHTTPSFn:     getHTTPSOK,
+				GetVersionFn: testutil.GetVersion,
+				GetHTTPSFn:   getHTTPSOK,
 			},
 			WantOutput: describeHTTPSOutput,
 		},
@@ -122,7 +122,7 @@ func TestHTTPSUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHTTPSFn:  updateHTTPSError,
 			},
@@ -131,7 +131,7 @@ func TestHTTPSUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateHTTPSFn:  updateHTTPSOK,
 			},
@@ -150,7 +150,7 @@ func TestHTTPSDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHTTPSFn:  deleteHTTPSError,
 			},
@@ -159,7 +159,7 @@ func TestHTTPSDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteHTTPSFn:  deleteHTTPSOK,
 			},

--- a/pkg/commands/service/logging/https/https_test.go
+++ b/pkg/commands/service/logging/https/https_test.go
@@ -217,8 +217,7 @@ func createCommandRequired() *https.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &https.CreateCommand{
@@ -256,8 +255,7 @@ func createCommandAll() *https.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &https.CreateCommand{

--- a/pkg/commands/service/logging/https/https_test.go
+++ b/pkg/commands/service/logging/https/https_test.go
@@ -71,6 +71,9 @@ func TestCreateHTTPSInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -114,7 +117,7 @@ func TestUpdateHTTPSInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHTTPSFn:     getHTTPSOK,
 			},
@@ -148,7 +151,7 @@ func TestUpdateHTTPSInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetHTTPSFn:     getHTTPSOK,
 			},
@@ -168,6 +171,9 @@ func TestUpdateHTTPSInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -210,6 +216,7 @@ func createCommandRequired() *https.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -248,6 +255,7 @@ func createCommandAll() *https.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -299,6 +307,7 @@ func createCommandAll() *https.CreateCommand {
 func createCommandMissingServiceID() *https.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -392,5 +401,6 @@ func updateCommandAll() *https.UpdateCommand {
 func updateCommandMissingServiceID() *https.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/https/https_test.go
+++ b/pkg/commands/service/logging/https/https_test.go
@@ -217,7 +217,7 @@ func createCommandRequired() *https.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &https.CreateCommand{
@@ -255,7 +255,7 @@ func createCommandAll() *https.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &https.CreateCommand{

--- a/pkg/commands/service/logging/https/update.go
+++ b/pkg/commands/service/logging/https/update.go
@@ -234,7 +234,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated HTTPS logging endpoint %s (service %s version %d)",
 		fastly.ToValue(https.Name),
 		fastly.ToValue(https.ServiceID),

--- a/pkg/commands/service/logging/kafka/create.go
+++ b/pkg/commands/service/logging/kafka/create.go
@@ -237,7 +237,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Kafka logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/kafka/kafka_integration_test.go
+++ b/pkg/commands/service/logging/kafka/kafka_integration_test.go
@@ -21,7 +21,7 @@ func TestKafkaCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --topic logs --brokers 127.0.0.1127.0.0.2 --parse-log-keyvals --max-batch-size 1024 --use-sasl --auth-method plain --username user --password password --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateKafkaFn:  createKafkaOK,
 			},
@@ -30,7 +30,7 @@ func TestKafkaCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --topic logs --brokers 127.0.0.1127.0.0.2 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateKafkaFn:  createKafkaError,
 			},
@@ -45,32 +45,32 @@ func TestKafkaList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKafkasFn:   listKafkasOK,
+				GetVersionFn: testutil.GetVersion,
+				ListKafkasFn: listKafkasOK,
 			},
 			WantOutput: listKafkasShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKafkasFn:   listKafkasOK,
+				GetVersionFn: testutil.GetVersion,
+				ListKafkasFn: listKafkasOK,
 			},
 			WantOutput: listKafkasVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKafkasFn:   listKafkasOK,
+				GetVersionFn: testutil.GetVersion,
+				ListKafkasFn: listKafkasOK,
 			},
 			WantOutput: listKafkasVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKafkasFn:   listKafkasError,
+				GetVersionFn: testutil.GetVersion,
+				ListKafkasFn: listKafkasError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -87,16 +87,16 @@ func TestKafkaDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetKafkaFn:     getKafkaError,
+				GetVersionFn: testutil.GetVersion,
+				GetKafkaFn:   getKafkaError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetKafkaFn:     getKafkaOK,
+				GetVersionFn: testutil.GetVersion,
+				GetKafkaFn:   getKafkaOK,
 			},
 			WantOutput: describeKafkaOutput,
 		},
@@ -113,7 +113,7 @@ func TestKafkaUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateKafkaFn:  updateKafkaError,
 			},
@@ -122,7 +122,7 @@ func TestKafkaUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateKafkaFn:  updateKafkaOK,
 			},
@@ -131,7 +131,7 @@ func TestKafkaUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --parse-log-keyvals --max-batch-size 1024 --use-sasl --auth-method plain --username user --password password --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateKafkaFn:  updateKafkaSASL,
 			},
@@ -150,7 +150,7 @@ func TestKafkaDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteKafkaFn:  deleteKafkaError,
 			},
@@ -159,7 +159,7 @@ func TestKafkaDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteKafkaFn:  deleteKafkaOK,
 			},

--- a/pkg/commands/service/logging/kafka/kafka_test.go
+++ b/pkg/commands/service/logging/kafka/kafka_test.go
@@ -269,8 +269,7 @@ func createCommandRequired() *kafka.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kafka.CreateCommand{
@@ -309,8 +308,7 @@ func createCommandAll() *kafka.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kafka.CreateCommand{
@@ -361,8 +359,7 @@ func createCommandSASL(authMethod, user, password string) *kafka.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kafka.CreateCommand{

--- a/pkg/commands/service/logging/kafka/kafka_test.go
+++ b/pkg/commands/service/logging/kafka/kafka_test.go
@@ -269,7 +269,7 @@ func createCommandRequired() *kafka.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kafka.CreateCommand{
@@ -308,7 +308,7 @@ func createCommandAll() *kafka.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kafka.CreateCommand{
@@ -359,7 +359,7 @@ func createCommandSASL(authMethod, user, password string) *kafka.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kafka.CreateCommand{

--- a/pkg/commands/service/logging/kafka/kafka_test.go
+++ b/pkg/commands/service/logging/kafka/kafka_test.go
@@ -81,6 +81,9 @@ func TestCreateKafkaInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -124,7 +127,7 @@ func TestUpdateKafkaInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
@@ -158,7 +161,7 @@ func TestUpdateKafkaInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
@@ -177,7 +180,7 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify SASL fields",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaOK,
 			},
@@ -198,7 +201,7 @@ func TestUpdateKafkaInput(t *testing.T) {
 		{
 			name: "verify disabling SASL",
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKafkaFn:     getKafkaSASL,
 			},
@@ -220,6 +223,9 @@ func TestUpdateKafkaInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -262,6 +268,7 @@ func createCommandRequired() *kafka.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -301,6 +308,7 @@ func createCommandAll() *kafka.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -352,6 +360,7 @@ func createCommandSASL(authMethod, user, password string) *kafka.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -391,6 +400,7 @@ func createCommandSASL(authMethod, user, password string) *kafka.CreateCommand {
 func createCommandMissingServiceID() *kafka.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -566,6 +576,7 @@ func updateCommandNoSASL() *kafka.UpdateCommand {
 func updateCommandMissingServiceID() *kafka.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 

--- a/pkg/commands/service/logging/kafka/update.go
+++ b/pkg/commands/service/logging/kafka/update.go
@@ -250,7 +250,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Kafka logging endpoint %s (service %s version %d)",
 		fastly.ToValue(kafka.Name),
 		fastly.ToValue(kafka.ServiceID),

--- a/pkg/commands/service/logging/kinesis/create.go
+++ b/pkg/commands/service/logging/kinesis/create.go
@@ -197,7 +197,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Kinesis logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/kinesis/kinesis_integration_test.go
+++ b/pkg/commands/service/logging/kinesis/kinesis_integration_test.go
@@ -21,7 +21,7 @@ func TestKinesisCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --stream-name log --region us-east-1 --secret-key bar --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
@@ -29,7 +29,7 @@ func TestKinesisCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
@@ -37,7 +37,7 @@ func TestKinesisCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --stream-name log --region us-east-1 --access-key foo --secret-key bar --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
@@ -45,7 +45,7 @@ func TestKinesisCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --stream-name log --access-key foo --secret-key bar --region us-east-1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisOK,
 			},
@@ -54,7 +54,7 @@ func TestKinesisCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --stream-name log --access-key foo --secret-key bar --region us-east-1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisError,
 			},
@@ -63,7 +63,7 @@ func TestKinesisCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log2 --stream-name log --region us-east-1 --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisOK,
 			},
@@ -72,7 +72,7 @@ func TestKinesisCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log2 --stream-name log --region us-east-1 --iam-role arn:aws:iam::123456789012:role/KinesisAccess --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				CreateKinesisFn: createKinesisError,
 			},
@@ -87,32 +87,32 @@ func TestKinesisList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKinesisFn:  listKinesesOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListKinesisFn: listKinesesOK,
 			},
 			WantOutput: listKinesesShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKinesisFn:  listKinesesOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListKinesisFn: listKinesesOK,
 			},
 			WantOutput: listKinesesVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKinesisFn:  listKinesesOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListKinesisFn: listKinesesOK,
 			},
 			WantOutput: listKinesesVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListKinesisFn:  listKinesesError,
+				GetVersionFn:  testutil.GetVersion,
+				ListKinesisFn: listKinesesError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -129,16 +129,16 @@ func TestKinesisDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetKinesisFn:   getKinesisError,
+				GetVersionFn: testutil.GetVersion,
+				GetKinesisFn: getKinesisError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetKinesisFn:   getKinesisOK,
+				GetVersionFn: testutil.GetVersion,
+				GetKinesisFn: getKinesisOK,
 			},
 			WantOutput: describeKinesisOutput,
 		},
@@ -155,7 +155,7 @@ func TestKinesisUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateKinesisFn: updateKinesisError,
 			},
@@ -164,7 +164,7 @@ func TestKinesisUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --region us-west-1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateKinesisFn: updateKinesisOK,
 			},
@@ -183,7 +183,7 @@ func TestKinesisDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteKinesisFn: deleteKinesisError,
 			},
@@ -192,7 +192,7 @@ func TestKinesisDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				DeleteKinesisFn: deleteKinesisOK,
 			},

--- a/pkg/commands/service/logging/kinesis/kinesis_test.go
+++ b/pkg/commands/service/logging/kinesis/kinesis_test.go
@@ -211,7 +211,7 @@ func createCommandRequired() *kinesis.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kinesis.CreateCommand{
@@ -252,7 +252,7 @@ func createCommandRequiredIAMRole() *kinesis.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kinesis.CreateCommand{
@@ -292,7 +292,7 @@ func createCommandAll() *kinesis.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kinesis.CreateCommand{

--- a/pkg/commands/service/logging/kinesis/kinesis_test.go
+++ b/pkg/commands/service/logging/kinesis/kinesis_test.go
@@ -211,8 +211,7 @@ func createCommandRequired() *kinesis.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kinesis.CreateCommand{
@@ -253,8 +252,7 @@ func createCommandRequiredIAMRole() *kinesis.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kinesis.CreateCommand{
@@ -294,8 +292,7 @@ func createCommandAll() *kinesis.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &kinesis.CreateCommand{

--- a/pkg/commands/service/logging/kinesis/kinesis_test.go
+++ b/pkg/commands/service/logging/kinesis/kinesis_test.go
@@ -74,6 +74,9 @@ func TestCreateKinesisInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -117,7 +120,7 @@ func TestUpdateKinesisInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKinesisFn:   getKinesisOK,
 			},
@@ -131,7 +134,7 @@ func TestUpdateKinesisInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetKinesisFn:   getKinesisOK,
 			},
@@ -162,6 +165,9 @@ func TestUpdateKinesisInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -204,6 +210,7 @@ func createCommandRequired() *kinesis.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -245,6 +252,7 @@ func createCommandRequiredIAMRole() *kinesis.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -285,6 +293,7 @@ func createCommandAll() *kinesis.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -325,6 +334,7 @@ func createCommandAll() *kinesis.CreateCommand {
 func createCommandMissingServiceID() *kinesis.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -408,5 +418,6 @@ func updateCommandAll() *kinesis.UpdateCommand {
 func updateCommandMissingServiceID() *kinesis.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/kinesis/update.go
+++ b/pkg/commands/service/logging/kinesis/update.go
@@ -178,7 +178,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Kinesis logging endpoint %s (service %s version %d)",
 		fastly.ToValue(kinesis.Name),
 		fastly.ToValue(kinesis.ServiceID),

--- a/pkg/commands/service/logging/loggly/create.go
+++ b/pkg/commands/service/logging/loggly/create.go
@@ -149,7 +149,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Loggly logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/loggly/loggly_integration_test.go
+++ b/pkg/commands/service/logging/loggly/loggly_integration_test.go
@@ -21,7 +21,7 @@ func TestLogglyCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateLogglyFn: createLogglyOK,
 			},
@@ -30,7 +30,7 @@ func TestLogglyCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateLogglyFn: createLogglyError,
 			},
@@ -45,32 +45,32 @@ func TestLogglyList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListLogglyFn:   listLogglysOK,
+				GetVersionFn: testutil.GetVersion,
+				ListLogglyFn: listLogglysOK,
 			},
 			WantOutput: listLogglysShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListLogglyFn:   listLogglysOK,
+				GetVersionFn: testutil.GetVersion,
+				ListLogglyFn: listLogglysOK,
 			},
 			WantOutput: listLogglysVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListLogglyFn:   listLogglysOK,
+				GetVersionFn: testutil.GetVersion,
+				ListLogglyFn: listLogglysOK,
 			},
 			WantOutput: listLogglysVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListLogglyFn:   listLogglysError,
+				GetVersionFn: testutil.GetVersion,
+				ListLogglyFn: listLogglysError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -87,16 +87,16 @@ func TestLogglyDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetLogglyFn:    getLogglyError,
+				GetVersionFn: testutil.GetVersion,
+				GetLogglyFn:  getLogglyError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetLogglyFn:    getLogglyOK,
+				GetVersionFn: testutil.GetVersion,
+				GetLogglyFn:  getLogglyOK,
 			},
 			WantOutput: describeLogglyOutput,
 		},
@@ -113,7 +113,7 @@ func TestLogglyUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateLogglyFn: updateLogglyError,
 			},
@@ -122,7 +122,7 @@ func TestLogglyUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateLogglyFn: updateLogglyOK,
 			},
@@ -141,7 +141,7 @@ func TestLogglyDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteLogglyFn: deleteLogglyError,
 			},
@@ -150,7 +150,7 @@ func TestLogglyDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteLogglyFn: deleteLogglyOK,
 			},

--- a/pkg/commands/service/logging/loggly/loggly_test.go
+++ b/pkg/commands/service/logging/loggly/loggly_test.go
@@ -56,6 +56,9 @@ func TestCreateLogglyInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -99,7 +102,7 @@ func TestUpdateLogglyInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetLogglyFn:    getLogglyOK,
 			},
@@ -113,7 +116,7 @@ func TestUpdateLogglyInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetLogglyFn:    getLogglyOK,
 			},
@@ -140,6 +143,9 @@ func TestUpdateLogglyInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -182,6 +188,7 @@ func createCommandOK() *loggly.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -225,6 +232,7 @@ func createCommandRequired() *loggly.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -257,6 +265,7 @@ func createCommandRequired() *loggly.CreateCommand {
 func createCommandMissingServiceID() *loggly.CreateCommand {
 	res := createCommandOK()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -336,5 +345,6 @@ func updateCommandAll() *loggly.UpdateCommand {
 func updateCommandMissingServiceID() *loggly.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/loggly/loggly_test.go
+++ b/pkg/commands/service/logging/loggly/loggly_test.go
@@ -189,7 +189,7 @@ func createCommandOK() *loggly.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &loggly.CreateCommand{
@@ -232,7 +232,7 @@ func createCommandRequired() *loggly.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &loggly.CreateCommand{

--- a/pkg/commands/service/logging/loggly/loggly_test.go
+++ b/pkg/commands/service/logging/loggly/loggly_test.go
@@ -189,8 +189,7 @@ func createCommandOK() *loggly.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &loggly.CreateCommand{
@@ -233,8 +232,7 @@ func createCommandRequired() *loggly.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &loggly.CreateCommand{

--- a/pkg/commands/service/logging/loggly/update.go
+++ b/pkg/commands/service/logging/loggly/update.go
@@ -154,7 +154,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Loggly logging endpoint %s (service %s version %d)",
 		fastly.ToValue(loggly.Name),
 		fastly.ToValue(loggly.ServiceID),

--- a/pkg/commands/service/logging/logshuttle/create.go
+++ b/pkg/commands/service/logging/logshuttle/create.go
@@ -154,7 +154,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Logshuttle logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/logshuttle/logshuttle_integration_test.go
+++ b/pkg/commands/service/logging/logshuttle/logshuttle_integration_test.go
@@ -21,7 +21,7 @@ func TestLogshuttleCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateLogshuttleFn: createLogshuttleOK,
 			},
@@ -30,7 +30,7 @@ func TestLogshuttleCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreateLogshuttleFn: createLogshuttleError,
 			},
@@ -45,7 +45,7 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			WantOutput: listLogshuttlesShortOutput,
@@ -53,7 +53,7 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			WantOutput: listLogshuttlesVerboseOutput,
@@ -61,7 +61,7 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListLogshuttlesFn: listLogshuttlesOK,
 			},
 			WantOutput: listLogshuttlesVerboseOutput,
@@ -69,7 +69,7 @@ func TestLogshuttleList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListLogshuttlesFn: listLogshuttlesError,
 			},
 			WantError: errTest.Error(),
@@ -87,7 +87,7 @@ func TestLogshuttleDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetLogshuttleFn: getLogshuttleError,
 			},
 			WantError: errTest.Error(),
@@ -95,7 +95,7 @@ func TestLogshuttleDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetLogshuttleFn: getLogshuttleOK,
 			},
 			WantOutput: describeLogshuttleOutput,
@@ -113,7 +113,7 @@ func TestLogshuttleUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateLogshuttleFn: updateLogshuttleError,
 			},
@@ -122,7 +122,7 @@ func TestLogshuttleUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdateLogshuttleFn: updateLogshuttleOK,
 			},
@@ -141,7 +141,7 @@ func TestLogshuttleDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteLogshuttleFn: deleteLogshuttleError,
 			},
@@ -150,7 +150,7 @@ func TestLogshuttleDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeleteLogshuttleFn: deleteLogshuttleOK,
 			},

--- a/pkg/commands/service/logging/logshuttle/logshuttle_test.go
+++ b/pkg/commands/service/logging/logshuttle/logshuttle_test.go
@@ -192,7 +192,7 @@ func createCommandRequired() *logshuttle.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &logshuttle.CreateCommand{
@@ -231,7 +231,7 @@ func createCommandAll() *logshuttle.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &logshuttle.CreateCommand{

--- a/pkg/commands/service/logging/logshuttle/logshuttle_test.go
+++ b/pkg/commands/service/logging/logshuttle/logshuttle_test.go
@@ -58,6 +58,9 @@ func TestCreateLogshuttleInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -101,7 +104,7 @@ func TestUpdateLogshuttleInput(t *testing.T) {
 			name: "no update",
 			cmd:  updateCommandNoUpdate(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetLogshuttleFn: getLogshuttleOK,
 			},
@@ -115,7 +118,7 @@ func TestUpdateLogshuttleInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetLogshuttleFn: getLogshuttleOK,
 			},
@@ -143,6 +146,9 @@ func TestUpdateLogshuttleInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -185,6 +191,7 @@ func createCommandRequired() *logshuttle.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -224,6 +231,7 @@ func createCommandAll() *logshuttle.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -262,6 +270,7 @@ func createCommandAll() *logshuttle.CreateCommand {
 func createCommandMissingServiceID() *logshuttle.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -342,5 +351,6 @@ func updateCommandAll() *logshuttle.UpdateCommand {
 func updateCommandMissingServiceID() *logshuttle.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/logshuttle/logshuttle_test.go
+++ b/pkg/commands/service/logging/logshuttle/logshuttle_test.go
@@ -192,8 +192,7 @@ func createCommandRequired() *logshuttle.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &logshuttle.CreateCommand{
@@ -232,8 +231,7 @@ func createCommandAll() *logshuttle.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &logshuttle.CreateCommand{

--- a/pkg/commands/service/logging/logshuttle/update.go
+++ b/pkg/commands/service/logging/logshuttle/update.go
@@ -161,7 +161,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Logshuttle logging endpoint %s (service %s version %d)",
 		fastly.ToValue(logshuttle.Name),
 		fastly.ToValue(logshuttle.ServiceID),

--- a/pkg/commands/service/logging/newrelic/create.go
+++ b/pkg/commands/service/logging/newrelic/create.go
@@ -113,7 +113,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created New Relic logging endpoint '%s' (service: %s, version: %d)",
 		fastly.ToValue(l.Name),
 		fastly.ToValue(l.ServiceID),

--- a/pkg/commands/service/logging/newrelic/newrelic_test.go
+++ b/pkg/commands/service/logging/newrelic/newrelic_test.go
@@ -2,6 +2,7 @@ package newrelic_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -18,28 +19,13 @@ func TestNewRelicCreate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--key abc --name foo --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--key abc --name foo --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--key abc --name foo --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate CreateNewRelic API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateNewRelicFn: func(_ context.Context, _ *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
@@ -50,7 +36,7 @@ func TestNewRelicCreate(t *testing.T) {
 		{
 			Name: "validate CreateNewRelic API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateNewRelicFn: func(_ context.Context, i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
 						Name:           i.Name,
@@ -65,7 +51,7 @@ func TestNewRelicCreate(t *testing.T) {
 		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateNewRelicFn: func(_ context.Context, i *fastly.CreateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
@@ -98,28 +84,13 @@ func TestNewRelicDelete(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate DeleteNewRelic API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteNewRelicFn: func(_ context.Context, _ *fastly.DeleteNewRelicInput) error {
 					return testutil.Err
 				},
@@ -130,7 +101,7 @@ func TestNewRelicDelete(t *testing.T) {
 		{
 			Name: "validate DeleteNewRelic API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteNewRelicFn: func(_ context.Context, _ *fastly.DeleteNewRelicInput) error {
 					return nil
 				},
@@ -139,15 +110,69 @@ func TestNewRelicDelete(t *testing.T) {
 			WantOutput: "Deleted New Relic logging endpoint 'foobar' (service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteNewRelicFn: func(_ context.Context, i *fastly.DeleteNewRelicInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteNewRelicFn: func(_ context.Context, i *fastly.DeleteNewRelicInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteNewRelicFn: func(_ context.Context, _ *fastly.DeleteNewRelicInput) error {
 					return nil
 				},
 			},
 			Args:       "--autoclone --name foo --service-id 123 --version 1",
+			WantOutput: "Deleted New Relic logging endpoint 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteNewRelicFn: func(_ context.Context, i *fastly.DeleteNewRelicInput) error {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 2",
+			WantOutput: "Deleted New Relic logging endpoint 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteNewRelicFn: func(_ context.Context, i *fastly.DeleteNewRelicInput) error {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 3",
 			WantOutput: "Deleted New Relic logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -175,7 +200,7 @@ func TestNewRelicDescribe(t *testing.T) {
 		{
 			Name: "validate GetNewRelic API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				GetNewRelicFn: func(_ context.Context, _ *fastly.GetNewRelicInput) (*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
@@ -186,8 +211,8 @@ func TestNewRelicDescribe(t *testing.T) {
 		{
 			Name: "validate GetNewRelic API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetNewRelicFn:  getNewRelic,
+				GetVersionFn:  testutil.GetVersion,
+				GetNewRelicFn: getNewRelic,
 			},
 			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nFormat: \nFormat Version: 0\nName: foobar\nPlacement: \nProcessing region: \nRegion: \nResponse Condition: \nService ID: 123\nService Version: 3\nToken: abc\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -195,8 +220,8 @@ func TestNewRelicDescribe(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetNewRelicFn:  getNewRelic,
+				GetVersionFn:  testutil.GetVersion,
+				GetNewRelicFn: getNewRelic,
 			},
 			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\nFormat: \nFormat Version: 0\nName: foobar\nPlacement: \nProcessing region: \nRegion: \nResponse Condition: \nService ID: 123\nService Version: 1\nToken: abc\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -220,7 +245,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate ListNewRelics API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				ListNewRelicFn: func(_ context.Context, _ *fastly.ListNewRelicInput) ([]*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
@@ -231,7 +256,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate ListNewRelics API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListNewRelicFn: listNewRelic,
 			},
 			Args:       "--service-id 123 --version 3",
@@ -240,7 +265,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListNewRelicFn: listNewRelic,
 			},
 			Args:       "--service-id 123 --version 1",
@@ -249,7 +274,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate missing --verbose flag",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListNewRelicFn: listNewRelic,
 			},
 			Args:       "--service-id 123 --verbose --version 1",
@@ -275,28 +300,13 @@ func TestNewRelicUpdate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate UpdateNewRelic API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateNewRelicFn: func(_ context.Context, _ *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
 					return nil, testutil.Err
 				},
@@ -307,7 +317,7 @@ func TestNewRelicUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateNewRelic API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
 						Name:           i.NewName,
@@ -320,9 +330,31 @@ func TestNewRelicUpdate(t *testing.T) {
 			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
 					return &fastly.NewRelic{
@@ -333,6 +365,46 @@ func TestNewRelicUpdate(t *testing.T) {
 				},
 			},
 			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
+			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.NewRelic{
+						Name:           i.NewName,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 2",
+			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateNewRelicFn: func(_ context.Context, i *fastly.UpdateNewRelicInput) (*fastly.NewRelic, error) {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.NewRelic{
+						Name:           i.NewName,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 3",
 			WantOutput: "Updated New Relic logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
 		},
 	}

--- a/pkg/commands/service/logging/newrelic/update.go
+++ b/pkg/commands/service/logging/newrelic/update.go
@@ -119,7 +119,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		prev = fmt.Sprintf("previously: %s, ", c.endpointName)
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated New Relic logging endpoint '%s' (%sservice: %s, version: %d)",
 		fastly.ToValue(l.Name),
 		prev,

--- a/pkg/commands/service/logging/newrelicotlp/create.go
+++ b/pkg/commands/service/logging/newrelicotlp/create.go
@@ -115,7 +115,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created New Relic OTLP logging endpoint '%s' (service: %s, version: %d)",
 		fastly.ToValue(l.Name),
 		fastly.ToValue(l.ServiceID),

--- a/pkg/commands/service/logging/newrelicotlp/newrelicotlp_test.go
+++ b/pkg/commands/service/logging/newrelicotlp/newrelicotlp_test.go
@@ -2,6 +2,7 @@ package newrelicotlp_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -18,28 +19,13 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--key abc --name foo --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--key abc --name foo --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--key abc --name foo --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate CreateNewRelicOTLP API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateNewRelicOTLPFn: func(_ context.Context, _ *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
@@ -50,7 +36,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 		{
 			Name: "validate CreateNewRelicOTLP API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateNewRelicOTLPFn: func(_ context.Context, i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
 						Name:           i.Name,
@@ -65,7 +51,7 @@ func TestNewRelicOTLPCreate(t *testing.T) {
 		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateNewRelicOTLPFn: func(_ context.Context, i *fastly.CreateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
@@ -98,28 +84,13 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate DeleteNewRelic API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteNewRelicOTLPFn: func(_ context.Context, _ *fastly.DeleteNewRelicOTLPInput) error {
 					return testutil.Err
 				},
@@ -130,7 +101,7 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 		{
 			Name: "validate DeleteNewRelic API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteNewRelicOTLPFn: func(_ context.Context, _ *fastly.DeleteNewRelicOTLPInput) error {
 					return nil
 				},
@@ -139,15 +110,69 @@ func TestNewRelicOTLPDelete(t *testing.T) {
 			WantOutput: "Deleted New Relic OTLP logging endpoint 'foobar' (service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteNewRelicOTLPFn: func(_ context.Context, i *fastly.DeleteNewRelicOTLPInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteNewRelicOTLPFn: func(_ context.Context, i *fastly.DeleteNewRelicOTLPInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteNewRelicOTLPFn: func(_ context.Context, _ *fastly.DeleteNewRelicOTLPInput) error {
 					return nil
 				},
 			},
 			Args:       "--autoclone --name foo --service-id 123 --version 1",
+			WantOutput: "Deleted New Relic OTLP logging endpoint 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteNewRelicOTLPFn: func(_ context.Context, i *fastly.DeleteNewRelicOTLPInput) error {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 2",
+			WantOutput: "Deleted New Relic OTLP logging endpoint 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteNewRelicOTLPFn: func(_ context.Context, i *fastly.DeleteNewRelicOTLPInput) error {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 3",
 			WantOutput: "Deleted New Relic OTLP logging endpoint 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -175,7 +200,7 @@ func TestNewRelicDescribe(t *testing.T) {
 		{
 			Name: "validate GetNewRelic API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				GetNewRelicOTLPFn: func(_ context.Context, _ *fastly.GetNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
@@ -186,7 +211,7 @@ func TestNewRelicDescribe(t *testing.T) {
 		{
 			Name: "validate GetNewRelic API success",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				GetNewRelicOTLPFn: getNewRelic,
 			},
 			Args:       "--name foobar --service-id 123 --version 3",
@@ -195,7 +220,7 @@ func TestNewRelicDescribe(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				GetNewRelicOTLPFn: getNewRelic,
 			},
 			Args:       "--name foobar --service-id 123 --version 1",
@@ -220,7 +245,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate ListNewRelics API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				ListNewRelicOTLPFn: func(_ context.Context, _ *fastly.ListNewRelicOTLPInput) ([]*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
@@ -231,7 +256,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate ListNewRelics API success",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListNewRelicOTLPFn: listNewRelic,
 			},
 			Args:       "--service-id 123 --version 3",
@@ -240,7 +265,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListNewRelicOTLPFn: listNewRelic,
 			},
 			Args:       "--service-id 123 --version 1",
@@ -249,7 +274,7 @@ func TestNewRelicList(t *testing.T) {
 		{
 			Name: "validate missing --verbose flag",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				ListNewRelicOTLPFn: listNewRelic,
 			},
 			Args:       "--service-id 123 --verbose --version 1",
@@ -275,28 +300,13 @@ func TestNewRelicUpdate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate UpdateNewRelic API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateNewRelicOTLPFn: func(_ context.Context, _ *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return nil, testutil.Err
 				},
@@ -307,7 +317,7 @@ func TestNewRelicUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateNewRelic API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
 						Name:           i.NewName,
@@ -320,9 +330,31 @@ func TestNewRelicUpdate(t *testing.T) {
 			WantOutput: "Updated New Relic OTLP logging endpoint 'beepboop' (previously: foobar, service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --new-name beepboop --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
 					return &fastly.NewRelicOTLP{
@@ -333,6 +365,46 @@ func TestNewRelicUpdate(t *testing.T) {
 				},
 			},
 			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 1",
+			WantOutput: "Updated New Relic OTLP logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.NewRelicOTLP{
+						Name:           i.NewName,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 2",
+			WantOutput: "Updated New Relic OTLP logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateNewRelicOTLPFn: func(_ context.Context, i *fastly.UpdateNewRelicOTLPInput) (*fastly.NewRelicOTLP, error) {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.NewRelicOTLP{
+						Name:           i.NewName,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:       "--autoclone --name foobar --new-name beepboop --service-id 123 --version 3",
 			WantOutput: "Updated New Relic OTLP logging endpoint 'beepboop' (previously: foobar, service: 123, version: 4)",
 		},
 	}

--- a/pkg/commands/service/logging/newrelicotlp/update.go
+++ b/pkg/commands/service/logging/newrelicotlp/update.go
@@ -121,7 +121,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		prev = fmt.Sprintf("previously: %s, ", c.endpointName)
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated New Relic OTLP logging endpoint '%s' (%sservice: %s, version: %d)",
 		fastly.ToValue(l.Name),
 		prev,

--- a/pkg/commands/service/logging/openstack/create.go
+++ b/pkg/commands/service/logging/openstack/create.go
@@ -213,7 +213,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created OpenStack logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/openstack/openstack_integration_test.go
+++ b/pkg/commands/service/logging/openstack/openstack_integration_test.go
@@ -21,7 +21,7 @@ func TestOpenstackCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateOpenstackFn: createOpenstackOK,
 			},
@@ -30,7 +30,7 @@ func TestOpenstackCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateOpenstackFn: createOpenstackError,
 			},
@@ -39,7 +39,7 @@ func TestOpenstackCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --user user --url https://example.com --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -53,7 +53,7 @@ func TestOpenstackList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			WantOutput: listOpenstacksShortOutput,
@@ -61,7 +61,7 @@ func TestOpenstackList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			WantOutput: listOpenstacksVerboseOutput,
@@ -69,7 +69,7 @@ func TestOpenstackList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListOpenstacksFn: listOpenstacksOK,
 			},
 			WantOutput: listOpenstacksVerboseOutput,
@@ -77,7 +77,7 @@ func TestOpenstackList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListOpenstacksFn: listOpenstacksError,
 			},
 			WantError: errTest.Error(),
@@ -95,7 +95,7 @@ func TestOpenstackDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetOpenstackFn: getOpenstackError,
 			},
 			WantError: errTest.Error(),
@@ -103,7 +103,7 @@ func TestOpenstackDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetOpenstackFn: getOpenstackOK,
 			},
 			WantOutput: describeOpenstackOutput,
@@ -121,7 +121,7 @@ func TestOpenstackUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateOpenstackFn: updateOpenstackError,
 			},
@@ -130,7 +130,7 @@ func TestOpenstackUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateOpenstackFn: updateOpenstackOK,
 			},
@@ -149,7 +149,7 @@ func TestOpenstackDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteOpenstackFn: deleteOpenstackError,
 			},
@@ -158,7 +158,7 @@ func TestOpenstackDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteOpenstackFn: deleteOpenstackOK,
 			},

--- a/pkg/commands/service/logging/openstack/openstack_test.go
+++ b/pkg/commands/service/logging/openstack/openstack_test.go
@@ -211,8 +211,7 @@ func createCommandRequired() *openstack.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &openstack.CreateCommand{
@@ -253,8 +252,7 @@ func createCommandAll() *openstack.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &openstack.CreateCommand{

--- a/pkg/commands/service/logging/openstack/openstack_test.go
+++ b/pkg/commands/service/logging/openstack/openstack_test.go
@@ -211,7 +211,7 @@ func createCommandRequired() *openstack.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &openstack.CreateCommand{
@@ -252,7 +252,7 @@ func createCommandAll() *openstack.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &openstack.CreateCommand{

--- a/pkg/commands/service/logging/openstack/openstack_test.go
+++ b/pkg/commands/service/logging/openstack/openstack_test.go
@@ -68,6 +68,9 @@ func TestCreateOpenstackInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -111,7 +114,7 @@ func TestUpdateOpenstackInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetOpenstackFn: getOpenstackOK,
 			},
@@ -142,7 +145,7 @@ func TestUpdateOpenstackInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetOpenstackFn: getOpenstackOK,
 			},
@@ -162,6 +165,9 @@ func TestUpdateOpenstackInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -204,6 +210,7 @@ func createCommandRequired() *openstack.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -245,6 +252,7 @@ func createCommandAll() *openstack.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -291,6 +299,7 @@ func createCommandAll() *openstack.CreateCommand {
 func createCommandMissingServiceID() *openstack.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -380,5 +389,6 @@ func updateCommandAll() *openstack.UpdateCommand {
 func updateCommandMissingServiceID() *openstack.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/openstack/update.go
+++ b/pkg/commands/service/logging/openstack/update.go
@@ -216,7 +216,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated OpenStack logging endpoint %s (service %s version %d)",
 		fastly.ToValue(openstack.Name),
 		fastly.ToValue(openstack.ServiceID),

--- a/pkg/commands/service/logging/papertrail/create.go
+++ b/pkg/commands/service/logging/papertrail/create.go
@@ -155,7 +155,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Papertrail logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/papertrail/papertrail_integration_test.go
+++ b/pkg/commands/service/logging/papertrail/papertrail_integration_test.go
@@ -21,7 +21,7 @@ func TestPapertrailCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com:123 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreatePapertrailFn: createPapertrailOK,
 			},
@@ -30,7 +30,7 @@ func TestPapertrailCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com:123 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				CreatePapertrailFn: createPapertrailError,
 			},
@@ -45,7 +45,7 @@ func TestPapertrailList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			WantOutput: listPapertrailsShortOutput,
@@ -53,7 +53,7 @@ func TestPapertrailList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			WantOutput: listPapertrailsVerboseOutput,
@@ -61,7 +61,7 @@ func TestPapertrailList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListPapertrailsFn: listPapertrailsOK,
 			},
 			WantOutput: listPapertrailsVerboseOutput,
@@ -69,7 +69,7 @@ func TestPapertrailList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ListPapertrailsFn: listPapertrailsError,
 			},
 			WantError: errTest.Error(),
@@ -87,7 +87,7 @@ func TestPapertrailDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetPapertrailFn: getPapertrailError,
 			},
 			WantError: errTest.Error(),
@@ -95,7 +95,7 @@ func TestPapertrailDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				GetPapertrailFn: getPapertrailOK,
 			},
 			WantOutput: describePapertrailOutput,
@@ -113,7 +113,7 @@ func TestPapertrailUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdatePapertrailFn: updatePapertrailError,
 			},
@@ -122,7 +122,7 @@ func TestPapertrailUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				UpdatePapertrailFn: updatePapertrailOK,
 			},
@@ -141,7 +141,7 @@ func TestPapertrailDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeletePapertrailFn: deletePapertrailError,
 			},
@@ -150,7 +150,7 @@ func TestPapertrailDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:     testutil.ListVersions,
+				GetVersionFn:       testutil.GetVersion,
 				CloneVersionFn:     testutil.CloneVersionResult(4),
 				DeletePapertrailFn: deletePapertrailOK,
 			},

--- a/pkg/commands/service/logging/papertrail/papertrail_test.go
+++ b/pkg/commands/service/logging/papertrail/papertrail_test.go
@@ -191,8 +191,7 @@ func createCommandRequired() *papertrail.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &papertrail.CreateCommand{
@@ -230,8 +229,7 @@ func createCommandAll() *papertrail.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &papertrail.CreateCommand{

--- a/pkg/commands/service/logging/papertrail/papertrail_test.go
+++ b/pkg/commands/service/logging/papertrail/papertrail_test.go
@@ -191,7 +191,7 @@ func createCommandRequired() *papertrail.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &papertrail.CreateCommand{
@@ -229,7 +229,7 @@ func createCommandAll() *papertrail.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &papertrail.CreateCommand{

--- a/pkg/commands/service/logging/papertrail/papertrail_test.go
+++ b/pkg/commands/service/logging/papertrail/papertrail_test.go
@@ -57,6 +57,9 @@ func TestCreatePapertrailInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -100,7 +103,7 @@ func TestUpdatePapertrailInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetPapertrailFn: getPapertrailOK,
 			},
@@ -114,7 +117,7 @@ func TestUpdatePapertrailInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				GetPapertrailFn: getPapertrailOK,
 			},
@@ -142,6 +145,9 @@ func TestUpdatePapertrailInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -184,6 +190,7 @@ func createCommandRequired() *papertrail.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -222,6 +229,7 @@ func createCommandAll() *papertrail.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -260,6 +268,7 @@ func createCommandAll() *papertrail.CreateCommand {
 func createCommandMissingServiceID() *papertrail.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -340,5 +349,6 @@ func updateCommandAll() *papertrail.UpdateCommand {
 func updateCommandMissingServiceID() *papertrail.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/papertrail/update.go
+++ b/pkg/commands/service/logging/papertrail/update.go
@@ -165,7 +165,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Papertrail logging endpoint %s (service %s version %d)",
 		fastly.ToValue(papertrail.Name),
 		fastly.ToValue(papertrail.ServiceID),

--- a/pkg/commands/service/logging/s3/create.go
+++ b/pkg/commands/service/logging/s3/create.go
@@ -302,7 +302,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created S3 logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/s3/s3_integration_test.go
+++ b/pkg/commands/service/logging/s3/s3_integration_test.go
@@ -21,7 +21,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --access-key and --secret-key flags or the --iam-role flag must be provided",
@@ -29,7 +29,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --secret-key bar --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
@@ -37,7 +37,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
@@ -45,7 +45,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --access-key and --secret-key flags are mutually exclusive with the --iam-role flag",
@@ -53,7 +53,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3OK,
 			},
@@ -62,7 +62,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --access-key foo --secret-key bar --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3Error,
 			},
@@ -71,7 +71,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log2 --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3OK,
 			},
@@ -80,7 +80,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log2 --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateS3Fn:     createS3Error,
 			},
@@ -89,7 +89,7 @@ func TestS3Create(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --bucket log --iam-role arn:aws:iam::123456789012:role/S3Access --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -103,32 +103,32 @@ func TestS3List(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListS3sFn:      listS3sOK,
+				GetVersionFn: testutil.GetVersion,
+				ListS3sFn:    listS3sOK,
 			},
 			WantOutput: listS3sShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListS3sFn:      listS3sOK,
+				GetVersionFn: testutil.GetVersion,
+				ListS3sFn:    listS3sOK,
 			},
 			WantOutput: listS3sVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListS3sFn:      listS3sOK,
+				GetVersionFn: testutil.GetVersion,
+				ListS3sFn:    listS3sOK,
 			},
 			WantOutput: listS3sVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListS3sFn:      listS3sError,
+				GetVersionFn: testutil.GetVersion,
+				ListS3sFn:    listS3sError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -145,16 +145,16 @@ func TestS3Describe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetS3Fn:        getS3Error,
+				GetVersionFn: testutil.GetVersion,
+				GetS3Fn:      getS3Error,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetS3Fn:        getS3OK,
+				GetVersionFn: testutil.GetVersion,
+				GetS3Fn:      getS3OK,
 			},
 			WantOutput: describeS3Output,
 		},
@@ -171,7 +171,7 @@ func TestS3Update(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateS3Fn:     updateS3Error,
 			},
@@ -180,7 +180,7 @@ func TestS3Update(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateS3Fn:     updateS3OK,
 			},
@@ -199,7 +199,7 @@ func TestS3Delete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteS3Fn:     deleteS3Error,
 			},
@@ -208,7 +208,7 @@ func TestS3Delete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteS3Fn:     deleteS3OK,
 			},

--- a/pkg/commands/service/logging/s3/s3_test.go
+++ b/pkg/commands/service/logging/s3/s3_test.go
@@ -83,6 +83,9 @@ func TestCreateS3Input(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -126,7 +129,7 @@ func TestUpdateS3Input(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetS3Fn:        getS3OK,
 			},
@@ -140,7 +143,7 @@ func TestUpdateS3Input(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetS3Fn:        getS3OK,
 			},
@@ -181,6 +184,9 @@ func TestUpdateS3Input(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -223,6 +229,7 @@ func createCommandRequired() *s3.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -263,6 +270,7 @@ func createCommandRequiredIAMRole() *s3.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -302,6 +310,7 @@ func createCommandAll() *s3.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -351,6 +360,7 @@ func createCommandAll() *s3.CreateCommand {
 func createCommandMissingServiceID() *s3.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -444,6 +454,7 @@ func updateCommandAll() *s3.UpdateCommand {
 func updateCommandMissingServiceID() *s3.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 

--- a/pkg/commands/service/logging/s3/s3_test.go
+++ b/pkg/commands/service/logging/s3/s3_test.go
@@ -230,7 +230,7 @@ func createCommandRequired() *s3.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &s3.CreateCommand{
@@ -270,7 +270,7 @@ func createCommandRequiredIAMRole() *s3.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &s3.CreateCommand{
@@ -309,7 +309,7 @@ func createCommandAll() *s3.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &s3.CreateCommand{

--- a/pkg/commands/service/logging/s3/s3_test.go
+++ b/pkg/commands/service/logging/s3/s3_test.go
@@ -230,8 +230,7 @@ func createCommandRequired() *s3.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &s3.CreateCommand{
@@ -271,8 +270,7 @@ func createCommandRequiredIAMRole() *s3.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &s3.CreateCommand{
@@ -311,8 +309,7 @@ func createCommandAll() *s3.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &s3.CreateCommand{

--- a/pkg/commands/service/logging/s3/update.go
+++ b/pkg/commands/service/logging/s3/update.go
@@ -253,7 +253,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated S3 logging endpoint %s (service %s version %d)",
 		fastly.ToValue(s3.Name),
 		fastly.ToValue(s3.ServiceID),

--- a/pkg/commands/service/logging/scalyr/create.go
+++ b/pkg/commands/service/logging/scalyr/create.go
@@ -153,7 +153,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Scalyr logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/scalyr/scalyr_integration_test.go
+++ b/pkg/commands/service/logging/scalyr/scalyr_integration_test.go
@@ -20,9 +20,10 @@ import (
 func TestScalyrCreate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
-			Args: "--name log --version 1 --auth-token abc --autoclone",
+			Args:    "--name log --version 1 --auth-token abc --autoclone",
+			EnvVars: map[string]string{"FASTLY_SERVICE_ID": ""},
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: fsterrs.ErrNoServiceID.Error(),
@@ -30,7 +31,7 @@ func TestScalyrCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateScalyrFn: createScalyrOK,
 			},
@@ -39,7 +40,7 @@ func TestScalyrCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --auth-token abc --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateScalyrFn: createScalyrError,
 			},
@@ -54,32 +55,32 @@ func TestScalyrList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListScalyrsFn:  listScalyrsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListScalyrsFn: listScalyrsOK,
 			},
 			WantOutput: listScalyrsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListScalyrsFn:  listScalyrsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListScalyrsFn: listScalyrsOK,
 			},
 			WantOutput: listScalyrsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListScalyrsFn:  listScalyrsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListScalyrsFn: listScalyrsOK,
 			},
 			WantOutput: listScalyrsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListScalyrsFn:  listScalyrsError,
+				GetVersionFn:  testutil.GetVersion,
+				ListScalyrsFn: listScalyrsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -96,16 +97,16 @@ func TestScalyrDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetScalyrFn:    getScalyrError,
+				GetVersionFn: testutil.GetVersion,
+				GetScalyrFn:  getScalyrError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetScalyrFn:    getScalyrOK,
+				GetVersionFn: testutil.GetVersion,
+				GetScalyrFn:  getScalyrOK,
 			},
 			WantOutput: describeScalyrOutput,
 		},
@@ -122,7 +123,7 @@ func TestScalyrUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateScalyrFn: updateScalyrError,
 			},
@@ -131,7 +132,7 @@ func TestScalyrUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateScalyrFn: updateScalyrOK,
 			},
@@ -150,7 +151,7 @@ func TestScalyrDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteScalyrFn: deleteScalyrError,
 			},
@@ -159,7 +160,7 @@ func TestScalyrDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteScalyrFn: deleteScalyrOK,
 			},

--- a/pkg/commands/service/logging/scalyr/scalyr_test.go
+++ b/pkg/commands/service/logging/scalyr/scalyr_test.go
@@ -193,8 +193,7 @@ func createCommandRequired() *scalyr.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &scalyr.CreateCommand{
@@ -232,8 +231,7 @@ func createCommandAll() *scalyr.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &scalyr.CreateCommand{

--- a/pkg/commands/service/logging/scalyr/scalyr_test.go
+++ b/pkg/commands/service/logging/scalyr/scalyr_test.go
@@ -193,7 +193,7 @@ func createCommandRequired() *scalyr.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &scalyr.CreateCommand{
@@ -231,7 +231,7 @@ func createCommandAll() *scalyr.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &scalyr.CreateCommand{

--- a/pkg/commands/service/logging/scalyr/scalyr_test.go
+++ b/pkg/commands/service/logging/scalyr/scalyr_test.go
@@ -58,6 +58,9 @@ func TestCreateScalyrInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -101,7 +104,7 @@ func TestUpdateScalyrInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetScalyrFn:    getScalyrOK,
 			},
@@ -115,7 +118,7 @@ func TestUpdateScalyrInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetScalyrFn:    getScalyrOK,
 			},
@@ -144,6 +147,9 @@ func TestUpdateScalyrInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -186,6 +192,7 @@ func createCommandRequired() *scalyr.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -224,6 +231,7 @@ func createCommandAll() *scalyr.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -263,6 +271,7 @@ func createCommandAll() *scalyr.CreateCommand {
 func createCommandMissingServiceID() *scalyr.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -344,5 +353,6 @@ func updateCommandAll() *scalyr.UpdateCommand {
 func updateCommandMissingServiceID() *scalyr.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/scalyr/update.go
+++ b/pkg/commands/service/logging/scalyr/update.go
@@ -156,7 +156,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Scalyr logging endpoint %s (service %s version %d)",
 		fastly.ToValue(scalyr.Name),
 		fastly.ToValue(scalyr.ServiceID),

--- a/pkg/commands/service/logging/sftp/create.go
+++ b/pkg/commands/service/logging/sftp/create.go
@@ -226,7 +226,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created SFTP logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/sftp/sftp_integration_test.go
+++ b/pkg/commands/service/logging/sftp/sftp_integration_test.go
@@ -21,7 +21,7 @@ func TestSFTPCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com --user user --ssh-known-hosts knownHosts() --port 80 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSFTPFn:   createSFTPOK,
 			},
@@ -30,7 +30,7 @@ func TestSFTPCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com --user user --ssh-known-hosts knownHosts() --port 80 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSFTPFn:   createSFTPError,
 			},
@@ -39,7 +39,7 @@ func TestSFTPCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address example.com --user anonymous --ssh-known-hosts knownHosts() --port 80 --compression-codec zstd --gzip-level 9 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: the --compression-codec flag is mutually exclusive with the --gzip-level flag",
@@ -53,32 +53,32 @@ func TestSFTPList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSFTPsFn:    listSFTPsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListSFTPsFn:  listSFTPsOK,
 			},
 			WantOutput: listSFTPsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSFTPsFn:    listSFTPsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListSFTPsFn:  listSFTPsOK,
 			},
 			WantOutput: listSFTPsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSFTPsFn:    listSFTPsOK,
+				GetVersionFn: testutil.GetVersion,
+				ListSFTPsFn:  listSFTPsOK,
 			},
 			WantOutput: listSFTPsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSFTPsFn:    listSFTPsError,
+				GetVersionFn: testutil.GetVersion,
+				ListSFTPsFn:  listSFTPsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -95,16 +95,16 @@ func TestSFTPDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSFTPFn:      getSFTPError,
+				GetVersionFn: testutil.GetVersion,
+				GetSFTPFn:    getSFTPError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSFTPFn:      getSFTPOK,
+				GetVersionFn: testutil.GetVersion,
+				GetSFTPFn:    getSFTPOK,
 			},
 			WantOutput: describeSFTPOutput,
 		},
@@ -121,7 +121,7 @@ func TestSFTPUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSFTPFn:   updateSFTPError,
 			},
@@ -130,7 +130,7 @@ func TestSFTPUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSFTPFn:   updateSFTPOK,
 			},
@@ -149,7 +149,7 @@ func TestSFTPDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSFTPFn:   deleteSFTPError,
 			},
@@ -158,7 +158,7 @@ func TestSFTPDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSFTPFn:   deleteSFTPOK,
 			},

--- a/pkg/commands/service/logging/sftp/sftp_test.go
+++ b/pkg/commands/service/logging/sftp/sftp_test.go
@@ -214,7 +214,7 @@ func createCommandRequired() *sftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sftp.CreateCommand{
@@ -254,7 +254,7 @@ func createCommandAll() *sftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sftp.CreateCommand{

--- a/pkg/commands/service/logging/sftp/sftp_test.go
+++ b/pkg/commands/service/logging/sftp/sftp_test.go
@@ -214,8 +214,7 @@ func createCommandRequired() *sftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sftp.CreateCommand{
@@ -255,8 +254,7 @@ func createCommandAll() *sftp.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sftp.CreateCommand{

--- a/pkg/commands/service/logging/sftp/sftp_test.go
+++ b/pkg/commands/service/logging/sftp/sftp_test.go
@@ -69,6 +69,9 @@ func TestCreateSFTPInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -112,7 +115,7 @@ func TestUpdateSFTPInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSFTPFn:      getSFTPOK,
 			},
@@ -145,7 +148,7 @@ func TestUpdateSFTPInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSFTPFn:      getSFTPOK,
 			},
@@ -165,6 +168,9 @@ func TestUpdateSFTPInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -207,6 +213,7 @@ func createCommandRequired() *sftp.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -247,6 +254,7 @@ func createCommandAll() *sftp.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -295,6 +303,7 @@ func createCommandAll() *sftp.CreateCommand {
 func createCommandMissingServiceID() *sftp.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -386,5 +395,6 @@ func updateCommandAll() *sftp.UpdateCommand {
 func updateCommandMissingServiceID() *sftp.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/sftp/update.go
+++ b/pkg/commands/service/logging/sftp/update.go
@@ -226,7 +226,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated SFTP logging endpoint %s (service %s version %d)",
 		fastly.ToValue(sftp.Name),
 		fastly.ToValue(sftp.ServiceID),

--- a/pkg/commands/service/logging/splunk/create.go
+++ b/pkg/commands/service/logging/splunk/create.go
@@ -180,7 +180,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Splunk logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/splunk/splunk_integration_test.go
+++ b/pkg/commands/service/logging/splunk/splunk_integration_test.go
@@ -20,7 +20,7 @@ func TestSplunkCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSplunkFn: createSplunkOK,
 			},
@@ -29,7 +29,7 @@ func TestSplunkCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSplunkFn: createSplunkError,
 			},
@@ -44,32 +44,32 @@ func TestSplunkList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSplunksFn:  listSplunksOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListSplunksFn: listSplunksOK,
 			},
 			WantOutput: listSplunksShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSplunksFn:  listSplunksOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListSplunksFn: listSplunksOK,
 			},
 			WantOutput: listSplunksVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSplunksFn:  listSplunksOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListSplunksFn: listSplunksOK,
 			},
 			WantOutput: listSplunksVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSplunksFn:  listSplunksError,
+				GetVersionFn:  testutil.GetVersion,
+				ListSplunksFn: listSplunksError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -86,16 +86,16 @@ func TestSplunkDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSplunkFn:    getSplunkError,
+				GetVersionFn: testutil.GetVersion,
+				GetSplunkFn:  getSplunkError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSplunkFn:    getSplunkOK,
+				GetVersionFn: testutil.GetVersion,
+				GetSplunkFn:  getSplunkOK,
 			},
 			WantOutput: describeSplunkOutput,
 		},
@@ -112,7 +112,7 @@ func TestSplunkUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSplunkFn: updateSplunkError,
 			},
@@ -121,7 +121,7 @@ func TestSplunkUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSplunkFn: updateSplunkOK,
 			},
@@ -140,7 +140,7 @@ func TestSplunkDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSplunkFn: deleteSplunkError,
 			},
@@ -149,7 +149,7 @@ func TestSplunkDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSplunkFn: deleteSplunkOK,
 			},

--- a/pkg/commands/service/logging/splunk/splunk_test.go
+++ b/pkg/commands/service/logging/splunk/splunk_test.go
@@ -199,7 +199,7 @@ func createCommandRequired() *splunk.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &splunk.CreateCommand{
@@ -237,7 +237,7 @@ func createCommandAll() *splunk.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &splunk.CreateCommand{

--- a/pkg/commands/service/logging/splunk/splunk_test.go
+++ b/pkg/commands/service/logging/splunk/splunk_test.go
@@ -61,6 +61,9 @@ func TestCreateSplunkInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -104,7 +107,7 @@ func TestUpdateSplunkInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSplunkFn:    getSplunkOK,
 			},
@@ -118,7 +121,7 @@ func TestUpdateSplunkInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSplunkFn:    getSplunkOK,
 			},
@@ -150,6 +153,9 @@ func TestUpdateSplunkInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -192,6 +198,7 @@ func createCommandRequired() *splunk.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -230,6 +237,7 @@ func createCommandAll() *splunk.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -273,6 +281,7 @@ func createCommandAll() *splunk.CreateCommand {
 func createCommandMissingServiceID() *splunk.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -357,5 +366,6 @@ func updateCommandAll() *splunk.UpdateCommand {
 func updateCommandMissingServiceID() *splunk.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/splunk/splunk_test.go
+++ b/pkg/commands/service/logging/splunk/splunk_test.go
@@ -199,8 +199,7 @@ func createCommandRequired() *splunk.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &splunk.CreateCommand{
@@ -238,8 +237,7 @@ func createCommandAll() *splunk.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &splunk.CreateCommand{

--- a/pkg/commands/service/logging/splunk/update.go
+++ b/pkg/commands/service/logging/splunk/update.go
@@ -185,7 +185,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Splunk logging endpoint %s (service %s version %d)",
 		fastly.ToValue(splunk.Name),
 		fastly.ToValue(splunk.ServiceID),

--- a/pkg/commands/service/logging/sumologic/create.go
+++ b/pkg/commands/service/logging/sumologic/create.go
@@ -155,7 +155,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Sumologic logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/sumologic/sumologic_integration_test.go
+++ b/pkg/commands/service/logging/sumologic/sumologic_integration_test.go
@@ -20,7 +20,7 @@ func TestSumologicCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateSumologicFn: createSumologicOK,
 			},
@@ -29,7 +29,7 @@ func TestSumologicCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --url example.com --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateSumologicFn: createSumologicError,
 			},
@@ -44,7 +44,7 @@ func TestSumologicList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			WantOutput: listSumologicsShortOutput,
@@ -52,7 +52,7 @@ func TestSumologicList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			WantOutput: listSumologicsVerboseOutput,
@@ -60,7 +60,7 @@ func TestSumologicList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListSumologicsFn: listSumologicsOK,
 			},
 			WantOutput: listSumologicsVerboseOutput,
@@ -68,7 +68,7 @@ func TestSumologicList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListSumologicsFn: listSumologicsError,
 			},
 			WantError: errTest.Error(),
@@ -86,7 +86,7 @@ func TestSumologicDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetSumologicFn: getSumologicError,
 			},
 			WantError: errTest.Error(),
@@ -94,7 +94,7 @@ func TestSumologicDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetSumologicFn: getSumologicOK,
 			},
 			WantOutput: describeSumologicOutput,
@@ -112,7 +112,7 @@ func TestSumologicUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateSumologicFn: updateSumologicError,
 			},
@@ -121,7 +121,7 @@ func TestSumologicUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateSumologicFn: updateSumologicOK,
 			},
@@ -140,7 +140,7 @@ func TestSumologicDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteSumologicFn: deleteSumologicError,
 			},
@@ -149,7 +149,7 @@ func TestSumologicDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteSumologicFn: deleteSumologicOK,
 			},

--- a/pkg/commands/service/logging/sumologic/sumologic_test.go
+++ b/pkg/commands/service/logging/sumologic/sumologic_test.go
@@ -191,8 +191,7 @@ func createCommandOK() *sumologic.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sumologic.CreateCommand{
@@ -236,8 +235,7 @@ func createCommandRequired() *sumologic.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sumologic.CreateCommand{

--- a/pkg/commands/service/logging/sumologic/sumologic_test.go
+++ b/pkg/commands/service/logging/sumologic/sumologic_test.go
@@ -57,6 +57,9 @@ func TestCreateSumologicInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -100,7 +103,7 @@ func TestUpdateSumologicInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSumologicFn: getSumologicOK,
 			},
@@ -114,7 +117,7 @@ func TestUpdateSumologicInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSumologicFn: getSumologicOK,
 			},
@@ -142,6 +145,9 @@ func TestUpdateSumologicInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -184,6 +190,7 @@ func createCommandOK() *sumologic.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -228,6 +235,7 @@ func createCommandRequired() *sumologic.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -260,6 +268,7 @@ func createCommandRequired() *sumologic.CreateCommand {
 func createCommandMissingServiceID() *sumologic.CreateCommand {
 	res := createCommandOK()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -340,5 +349,6 @@ func updateCommandAll() *sumologic.UpdateCommand {
 func updateCommandMissingServiceID() *sumologic.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/sumologic/sumologic_test.go
+++ b/pkg/commands/service/logging/sumologic/sumologic_test.go
@@ -191,7 +191,7 @@ func createCommandOK() *sumologic.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sumologic.CreateCommand{
@@ -235,7 +235,7 @@ func createCommandRequired() *sumologic.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &sumologic.CreateCommand{

--- a/pkg/commands/service/logging/sumologic/update.go
+++ b/pkg/commands/service/logging/sumologic/update.go
@@ -160,7 +160,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Sumologic logging endpoint %s (service %s version %d)",
 		fastly.ToValue(sumologic.Name),
 		fastly.ToValue(sumologic.ServiceID),

--- a/pkg/commands/service/logging/syslog/create.go
+++ b/pkg/commands/service/logging/syslog/create.go
@@ -197,7 +197,8 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Created Syslog logging endpoint %s (service %s version %d)",
 		fastly.ToValue(d.Name),
 		fastly.ToValue(d.ServiceID),

--- a/pkg/commands/service/logging/syslog/syslog_integration_test.go
+++ b/pkg/commands/service/logging/syslog/syslog_integration_test.go
@@ -21,7 +21,7 @@ func TestSyslogCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address 127.0.0.1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSyslogFn: createSyslogOK,
 			},
@@ -30,7 +30,7 @@ func TestSyslogCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name log --address 127.0.0.1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSyslogFn: createSyslogError,
 			},
@@ -45,32 +45,32 @@ func TestSyslogList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSyslogsFn:  listSyslogsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListSyslogsFn: listSyslogsOK,
 			},
 			WantOutput: listSyslogsShortOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSyslogsFn:  listSyslogsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListSyslogsFn: listSyslogsOK,
 			},
 			WantOutput: listSyslogsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSyslogsFn:  listSyslogsOK,
+				GetVersionFn:  testutil.GetVersion,
+				ListSyslogsFn: listSyslogsOK,
 			},
 			WantOutput: listSyslogsVerboseOutput,
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListSyslogsFn:  listSyslogsError,
+				GetVersionFn:  testutil.GetVersion,
+				ListSyslogsFn: listSyslogsError,
 			},
 			WantError: errTest.Error(),
 		},
@@ -87,16 +87,16 @@ func TestSyslogDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSyslogFn:    getSyslogError,
+				GetVersionFn: testutil.GetVersion,
+				GetSyslogFn:  getSyslogError,
 			},
 			WantError: errTest.Error(),
 		},
 		{
 			Args: "--service-id 123 --version 1 --name logs",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSyslogFn:    getSyslogOK,
+				GetVersionFn: testutil.GetVersion,
+				GetSyslogFn:  getSyslogOK,
 			},
 			WantOutput: describeSyslogOutput,
 		},
@@ -113,7 +113,7 @@ func TestSyslogUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSyslogFn: updateSyslogError,
 			},
@@ -122,7 +122,7 @@ func TestSyslogUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --new-name log --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSyslogFn: updateSyslogOK,
 			},
@@ -141,7 +141,7 @@ func TestSyslogDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSyslogFn: deleteSyslogError,
 			},
@@ -150,7 +150,7 @@ func TestSyslogDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name logs --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSyslogFn: deleteSyslogOK,
 			},

--- a/pkg/commands/service/logging/syslog/syslog_test.go
+++ b/pkg/commands/service/logging/syslog/syslog_test.go
@@ -205,7 +205,7 @@ func createCommandRequired() *syslog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &syslog.CreateCommand{
@@ -243,7 +243,7 @@ func createCommandAll() *syslog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-				CloneVersionFn: testutil.CloneVersionResult(4),
+		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &syslog.CreateCommand{

--- a/pkg/commands/service/logging/syslog/syslog_test.go
+++ b/pkg/commands/service/logging/syslog/syslog_test.go
@@ -205,8 +205,7 @@ func createCommandRequired() *syslog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &syslog.CreateCommand{
@@ -244,8 +243,7 @@ func createCommandAll() *syslog.CreateCommand {
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
 		GetVersionFn:   testutil.GetVersion,
-		ListVersionsFn: testutil.ListVersions,
-		CloneVersionFn: testutil.CloneVersionResult(4),
+				CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
 
 	return &syslog.CreateCommand{

--- a/pkg/commands/service/logging/syslog/syslog_test.go
+++ b/pkg/commands/service/logging/syslog/syslog_test.go
@@ -64,6 +64,9 @@ func TestCreateSyslogInput(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var bs []byte
 			out := bytes.NewBuffer(bs)
 			verboseMode := true
@@ -107,7 +110,7 @@ func TestUpdateSyslogInput(t *testing.T) {
 			name: "no updates",
 			cmd:  updateCommandNoUpdates(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSyslogFn:    getSyslogOK,
 			},
@@ -121,7 +124,7 @@ func TestUpdateSyslogInput(t *testing.T) {
 			name: "all values set flag serviceID",
 			cmd:  updateCommandAll(),
 			api: mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				GetSyslogFn:    getSyslogOK,
 			},
@@ -156,6 +159,9 @@ func TestUpdateSyslogInput(t *testing.T) {
 	for testcaseIdx := range scenarios {
 		testcase := &scenarios[testcaseIdx]
 		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.wantError == errors.ErrNoServiceID.Error() {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			testcase.cmd.Globals.APIClient = testcase.api
 
 			var bs []byte
@@ -198,6 +204,7 @@ func createCommandRequired() *syslog.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -236,6 +243,7 @@ func createCommandAll() *syslog.CreateCommand {
 		Output: &b,
 	}
 	g.APIClient, _ = mock.APIClient(mock.API{
+		GetVersionFn:   testutil.GetVersion,
 		ListVersionsFn: testutil.ListVersions,
 		CloneVersionFn: testutil.CloneVersionResult(4),
 	})("token", "endpoint", false)
@@ -281,6 +289,7 @@ func createCommandAll() *syslog.CreateCommand {
 func createCommandMissingServiceID() *syslog.CreateCommand {
 	res := createCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }
 
@@ -368,5 +377,6 @@ func updateCommandAll() *syslog.UpdateCommand {
 func updateCommandMissingServiceID() *syslog.UpdateCommand {
 	res := updateCommandAll()
 	res.Manifest = manifest.Data{}
+	res.ServiceVersion = argparser.OptionalServiceVersion{}
 	return res
 }

--- a/pkg/commands/service/logging/syslog/update.go
+++ b/pkg/commands/service/logging/syslog/update.go
@@ -203,7 +203,8 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out,
+	text.Success(
+		out,
 		"Updated Syslog logging endpoint %s (service %s version %d)",
 		fastly.ToValue(syslog.Name),
 		fastly.ToValue(syslog.ServiceID),

--- a/pkg/commands/service/purge/purge_test.go
+++ b/pkg/commands/service/purge/purge_test.go
@@ -23,6 +23,7 @@ func TestPurgeAll(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--all",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -33,6 +34,7 @@ func TestPurgeAll(t *testing.T) {
 		{
 			Name: "validate PurgeAll API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeAllFn: func(_ context.Context, _ *fastly.PurgeAllInput) (*fastly.Purge, error) {
 					return nil, testutil.Err
 				},
@@ -43,6 +45,7 @@ func TestPurgeAll(t *testing.T) {
 		{
 			Name: "validate PurgeAll API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeAllFn: func(_ context.Context, _ *fastly.PurgeAllInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status: fastly.ToPointer(testStatus),
@@ -73,11 +76,13 @@ func TestPurgeKeys(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--file ./testdata/keys",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate PurgeKeys API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeKeysFn: func(_ context.Context, _ *fastly.PurgeKeysInput) (map[string]string, error) {
 					return nil, testutil.Err
 				},
@@ -88,6 +93,7 @@ func TestPurgeKeys(t *testing.T) {
 		{
 			Name: "validate PurgeKeys API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeKeysFn: func(_ context.Context, i *fastly.PurgeKeysInput) (map[string]string, error) {
 					// Track the keys parsed
 					keys = i.Keys
@@ -130,11 +136,13 @@ func TestPurgeKey(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--key " + testKey,
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate PurgeKeys API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeKeysFn: func(_ context.Context, _ *fastly.PurgeKeysInput) (map[string]string, error) {
 					return nil, testutil.Err
 				},
@@ -145,6 +153,7 @@ func TestPurgeKey(t *testing.T) {
 		{
 			Name: "validate PurgeKeys API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeKeysFn: func(_ context.Context, _ *fastly.PurgeKeysInput) (map[string]string, error) {
 					return map[string]string{
 						testKey: testPurgeID,
@@ -157,6 +166,7 @@ func TestPurgeKey(t *testing.T) {
 		{
 			Name: "validate PurgeKeys API success with soft purge",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeKeysFn: func(_ context.Context, _ *fastly.PurgeKeysInput) (map[string]string, error) {
 					return map[string]string{
 						testKey: testPurgeID,
@@ -183,6 +193,7 @@ func TestPurgeURL(t *testing.T) {
 		{
 			Name: "validate Purge API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeFn: func(_ context.Context, _ *fastly.PurgeInput) (*fastly.Purge, error) {
 					return nil, testutil.Err
 				},
@@ -193,6 +204,7 @@ func TestPurgeURL(t *testing.T) {
 		{
 			Name: "validate Purge API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeFn: func(_ context.Context, _ *fastly.PurgeInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status:  fastly.ToPointer(testStatus),
@@ -206,6 +218,7 @@ func TestPurgeURL(t *testing.T) {
 		{
 			Name: "validate Purge API success with soft purge",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				PurgeFn: func(_ context.Context, _ *fastly.PurgeInput) (*fastly.Purge, error) {
 					return &fastly.Purge{
 						Status:  fastly.ToPointer(testStatus),

--- a/pkg/commands/service/ratelimit/ratelimit_test.go
+++ b/pkg/commands/service/ratelimit/ratelimit_test.go
@@ -17,6 +17,7 @@ func TestRateLimitCreate(t *testing.T) {
 		{
 			Name: "validate CreateERL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				CreateERLFn: func(_ context.Context, _ *fastly.CreateERLInput) (*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
@@ -28,6 +29,7 @@ func TestRateLimitCreate(t *testing.T) {
 		{
 			Name: "validate CreateERL API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				CreateERLFn: func(_ context.Context, i *fastly.CreateERLInput) (*fastly.ERL, error) {
 					return &fastly.ERL{
 						Name:          i.Name,
@@ -49,6 +51,7 @@ func TestRateLimitDelete(t *testing.T) {
 		{
 			Name: "validate DeleteERL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				DeleteERLFn: func(_ context.Context, _ *fastly.DeleteERLInput) error {
 					return testutil.Err
 				},
@@ -59,6 +62,7 @@ func TestRateLimitDelete(t *testing.T) {
 		{
 			Name: "validate DeleteERL API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				DeleteERLFn: func(_ context.Context, _ *fastly.DeleteERLInput) error {
 					return nil
 				},
@@ -76,6 +80,7 @@ func TestRateLimitDescribe(t *testing.T) {
 		{
 			Name: "validate GetERL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetERLFn: func(_ context.Context, _ *fastly.GetERLInput) (*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
@@ -86,6 +91,7 @@ func TestRateLimitDescribe(t *testing.T) {
 		{
 			Name: "validate ListERL API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetERLFn: func(_ context.Context, _ *fastly.GetERLInput) (*fastly.ERL, error) {
 					return &fastly.ERL{
 						RateLimiterID:      fastly.ToPointer("123"),
@@ -110,6 +116,7 @@ func TestRateLimitList(t *testing.T) {
 		{
 			Name: "validate ListERL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListERLsFn: func(_ context.Context, _ *fastly.ListERLsInput) ([]*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
@@ -121,6 +128,7 @@ func TestRateLimitList(t *testing.T) {
 		{
 			Name: "validate ListERL API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListERLsFn: func(_ context.Context, _ *fastly.ListERLsInput) ([]*fastly.ERL, error) {
 					return []*fastly.ERL{
 						{
@@ -148,6 +156,7 @@ func TesRateLimitUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateERL API error",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				UpdateERLFn: func(_ context.Context, _ *fastly.UpdateERLInput) (*fastly.ERL, error) {
 					return nil, testutil.Err
 				},
@@ -158,6 +167,7 @@ func TesRateLimitUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateERL API success",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				UpdateERLFn: func(_ context.Context, i *fastly.UpdateERLInput) (*fastly.ERL, error) {
 					return &fastly.ERL{
 						Name:          i.Name,

--- a/pkg/commands/service/resourcelink/resourcelink_test.go
+++ b/pkg/commands/service/resourcelink/resourcelink_test.go
@@ -35,9 +35,6 @@ func TestCreateServiceResourceCommand(t *testing.T) {
 			Args: "--resource-id abc --service-id 123 --version 42",
 			API: &mock.API{
 				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
-				},
 				CreateResourceFn: func(_ context.Context, i *fastly.CreateResourceInput) (*fastly.Resource, error) {
 					if got, want := *i.ResourceID, "abc"; got != want {
 						return nil, fmt.Errorf("ResourceID: got %q, want %q", got, want)
@@ -67,9 +64,6 @@ func TestCreateServiceResourceCommand(t *testing.T) {
 			Args: "--resource-id abc --service-id 123 --version 42 --name testing",
 			API: &mock.API{
 				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
-				},
 				CreateResourceFn: func(_ context.Context, i *fastly.CreateResourceInput) (*fastly.Resource, error) {
 					if got, want := *i.ResourceID, "abc"; got != want {
 						return nil, fmt.Errorf("ResourceID: got %q, want %q", got, want)
@@ -157,9 +151,6 @@ func TestDeleteServiceResourceCommand(t *testing.T) {
 			Args: "--service-id 123 --version 42 --id LINKID",
 			API: &mock.API{
 				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
-				},
 				DeleteResourceFn: func(_ context.Context, i *fastly.DeleteResourceInput) error {
 					if got, want := i.ResourceID, "LINKID"; got != want {
 						return fmt.Errorf("ID: got %q, want %q", got, want)
@@ -179,10 +170,9 @@ func TestDeleteServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 42 --id LINKID --autoclone",
 			API: &mock.API{
-				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+				GetVersionFn: func(_ context.Context, i *fastly.GetVersionInput) (*fastly.Version, error) {
 					// Specified version is active, meaning a service clone will be attempted.
-					return []*fastly.Version{{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}}, nil
+					return &fastly.Version{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}, nil
 				},
 				CloneVersionFn: func(_ context.Context, _ *fastly.CloneVersionInput) (*fastly.Version, error) {
 					return &fastly.Version{Number: fastly.ToPointer(43)}, nil
@@ -228,9 +218,6 @@ func TestDescribeServiceResourceCommand(t *testing.T) {
 			Args: "--service-id 123 --version 42 --id LINKID",
 			API: &mock.API{
 				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
-				},
 				GetResourceFn: func(_ context.Context, i *fastly.GetResourceInput) (*fastly.Resource, error) {
 					if got, want := i.ResourceID, "LINKID"; got != want {
 						return nil, fmt.Errorf("ID: got %q, want %q", got, want)
@@ -287,9 +274,6 @@ func TestListServiceResourceCommand(t *testing.T) {
 			Args: "--service-id 123 --version 42",
 			API: &mock.API{
 				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
-				},
 				ListResourcesFn: func(_ context.Context, i *fastly.ListResourcesInput) ([]*fastly.Resource, error) {
 					if got, want := i.ServiceID, "123"; got != want {
 						return nil, fmt.Errorf("ServiceID: got %q, want %q", got, want)
@@ -377,9 +361,6 @@ func TestUpdateServiceResourceCommand(t *testing.T) {
 			Args: "--id LINK-ID --name new-name --service-id 123 --version 42",
 			API: &mock.API{
 				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
-					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
-				},
 				UpdateResourceFn: func(_ context.Context, i *fastly.UpdateResourceInput) (*fastly.Resource, error) {
 					if got, want := i.ResourceID, "LINK-ID"; got != want {
 						return nil, fmt.Errorf("ID: got %q, want %q", got, want)
@@ -413,10 +394,9 @@ func TestUpdateServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--id LINK-ID --name new-name --service-id 123 --version 42 --autoclone",
 			API: &mock.API{
-				GetVersionFn: testutil.GetVersion,
-				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+				GetVersionFn: func(_ context.Context, i *fastly.GetVersionInput) (*fastly.Version, error) {
 					// Specified version is active, meaning a service clone will be attempted.
-					return []*fastly.Version{{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}}, nil
+					return &fastly.Version{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}, nil
 				},
 				CloneVersionFn: func(_ context.Context, _ *fastly.CloneVersionInput) (*fastly.Version, error) {
 					return &fastly.Version{Number: fastly.ToPointer(43)}, nil

--- a/pkg/commands/service/resourcelink/resourcelink_test.go
+++ b/pkg/commands/service/resourcelink/resourcelink_test.go
@@ -27,12 +27,14 @@ func TestCreateServiceResourceCommand(t *testing.T) {
 		},
 		{
 			Args:      "--resource-id abc --version latest",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		// Success.
 		{
 			Args: "--resource-id abc --service-id 123 --version 42",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
 				},
@@ -64,6 +66,7 @@ func TestCreateServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--resource-id abc --service-id 123 --version 42 --name testing",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
 				},
@@ -95,6 +98,8 @@ func TestCreateServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--resource-id abc --service-id 123 --version=latest --autoclone",
 			API: &mock.API{
+				GetVersionFn:        testutil.GetVersion,
+				GetServiceDetailsFn: testutil.GetServiceDetails,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					// Specified version is active, meaning a service clone will be attempted.
 					return []*fastly.Version{{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}}, nil
@@ -140,6 +145,7 @@ func TestDeleteServiceResourceCommand(t *testing.T) {
 		},
 		{
 			Args:      "--id LINK-ID --version 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -150,6 +156,7 @@ func TestDeleteServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 42 --id LINKID",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
 				},
@@ -172,6 +179,7 @@ func TestDeleteServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 42 --id LINKID --autoclone",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					// Specified version is active, meaning a service clone will be attempted.
 					return []*fastly.Version{{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}}, nil
@@ -208,6 +216,7 @@ func TestDescribeServiceResourceCommand(t *testing.T) {
 		},
 		{
 			Args:      "--id LINK-ID --version 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -218,6 +227,7 @@ func TestDescribeServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 42 --id LINKID",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
 				},
@@ -269,12 +279,14 @@ func TestListServiceResourceCommand(t *testing.T) {
 		},
 		{
 			Args:      "--version 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		// Success.
 		{
 			Args: "--service-id 123 --version 42",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
 				},
@@ -349,6 +361,7 @@ func TestUpdateServiceResourceCommand(t *testing.T) {
 		},
 		{
 			Args:      "--id LINK-ID --name new-name --version 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -363,6 +376,7 @@ func TestUpdateServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--id LINK-ID --name new-name --service-id 123 --version 42",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					return []*fastly.Version{{Number: fastly.ToPointer(42)}}, nil
 				},
@@ -399,6 +413,7 @@ func TestUpdateServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--id LINK-ID --name new-name --service-id 123 --version 42 --autoclone",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				ListVersionsFn: func(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 					// Specified version is active, meaning a service clone will be attempted.
 					return []*fastly.Version{{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}}, nil

--- a/pkg/commands/service/resourcelink/resourcelink_test.go
+++ b/pkg/commands/service/resourcelink/resourcelink_test.go
@@ -170,7 +170,7 @@ func TestDeleteServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 42 --id LINKID --autoclone",
 			API: &mock.API{
-				GetVersionFn: func(_ context.Context, i *fastly.GetVersionInput) (*fastly.Version, error) {
+				GetVersionFn: func(_ context.Context, _ *fastly.GetVersionInput) (*fastly.Version, error) {
 					// Specified version is active, meaning a service clone will be attempted.
 					return &fastly.Version{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}, nil
 				},
@@ -394,7 +394,7 @@ func TestUpdateServiceResourceCommand(t *testing.T) {
 		{
 			Args: "--id LINK-ID --name new-name --service-id 123 --version 42 --autoclone",
 			API: &mock.API{
-				GetVersionFn: func(_ context.Context, i *fastly.GetVersionInput) (*fastly.Version, error) {
+				GetVersionFn: func(_ context.Context, _ *fastly.GetVersionInput) (*fastly.Version, error) {
 					// Specified version is active, meaning a service clone will be attempted.
 					return &fastly.Version{Active: fastly.ToPointer(true), Number: fastly.ToPointer(42)}, nil
 				},

--- a/pkg/commands/service/service_test.go
+++ b/pkg/commands/service/service_test.go
@@ -70,6 +70,7 @@ func TestServiceList(t *testing.T) {
 		{
 			Name: "api failure",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
 					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{
@@ -85,6 +86,7 @@ func TestServiceList(t *testing.T) {
 		{
 			Name: "success with pagination",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
 					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
@@ -123,6 +125,7 @@ func TestServiceList(t *testing.T) {
 		{
 			Name: "success with verbose",
 			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
 				GetServicesFn: func(ctx context.Context, _ *fastly.GetServicesInput) *fastly.ListPaginator[fastly.Service] {
 					return fastly.NewPaginator[fastly.Service](ctx, &mock.HTTPClient{
 						Errors: []error{nil},
@@ -199,6 +202,7 @@ func TestServiceDescribe(t *testing.T) {
 			Name:      "no service id",
 			Args:      "",
 			API:       &mock.API{GetServiceDetailsFn: describeServiceOK},
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -266,9 +270,11 @@ func TestServiceUpdate(t *testing.T) {
 			Name: "no service id",
 			Args: "",
 			API: &mock.API{
+				GetVersionFn:    testutil.GetVersion,
 				GetServiceFn:    getServiceOK,
 				UpdateServiceFn: updateServiceOK,
 			},
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{

--- a/pkg/commands/service/vcl/condition/condition_test.go
+++ b/pkg/commands/service/vcl/condition/condition_test.go
@@ -19,12 +19,13 @@ func TestConditionCreate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--version 1",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Args: "--service-id 123 --version 1 --name always_false --statement false --type REQUEST --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateConditionFn: createConditionOK,
 			},
@@ -33,7 +34,7 @@ func TestConditionCreate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false --statement false --type REQUEST --priority 10 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				CreateConditionFn: createConditionError,
 			},
@@ -53,7 +54,7 @@ func TestConditionDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteConditionFn: deleteConditionError,
 			},
@@ -62,7 +63,7 @@ func TestConditionDelete(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				DeleteConditionFn: deleteConditionOK,
 			},
@@ -82,7 +83,7 @@ func TestConditionUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateConditionFn: updateConditionOK,
 			},
@@ -91,7 +92,7 @@ func TestConditionUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false --new-name false_always --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateConditionFn: updateConditionError,
 			},
@@ -100,7 +101,7 @@ func TestConditionUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false --new-name false_always --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				UpdateConditionFn: updateConditionOK,
 			},
@@ -120,7 +121,7 @@ func TestConditionDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetConditionFn: getConditionError,
 			},
 			WantError: errTest.Error(),
@@ -128,7 +129,7 @@ func TestConditionDescribe(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --name always_false",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				GetConditionFn: getConditionOK,
 			},
 			WantOutput: describeConditionOutput,
@@ -143,7 +144,7 @@ func TestConditionList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListConditionsFn: listConditionsOK,
 			},
 			WantOutput: listConditionsShortOutput,
@@ -151,7 +152,7 @@ func TestConditionList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --verbose",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListConditionsFn: listConditionsOK,
 			},
 			WantOutput: listConditionsVerboseOutput,
@@ -159,7 +160,7 @@ func TestConditionList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 -v",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListConditionsFn: listConditionsOK,
 			},
 			WantOutput: listConditionsVerboseOutput,
@@ -167,7 +168,7 @@ func TestConditionList(t *testing.T) {
 		{
 			Args: "--verbose --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListConditionsFn: listConditionsOK,
 			},
 			WantOutput: listConditionsVerboseOutput,
@@ -175,7 +176,7 @@ func TestConditionList(t *testing.T) {
 		{
 			Args: "-v --service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListConditionsFn: listConditionsOK,
 			},
 			WantOutput: listConditionsVerboseOutput,
@@ -183,7 +184,7 @@ func TestConditionList(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:   testutil.ListVersions,
+				GetVersionFn:     testutil.GetVersion,
 				ListConditionsFn: listConditionsError,
 			},
 			WantError: errTest.Error(),

--- a/pkg/commands/service/vcl/custom/custom_test.go
+++ b/pkg/commands/service/vcl/custom/custom_test.go
@@ -2,6 +2,7 @@ package custom_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -17,25 +18,9 @@ func TestVCLCustomCreate(t *testing.T) {
 	var content string
 	scenarios := []testutil.CLIScenario{
 		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--content ./testdata/example.vcl --name foo --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--content ./testdata/example.vcl --name foo --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
-		},
-		{
 			Name: "validate CreateVCL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateVCLFn: func(_ context.Context, _ *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
@@ -46,7 +31,7 @@ func TestVCLCustomCreate(t *testing.T) {
 		{
 			Name: "validate CreateVCL API success for non-main VCL",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -76,7 +61,7 @@ func TestVCLCustomCreate(t *testing.T) {
 		{
 			Name: "validate CreateVCL API success for main VCL",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					// Track the contents parsed
@@ -107,7 +92,7 @@ func TestVCLCustomCreate(t *testing.T) {
 		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
@@ -138,7 +123,7 @@ func TestVCLCustomCreate(t *testing.T) {
 		{
 			Name: "validate CreateVCL API success with inline VCL content",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateVCLFn: func(_ context.Context, i *fastly.CreateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -185,28 +170,13 @@ func TestVCLCustomDelete(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate DeleteVCL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteVCLFn: func(_ context.Context, _ *fastly.DeleteVCLInput) error {
 					return testutil.Err
 				},
@@ -217,7 +187,7 @@ func TestVCLCustomDelete(t *testing.T) {
 		{
 			Name: "validate DeleteVCL API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteVCLFn: func(_ context.Context, _ *fastly.DeleteVCLInput) error {
 					return nil
 				},
@@ -226,15 +196,69 @@ func TestVCLCustomDelete(t *testing.T) {
 			WantOutput: "Deleted custom VCL 'foobar' (service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteVCLFn: func(_ context.Context, i *fastly.DeleteVCLInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteVCLFn: func(_ context.Context, i *fastly.DeleteVCLInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteVCLFn: func(_ context.Context, _ *fastly.DeleteVCLInput) error {
 					return nil
 				},
 			},
 			Args:       "--autoclone --name foo --service-id 123 --version 1",
+			WantOutput: "Deleted custom VCL 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteVCLFn: func(_ context.Context, i *fastly.DeleteVCLInput) error {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 2",
+			WantOutput: "Deleted custom VCL 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteVCLFn: func(_ context.Context, i *fastly.DeleteVCLInput) error {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 3",
 			WantOutput: "Deleted custom VCL 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -262,7 +286,7 @@ func TestVCLCustomDescribe(t *testing.T) {
 		{
 			Name: "validate GetVCL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				GetVCLFn: func(_ context.Context, _ *fastly.GetVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
@@ -273,8 +297,8 @@ func TestVCLCustomDescribe(t *testing.T) {
 		{
 			Name: "validate GetVCL API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetVCLFn:       getVCL,
+				GetVersionFn: testutil.GetVersion,
+				GetVCLFn:     getVCL,
 			},
 			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -282,8 +306,8 @@ func TestVCLCustomDescribe(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetVCLFn:       getVCL,
+				GetVersionFn: testutil.GetVersion,
+				GetVCLFn:     getVCL,
 			},
 			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -302,12 +326,13 @@ func TestVCLCustomList(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate ListVCLs API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				ListVCLsFn: func(_ context.Context, _ *fastly.ListVCLsInput) ([]*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
@@ -318,8 +343,8 @@ func TestVCLCustomList(t *testing.T) {
 		{
 			Name: "validate ListVCLs API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListVCLsFn:     listVCLs,
+				GetVersionFn: testutil.GetVersion,
+				ListVCLsFn:   listVCLs,
 			},
 			Args:       "--service-id 123 --version 3",
 			WantOutput: "SERVICE ID  VERSION  NAME  MAIN\n123         3        foo   true\n123         3        bar   false\n",
@@ -327,8 +352,8 @@ func TestVCLCustomList(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListVCLsFn:     listVCLs,
+				GetVersionFn: testutil.GetVersion,
+				ListVCLsFn:   listVCLs,
 			},
 			Args:       "--service-id 123 --version 1",
 			WantOutput: "SERVICE ID  VERSION  NAME  MAIN\n123         1        foo   true\n123         1        bar   false\n",
@@ -336,8 +361,8 @@ func TestVCLCustomList(t *testing.T) {
 		{
 			Name: "validate missing --verbose flag",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				ListVCLsFn:     listVCLs,
+				GetVersionFn: testutil.GetVersion,
+				ListVCLsFn:   listVCLs,
 			},
 			Args:       "--service-id 123 --verbose --version 1",
 			WantOutput: "Fastly API endpoint: https://api.fastly.com\nFastly API token provided via config file (auth: user)\n\nService ID (via --service-id): 123\n\nService Version: 1\n\nName: foo\nMain: true\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n\nName: bar\nMain: false\nContent: \n# some vcl content\n\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -363,28 +388,13 @@ func TestVCLCustomUpdate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate UpdateVCL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateVCLFn: func(_ context.Context, _ *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
@@ -395,7 +405,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateVCL API success with --new-name",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					return &fastly.VCL{
 						Content:        fastly.ToPointer("# untouched"),
@@ -412,7 +422,7 @@ func TestVCLCustomUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateVCL API success with --content",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -431,9 +441,31 @@ func TestVCLCustomUpdate(t *testing.T) {
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--content updated --name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--content updated --name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
 					// Track the contents parsed
@@ -449,6 +481,58 @@ func TestVCLCustomUpdate(t *testing.T) {
 				},
 			},
 			Args:            "--autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 1",
+			WantOutput:      "Updated custom VCL 'foo' (service: 123, version: 4)",
+			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					// Track the contents parsed
+					content = *i.Content
+
+					return &fastly.VCL{
+						Content:        i.Content,
+						Main:           fastly.ToPointer(true),
+						Name:           fastly.ToPointer(i.Name),
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:            "--autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 2",
+			WantOutput:      "Updated custom VCL 'foo' (service: 123, version: 4)",
+			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateVCLFn: func(_ context.Context, i *fastly.UpdateVCLInput) (*fastly.VCL, error) {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					// Track the contents parsed
+					content = *i.Content
+
+					return &fastly.VCL{
+						Content:        i.Content,
+						Main:           fastly.ToPointer(true),
+						Name:           fastly.ToPointer(i.Name),
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+					}, nil
+				},
+			},
+			Args:            "--autoclone --content ./testdata/example.vcl --name foo --service-id 123 --version 3",
 			WantOutput:      "Updated custom VCL 'foo' (service: 123, version: 4)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "example.vcl", Content: func() string { return content }},
 		},

--- a/pkg/commands/service/vcl/snippet/snippet_test.go
+++ b/pkg/commands/service/vcl/snippet/snippet_test.go
@@ -2,6 +2,7 @@ package snippet_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/fastly/go-fastly/v15/fastly"
@@ -19,28 +20,13 @@ func TestVCLSnippetCreate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--content /path/to/snippet.vcl --name foo --type recv --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--content ./testdata/snippet.vcl --name foo --type recv --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate CreateSnippet API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateSnippetFn: func(_ context.Context, _ *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
@@ -51,7 +37,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 		{
 			Name: "validate CreateSnippet API success for versioned Snippet",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -85,7 +71,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 		{
 			Name: "validate CreateSnippet API success for dynamic Snippet",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -119,7 +105,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 		{
 			Name: "validate Priority set",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -153,7 +139,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
@@ -188,7 +174,7 @@ func TestVCLSnippetCreate(t *testing.T) {
 		{
 			Name: "validate CreateSnippet API success with inline Snippet content",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				CreateSnippetFn: func(_ context.Context, i *fastly.CreateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -239,28 +225,13 @@ func TestVCLSnippetDelete(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--name foobar --version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--name foobar --service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate DeleteSnippet API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteSnippetFn: func(_ context.Context, _ *fastly.DeleteSnippetInput) error {
 					return testutil.Err
 				},
@@ -271,7 +242,7 @@ func TestVCLSnippetDelete(t *testing.T) {
 		{
 			Name: "validate DeleteSnippet API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				DeleteSnippetFn: func(_ context.Context, _ *fastly.DeleteSnippetInput) error {
 					return nil
 				},
@@ -280,15 +251,69 @@ func TestVCLSnippetDelete(t *testing.T) {
 			WantOutput: "Deleted VCL snippet 'foobar' (service: 123, version: 3)",
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteSnippetFn: func(_ context.Context, i *fastly.DeleteSnippetInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				DeleteSnippetFn: func(_ context.Context, i *fastly.DeleteSnippetInput) error {
+					return fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--name foobar --service-id 123 --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				DeleteSnippetFn: func(_ context.Context, _ *fastly.DeleteSnippetInput) error {
 					return nil
 				},
 			},
 			Args:       "--autoclone --name foo --service-id 123 --version 1",
+			WantOutput: "Deleted VCL snippet 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteSnippetFn: func(_ context.Context, i *fastly.DeleteSnippetInput) error {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 2",
+			WantOutput: "Deleted VCL snippet 'foo' (service: 123, version: 4)",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				DeleteSnippetFn: func(_ context.Context, i *fastly.DeleteSnippetInput) error {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return nil
+				},
+			},
+			Args:       "--autoclone --name foo --service-id 123 --version 3",
 			WantOutput: "Deleted VCL snippet 'foo' (service: 123, version: 4)",
 		},
 	}
@@ -310,7 +335,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate missing --name flag with versioned snippet",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --name with a versioned VCL snippet",
@@ -318,7 +343,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate missing --snippet-id flag with dynamic snippet",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--dynamic --service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --snippet-id with a dynamic VCL snippet",
@@ -326,7 +351,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate GetSnippet API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				GetSnippetFn: func(_ context.Context, _ *fastly.GetSnippetInput) (*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
@@ -337,8 +362,8 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate GetSnippet API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSnippetFn:   getSnippet,
+				GetVersionFn: testutil.GetVersion,
+				GetSnippetFn: getSnippet,
 			},
 			Args:       "--name foobar --service-id 123 --version 3",
 			WantOutput: "\nService ID: 123\nService Version: 3\n\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -346,8 +371,8 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSnippetFn:   getSnippet,
+				GetVersionFn: testutil.GetVersion,
+				GetSnippetFn: getSnippet,
 			},
 			Args:       "--name foobar --service-id 123 --version 1",
 			WantOutput: "\nService ID: 123\nService Version: 1\n\nName: foobar\nID: 456\nPriority: 0\nDynamic: false\nType: recv\nContent: \n# some vcl content\nCreated at: 2021-06-15 23:00:00 +0000 UTC\nUpdated at: 2021-06-15 23:00:00 +0000 UTC\nDeleted at: 2021-06-15 23:00:00 +0000 UTC\n",
@@ -355,7 +380,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate dynamic GetSnippet API success",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				GetDynamicSnippetFn: getDynamicSnippet,
 			},
 			Args:       "--dynamic --service-id 123 --snippet-id 456 --version 3",
@@ -364,8 +389,8 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate --content flag outputs raw VCL only for versioned snippet",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				GetSnippetFn:   getSnippet,
+				GetVersionFn: testutil.GetVersion,
+				GetSnippetFn: getSnippet,
 			},
 			Args:       "--content --name foobar --service-id 123 --version 3",
 			WantOutput: "# some vcl content",
@@ -373,7 +398,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate --content flag outputs raw VCL only for dynamic snippet",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				GetDynamicSnippetFn: getDynamicSnippet,
 			},
 			Args:       "--content --dynamic --service-id 123 --snippet-id 456 --version 3",
@@ -382,7 +407,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate --content flag with --verbose returns error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--content --name foobar --service-id 123 --verbose --version 3",
 			WantError: "invalid flag combination, --content cannot be used together with --json or --verbose",
@@ -390,7 +415,7 @@ func TestVCLSnippetDescribe(t *testing.T) {
 		{
 			Name: "validate --content flag with --json returns error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--content --json --name foobar --service-id 123 --version 3",
 			WantError: "invalid flag combination, --content cannot be used together with --json or --verbose",
@@ -414,7 +439,7 @@ func TestVCLSnippetList(t *testing.T) {
 		{
 			Name: "validate ListSnippets API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				ListSnippetsFn: func(_ context.Context, _ *fastly.ListSnippetsInput) ([]*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
@@ -425,7 +450,7 @@ func TestVCLSnippetList(t *testing.T) {
 		{
 			Name: "validate ListSnippets API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListSnippetsFn: listSnippets,
 			},
 			Args:       "--service-id 123 --version 3",
@@ -434,7 +459,7 @@ func TestVCLSnippetList(t *testing.T) {
 		{
 			Name: "validate missing --autoclone flag is OK",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListSnippetsFn: listSnippets,
 			},
 			Args:       "--service-id 123 --version 1",
@@ -443,7 +468,7 @@ func TestVCLSnippetList(t *testing.T) {
 		{
 			Name: "validate missing --verbose flag",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				ListSnippetsFn: listSnippets,
 			},
 			Args:       "--service-id 123 --verbose --version 1",
@@ -464,28 +489,13 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'active' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--service-id 123 --version 1",
-			WantError: "service version 1 is active",
-		},
-		{
-			Name: "validate missing --autoclone flag with 'locked' service",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			Args:      "--service-id 123 --version 2",
-			WantError: "service version 2 is locked",
 		},
 		{
 			Name: "validate versioned snippet missing --name",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--content inline_vcl --new-name bar --service-id 123 --type recv --version 3",
 			WantError: "error parsing arguments: must provide --name to update a versioned VCL snippet",
@@ -493,7 +503,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		{
 			Name: "validate dynamic snippet missing --snippet-id",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--content inline_vcl --dynamic --service-id 123 --version 3",
 			WantError: "error parsing arguments: must provide --snippet-id to update a dynamic VCL snippet",
@@ -501,7 +511,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		{
 			Name: "validate versioned snippet with --snippet-id is not allowed",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--content inline_vcl --new-name foobar --service-id 123 --snippet-id 456 --version 3",
 			WantError: "error parsing arguments: --snippet-id is not supported when updating a versioned VCL snippet",
@@ -509,7 +519,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		{
 			Name: "validate dynamic snippet with --new-name is not allowed",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 			},
 			Args:      "--content inline_vcl --dynamic --new-name foobar --service-id 123 --snippet-id 456 --version 3",
 			WantError: "error parsing arguments: --new-name is not supported when updating a dynamic VCL snippet",
@@ -517,7 +527,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateSnippet API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateSnippetFn: func(_ context.Context, _ *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
 					return nil, testutil.Err
 				},
@@ -528,7 +538,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateSnippet API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -550,7 +560,7 @@ func TestVCLSnippetUpdate(t *testing.T) {
 		{
 			Name: "validate UpdateDynamicSnippet API success",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				UpdateDynamicSnippetFn: func(_ context.Context, i *fastly.UpdateDynamicSnippetInput) (*fastly.DynamicSnippet, error) {
 					// Track the contents parsed
 					content = *i.Content
@@ -567,9 +577,31 @@ func TestVCLSnippetUpdate(t *testing.T) {
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},
 		{
+			Name: "validate API error when modifying active version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been activated cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3",
+			WantError: "Cannot update version 3. Versions that have been activated cannot be updated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					return nil, fmt.Errorf("Cannot update version %d. Versions that have been locked cannot be updated", i.ServiceVersion)
+				},
+			},
+			Args:      "--content inline_vcl --name foo --new-name bar --service-id 123 --type recv --version 3",
+			WantError: "Cannot update version 3. Versions that have been locked cannot be updated",
+		},
+		{
 			Name: "validate --autoclone results in cloned service version",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
 					// Track the contents parsed
@@ -586,6 +618,60 @@ func TestVCLSnippetUpdate(t *testing.T) {
 				},
 			},
 			Args:            "--autoclone --content inline_vcl --name foo --new-name bar --priority 1 --service-id 123 --type recv --version 1",
+			WantOutput:      "Updated VCL snippet 'bar' (previously: 'foo', service: 123, version: 4, type: recv, priority: 1)",
+			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					// Verify operation happens on the cloned version (4), not original (2)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					// Track the contents parsed
+					content = *i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Name:           i.NewName,
+						Priority:       i.Priority,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+						Type:           i.Type,
+					}, nil
+				},
+			},
+			Args:            "--autoclone --content inline_vcl --name foo --new-name bar --priority 1 --service-id 123 --type recv --version 2",
+			WantOutput:      "Updated VCL snippet 'bar' (previously: 'foo', service: 123, version: 4, type: recv, priority: 1)",
+			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				UpdateSnippetFn: func(_ context.Context, i *fastly.UpdateSnippetInput) (*fastly.Snippet, error) {
+					// Verify operation happens on the cloned version (4), not original (3)
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected operation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					// Track the contents parsed
+					content = *i.Content
+
+					return &fastly.Snippet{
+						Content:        i.Content,
+						Name:           i.NewName,
+						Priority:       i.Priority,
+						ServiceID:      fastly.ToPointer(i.ServiceID),
+						ServiceVersion: fastly.ToPointer(i.ServiceVersion),
+						Type:           i.Type,
+					}, nil
+				},
+			},
+			Args:            "--autoclone --content inline_vcl --name foo --new-name bar --priority 1 --service-id 123 --type recv --version 3",
 			WantOutput:      "Updated VCL snippet 'bar' (previously: 'foo', service: 123, version: 4, type: recv, priority: 1)",
 			PathContentFlag: &testutil.PathContentFlag{Flag: "content", Fixture: "snippet.vcl", Content: func() string { return content }},
 		},

--- a/pkg/commands/service/vcl/vcl_test.go
+++ b/pkg/commands/service/vcl/vcl_test.go
@@ -21,12 +21,13 @@ func TestVCLDescribe(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--version 3",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name: "validate DescribeVCL API error",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
 				GetGeneratedVCLFn: func(_ context.Context, _ *fastly.GetGeneratedVCLInput) (*fastly.VCL, error) {
 					return nil, testutil.Err
 				},
@@ -37,7 +38,7 @@ func TestVCLDescribe(t *testing.T) {
 		{
 			Name: "validate DescribeVCL API success",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				GetGeneratedVCLFn: getVCL,
 			},
 			Args:       "--service-id 123 --version 3",
@@ -46,7 +47,7 @@ func TestVCLDescribe(t *testing.T) {
 		{
 			Name: "validate missing --verbose flag",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				GetGeneratedVCLFn: getVCL,
 			},
 			Args:       "--service-id 123 --verbose --version 1",

--- a/pkg/commands/service/version/serviceversion_test.go
+++ b/pkg/commands/service/version/serviceversion_test.go
@@ -2,6 +2,7 @@ package version_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -18,6 +19,7 @@ func TestVersionClone(t *testing.T) {
 		{
 			Name:      "validate missing --service-id flag",
 			Args:      "--version 1",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error reading service: no service ID found",
 		},
 		{
@@ -29,7 +31,7 @@ func TestVersionClone(t *testing.T) {
 			Name: "validate successful clone",
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantOutput: "Cloned service 123 version 1 to version 4",
@@ -38,7 +40,7 @@ func TestVersionClone(t *testing.T) {
 			Name: "validate successful clone json output",
 			Args: "--service-id 123 --version 1 --json",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantOutput: cloneServiceVersionJSONOutput,
@@ -47,7 +49,7 @@ func TestVersionClone(t *testing.T) {
 			Name: "validate error will be passed through if cloning fails",
 			Args: "--service-id 456 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionError,
 			},
 			WantError: testutil.Err.Error(),
@@ -99,7 +101,7 @@ func TestVersionUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --comment foo --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateVersionFn: updateVersionOK,
 			},
@@ -108,7 +110,7 @@ func TestVersionUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
+				GetVersionFn:   testutil.GetVersion,
 				CloneVersionFn: testutil.CloneVersionResult(4),
 			},
 			WantError: "error parsing arguments: required flag --comment not provided",
@@ -116,7 +118,7 @@ func TestVersionUpdate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --comment foo --autoclone",
 			API: &mock.API{
-				ListVersionsFn:  testutil.ListVersions,
+				GetVersionFn:    testutil.GetVersion,
 				CloneVersionFn:  testutil.CloneVersionResult(4),
 				UpdateVersionFn: updateVersionError,
 			},
@@ -134,16 +136,9 @@ func TestVersionActivate(t *testing.T) {
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
-			Args: "--service-id 123 --version 1",
-			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-			},
-			WantError: "service version 1 is active",
-		},
-		{
 			Args: "--service-id 123 --version 1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				ActivateVersionFn: activateVersionError,
 			},
@@ -152,7 +147,7 @@ func TestVersionActivate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				ActivateVersionFn: activateVersionOK,
 			},
@@ -161,19 +156,95 @@ func TestVersionActivate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 2 --autoclone",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				CloneVersionFn:    testutil.CloneVersionResult(4),
 				ActivateVersionFn: activateVersionOK,
 			},
 			WantOutput: "Activated service 123 version 4",
 		},
 		{
-			Args: "--service-id 123 --version 3 --autoclone",
+			Name: "validate API error when modifying active version",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn: testutil.GetVersion,
+				ActivateVersionFn: func(_ context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+					return nil, fmt.Errorf("Cannot activate version %d. Versions that have been activated cannot be activated", i.ServiceVersion)
+				},
+			},
+			Args:      "--service-id 123 --version 3",
+			WantError: "Cannot activate version 3. Versions that have been activated cannot be activated",
+		},
+		{
+			Name: "validate API error when modifying locked version",
+			API: &mock.API{
+				GetVersionFn: testutil.GetVersion,
+				ActivateVersionFn: func(_ context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+					return nil, fmt.Errorf("Cannot activate version %d. Versions that have been locked cannot be activated", i.ServiceVersion)
+				},
+			},
+			Args:      "--service-id 123 --version 3",
+			WantError: "Cannot activate version 3. Versions that have been locked cannot be activated",
+		},
+		{
+			Args: "--service-id 123 --version 3",
+			API: &mock.API{
+				GetVersionFn:      testutil.GetVersion,
 				ActivateVersionFn: activateVersionOK,
 			},
 			WantOutput: "Activated service 123 version 3",
+		},
+		{
+			Name: "validate --autoclone results in cloned service version",
+			API: &mock.API{
+				GetVersionFn:      testutil.GetVersion,
+				CloneVersionFn:    testutil.CloneVersionResult(4),
+				ActivateVersionFn: activateVersionOK,
+			},
+			Args:       "--service-id 123 --version 3 --autoclone",
+			WantOutput: "Activated service 123 version 4",
+		},
+		{
+			Name: "validate --autoclone on locked version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				ActivateVersionFn: func(_ context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected activation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.Version{
+						Number:    fastly.ToPointer(i.ServiceVersion),
+						ServiceID: fastly.ToPointer("123"),
+						Active:    fastly.ToPointer(true),
+						Deployed:  fastly.ToPointer(true),
+						CreatedAt: testutil.MustParseTimeRFC3339("2010-11-15T19:01:02Z"),
+						UpdatedAt: testutil.MustParseTimeRFC3339("2010-11-15T19:01:02Z"),
+					}, nil
+				},
+			},
+			Args:       "--service-id 123 --version 3 --autoclone",
+			WantOutput: "Activated service 123 version 4",
+		},
+		{
+			Name: "validate --autoclone on editable version",
+			API: &mock.API{
+				GetVersionFn:   testutil.GetVersion,
+				CloneVersionFn: testutil.CloneVersionResult(4),
+				ActivateVersionFn: func(_ context.Context, i *fastly.ActivateVersionInput) (*fastly.Version, error) {
+					if i.ServiceVersion != 4 {
+						return nil, fmt.Errorf("expected activation on cloned version 4, got %d", i.ServiceVersion)
+					}
+					return &fastly.Version{
+						Number:    fastly.ToPointer(i.ServiceVersion),
+						ServiceID: fastly.ToPointer("123"),
+						Active:    fastly.ToPointer(true),
+						Deployed:  fastly.ToPointer(true),
+						CreatedAt: testutil.MustParseTimeRFC3339("2010-11-15T19:01:02Z"),
+						UpdatedAt: testutil.MustParseTimeRFC3339("2010-11-15T19:01:02Z"),
+					}, nil
+				},
+			},
+			Args:       "--service-id 123 --version 3 --autoclone",
+			WantOutput: "Activated service 123 version 4",
 		},
 	}
 
@@ -184,12 +255,13 @@ func TestVersionDeactivate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--service-id 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				DeactivateVersionFn: deactivateVersionOK,
 			},
 			WantOutput: "Deactivated service 123 version 1",
@@ -197,7 +269,7 @@ func TestVersionDeactivate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				DeactivateVersionFn: deactivateVersionOK,
 			},
 			WantError: "service version 3 is not active",
@@ -205,7 +277,7 @@ func TestVersionDeactivate(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				DeactivateVersionFn: deactivateVersionError,
 			},
 			WantError: testutil.Err.Error(),
@@ -219,21 +291,22 @@ func TestVersionLock(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--service-id 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				LockVersionFn:  lockVersionOK,
+				GetVersionFn:  testutil.GetVersion,
+				LockVersionFn: lockVersionOK,
 			},
 			WantOutput: "Locked service 123 version 1",
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn: testutil.ListVersions,
-				LockVersionFn:  lockVersionError,
+				GetVersionFn:  testutil.GetVersion,
+				LockVersionFn: lockVersionError,
 			},
 			WantError: testutil.Err.Error(),
 		},
@@ -246,28 +319,13 @@ func TestVersionStage(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--service-id 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error parsing arguments: required flag --version not provided",
-		},
-		{
-			Args: "--service-id 123 --version 1",
-			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
-				ActivateVersionFn: stageVersionOK,
-			},
-			WantError: "service version 1 is active",
-		},
-		{
-			Args: "--service-id 123 --version 2",
-			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
-				ActivateVersionFn: stageVersionOK,
-			},
-			WantError: "service version 2 is locked",
 		},
 		{
 			Args: "--service-id 123 --version 3",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ActivateVersionFn: stageVersionError,
 			},
 			WantError: testutil.Err.Error(),
@@ -275,7 +333,7 @@ func TestVersionStage(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ActivateVersionFn: stageVersionOK,
 			},
 			WantOutput: "Staged service 123 version 3",
@@ -283,7 +341,7 @@ func TestVersionStage(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 4",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ActivateVersionFn: stageVersionOK,
 			},
 			WantOutput: "Staged service 123 version 4",
@@ -297,12 +355,13 @@ func TestVersionUnstage(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
 			Args:      "--service-id 123",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				DeactivateVersionFn: unstageVersionOK,
 			},
 			WantError: "service version 1 is not staged",
@@ -310,7 +369,7 @@ func TestVersionUnstage(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 3",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				DeactivateVersionFn: unstageVersionError,
 			},
 			WantError: "service version 3 is not staged",
@@ -318,7 +377,7 @@ func TestVersionUnstage(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 4",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				DeactivateVersionFn: unstageVersionError,
 			},
 			WantError: testutil.Err.Error(),
@@ -326,7 +385,7 @@ func TestVersionUnstage(t *testing.T) {
 		{
 			Args: "--service-id 123 --version 4",
 			API: &mock.API{
-				ListVersionsFn:      testutil.ListVersions,
+				GetVersionFn:        testutil.GetVersion,
 				DeactivateVersionFn: unstageVersionOK,
 			},
 			WantOutput: "Unstaged service 123 version 4",
@@ -355,10 +414,10 @@ var cloneServiceVersionJSONOutput = strings.TrimSpace(`
 
 var listVersionsShortOutput = strings.TrimSpace(`
 NUMBER  ACTIVE  STAGED  LAST EDITED (UTC)
-1       true    false   2000-01-01 01:00
-2       false   false   2000-01-02 01:00
-3       false   false   2000-01-03 01:00
 4       false   true    2000-01-04 01:00
+3       false   false   2000-01-03 01:00
+2       false   false   2000-01-02 01:00
+1       true    false   2000-01-01 01:00
 `) + "\n"
 
 var listVersionsVerboseOutput = strings.TrimSpace(`
@@ -369,24 +428,24 @@ Service ID (via --service-id): 123
 
 Versions: 4
 	Version 1/4
-		Number: 1
-		Service ID: 123
-		Active: true
-		Last edited (UTC): 2000-01-01 01:00
-	Version 2/4
-		Number: 2
-		Service ID: 123
-		Locked: true
-		Last edited (UTC): 2000-01-02 01:00
-	Version 3/4
-		Number: 3
-		Service ID: 123
-		Last edited (UTC): 2000-01-03 01:00
-	Version 4/4
 		Number: 4
 		Service ID: 123
 		Staged: true
 		Last edited (UTC): 2000-01-04 01:00
+	Version 2/4
+		Number: 3
+		Service ID: 123
+		Last edited (UTC): 2000-01-03 01:00
+	Version 3/4
+		Number: 2
+		Service ID: 123
+		Locked: true
+		Last edited (UTC): 2000-01-02 01:00
+	Version 4/4
+		Number: 1
+		Service ID: 123
+		Active: true
+		Last edited (UTC): 2000-01-01 01:00
 `) + "\n\n"
 
 func updateVersionOK(_ context.Context, i *fastly.UpdateVersionInput) (*fastly.Version, error) {
@@ -498,7 +557,7 @@ func TestVersionValidate(t *testing.T) {
 			Name: "validate successful - valid version without message",
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ValidateVersionFn: validateVersionValid(""),
 			},
 			WantOutput: "Service 123 version 1 is valid",
@@ -507,7 +566,7 @@ func TestVersionValidate(t *testing.T) {
 			Name: "validate successful - valid version with message",
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ValidateVersionFn: validateVersionValid("All checks passed"),
 			},
 			WantOutput: "Service 123 version 1 is valid: All checks passed",
@@ -516,7 +575,7 @@ func TestVersionValidate(t *testing.T) {
 			Name: "validate successful - invalid version without message",
 			Args: "--service-id 123 --version 2",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ValidateVersionFn: validateVersionInvalid(""),
 			},
 			WantOutput: "Service 123 version 2 is not valid",
@@ -525,7 +584,7 @@ func TestVersionValidate(t *testing.T) {
 			Name: "validate successful - invalid version with message",
 			Args: "--service-id 123 --version 2",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ValidateVersionFn: validateVersionInvalid("Missing required backend"),
 			},
 			WantOutput: "Service 123 version 2 is not valid: Missing required backend",
@@ -534,7 +593,7 @@ func TestVersionValidate(t *testing.T) {
 			Name: "validate with json output - valid version",
 			Args: "--service-id 123 --version 1 --json",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ValidateVersionFn: validateVersionValid("All checks passed"),
 			},
 			WantOutput: validateVersionValidJSONOutput,
@@ -543,7 +602,7 @@ func TestVersionValidate(t *testing.T) {
 			Name: "validate with json output - invalid version",
 			Args: "--service-id 123 --version 2 --json",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ValidateVersionFn: validateVersionInvalid("Missing required backend"),
 			},
 			WantOutput: validateVersionInvalidJSONOutput,
@@ -552,7 +611,7 @@ func TestVersionValidate(t *testing.T) {
 			Name: "validate error from API",
 			Args: "--service-id 123 --version 1",
 			API: &mock.API{
-				ListVersionsFn:    testutil.ListVersions,
+				GetVersionFn:      testutil.GetVersion,
 				ValidateVersionFn: validateVersionError,
 			},
 			WantError: testutil.Err.Error(),

--- a/pkg/commands/stats/domain_inspector_test.go
+++ b/pkg/commands/stats/domain_inspector_test.go
@@ -65,9 +65,11 @@ func TestDomainInspector(t *testing.T) {
 			wantError: "non-success response",
 		},
 		{
-			name:      "missing service ID",
-			args:      args("stats domain-inspector"),
-			api:       mock.API{},
+			name: "missing service ID",
+			args: args("stats domain-inspector"),
+			api: mock.API{
+				GetDomainMetricsForServiceFn: getDomainMetricsOK,
+			},
 			wantError: "error reading service",
 		},
 		{
@@ -129,6 +131,10 @@ func TestDomainInspector(t *testing.T) {
 	}
 	for _, tc := range scenarios {
 		t.Run(tc.name, func(t *testing.T) {
+			// Clear FASTLY_SERVICE_ID for tests that validate missing service ID
+			if tc.name == "missing service ID" {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var stdout bytes.Buffer
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {
 				opts := testutil.MockGlobalData(tc.args, &stdout)

--- a/pkg/commands/stats/origin_inspector_test.go
+++ b/pkg/commands/stats/origin_inspector_test.go
@@ -129,6 +129,10 @@ func TestOriginInspector(t *testing.T) {
 	}
 	for _, tc := range scenarios {
 		t.Run(tc.name, func(t *testing.T) {
+			// Clear FASTLY_SERVICE_ID for tests that validate missing service ID
+			if tc.name == "missing service ID" {
+				t.Setenv("FASTLY_SERVICE_ID", "")
+			}
 			var stdout bytes.Buffer
 			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {
 				opts := testutil.MockGlobalData(tc.args, &stdout)

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -1,5 +1,86 @@
 package testutil
 
+// Service Version Testing Guide
+//
+// This package provides standard mock functions for testing service version operations.
+// The version mocks follow a consistent pattern across all tests:
+//
+// Version States:
+//   - Version 1: ACTIVE (cannot modify without --autoclone)
+//   - Version 2: LOCKED (cannot modify without --autoclone)
+//   - Version 3: EDITABLE (can modify directly)
+//   - Version 4: STAGING (can modify directly)
+//
+// Test Scenario Guide:
+//
+// 1. Testing --autoclone behavior:
+//      Use: --version 1 or --version 2
+//      Why: Tests that the CLI correctly clones active/locked versions
+//      Example: "validate --autoclone on locked version"
+//
+// 2. Testing successful modifications (create/update/delete):
+//      Use: --version 3
+//      Why: Version is editable, so modification succeeds directly
+//      Example: "validate backend creation"
+//
+// 3. Testing API errors:
+//      Use: --version 3
+//      Why: Avoids autoclone logic interfering with error testing
+//      Example: "validate API error when creating backend"
+//
+// 4. Testing version activation:
+//      Use: --version 3
+//      Why: Version 1 is already active, so test would fail validation
+//      Example: "validate version activation"
+//
+// 5. Testing without --version flag:
+//      Use: No --version flag (defaults to active or latest)
+//      Mock: ListVersionsFn only (GetVersionFn not needed)
+//
+// 6. Testing keyword versions (--version active/latest):
+//      Use: --version active or --version latest
+//      Mock: ListVersionsFn only (GetVersionFn not needed)
+//
+// Required Mock Functions:
+//   - GetVersionFn: REQUIRED when using numeric --version flags (--version 1, --version 2, etc.)
+//   - ListVersionsFn: REQUIRED when using keyword versions or no --version flag
+//   - Both: REQUIRED when using --autoclone (needs GetVersion for initial parse, ListVersions for clone check)
+//
+// Example Test Patterns:
+//
+//	// Pattern 1: Testing --autoclone on locked version
+//	{
+//	    Args: "--service-id 123 --version 2 --name test --autoclone",
+//	    API: &mock.API{
+//	        GetVersionFn:   testutil.GetVersion,           // Parse --version 2
+//	        ListVersionsFn: testutil.ListVersions,         // Check if locked
+//	        CloneVersionFn: testutil.CloneVersionResult(4), // Clone to v4
+//	        UpdateBackendFn: updateBackendOK,               // Modify v4
+//	    },
+//	    WantOutput: "Updated backend (service 123 version 4)",
+//	}
+//
+//	// Pattern 2: Testing API error
+//	{
+//	    Args: "--service-id 123 --version 3 --name test",
+//	    API: &mock.API{
+//	        GetVersionFn:   testutil.GetVersion,  // Parse --version 3
+//	        ListVersionsFn: testutil.ListVersions, // Check if editable
+//	        UpdateBackendFn: updateBackendError,   // API fails
+//	    },
+//	    WantError: "API error",
+//	}
+//
+//	// Pattern 3: Testing with keyword version
+//	{
+//	    Args: "--service-id 123 --version active --name test",
+//	    API: &mock.API{
+//	        ListVersionsFn: testutil.ListVersions, // Find active version
+//	        GetBackendFn:   getBackendOK,
+//	    },
+//	    WantOutput: "Backend details",
+//	}
+
 import (
 	"context"
 	"encoding/json"
@@ -18,19 +99,41 @@ var Err = errors.New("test error")
 
 // ListVersions returns a list of service versions in different states.
 //
-// The first element is active, the second is locked, the third is
-// editable, the fourth is staged.
+// Versions are returned in descending order by version number (highest first),
+// matching the real Fastly API behavior.
+//
+// Version states:
+//   - Version 4: Staged (can be modified directly)
+//   - Version 3: Editable (can be modified directly)
+//   - Version 2: Locked (cannot be modified without --autoclone)
+//   - Version 1: Active (cannot be modified without --autoclone)
+//
+// Usage guide for test scenarios:
+//   - Testing --autoclone behavior: Use version 1 or 2 (active/locked)
+//   - Testing successful modifications: Use version 3 (editable)
+//   - Testing API errors: Use version 3 (so autoclone logic doesn't interfere)
+//   - Testing version activation: Use version 3 or 4 (not already active)
+//   - Testing staging/unstaging: Use version 4 (staged)
 //
 // NOTE: consult the entire test suite before adding any new entries to the
 // returned type as the tests currently use testutil.CloneVersionResult() as a
 // way of making the test output and expectations as accurate as possible.
+//
+// IMPORTANT: When using numeric --version flags in tests, you must include
+// GetVersionFn: testutil.GetVersion in the mock API, as the CLI now calls
+// GetVersion for numeric versions.
 func ListVersions(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return []*fastly.Version{
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
-			Number:    fastly.ToPointer(1),
-			Active:    fastly.ToPointer(true),
-			UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+			Number:    fastly.ToPointer(4),
+			Staging:   fastly.ToPointer(true),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
+		},
+		{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(3),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
 		},
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
@@ -40,14 +143,9 @@ func ListVersions(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Ver
 		},
 		{
 			ServiceID: fastly.ToPointer(i.ServiceID),
-			Number:    fastly.ToPointer(3),
-			UpdatedAt: MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
-		},
-		{
-			ServiceID: fastly.ToPointer(i.ServiceID),
-			Number:    fastly.ToPointer(4),
-			Staging:   fastly.ToPointer(true),
-			UpdatedAt: MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
+			Number:    fastly.ToPointer(1),
+			Active:    fastly.ToPointer(true),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
 		},
 	}, nil
 }
@@ -56,6 +154,79 @@ func ListVersions(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Ver
 // service versions.
 func ListVersionsError(_ context.Context, _ *fastly.ListVersionsInput) ([]*fastly.Version, error) {
 	return nil, Err
+}
+
+// GetVersion returns a version matching the requested version number.
+//
+// This function must be included in mock APIs when tests use numeric --version
+// flags (e.g., --version 1, --version 2), as the CLI now calls GetVersion for
+// numeric versions before processing them.
+//
+// Version states returned:
+//   - Version 1: Active (Active=true)
+//   - Version 2: Locked (Locked=true)
+//   - Version 3: Editable (no Active/Locked flags)
+//   - Version 4: Staging (Staging=true)
+//   - Version 5: Generic editable version (commonly used after cloning version 4)
+//   - Version 999: Returns an error (version not found - use this to test error handling)
+//   - Other numbers: Returns a generic editable version
+//
+// This matches the versions returned by ListVersions for versions 1-4.
+//
+// Example test setup:
+//
+//	API: &mock.API{
+//	    GetVersionFn:   testutil.GetVersion,    // Required for numeric --version flags
+//	    ListVersionsFn: testutil.ListVersions,  // Required for keyword versions (active/latest)
+//	    CloneVersionFn: testutil.CloneVersionResult(4),
+//	}
+func GetVersion(_ context.Context, i *fastly.GetVersionInput) (*fastly.Version, error) {
+	switch i.ServiceVersion {
+	case 1:
+		return &fastly.Version{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(1),
+			Active:    fastly.ToPointer(true),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		}, nil
+	case 2:
+		return &fastly.Version{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(2),
+			Locked:    fastly.ToPointer(true),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-02T01:00:00Z"),
+		}, nil
+	case 3:
+		return &fastly.Version{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(3),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-03T01:00:00Z"),
+		}, nil
+	case 4:
+		return &fastly.Version{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(4),
+			Staging:   fastly.ToPointer(true),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
+		}, nil
+	case 5:
+		// Version 5 is commonly used in tests after cloning version 4
+		return &fastly.Version{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(5),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-05T01:00:00Z"),
+		}, nil
+	case 999:
+		// Return an error for test cases that explicitly want to test version not found
+		return nil, Err
+	default:
+		// Return a generic version for any other number to avoid breaking existing tests
+		return &fastly.Version{
+			ServiceID: fastly.ToPointer(i.ServiceID),
+			Number:    fastly.ToPointer(i.ServiceVersion),
+			UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+		}, nil
+	}
 }
 
 // CloneVersionResult returns a function which returns a specific cloned version.
@@ -122,4 +293,45 @@ func (c CurrentCustomerClient) Do(*http.Request) (*http.Response, error) {
 var CurrentCustomerResponse = authcmd.CurrentCustomerResponse{
 	ID:   "abc",
 	Name: "Computer Company",
+}
+
+// GetServiceDetails returns service details with versions matching the filter.
+//
+// This function must be included in mock APIs when the CLI calls GetServiceDetails,
+// which happens when using the --version active flag.
+//
+// Filters supported:
+//   - versions.active: Returns version 1 (active)
+//
+// This matches the version states returned by ListVersions and GetVersion.
+//
+// Example test setup:
+//
+//	API: &mock.API{
+//	    GetServiceDetailsFn: testutil.GetServiceDetails,  // Required for --version active
+//	    GetVersionFn:        testutil.GetVersion,         // Required for numeric --version flags
+//	    ListVersionsFn:      testutil.ListVersions,       // Required for --version latest or omitted flag
+//	}
+func GetServiceDetails(_ context.Context, i *fastly.GetServiceDetailsInput) (*fastly.ServiceDetail, error) {
+	detail := &fastly.ServiceDetail{
+		ServiceID: fastly.ToPointer(i.ServiceID),
+		Versions:  []*fastly.Version{},
+	}
+
+	// Check filters to determine which version to return
+	for _, filter := range i.Filters {
+		if filter.Key == "versions.active" && filter.Value {
+			version := &fastly.Version{
+				ServiceID: fastly.ToPointer(i.ServiceID),
+				Number:    fastly.ToPointer(1),
+				Active:    fastly.ToPointer(true),
+				UpdatedAt: MustParseTimeRFC3339("2000-01-01T01:00:00Z"),
+			}
+			detail.ActiveVersion = version
+			detail.Version = version
+			detail.Versions = append(detail.Versions, version)
+		}
+	}
+
+	return detail, nil
 }

--- a/pkg/testutil/api.go
+++ b/pkg/testutil/api.go
@@ -331,6 +331,16 @@ func GetServiceDetails(_ context.Context, i *fastly.GetServiceDetailsInput) (*fa
 			detail.Version = version
 			detail.Versions = append(detail.Versions, version)
 		}
+		if filter.Key == "versions.staged" && filter.Value {
+			version := &fastly.Version{
+				ServiceID: fastly.ToPointer(i.ServiceID),
+				Number:    fastly.ToPointer(4),
+				Staging:   fastly.ToPointer(true),
+				UpdatedAt: MustParseTimeRFC3339("2000-01-04T01:00:00Z"),
+			}
+			detail.Version = version
+			detail.Versions = append(detail.Versions, version)
+		}
 	}
 
 	return detail, nil


### PR DESCRIPTION
### Change summary

  Performance Optimization - Skip ListVersions API call for numeric versions                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                       
  Changes to pkg/argparser/flags.go:                                                                                                                                                                                                                                                   
                                                            
  1. OptionalServiceVersion.Parse() - Skip API call for numeric versions                                                                                                                                                                                                               
    - Added early return when user provides numeric version (e.g., --version 1)
    - Returns &fastly.Version{Number: n} directly without calling ListVersions API                                                                                                                                                                                                     
    - Saves 1 API call per command when numeric version is used                                                                                                                                                                                                                        
    - Non-numeric versions (e.g., "latest", "active") still call API as before                                                                                                                                                                                                         
  2. OptionalAutoClone.Parse() - Handle unknown version state                                                                                                                                                                                                                          
    - Added stateUnknown check: v.Active == nil && v.Locked == nil                                                                                                                                                                                                                     
    - Updated autoclone condition to include stateUnknown case                                                                                                                                                                                                                         
    - Effect: When --autoclone is provided with numeric version, always clones (defensive behavior) since state is unknown                                                                                                                                                             
    - Maintains safety while benefiting from optimization                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                       
  Changes to pkg/argparser/flags_test.go:                                                                                                                                                                                                                                              
  - Updated test "specific version not in list" - now expects success (version 5) instead of error                                                                                                                                                                                     
  - Added explicit Active/Locked fields to "version is editable" test      

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?