### PR TITLE
Correct completion message in 'kv-store-entry delete'.

### DIFF
--- a/pkg/commands/kvstoreentry/delete.go
+++ b/pkg/commands/kvstoreentry/delete.go
@@ -247,6 +247,10 @@ func (c *DeleteCommand) DeleteMultipleKeys(out io.Writer, prefix string) error {
 		return fmt.Errorf("failed to stop spinner: %w", err)
 	}
 
-	text.Success(out, "\nDeleted all keys from KV Store '%s'", c.StoreID)
+	if prefix == "" {
+		text.Success(out, "\nDeleted all keys from KV Store '%s'", c.StoreID)
+	} else {
+		text.Success(out, "\nDeleted %s keys from KV Store '%s'", strconv.FormatUint(deleteCount.Load(), 10), c.StoreID)
+	}
 	return nil
 }


### PR DESCRIPTION
### Change summary

When 'kv-store-entry delete' is used to delete multiple keys matching a prefix, the completion message should indicate the number of keys that were deleted (not 'all').

All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?
