### PR TITLE
Support `--autoclone` when staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes:
 
+- fix(service-version): support autoclone when staging a service version. ([#1850](https://github.com/fastly/cli/pull/1850))
+
 ### Enhancements:
 
 ### Dependencies:

--- a/pkg/commands/service/version/serviceversion_test.go
+++ b/pkg/commands/service/version/serviceversion_test.go
@@ -323,6 +323,26 @@ func TestVersionStage(t *testing.T) {
 			WantError: "error parsing arguments: required flag --version not provided",
 		},
 		{
+			Name: "validate --autoclone stages a clone of an active version",
+			Args: "--service-id 123 --version 1 --autoclone",
+			API: &mock.API{
+				GetVersionFn:      testutil.GetVersion,
+				CloneVersionFn:    testutil.CloneVersionResult(4),
+				ActivateVersionFn: stageVersionOK,
+			},
+			WantOutput: "Staged service 123 version 4",
+		},
+		{
+			Name: "validate --autoclone stages a clone of a locked version",
+			Args: "--service-id 123 --version 2 --autoclone",
+			API: &mock.API{
+				GetVersionFn:      testutil.GetVersion,
+				CloneVersionFn:    testutil.CloneVersionResult(4),
+				ActivateVersionFn: stageVersionOK,
+			},
+			WantOutput: "Staged service 123 version 4",
+		},
+		{
 			Args: "--service-id 123 --version 3",
 			API: &mock.API{
 				GetVersionFn:      testutil.GetVersion,

--- a/pkg/commands/service/version/stage.go
+++ b/pkg/commands/service/version/stage.go
@@ -20,6 +20,7 @@ type StageCommand struct {
 	Input          fastly.ActivateVersionInput
 	serviceName    argparser.OptionalServiceNameID
 	serviceVersion argparser.OptionalServiceVersion
+	autoClone      argparser.OptionalAutoClone
 }
 
 // NewStageCommand returns a usable command registered under the parent.
@@ -45,6 +46,10 @@ func NewStageCommand(parent argparser.Registerer, g *global.Data) *StageCommand 
 		Dst:         &c.serviceVersion.Value,
 		Required:    true,
 	})
+	c.RegisterAutoCloneFlag(argparser.AutoCloneFlagOpts{
+		Action: c.autoClone.Set,
+		Dst:    &c.autoClone.Value,
+	})
 	return &c
 }
 
@@ -53,6 +58,7 @@ func (c *StageCommand) Exec(_ io.Reader, out io.Writer) error {
 	serviceID, serviceVersion, err := argparser.ServiceDetails(argparser.ServiceDetailsOpts{
 		Active:             optional.Of(false),
 		Locked:             optional.Of(false),
+		AutoCloneFlag:      c.autoClone,
 		APIClient:          c.Globals.APIClient,
 		Manifest:           *c.Globals.Manifest,
 		Out:                out,


### PR DESCRIPTION
### Change summary

Add `--autoclone` support to `fastly service version stage`.

The command already recommends `--autoclone` when the selected version is active or locked, but previously rejected the flag as invalid. This change aligns `stage` with `service version activate` by cloning the selected version before staging it.

Tests cover staging clones of both active and locked versions.


All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

The recommended suggestion is finally supported.

### Are there any considerations that need to be addressed for release?

No.