### PR TITLE
Improve "Dependabot Changelog" workflow

### DIFF
--- a/.github/workflows/dependabot_changelog_update.yml
+++ b/.github/workflows/dependabot_changelog_update.yml
@@ -2,26 +2,33 @@ name: Generate changelog entry for Dependabot
 
 on:
   pull_request:
+    # This job should only run when the PR is first opened, not when
+    # additional commits are pushed to its branch (which is done by
+    # this workflow, or by someone using the GitHub web interface
+    # 'Update Branch' button). Thus the 'types' list here contains
+    # only 'opened', and does not contain 'synchronize' or 'labeled'.
     types:
       - opened
-      - synchronize
-      - reopened
-permissions:
-  contents: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+
+# Jobs in this workflow which require GITHUB_TOKEN to have permissions
+# specify that at the job level.
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  dependabot-changelog-update:
-    name: Append changelog entry
+  check-labels:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write # add the Skip-Changelog label when the PR doesn't need an entry
+    outputs:
+      need_changelog_entry: ${{ steps.check.outputs.result == 'true' }}
     steps:
       - name: Check labels
-        id: check-labels
+        id: check
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -37,34 +44,36 @@ jobs:
             }
             return !skip;
           result-encoding: string
+
+  dependabot-changelog-update:
+    needs: check-labels
+    if: needs.check-labels.outputs.need_changelog_entry == 'true'
+    runs-on: ubuntu-latest
+    steps:
       - name: Generate a GitHub token
-        if: steps.check-labels.outputs.result == 'true'
         id: github-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: "cli"
+          repositories: ${{ github.repository }}
           permission-contents: write
-          permission-pull-requests: write
+
       - name: Checkout code
-        if: steps.check-labels.outputs.result == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.github-token.outputs.token }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: true
+
       - name: Generate changelog entry
-        if: steps.check-labels.outputs.result == 'true'
         uses: dangoslen/dependabot-changelog-helper@291c8cb629d7cd7b57ea065782c435ec2bedb138 # v4.3.0
         with:
           activationLabels: dependencies
           changelogPath: './CHANGELOG.md'
           entryPrefix: 'build(deps): '
+
       - name: Commit changelog entry
-        if: steps.check-labels.outputs.result == 'true'
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
-          commit_message: "docs(CHANGELOG.md): add dependency bump from dependabot"
+          commit_message: "docs(CHANGELOG.md): add dependency bump from Dependabot"


### PR DESCRIPTION
### Change summary

1. Ensure that it is only triggered when a PR is opened, not when the PR branch is updated or labels are added/removed on the PR.

2. Remove all permissions from GITHUB_TOKEN at the workflow level.

3. Eliminate hardcoded repository name in token-creation step, and removed unnecessary permission.

4. Remove unnecessary arguments supplied to the actions/checkout Action.

5. Corrected name of Dependabot in commit message.

6. Removed concurrency protection since the workflow will only run once per PR.

7. Split the workflow into 'check-labels' and 'dependabot-changelog-update' jobs, so the steps for making the changelog update don't all have to check the 'need changelog' status.

All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?
