### PR TITLE
Send deprecation warnings to stderr instead of stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes:
 
+- fix(text): send deprecation warnings to stderr instead of stdout ((#1782)[https://github.com/fastly/cli/pull/1782])
+
 ### Enhancements:
 
 ### Dependencies:

--- a/pkg/commands/alias/acl/create.go
+++ b/pkg/commands/alias/acl/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service acl create' command instead.")
+	text.Deprecated("Use the 'service acl create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/acl/delete.go
+++ b/pkg/commands/alias/acl/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service acl delete' command instead.")
+	text.Deprecated("Use the 'service acl delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/acl/describe.go
+++ b/pkg/commands/alias/acl/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service acl describe' command instead.")
+		text.Deprecated("Use the 'service acl describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/acl/list.go
+++ b/pkg/commands/alias/acl/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service acl list' command instead.")
+		text.Deprecated("Use the 'service acl list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/acl/update.go
+++ b/pkg/commands/alias/acl/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service acl update' command instead.")
+	text.Deprecated("Use the 'service acl update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/aclentry/create.go
+++ b/pkg/commands/alias/aclentry/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service aclentry create' command instead.")
+	text.Deprecated("Use the 'service aclentry create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/aclentry/delete.go
+++ b/pkg/commands/alias/aclentry/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service aclentry delete' command instead.")
+	text.Deprecated("Use the 'service aclentry delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/aclentry/describe.go
+++ b/pkg/commands/alias/aclentry/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service aclentry describe' command instead.")
+		text.Deprecated("Use the 'service aclentry describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/aclentry/list.go
+++ b/pkg/commands/alias/aclentry/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service aclentry list' command instead.")
+		text.Deprecated("Use the 'service aclentry list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/aclentry/update.go
+++ b/pkg/commands/alias/aclentry/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service aclentry update' command instead.")
+	text.Deprecated("Use the 'service aclentry update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/alerts/create.go
+++ b/pkg/commands/alias/alerts/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service alert create' command instead.")
+	text.Deprecated("Use the 'service alert create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/alerts/delete.go
+++ b/pkg/commands/alias/alerts/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service alert delete' command instead.")
+	text.Deprecated("Use the 'service alert delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/alerts/describe.go
+++ b/pkg/commands/alias/alerts/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service alert describe' command instead.")
+		text.Deprecated("Use the 'service alert describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/alerts/history.go
+++ b/pkg/commands/alias/alerts/history.go
@@ -25,7 +25,7 @@ func NewListHistoryCommand(parent argparser.Registerer, g *global.Data) *ListHis
 // Exec implements the command interface.
 func (c *ListHistoryCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service alert list history' command instead.")
+		text.Deprecated("Use the 'service alert list history' command instead.")
 	}
 	return c.ListHistoryCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/alerts/list.go
+++ b/pkg/commands/alias/alerts/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service alert list' command instead.")
+		text.Deprecated("Use the 'service alert list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/alerts/update.go
+++ b/pkg/commands/alias/alerts/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service alert update' command instead.")
+	text.Deprecated("Use the 'service alert update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/backend/create.go
+++ b/pkg/commands/alias/backend/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service backend create' command instead.")
+	text.Deprecated("Use the 'service backend create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/backend/delete.go
+++ b/pkg/commands/alias/backend/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service backend delete' command instead.")
+	text.Deprecated("Use the 'service backend delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/backend/describe.go
+++ b/pkg/commands/alias/backend/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service backend describe' command instead.")
+		text.Deprecated("Use the 'service backend describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/backend/list.go
+++ b/pkg/commands/alias/backend/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service backend list' command instead.")
+		text.Deprecated("Use the 'service backend list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/backend/update.go
+++ b/pkg/commands/alias/backend/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service backend update' command instead.")
+	text.Deprecated("Use the 'service backend update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionary/create.go
+++ b/pkg/commands/alias/dictionary/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service dictionary create' command instead.")
+	text.Deprecated("Use the 'service dictionary create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionary/delete.go
+++ b/pkg/commands/alias/dictionary/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service dictionary delete' command instead.")
+	text.Deprecated("Use the 'service dictionary delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionary/describe.go
+++ b/pkg/commands/alias/dictionary/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service dictionary describe' command instead.")
+		text.Deprecated("Use the 'service dictionary describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionary/list.go
+++ b/pkg/commands/alias/dictionary/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service dictionary list' command instead.")
+		text.Deprecated("Use the 'service dictionary list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionary/update.go
+++ b/pkg/commands/alias/dictionary/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service dictionary update' command instead.")
+	text.Deprecated("Use the 'service dictionary update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionaryentry/create.go
+++ b/pkg/commands/alias/dictionaryentry/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service dictionary-entry create' command instead.")
+	text.Deprecated("Use the 'service dictionary-entry create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionaryentry/delete.go
+++ b/pkg/commands/alias/dictionaryentry/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service dictionary-entry delete' command instead.")
+	text.Deprecated("Use the 'service dictionary-entry delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionaryentry/describe.go
+++ b/pkg/commands/alias/dictionaryentry/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service dictionary-entry describe' command instead.")
+		text.Deprecated("Use the 'service dictionary-entry describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionaryentry/list.go
+++ b/pkg/commands/alias/dictionaryentry/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service dictionary-entry list' command instead.")
+		text.Deprecated("Use the 'service dictionary-entry list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/dictionaryentry/update.go
+++ b/pkg/commands/alias/dictionaryentry/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service dictionary-entry update' command instead.")
+	text.Deprecated("Use the 'service dictionary-entry update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/healthcheck/create.go
+++ b/pkg/commands/alias/healthcheck/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service healthcheck create' command instead.")
+	text.Deprecated("Use the 'service healthcheck create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/healthcheck/delete.go
+++ b/pkg/commands/alias/healthcheck/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service healthcheck delete' command instead.")
+	text.Deprecated("Use the 'service healthcheck delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/healthcheck/describe.go
+++ b/pkg/commands/alias/healthcheck/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service healthcheck describe' command instead.")
+		text.Deprecated("Use the 'service healthcheck describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/healthcheck/list.go
+++ b/pkg/commands/alias/healthcheck/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service healthcheck list' command instead.")
+		text.Deprecated("Use the 'service healthcheck list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/healthcheck/update.go
+++ b/pkg/commands/alias/healthcheck/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service healthcheck update' command instead.")
+	text.Deprecated("Use the 'service healthcheck update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/imageoptimizerdefaults/get.go
+++ b/pkg/commands/alias/imageoptimizerdefaults/get.go
@@ -24,6 +24,6 @@ func NewGetCommand(parent argparser.Registerer, g *global.Data) *GetCommand {
 
 // Exec implements the command interface.
 func (c *GetCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service imageoptimizerdefaults get' command instead.")
+	text.Deprecated("Use the 'service imageoptimizerdefaults get' command instead.")
 	return c.GetCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/imageoptimizerdefaults/update.go
+++ b/pkg/commands/alias/imageoptimizerdefaults/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service imageoptimizerdefaults update' command instead.")
+	text.Deprecated("Use the 'service imageoptimizerdefaults update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/azureblob/create.go
+++ b/pkg/commands/alias/logging/azureblob/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging azureblob create' command instead.")
+	text.Deprecated("Use the 'service logging azureblob create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/azureblob/delete.go
+++ b/pkg/commands/alias/logging/azureblob/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging azureblob delete' command instead.")
+	text.Deprecated("Use the 'service logging azureblob delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/azureblob/describe.go
+++ b/pkg/commands/alias/logging/azureblob/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging azureblob describe' command instead.")
+		text.Deprecated("Use the 'service logging azureblob describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/azureblob/list.go
+++ b/pkg/commands/alias/logging/azureblob/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging azureblob list' command instead.")
+		text.Deprecated("Use the 'service logging azureblob list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/azureblob/update.go
+++ b/pkg/commands/alias/logging/azureblob/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging azureblob update' command instead.")
+	text.Deprecated("Use the 'service logging azureblob update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/bigquery/create.go
+++ b/pkg/commands/alias/logging/bigquery/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging bigquery create' command instead.")
+	text.Deprecated("Use the 'service logging bigquery create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/bigquery/delete.go
+++ b/pkg/commands/alias/logging/bigquery/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging bigquery delete' command instead.")
+	text.Deprecated("Use the 'service logging bigquery delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/bigquery/describe.go
+++ b/pkg/commands/alias/logging/bigquery/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging bigquery describe' command instead.")
+		text.Deprecated("Use the 'service logging bigquery describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/bigquery/list.go
+++ b/pkg/commands/alias/logging/bigquery/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging bigquery list' command instead.")
+		text.Deprecated("Use the 'service logging bigquery list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/bigquery/update.go
+++ b/pkg/commands/alias/logging/bigquery/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging bigquery update' command instead.")
+	text.Deprecated("Use the 'service logging bigquery update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/cloudfiles/create.go
+++ b/pkg/commands/alias/logging/cloudfiles/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging cloudfiles create' command instead.")
+	text.Deprecated("Use the 'service logging cloudfiles create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/cloudfiles/delete.go
+++ b/pkg/commands/alias/logging/cloudfiles/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging cloudfiles delete' command instead.")
+	text.Deprecated("Use the 'service logging cloudfiles delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/cloudfiles/describe.go
+++ b/pkg/commands/alias/logging/cloudfiles/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging cloudfiles describe' command instead.")
+		text.Deprecated("Use the 'service logging cloudfiles describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/cloudfiles/list.go
+++ b/pkg/commands/alias/logging/cloudfiles/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging cloudfiles list' command instead.")
+		text.Deprecated("Use the 'service logging cloudfiles list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/cloudfiles/update.go
+++ b/pkg/commands/alias/logging/cloudfiles/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging cloudfiles update' command instead.")
+	text.Deprecated("Use the 'service logging cloudfiles update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/datadog/create.go
+++ b/pkg/commands/alias/logging/datadog/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging datadog create' command instead.")
+	text.Deprecated("Use the 'service logging datadog create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/datadog/delete.go
+++ b/pkg/commands/alias/logging/datadog/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging datadog delete' command instead.")
+	text.Deprecated("Use the 'service logging datadog delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/datadog/describe.go
+++ b/pkg/commands/alias/logging/datadog/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging datadog describe' command instead.")
+		text.Deprecated("Use the 'service logging datadog describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/datadog/list.go
+++ b/pkg/commands/alias/logging/datadog/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging datadog list' command instead.")
+		text.Deprecated("Use the 'service logging datadog list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/datadog/update.go
+++ b/pkg/commands/alias/logging/datadog/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging datadog update' command instead.")
+	text.Deprecated("Use the 'service logging datadog update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/digitalocean/create.go
+++ b/pkg/commands/alias/logging/digitalocean/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging digitalocean create' command instead.")
+	text.Deprecated("Use the 'service logging digitalocean create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/digitalocean/delete.go
+++ b/pkg/commands/alias/logging/digitalocean/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging digitalocean delete' command instead.")
+	text.Deprecated("Use the 'service logging digitalocean delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/digitalocean/describe.go
+++ b/pkg/commands/alias/logging/digitalocean/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging digitalocean describe' command instead.")
+		text.Deprecated("Use the 'service logging digitalocean describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/digitalocean/list.go
+++ b/pkg/commands/alias/logging/digitalocean/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging digitalocean list' command instead.")
+		text.Deprecated("Use the 'service logging digitalocean list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/digitalocean/update.go
+++ b/pkg/commands/alias/logging/digitalocean/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging digitalocean update' command instead.")
+	text.Deprecated("Use the 'service logging digitalocean update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/elasticsearch/create.go
+++ b/pkg/commands/alias/logging/elasticsearch/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging elasticsearch create' command instead.")
+	text.Deprecated("Use the 'service logging elasticsearch create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/elasticsearch/delete.go
+++ b/pkg/commands/alias/logging/elasticsearch/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging elasticsearch delete' command instead.")
+	text.Deprecated("Use the 'service logging elasticsearch delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/elasticsearch/describe.go
+++ b/pkg/commands/alias/logging/elasticsearch/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging elasticsearch describe' command instead.")
+		text.Deprecated("Use the 'service logging elasticsearch describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/elasticsearch/list.go
+++ b/pkg/commands/alias/logging/elasticsearch/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging elasticsearch list' command instead.")
+		text.Deprecated("Use the 'service logging elasticsearch list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/elasticsearch/update.go
+++ b/pkg/commands/alias/logging/elasticsearch/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging elasticsearch update' command instead.")
+	text.Deprecated("Use the 'service logging elasticsearch update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/ftp/create.go
+++ b/pkg/commands/alias/logging/ftp/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging ftp create' command instead.")
+	text.Deprecated("Use the 'service logging ftp create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/ftp/delete.go
+++ b/pkg/commands/alias/logging/ftp/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging ftp delete' command instead.")
+	text.Deprecated("Use the 'service logging ftp delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/ftp/describe.go
+++ b/pkg/commands/alias/logging/ftp/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging ftp describe' command instead.")
+		text.Deprecated("Use the 'service logging ftp describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/ftp/list.go
+++ b/pkg/commands/alias/logging/ftp/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging ftp list' command instead.")
+		text.Deprecated("Use the 'service logging ftp list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/ftp/update.go
+++ b/pkg/commands/alias/logging/ftp/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging ftp update' command instead.")
+	text.Deprecated("Use the 'service logging ftp update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/gcs/create.go
+++ b/pkg/commands/alias/logging/gcs/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging gcs create' command instead.")
+	text.Deprecated("Use the 'service logging gcs create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/gcs/delete.go
+++ b/pkg/commands/alias/logging/gcs/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging gcs delete' command instead.")
+	text.Deprecated("Use the 'service logging gcs delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/gcs/describe.go
+++ b/pkg/commands/alias/logging/gcs/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging gcs describe' command instead.")
+		text.Deprecated("Use the 'service logging gcs describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/gcs/list.go
+++ b/pkg/commands/alias/logging/gcs/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging gcs list' command instead.")
+		text.Deprecated("Use the 'service logging gcs list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/gcs/update.go
+++ b/pkg/commands/alias/logging/gcs/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging gcs update' command instead.")
+	text.Deprecated("Use the 'service logging gcs update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/googlepubsub/create.go
+++ b/pkg/commands/alias/logging/googlepubsub/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging googlepubsub create' command instead.")
+	text.Deprecated("Use the 'service logging googlepubsub create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/googlepubsub/delete.go
+++ b/pkg/commands/alias/logging/googlepubsub/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging googlepubsub delete' command instead.")
+	text.Deprecated("Use the 'service logging googlepubsub delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/googlepubsub/describe.go
+++ b/pkg/commands/alias/logging/googlepubsub/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging googlepubsub describe' command instead.")
+		text.Deprecated("Use the 'service logging googlepubsub describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/googlepubsub/list.go
+++ b/pkg/commands/alias/logging/googlepubsub/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging googlepubsub list' command instead.")
+		text.Deprecated("Use the 'service logging googlepubsub list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/googlepubsub/update.go
+++ b/pkg/commands/alias/logging/googlepubsub/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging googlepubsub update' command instead.")
+	text.Deprecated("Use the 'service logging googlepubsub update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/grafanacloudlogs/create.go
+++ b/pkg/commands/alias/logging/grafanacloudlogs/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging grafanacloudlogs create' command instead.")
+	text.Deprecated("Use the 'service logging grafanacloudlogs create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/grafanacloudlogs/delete.go
+++ b/pkg/commands/alias/logging/grafanacloudlogs/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging grafanacloudlogs delete' command instead.")
+	text.Deprecated("Use the 'service logging grafanacloudlogs delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/grafanacloudlogs/describe.go
+++ b/pkg/commands/alias/logging/grafanacloudlogs/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging grafanacloudlogs describe' command instead.")
+		text.Deprecated("Use the 'service logging grafanacloudlogs describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/grafanacloudlogs/list.go
+++ b/pkg/commands/alias/logging/grafanacloudlogs/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging grafanacloudlogs list' command instead.")
+		text.Deprecated("Use the 'service logging grafanacloudlogs list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/grafanacloudlogs/update.go
+++ b/pkg/commands/alias/logging/grafanacloudlogs/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging grafanacloudlogs update' command instead.")
+	text.Deprecated("Use the 'service logging grafanacloudlogs update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/heroku/create.go
+++ b/pkg/commands/alias/logging/heroku/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging heroku create' command instead.")
+	text.Deprecated("Use the 'service logging heroku create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/heroku/delete.go
+++ b/pkg/commands/alias/logging/heroku/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging heroku delete' command instead.")
+	text.Deprecated("Use the 'service logging heroku delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/heroku/describe.go
+++ b/pkg/commands/alias/logging/heroku/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging heroku describe' command instead.")
+		text.Deprecated("Use the 'service logging heroku describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/heroku/list.go
+++ b/pkg/commands/alias/logging/heroku/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging heroku list' command instead.")
+		text.Deprecated("Use the 'service logging heroku list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/heroku/update.go
+++ b/pkg/commands/alias/logging/heroku/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging heroku update' command instead.")
+	text.Deprecated("Use the 'service logging heroku update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/honeycomb/create.go
+++ b/pkg/commands/alias/logging/honeycomb/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging honeycomb create' command instead.")
+	text.Deprecated("Use the 'service logging honeycomb create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/honeycomb/delete.go
+++ b/pkg/commands/alias/logging/honeycomb/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging honeycomb delete' command instead.")
+	text.Deprecated("Use the 'service logging honeycomb delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/honeycomb/describe.go
+++ b/pkg/commands/alias/logging/honeycomb/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging honeycomb describe' command instead.")
+		text.Deprecated("Use the 'service logging honeycomb describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/honeycomb/list.go
+++ b/pkg/commands/alias/logging/honeycomb/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging honeycomb list' command instead.")
+		text.Deprecated("Use the 'service logging honeycomb list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/honeycomb/update.go
+++ b/pkg/commands/alias/logging/honeycomb/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging honeycomb update' command instead.")
+	text.Deprecated("Use the 'service logging honeycomb update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/https/create.go
+++ b/pkg/commands/alias/logging/https/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging https create' command instead.")
+	text.Deprecated("Use the 'service logging https create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/https/delete.go
+++ b/pkg/commands/alias/logging/https/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging https delete' command instead.")
+	text.Deprecated("Use the 'service logging https delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/https/describe.go
+++ b/pkg/commands/alias/logging/https/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging https describe' command instead.")
+		text.Deprecated("Use the 'service logging https describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/https/list.go
+++ b/pkg/commands/alias/logging/https/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging https list' command instead.")
+		text.Deprecated("Use the 'service logging https list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/https/update.go
+++ b/pkg/commands/alias/logging/https/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging https update' command instead.")
+	text.Deprecated("Use the 'service logging https update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kafka/create.go
+++ b/pkg/commands/alias/logging/kafka/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging kafka create' command instead.")
+	text.Deprecated("Use the 'service logging kafka create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kafka/delete.go
+++ b/pkg/commands/alias/logging/kafka/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging kafka delete' command instead.")
+	text.Deprecated("Use the 'service logging kafka delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kafka/describe.go
+++ b/pkg/commands/alias/logging/kafka/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging kafka describe' command instead.")
+		text.Deprecated("Use the 'service logging kafka describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kafka/list.go
+++ b/pkg/commands/alias/logging/kafka/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging kafka list' command instead.")
+		text.Deprecated("Use the 'service logging kafka list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kafka/update.go
+++ b/pkg/commands/alias/logging/kafka/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging kafka update' command instead.")
+	text.Deprecated("Use the 'service logging kafka update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kinesis/create.go
+++ b/pkg/commands/alias/logging/kinesis/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging kinesis create' command instead.")
+	text.Deprecated("Use the 'service logging kinesis create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kinesis/delete.go
+++ b/pkg/commands/alias/logging/kinesis/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging kinesis delete' command instead.")
+	text.Deprecated("Use the 'service logging kinesis delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kinesis/describe.go
+++ b/pkg/commands/alias/logging/kinesis/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging kinesis describe' command instead.")
+		text.Deprecated("Use the 'service logging kinesis describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kinesis/list.go
+++ b/pkg/commands/alias/logging/kinesis/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging kinesis list' command instead.")
+		text.Deprecated("Use the 'service logging kinesis list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/kinesis/update.go
+++ b/pkg/commands/alias/logging/kinesis/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging kinesis update' command instead.")
+	text.Deprecated("Use the 'service logging kinesis update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/loggly/create.go
+++ b/pkg/commands/alias/logging/loggly/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging loggly create' command instead.")
+	text.Deprecated("Use the 'service logging loggly create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/loggly/delete.go
+++ b/pkg/commands/alias/logging/loggly/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging loggly delete' command instead.")
+	text.Deprecated("Use the 'service logging loggly delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/loggly/describe.go
+++ b/pkg/commands/alias/logging/loggly/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging loggly describe' command instead.")
+		text.Deprecated("Use the 'service logging loggly describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/loggly/list.go
+++ b/pkg/commands/alias/logging/loggly/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging loggly list' command instead.")
+		text.Deprecated("Use the 'service logging loggly list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/loggly/update.go
+++ b/pkg/commands/alias/logging/loggly/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging loggly update' command instead.")
+	text.Deprecated("Use the 'service logging loggly update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/logshuttle/create.go
+++ b/pkg/commands/alias/logging/logshuttle/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging logshuttle create' command instead.")
+	text.Deprecated("Use the 'service logging logshuttle create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/logshuttle/delete.go
+++ b/pkg/commands/alias/logging/logshuttle/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging logshuttle delete' command instead.")
+	text.Deprecated("Use the 'service logging logshuttle delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/logshuttle/describe.go
+++ b/pkg/commands/alias/logging/logshuttle/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging logshuttle describe' command instead.")
+		text.Deprecated("Use the 'service logging logshuttle describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/logshuttle/list.go
+++ b/pkg/commands/alias/logging/logshuttle/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging logshuttle list' command instead.")
+		text.Deprecated("Use the 'service logging logshuttle list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/logshuttle/update.go
+++ b/pkg/commands/alias/logging/logshuttle/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging logshuttle update' command instead.")
+	text.Deprecated("Use the 'service logging logshuttle update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelic/create.go
+++ b/pkg/commands/alias/logging/newrelic/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging newrelic create' command instead.")
+	text.Deprecated("Use the 'service logging newrelic create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelic/delete.go
+++ b/pkg/commands/alias/logging/newrelic/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging newrelic delete' command instead.")
+	text.Deprecated("Use the 'service logging newrelic delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelic/describe.go
+++ b/pkg/commands/alias/logging/newrelic/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging newrelic describe' command instead.")
+		text.Deprecated("Use the 'service logging newrelic describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelic/list.go
+++ b/pkg/commands/alias/logging/newrelic/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging newrelic list' command instead.")
+		text.Deprecated("Use the 'service logging newrelic list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelic/update.go
+++ b/pkg/commands/alias/logging/newrelic/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging newrelic update' command instead.")
+	text.Deprecated("Use the 'service logging newrelic update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelicotlp/create.go
+++ b/pkg/commands/alias/logging/newrelicotlp/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging newrelicotlp create' command instead.")
+	text.Deprecated("Use the 'service logging newrelicotlp create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelicotlp/delete.go
+++ b/pkg/commands/alias/logging/newrelicotlp/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging newrelicotlp delete' command instead.")
+	text.Deprecated("Use the 'service logging newrelicotlp delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelicotlp/describe.go
+++ b/pkg/commands/alias/logging/newrelicotlp/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging newrelicotlp describe' command instead.")
+		text.Deprecated("Use the 'service logging newrelicotlp describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelicotlp/list.go
+++ b/pkg/commands/alias/logging/newrelicotlp/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging newrelicotlp list' command instead.")
+		text.Deprecated("Use the 'service logging newrelicotlp list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/newrelicotlp/update.go
+++ b/pkg/commands/alias/logging/newrelicotlp/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging newrelicotlp update' command instead.")
+	text.Deprecated("Use the 'service logging newrelicotlp update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/openstack/create.go
+++ b/pkg/commands/alias/logging/openstack/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging openstack create' command instead.")
+	text.Deprecated("Use the 'service logging openstack create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/openstack/delete.go
+++ b/pkg/commands/alias/logging/openstack/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging openstack delete' command instead.")
+	text.Deprecated("Use the 'service logging openstack delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/openstack/describe.go
+++ b/pkg/commands/alias/logging/openstack/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging openstack describe' command instead.")
+		text.Deprecated("Use the 'service logging openstack describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/openstack/list.go
+++ b/pkg/commands/alias/logging/openstack/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging openstack list' command instead.")
+		text.Deprecated("Use the 'service logging openstack list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/openstack/update.go
+++ b/pkg/commands/alias/logging/openstack/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging openstack update' command instead.")
+	text.Deprecated("Use the 'service logging openstack update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/papertrail/create.go
+++ b/pkg/commands/alias/logging/papertrail/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging papertrail create' command instead.")
+	text.Deprecated("Use the 'service logging papertrail create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/papertrail/delete.go
+++ b/pkg/commands/alias/logging/papertrail/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging papertrail delete' command instead.")
+	text.Deprecated("Use the 'service logging papertrail delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/papertrail/describe.go
+++ b/pkg/commands/alias/logging/papertrail/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging papertrail describe' command instead.")
+		text.Deprecated("Use the 'service logging papertrail describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/papertrail/list.go
+++ b/pkg/commands/alias/logging/papertrail/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging papertrail list' command instead.")
+		text.Deprecated("Use the 'service logging papertrail list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/papertrail/update.go
+++ b/pkg/commands/alias/logging/papertrail/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging papertrail update' command instead.")
+	text.Deprecated("Use the 'service logging papertrail update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/s3/create.go
+++ b/pkg/commands/alias/logging/s3/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging s3 create' command instead.")
+	text.Deprecated("Use the 'service logging s3 create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/s3/delete.go
+++ b/pkg/commands/alias/logging/s3/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging s3 delete' command instead.")
+	text.Deprecated("Use the 'service logging s3 delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/s3/describe.go
+++ b/pkg/commands/alias/logging/s3/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging s3 describe' command instead.")
+		text.Deprecated("Use the 'service logging s3 describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/s3/list.go
+++ b/pkg/commands/alias/logging/s3/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging s3 list' command instead.")
+		text.Deprecated("Use the 'service logging s3 list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/s3/update.go
+++ b/pkg/commands/alias/logging/s3/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging s3 update' command instead.")
+	text.Deprecated("Use the 'service logging s3 update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/scalyr/create.go
+++ b/pkg/commands/alias/logging/scalyr/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging scalyr create' command instead.")
+	text.Deprecated("Use the 'service logging scalyr create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/scalyr/delete.go
+++ b/pkg/commands/alias/logging/scalyr/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging scalyr delete' command instead.")
+	text.Deprecated("Use the 'service logging scalyr delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/scalyr/describe.go
+++ b/pkg/commands/alias/logging/scalyr/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging scalyr describe' command instead.")
+		text.Deprecated("Use the 'service logging scalyr describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/scalyr/list.go
+++ b/pkg/commands/alias/logging/scalyr/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging scalyr list' command instead.")
+		text.Deprecated("Use the 'service logging scalyr list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/scalyr/update.go
+++ b/pkg/commands/alias/logging/scalyr/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging scalyr update' command instead.")
+	text.Deprecated("Use the 'service logging scalyr update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sftp/create.go
+++ b/pkg/commands/alias/logging/sftp/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging sftp create' command instead.")
+	text.Deprecated("Use the 'service logging sftp create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sftp/delete.go
+++ b/pkg/commands/alias/logging/sftp/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging sftp delete' command instead.")
+	text.Deprecated("Use the 'service logging sftp delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sftp/describe.go
+++ b/pkg/commands/alias/logging/sftp/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging sftp describe' command instead.")
+		text.Deprecated("Use the 'service logging sftp describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sftp/list.go
+++ b/pkg/commands/alias/logging/sftp/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging sftp list' command instead.")
+		text.Deprecated("Use the 'service logging sftp list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sftp/update.go
+++ b/pkg/commands/alias/logging/sftp/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging sftp update' command instead.")
+	text.Deprecated("Use the 'service logging sftp update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/splunk/create.go
+++ b/pkg/commands/alias/logging/splunk/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging splunk create' command instead.")
+	text.Deprecated("Use the 'service logging splunk create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/splunk/delete.go
+++ b/pkg/commands/alias/logging/splunk/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging splunk delete' command instead.")
+	text.Deprecated("Use the 'service logging splunk delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/splunk/describe.go
+++ b/pkg/commands/alias/logging/splunk/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging splunk describe' command instead.")
+		text.Deprecated("Use the 'service logging splunk describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/splunk/list.go
+++ b/pkg/commands/alias/logging/splunk/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging splunk list' command instead.")
+		text.Deprecated("Use the 'service logging splunk list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/splunk/update.go
+++ b/pkg/commands/alias/logging/splunk/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging splunk update' command instead.")
+	text.Deprecated("Use the 'service logging splunk update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sumologic/create.go
+++ b/pkg/commands/alias/logging/sumologic/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging sumologic create' command instead.")
+	text.Deprecated("Use the 'service logging sumologic create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sumologic/delete.go
+++ b/pkg/commands/alias/logging/sumologic/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging sumologic delete' command instead.")
+	text.Deprecated("Use the 'service logging sumologic delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sumologic/describe.go
+++ b/pkg/commands/alias/logging/sumologic/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging sumologic describe' command instead.")
+		text.Deprecated("Use the 'service logging sumologic describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sumologic/list.go
+++ b/pkg/commands/alias/logging/sumologic/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging sumologic list' command instead.")
+		text.Deprecated("Use the 'service logging sumologic list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/sumologic/update.go
+++ b/pkg/commands/alias/logging/sumologic/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging sumologic update' command instead.")
+	text.Deprecated("Use the 'service logging sumologic update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/syslog/create.go
+++ b/pkg/commands/alias/logging/syslog/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging syslog create' command instead.")
+	text.Deprecated("Use the 'service logging syslog create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/syslog/delete.go
+++ b/pkg/commands/alias/logging/syslog/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging syslog delete' command instead.")
+	text.Deprecated("Use the 'service logging syslog delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/syslog/describe.go
+++ b/pkg/commands/alias/logging/syslog/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging syslog describe' command instead.")
+		text.Deprecated("Use the 'service logging syslog describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/syslog/list.go
+++ b/pkg/commands/alias/logging/syslog/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service logging syslog list' command instead.")
+		text.Deprecated("Use the 'service logging syslog list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/logging/syslog/update.go
+++ b/pkg/commands/alias/logging/syslog/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service logging syslog update' command instead.")
+	text.Deprecated("Use the 'service logging syslog update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/purge/purge.go
+++ b/pkg/commands/alias/purge/purge.go
@@ -24,6 +24,6 @@ func NewCommand(parent argparser.Registerer, g *global.Data) *Command {
 
 // Exec implements the command interface.
 func (c *Command) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service purge' command instead.")
+	text.Deprecated("Use the 'service purge' command instead.")
 	return c.PurgeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/ratelimit/create.go
+++ b/pkg/commands/alias/ratelimit/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service rate-limit create' command instead.")
+	text.Deprecated("Use the 'service rate-limit create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/ratelimit/delete.go
+++ b/pkg/commands/alias/ratelimit/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service rate-limit delete' command instead.")
+	text.Deprecated("Use the 'service rate-limit delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/ratelimit/describe.go
+++ b/pkg/commands/alias/ratelimit/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service rate-limit describe' command instead.")
+		text.Deprecated("Use the 'service rate-limit describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/ratelimit/list.go
+++ b/pkg/commands/alias/ratelimit/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service rate-limit list' command instead.")
+		text.Deprecated("Use the 'service rate-limit list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/ratelimit/update.go
+++ b/pkg/commands/alias/ratelimit/update.go
@@ -25,7 +25,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service rate-limit update' command instead.")
+		text.Deprecated("Use the 'service rate-limit update' command instead.")
 	}
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/resourcelink/create.go
+++ b/pkg/commands/alias/resourcelink/create.go
@@ -25,7 +25,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service resource-link create' command instead.")
+		text.Deprecated("Use the 'service resource-link create' command instead.")
 	}
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/resourcelink/delete.go
+++ b/pkg/commands/alias/resourcelink/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service resource-link delete' command instead.")
+	text.Deprecated("Use the 'service resource-link delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/resourcelink/describe.go
+++ b/pkg/commands/alias/resourcelink/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service resource-link describe' command instead.")
+		text.Deprecated("Use the 'service resource-link describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/resourcelink/list.go
+++ b/pkg/commands/alias/resourcelink/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service resource-link list' command instead.")
+		text.Deprecated("Use the 'service resource-link list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/resourcelink/update.go
+++ b/pkg/commands/alias/resourcelink/update.go
@@ -25,7 +25,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service resource-link update' command instead.")
+		text.Deprecated("Use the 'service resource-link update' command instead.")
 	}
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceauth/create.go
+++ b/pkg/commands/alias/serviceauth/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service auth create' command instead.")
+	text.Deprecated("Use the 'service auth create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceauth/delete.go
+++ b/pkg/commands/alias/serviceauth/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service auth delete' command instead.")
+	text.Deprecated("Use the 'service auth delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceauth/describe.go
+++ b/pkg/commands/alias/serviceauth/describe.go
@@ -25,7 +25,7 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service auth describe' command instead.")
+		text.Deprecated("Use the 'service auth describe' command instead.")
 	}
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceauth/list.go
+++ b/pkg/commands/alias/serviceauth/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service auth list' command instead.")
+		text.Deprecated("Use the 'service auth list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceauth/update.go
+++ b/pkg/commands/alias/serviceauth/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service auth update' command instead.")
+	text.Deprecated("Use the 'service auth update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/activate.go
+++ b/pkg/commands/alias/serviceversion/activate.go
@@ -24,6 +24,6 @@ func NewActivateCommand(parent argparser.Registerer, g *global.Data) *ActivateCo
 
 // Exec implements the command interface.
 func (c *ActivateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service version activate' command instead.")
+	text.Deprecated("Use the 'service version activate' command instead.")
 	return c.ActivateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/clone.go
+++ b/pkg/commands/alias/serviceversion/clone.go
@@ -25,7 +25,7 @@ func NewCloneCommand(parent argparser.Registerer, g *global.Data) *CloneCommand 
 // Exec implements the command interface.
 func (c *CloneCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service version clone' command instead.")
+		text.Deprecated("Use the 'service version clone' command instead.")
 	}
 	return c.CloneCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/deactivate.go
+++ b/pkg/commands/alias/serviceversion/deactivate.go
@@ -24,6 +24,6 @@ func NewDeactivateCommand(parent argparser.Registerer, g *global.Data) *Deactiva
 
 // Exec implements the command interface.
 func (c *DeactivateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service version deactivate' command instead.")
+	text.Deprecated("Use the 'service version deactivate' command instead.")
 	return c.DeactivateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/list.go
+++ b/pkg/commands/alias/serviceversion/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service version list' command instead.")
+		text.Deprecated("Use the 'service version list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/lock.go
+++ b/pkg/commands/alias/serviceversion/lock.go
@@ -24,6 +24,6 @@ func NewLockCommand(parent argparser.Registerer, g *global.Data) *LockCommand {
 
 // Exec implements the command interface.
 func (c *LockCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service version lock' command instead.")
+	text.Deprecated("Use the 'service version lock' command instead.")
 	return c.LockCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/stage.go
+++ b/pkg/commands/alias/serviceversion/stage.go
@@ -24,6 +24,6 @@ func NewStageCommand(parent argparser.Registerer, g *global.Data) *StageCommand 
 
 // Exec implements the command interface.
 func (c *StageCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service version stage' command instead.")
+	text.Deprecated("Use the 'service version stage' command instead.")
 	return c.StageCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/unstage.go
+++ b/pkg/commands/alias/serviceversion/unstage.go
@@ -24,6 +24,6 @@ func NewUnstageCommand(parent argparser.Registerer, g *global.Data) *UnstageComm
 
 // Exec implements the command interface.
 func (c *UnstageCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service version unstage' command instead.")
+	text.Deprecated("Use the 'service version unstage' command instead.")
 	return c.UnstageCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/serviceversion/update.go
+++ b/pkg/commands/alias/serviceversion/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service version update' command instead.")
+	text.Deprecated("Use the 'service version update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/condition/create.go
+++ b/pkg/commands/alias/vcl/condition/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl condition create' command instead.")
+	text.Deprecated("Use the 'service vcl condition create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/condition/delete.go
+++ b/pkg/commands/alias/vcl/condition/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl condition delete' command instead.")
+	text.Deprecated("Use the 'service vcl condition delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/condition/describe.go
+++ b/pkg/commands/alias/vcl/condition/describe.go
@@ -24,6 +24,6 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl condition describe' command instead.")
+	text.Deprecated("Use the 'service vcl condition describe' command instead.")
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/condition/list.go
+++ b/pkg/commands/alias/vcl/condition/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service vcl condition list' command instead.")
+		text.Deprecated("Use the 'service vcl condition list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/condition/update.go
+++ b/pkg/commands/alias/vcl/condition/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl condition update' command instead.")
+	text.Deprecated("Use the 'service vcl condition update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/custom/create.go
+++ b/pkg/commands/alias/vcl/custom/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl custom create' command instead.")
+	text.Deprecated("Use the 'service vcl custom create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/custom/delete.go
+++ b/pkg/commands/alias/vcl/custom/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl custom delete' command instead.")
+	text.Deprecated("Use the 'service vcl custom delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/custom/describe.go
+++ b/pkg/commands/alias/vcl/custom/describe.go
@@ -24,6 +24,6 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl custom describe' command instead.")
+	text.Deprecated("Use the 'service vcl custom describe' command instead.")
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/custom/list.go
+++ b/pkg/commands/alias/vcl/custom/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service vcl custom list' command instead.")
+		text.Deprecated("Use the 'service vcl custom list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/custom/update.go
+++ b/pkg/commands/alias/vcl/custom/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl custom update' command instead.")
+	text.Deprecated("Use the 'service vcl custom update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/describe.go
+++ b/pkg/commands/alias/vcl/describe.go
@@ -24,6 +24,6 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl describe' command instead.")
+	text.Deprecated("Use the 'service vcl describe' command instead.")
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/snippet/create.go
+++ b/pkg/commands/alias/vcl/snippet/create.go
@@ -24,6 +24,6 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl snippet create' command instead.")
+	text.Deprecated("Use the 'service vcl snippet create' command instead.")
 	return c.CreateCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/snippet/delete.go
+++ b/pkg/commands/alias/vcl/snippet/delete.go
@@ -24,6 +24,6 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 
 // Exec implements the command interface.
 func (c *DeleteCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl snippet delete' command instead.")
+	text.Deprecated("Use the 'service vcl snippet delete' command instead.")
 	return c.DeleteCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/snippet/describe.go
+++ b/pkg/commands/alias/vcl/snippet/describe.go
@@ -24,6 +24,6 @@ func NewDescribeCommand(parent argparser.Registerer, g *global.Data) *DescribeCo
 
 // Exec implements the command interface.
 func (c *DescribeCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl snippet describe' command instead.")
+	text.Deprecated("Use the 'service vcl snippet describe' command instead.")
 	return c.DescribeCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/snippet/list.go
+++ b/pkg/commands/alias/vcl/snippet/list.go
@@ -25,7 +25,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec implements the command interface.
 func (c *ListCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.JSONOutput.Enabled {
-		text.Deprecated(out, "Use the 'service vcl snippet list' command instead.")
+		text.Deprecated("Use the 'service vcl snippet list' command instead.")
 	}
 	return c.ListCommand.Exec(in, out)
 }

--- a/pkg/commands/alias/vcl/snippet/update.go
+++ b/pkg/commands/alias/vcl/snippet/update.go
@@ -24,6 +24,6 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 
 // Exec implements the command interface.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
-	text.Deprecated(out, "Use the 'service vcl snippet update' command instead.")
+	text.Deprecated("Use the 'service vcl snippet update' command instead.")
 	return c.UpdateCommand.Exec(in, out)
 }

--- a/pkg/commands/authtoken/authtoken_test.go
+++ b/pkg/commands/authtoken/authtoken_test.go
@@ -296,9 +296,6 @@ func listTokenOutputVerbose() string {
 	return `Fastly API endpoint: https://api.fastly.com
 Fastly API token provided via config file (auth: user)
 
-DEPRECATED: The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API
-tokens.
-
 
 ID: 123
 Name: Foo

--- a/pkg/commands/authtoken/create.go
+++ b/pkg/commands/authtoken/create.go
@@ -64,7 +64,7 @@ type CreateCommand struct {
 // Exec invokes the application logic for the command.
 func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
+		text.Deprecated("The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
 	}
 
 	input := c.constructInput()

--- a/pkg/commands/authtoken/delete.go
+++ b/pkg/commands/authtoken/delete.go
@@ -42,7 +42,7 @@ type DeleteCommand struct {
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
+		text.Deprecated("The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
 	}
 
 	if !c.current && c.file == "" && c.id == "" {

--- a/pkg/commands/authtoken/describe.go
+++ b/pkg/commands/authtoken/describe.go
@@ -36,7 +36,7 @@ type DescribeCommand struct {
 // Exec invokes the application logic for the command.
 func (c *DescribeCommand) Exec(_ io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet && !c.JSONOutput.Enabled {
-		text.Deprecated(out, "The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
+		text.Deprecated("The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
 	}
 
 	if c.Globals.Verbose() && c.JSONOutput.Enabled {

--- a/pkg/commands/authtoken/list.go
+++ b/pkg/commands/authtoken/list.go
@@ -44,7 +44,7 @@ type ListCommand struct {
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet && !c.JSONOutput.Enabled {
-		text.Deprecated(out, "The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
+		text.Deprecated("The 'auth-token' command tree will be removed in a future release. Use the Fastly API directly to manage API tokens.\n\n")
 	}
 
 	if c.Globals.Verbose() && c.JSONOutput.Enabled {

--- a/pkg/commands/compute/language_assemblyscript.go
+++ b/pkg/commands/compute/language_assemblyscript.go
@@ -126,7 +126,7 @@ func (a *AssemblyScript) Build() error {
 	if !a.verbose {
 		text.Break(a.output)
 	}
-	text.Deprecated(a.output, "The Fastly AssemblyScript SDK is being deprecated in favor of the more up-to-date and feature-rich JavaScript SDK. You can learn more about the JavaScript SDK on our Developer Hub Page - https://www.fastly.com/documentation/guides/computejavascript/\n\n")
+	text.Deprecated("The Fastly AssemblyScript SDK is being deprecated in favor of the more up-to-date and feature-rich JavaScript SDK. You can learn more about the JavaScript SDK on our Developer Hub Page - https://www.fastly.com/documentation/guides/computejavascript/\n\n")
 
 	if a.build == "" {
 		a.build = AsDefaultBuildCommand

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -38,7 +38,7 @@ func NewCreateCommand(parent argparser.Registerer, g *global.Data) *CreateComman
 // Exec implements the command interface.
 func (c *CreateCommand) Exec(in io.Reader, out io.Writer) (err error) {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "This command will be removed in a future release. Use 'fastly auth login' or 'fastly auth add' instead.\n\n")
+		text.Deprecated("This command will be removed in a future release. Use 'fastly auth login' or 'fastly auth add' instead.\n\n")
 	}
 
 	if c.Globals.Verbose() {

--- a/pkg/commands/profile/delete.go
+++ b/pkg/commands/profile/delete.go
@@ -28,7 +28,7 @@ func NewDeleteCommand(parent argparser.Registerer, g *global.Data) *DeleteComman
 // Exec invokes the application logic for the command.
 func (c *DeleteCommand) Exec(_ io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "This command will be removed in a future release. Use 'fastly auth delete' instead.\n\n")
+		text.Deprecated("This command will be removed in a future release. Use 'fastly auth delete' instead.\n\n")
 	}
 
 	if !c.Globals.Config.DeleteAuthToken(c.profile) {

--- a/pkg/commands/profile/list.go
+++ b/pkg/commands/profile/list.go
@@ -29,7 +29,7 @@ func NewListCommand(parent argparser.Registerer, g *global.Data) *ListCommand {
 // Exec invokes the application logic for the command.
 func (c *ListCommand) Exec(_ io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet && !c.JSONOutput.Enabled {
-		text.Deprecated(out, "This command will be removed in a future release. Use 'fastly auth list' instead.\n\n")
+		text.Deprecated("This command will be removed in a future release. Use 'fastly auth list' instead.\n\n")
 	}
 
 	if c.Globals.Verbose() && c.JSONOutput.Enabled {

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -362,7 +362,7 @@ func TestProfileToken(t *testing.T) {
 					},
 				},
 			},
-			WantOutputs: []string{"DEPRECATED", "This command will be removed", "123"},
+			WantOutputs: []string{"123"},
 		},
 		{
 			Name: "validate --quiet suppresses deprecation warning",
@@ -392,8 +392,7 @@ func TestProfileToken(t *testing.T) {
 					},
 				},
 			},
-			WantOutput:      "123",
-			DontWantOutputs: []string{"DEPRECATED", "This command will be removed"},
+			WantOutput: "123",
 		},
 		{
 			Name: "validate the active profile non-SSO token is displayed by default",

--- a/pkg/commands/profile/switch.go
+++ b/pkg/commands/profile/switch.go
@@ -31,7 +31,7 @@ func NewSwitchCommand(parent argparser.Registerer, g *global.Data) *SwitchComman
 // Exec invokes the application logic for the command.
 func (c *SwitchCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "This command will be removed in a future release. Use 'fastly auth use' instead.\n\n")
+		text.Deprecated("This command will be removed in a future release. Use 'fastly auth use' instead.\n\n")
 	}
 
 	at := c.Globals.Config.GetAuthToken(c.profile)

--- a/pkg/commands/profile/token.go
+++ b/pkg/commands/profile/token.go
@@ -36,7 +36,7 @@ const defaultTokenTTL time.Duration = 5 * time.Minute
 // Exec implements the command interface.
 func (c *TokenCommand) Exec(_ io.Reader, out io.Writer) (err error) {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "This command will be removed in a future release. Use 'fastly auth show' instead.\n\n")
+		text.Deprecated("This command will be removed in a future release. Use 'fastly auth show' instead.\n\n")
 	}
 
 	var name string

--- a/pkg/commands/profile/update.go
+++ b/pkg/commands/profile/update.go
@@ -34,7 +34,7 @@ func NewUpdateCommand(parent argparser.Registerer, g *global.Data) *UpdateComman
 // Exec invokes the application logic for the command.
 func (c *UpdateCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "This command will be removed in a future release. Use 'fastly auth login' or 'fastly auth add' instead.\n\n")
+		text.Deprecated("This command will be removed in a future release. Use 'fastly auth login' or 'fastly auth add' instead.\n\n")
 	}
 
 	profileName, at, err := c.identifyProfile()

--- a/pkg/commands/service/backend/create.go
+++ b/pkg/commands/service/backend/create.go
@@ -224,7 +224,7 @@ func (c *CreateCommand) Exec(_ io.Reader, out io.Writer) error {
 		input.SSLCertHostname = &c.sslCertHostname.Value
 	}
 	if c.sslCheckCert.WasSet {
-		text.Deprecated(out, "The Fastly API defaults `ssl_check_cert` to true. Use `--no-ssl-check-cert` to disable this setting.\n\n")
+		text.Deprecated("The Fastly API defaults `ssl_check_cert` to true. Use `--no-ssl-check-cert` to disable this setting.\n\n")
 		input.SSLCheckCert = fastly.ToPointer(fastly.Compatibool(c.sslCheckCert.Value))
 	}
 	if c.sslCiphers.WasSet {

--- a/pkg/commands/service/backend/update.go
+++ b/pkg/commands/service/backend/update.go
@@ -237,7 +237,7 @@ func (c *UpdateCommand) Exec(_ io.Reader, out io.Writer) error {
 	}
 
 	if c.SSLCheckCert.WasSet {
-		text.Deprecated(out, "The Fastly API defaults `ssl_check_cert` to true. Use `--no-ssl-check-cert` to disable this setting.\n\n")
+		text.Deprecated("The Fastly API defaults `ssl_check_cert` to true. Use `--no-ssl-check-cert` to disable this setting.\n\n")
 		input.SSLCheckCert = fastly.ToPointer(fastly.Compatibool(c.SSLCheckCert.Value))
 	}
 

--- a/pkg/commands/sso/root.go
+++ b/pkg/commands/sso/root.go
@@ -37,7 +37,7 @@ func NewRootCommand(parent argparser.Registerer, g *global.Data) *RootCommand {
 // Exec implements the command interface.
 func (c *RootCommand) Exec(in io.Reader, out io.Writer) error {
 	if !c.Globals.Flags.Quiet {
-		text.Deprecated(out, "This command will be removed in a future release. Use 'fastly auth login --sso --token <name>' instead.\n\n")
+		text.Deprecated("This command will be removed in a future release. Use 'fastly auth login --sso --token <name>' instead.\n\n")
 	}
 
 	tokenName, isFallback := c.resolveTokenName()

--- a/pkg/text/text.go
+++ b/pkg/text/text.go
@@ -216,12 +216,13 @@ func BreakN(w io.Writer, n int) {
 }
 
 // Deprecated is a wrapper for fmt.Fprintf with a bold red "DEPRECATED: " prefix.
-func Deprecated(w io.Writer, format string, args ...any) {
+// Deprecation warnings are always written to stderr.
+func Deprecated(format string, args ...any) {
 	prefix, suffix, txt := ParseBreaks(format)
 	if suffix == 0 {
 		suffix++
 	}
-	fmt.Fprintf(w, WrapString(BoldRed, "DEPRECATED", txt, prefix, suffix), args...)
+	fmt.Fprintf(os.Stderr, WrapString(BoldRed, "DEPRECATED", txt, prefix, suffix), args...)
 }
 
 // Error is a wrapper for fmt.Fprintf with a bold red "ERROR: " prefix.

--- a/pkg/text/text_test.go
+++ b/pkg/text/text_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -130,13 +131,6 @@ func TestPrefixes(t *testing.T) {
 		args   []any
 		want   string
 	}{
-		{
-			name:   "Deprecated",
-			f:      text.Deprecated,
-			format: "Test string %d.",
-			args:   []any{123},
-			want:   "DEPRECATED: Test string 123.\n",
-		},
 		{
 			name:   "Error",
 			f:      text.Error,
@@ -309,5 +303,30 @@ func TestParseBreaks(t *testing.T) {
 				t.Errorf("want: %s, have: %s", testcase.txt, txt)
 			}
 		})
+	}
+}
+
+func TestDeprecated(t *testing.T) {
+	// Save original stderr and create pipe to capture output
+	origStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	// Call Deprecated
+	text.Deprecated("Test warning message %d.", 123)
+
+	// Restore stderr and close writer
+	os.Stderr = origStderr
+	w.Close()
+
+	// Read captured output
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	// Verify output contains expected text
+	want := "DEPRECATED: Test warning message 123.\n"
+	if output != want {
+		t.Errorf("Deprecated output mismatch:\ngot:  %q\nwant: %q", output, want)
 	}
 }

--- a/pkg/text/text_test.go
+++ b/pkg/text/text_test.go
@@ -321,7 +321,9 @@ func TestDeprecated(t *testing.T) {
 
 	// Read captured output
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read from pipe: %v", err)
+	}
 	output := buf.String()
 
 	// Verify output contains expected text


### PR DESCRIPTION
### Change summary

Previously, the text.Deprecated() function wrote warnings to stdout (via the provided io.Writer parameter), which mixed warnings with actual command output. This made it difficult for users to redirect output cleanly or for tools to parse stdout.

Changes:
- Modified text.Deprecated() to write directly to os.Stderr
- Added TestDeprecated() to verify stderr output
- Updated test expectations to not check for deprecation messages in stdout

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

No more deprecation warnings in stdOut
