### PR TITLE
Add Dockerfile-go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements:
 
 - feat(kvstoreentry/delete): Add support for multiple-key deletion using a key prefix. ([#XXX](https://github.com/fastly/cli/pull/XXX))
+- build(dockerfile-go): add Go Dockerfile alongside the existing Node and Rust ones ([#XXX](https://github.com/fastly/cli/pull/1828))
 
 ### Dependencies:
 - build(deps): `github.com/nwaples/rardecode/v2` from 2.2.3 to 2.2.5 ([#1825](https://github.com/fastly/cli/pull/1825))

--- a/Dockerfile-go
+++ b/Dockerfile-go
@@ -1,0 +1,21 @@
+FROM golang:latest
+LABEL maintainer="Fastly OSS <oss@fastly.com>"
+
+RUN apt-get update && apt-get install -y curl jq && apt-get -y clean && rm -rf /var/lib/apt/lists/* \
+  && export FASTLY_CLI_VERSION=$(curl -s https://api.github.com/repos/fastly/cli/releases/latest | jq -r .tag_name | cut -d 'v' -f 2) \
+            GOARCH=$(dpkg --print-architecture) \
+  && curl -sL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_linux-$GOARCH.tar.gz" -o fastly.tar.gz \
+  && curl -sL "https://github.com/fastly/cli/releases/download/v${FASTLY_CLI_VERSION}/fastly_v${FASTLY_CLI_VERSION}_SHA256SUMS" -o sha256sums \
+  && dlsha=$(shasum -a 256 fastly.tar.gz | cut -d " " -f 1) && expected=$(cat sha256sums | awk -v pat="$dlsha" '$0~pat' | cut -d " " -f 1) \
+  && if [ "$dlsha" != "$expected" ]; then echo "shasums don't match" && exit 1; fi \
+  && tar -xzf fastly.tar.gz --directory /usr/bin && rm -f sha256sums fastly.tar.gz \
+  && useradd -ms /bin/bash fastly
+
+USER fastly
+
+WORKDIR /app
+ENTRYPOINT ["/usr/bin/fastly"]
+CMD ["--help"]
+
+# docker build -t fastly/cli/go . -f ./Dockerfile-go
+# docker run -v $PWD:/app -it -p 7676:7676 fastly/cli/go compute serve --addr="0.0.0.0:7676"


### PR DESCRIPTION
### Change summary

Adds a `Dockerfile-go` to the repo, mirroring the existing `Dockerfile-node` and `Dockerfile-rust` but based on the `golang:latest` image. Like the others, this is a convenience Dockerfile that users can build to get a container with the Fastly CLI installed.

Build/run usage is documented in comments at the bottom of the file:

```
docker build -t fastly/cli/go . -f ./Dockerfile-go
docker run -v $PWD:/app -it -p 7676:7676 fastly/cli/go compute serve --addr="0.0.0.0:7676"
```

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### User Impact

Adds a Go-based Dockerfile option alongside the existing Node and Rust ones for users who prefer to build their own Fastly CLI container. No impact on existing functionality or users.

### Are there any considerations that need to be addressed for release?

None. No breaking changes, and the image is not part of any build or release pipeline.