### PR TITLE
Accept SSO JWT audiences with or without a trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug Fixes:
 
-- fix(auth): accept SSO JWT audiences with or without a trailing slash when validating the Fastly API endpoint.
+- fix(auth): accept SSO JWT audiences with or without a trailing slash when validating the Fastly API endpoint. ([#1837](https://github.com/fastly/cli/pull/1837))
 
 ### Enhancements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes:
 
+- fix(auth): accept SSO JWT audiences with or without a trailing slash when validating the Fastly API endpoint.
+
 ### Enhancements:
 
 ### Dependencies:

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -283,8 +283,8 @@ func (s *Server) ValidateAndRetrieveAPIToken(accessToken string) (string, *APITo
 		return "", nil, errors.New("failed to extract aud from JWT claims")
 	}
 
-	if aud != s.APIEndpoint {
-		return "", nil, fmt.Errorf("failed to match expected aud: %s", s.APIEndpoint)
+	if err := validateAudienceClaim(aud, s.APIEndpoint); err != nil {
+		return "", nil, err
 	}
 
 	email, ok := claims["email"]
@@ -303,6 +303,24 @@ func (s *Server) ValidateAndRetrieveAPIToken(accessToken string) (string, *APITo
 		return "", nil, fmt.Errorf("failed to type assert 'email' (%#v) to a string", email)
 	}
 	return e, at, nil
+}
+
+func validateAudienceClaim(aud any, apiEndpoint string) error {
+	audString, ok := aud.(string)
+	if !ok {
+		return fmt.Errorf("failed to type assert 'aud' (%#v) to a string", aud)
+	}
+
+	if !audienceMatchesAPIEndpoint(audString, apiEndpoint) {
+		return fmt.Errorf("failed to match expected aud %q, got %q", apiEndpoint, audString)
+	}
+	return nil
+}
+
+func audienceMatchesAPIEndpoint(aud, apiEndpoint string) bool {
+	// The auth provider has returned audiences with and without a trailing slash
+	// for the same API endpoint. Accept either form for compatibility.
+	return strings.TrimSuffix(aud, "/") == strings.TrimSuffix(apiEndpoint, "/")
 }
 
 // VerifyJWTSignature calls the jwks_uri endpoint and extracts its claims.

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,100 @@
+package auth
+
+import "testing"
+
+func TestValidateAudienceClaim(t *testing.T) {
+	t.Parallel()
+
+	const apiEndpoint = "https://api.fastly.com"
+
+	tests := []struct {
+		name    string
+		aud     any
+		wantErr bool
+	}{
+		{
+			name: "exact match",
+			aud:  apiEndpoint,
+		},
+		{
+			name: "trailing slash match",
+			aud:  apiEndpoint + "/",
+		},
+		{
+			name:    "different audience",
+			aud:     "https://api.example.com/",
+			wantErr: true,
+		},
+		{
+			name:    "non string audience",
+			aud:     []string{apiEndpoint},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateAudienceClaim(tt.aud, apiEndpoint)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateAudienceClaim() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAudienceMatchesAPIEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		aud         string
+		apiEndpoint string
+		want        bool
+	}{
+		{
+			name:        "exact match without trailing slash",
+			aud:         "https://api.fastly.com",
+			apiEndpoint: "https://api.fastly.com",
+			want:        true,
+		},
+		{
+			name:        "audience trailing slash accepted",
+			aud:         "https://api.fastly.com/",
+			apiEndpoint: "https://api.fastly.com",
+			want:        true,
+		},
+		{
+			name:        "configured endpoint trailing slash accepted",
+			aud:         "https://api.fastly.com",
+			apiEndpoint: "https://api.fastly.com/",
+			want:        true,
+		},
+		{
+			name:        "double trailing slash rejected",
+			aud:         "https://api.fastly.com//",
+			apiEndpoint: "https://api.fastly.com",
+			want:        false,
+		},
+		{
+			name:        "different audience rejected",
+			aud:         "https://example.com/",
+			apiEndpoint: "https://api.fastly.com",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := audienceMatchesAPIEndpoint(tt.aud, tt.apiEndpoint)
+			if got != tt.want {
+				t.Fatalf("audienceMatchesAPIEndpoint(%q, %q) = %t, want %t", tt.aud, tt.apiEndpoint, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Change summary

Allow SSO JWT validation to accept Fastly API endpoint values with or without a single trailing slash.

All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls)
for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Test run:

```sh
go test ./pkg/auth
```

### User Impact

Avoid JWT tokens with an inconsistent identifier to be rejected.

### Are there any considerations that need to be addressed for release?

No breaking changes. This is a compatibility fix for JWT claim validation.