### PR TITLE
[CDTOOL-1144] Let profile accept service-limited tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Enhancements:
 
+- feat(profile): profiles can now be created and updated with service-limited tokens, which cannot access `/current_user` ([#1856](https://github.com/fastly/cli/pull/1856))
+
 ### Dependencies:
 - build(deps): `golang.org/x/crypto` from 0.53.0 to 0.54.0 ([#1847](https://github.com/fastly/cli/pull/1847))
 - build(deps): `github.com/bodgit/sevenzip` from 1.6.4 to 1.6.5 ([#1847](https://github.com/fastly/cli/pull/1847))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@
 
 - fix(service-version): support autoclone when staging a service version. ([#1850](https://github.com/fastly/cli/pull/1850))
 - fix(logging): the `placement` flag for all loggging commands can now be reset back to `null` by setting it's value to `""` when it was previously set to another value ([#1855](https://github.com/fastly/cli/pull/1855))
+- fix(profile): profiles can now be created and updated with service-limited tokens, which cannot access `/current_user` ([#1856](https://github.com/fastly/cli/pull/1856))
 
 ### Enhancements:
-
-- feat(profile): profiles can now be created and updated with service-limited tokens, which cannot access `/current_user` ([#1856](https://github.com/fastly/cli/pull/1856))
 
 ### Dependencies:
 - build(deps): `golang.org/x/crypto` from 0.53.0 to 0.54.0 ([#1847](https://github.com/fastly/cli/pull/1847))

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -643,7 +643,11 @@ func promptForAuth(data *global.Data) (string, lookup.Source, error) {
 		return "", lookup.SourceUndefined, err
 	}
 
-	text.Success(data.Output, "Authenticated as %s (token stored as %q)", md.Email, name)
+	if md.Email != "" {
+		text.Success(data.Output, "Authenticated as %s (token stored as %q)", md.Email, name)
+	} else {
+		text.Success(data.Output, "Authenticated (token stored as %q)", name)
+	}
 	text.Info(data.Output, "Token saved to %s", data.ConfigPath)
 	return token, lookup.SourceAuth, nil
 }

--- a/pkg/commands/auth/add.go
+++ b/pkg/commands/auth/add.go
@@ -36,7 +36,7 @@ func (c *AddCommand) Exec(_ io.Reader, out io.Writer) error {
 		return fmt.Errorf("token %q already exists; use 'fastly auth delete %s' first", c.name, c.name)
 	}
 
-	md, err := FetchTokenMetadataLenient(c.Globals, c.token)
+	md, err := FetchTokenMetadata(c.Globals, c.token)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/auth/login.go
+++ b/pkg/commands/auth/login.go
@@ -45,7 +45,11 @@ func (c *LoginCommand) Exec(in io.Reader, out io.Writer) error {
 		return err
 	}
 
-	text.Success(out, "Authenticated as %s (token stored as %q)", md.Email, name)
+	if md.Email != "" {
+		text.Success(out, "Authenticated as %s (token stored as %q)", md.Email, name)
+	} else {
+		text.Success(out, "Authenticated (token stored as %q)", name)
+	}
 	text.Info(out, "Token saved to %s", c.Globals.ConfigPath)
 	return nil
 }

--- a/pkg/commands/auth/metadata.go
+++ b/pkg/commands/auth/metadata.go
@@ -53,7 +53,7 @@ func FetchTokenMetadata(g *global.Data, token string) (*TokenMetadata, error) {
 	}
 
 	if !anyOK {
-		return nil, fmt.Errorf("token validation failed: neither /current_user nor /tokens/self responded successfully")
+		return nil, fmt.Errorf("token validation failed: neither /current_user nor /tokens/self responded successfully: %w", err)
 	}
 
 	return md, nil

--- a/pkg/commands/auth/metadata.go
+++ b/pkg/commands/auth/metadata.go
@@ -23,36 +23,13 @@ type TokenMetadata struct {
 	APITokenID        string
 }
 
-// FetchTokenMetadata validates a token by calling GetCurrentUser (required)
-// and GetTokenSelf (best-effort), returning metadata for storage.
+// FetchTokenMetadata validates a token by calling GetCurrentUser and
+// GetTokenSelf, returning metadata for storage.
+// Both calls are best-effort because scoped tokens may lack permission to
+// call /current_user, but at least one must succeed to confirm the token
+// is valid.
 // It constructs its own API client from the provided token string.
 func FetchTokenMetadata(g *global.Data, token string) (*TokenMetadata, error) {
-	endpoint, _ := g.APIEndpoint()
-	apiClient, err := g.APIClientFactory(token, endpoint, g.Flags.Debug)
-	if err != nil {
-		return nil, fmt.Errorf("error creating API client: %w", err)
-	}
-
-	user, err := apiClient.GetCurrentUser(context.TODO())
-	if err != nil {
-		return nil, fmt.Errorf("token validation failed (could not look up current user): %w", err)
-	}
-
-	md := &TokenMetadata{
-		Email:     fastly.ToValue(user.Login),
-		AccountID: fastly.ToValue(user.CustomerID),
-	}
-
-	fetchTokenSelf(g, apiClient, md)
-
-	return md, nil
-}
-
-// FetchTokenMetadataLenient is like FetchTokenMetadata but treats
-// GetCurrentUser as best-effort. Use this for scoped tokens that may lack
-// permission to call /current_user. At least one of GetCurrentUser or
-// GetTokenSelf must succeed to confirm the token is valid.
-func FetchTokenMetadataLenient(g *global.Data, token string) (*TokenMetadata, error) {
 	endpoint, _ := g.APIEndpoint()
 	apiClient, err := g.APIClientFactory(token, endpoint, g.Flags.Debug)
 	if err != nil {

--- a/pkg/commands/auth/metadata_test.go
+++ b/pkg/commands/auth/metadata_test.go
@@ -462,6 +462,12 @@ func TestAuthAddScopedToken(t *testing.T) {
 				},
 			},
 			WantError: "token validation failed: neither /current_user nor /tokens/self responded successfully",
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
+				t.Helper()
+				if opts.Config.GetAuthToken("bad-token") != nil {
+					t.Error("expected token not to be saved when validation fails")
+				}
+			},
 		},
 		{
 			Name: "add without name gives friendly error for scoped token",

--- a/pkg/commands/auth/metadata_test.go
+++ b/pkg/commands/auth/metadata_test.go
@@ -208,6 +208,30 @@ func TestAuthLogin(t *testing.T) {
 			},
 		},
 		{
+			Name: "login succeeds with a service-limited token",
+			Args: "login",
+			API: &mock.API{
+				GetCurrentUserFn: func(_ context.Context) (*fastly.User, error) {
+					return nil, fmt.Errorf("403 Forbidden")
+				},
+				GetTokenSelfFn: testTokenSelfFull,
+			},
+			Stdin: []string{
+				"my-login-token",
+			},
+			WantOutputs: []string{`Authenticated (token stored as "my-api-token")`, "Token saved to"},
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
+				t.Helper()
+				at := opts.Config.GetAuthToken("my-api-token")
+				if at == nil {
+					t.Fatal("expected auth token 'my-api-token' to exist")
+				}
+				if at.Email != "" {
+					t.Errorf("want empty email for service-limited token, got %s", at.Email)
+				}
+			},
+		},
+		{
 			Name: "login falls back to default when API token has no name",
 			Args: "login",
 			API: &mock.API{

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -105,7 +105,7 @@ func (c *CreateCommand) staticTokenFlow(makeDefault bool, in io.Reader, out io.W
 
 	var md *authcmd.TokenMetadata
 	err = spinner.Process("Validating token", func(_ *text.SpinnerWrapper) error {
-		md, err = authcmd.FetchTokenMetadata(c.Globals, token)
+		md, err = authcmd.FetchTokenMetadataLenient(c.Globals, token)
 		return err
 	})
 	if err != nil {

--- a/pkg/commands/profile/create.go
+++ b/pkg/commands/profile/create.go
@@ -105,7 +105,7 @@ func (c *CreateCommand) staticTokenFlow(makeDefault bool, in io.Reader, out io.W
 
 	var md *authcmd.TokenMetadata
 	err = spinner.Process("Validating token", func(_ *text.SpinnerWrapper) error {
-		md, err = authcmd.FetchTokenMetadataLenient(c.Globals, token)
+		md, err = authcmd.FetchTokenMetadata(c.Globals, token)
 		return err
 	})
 	if err != nil {

--- a/pkg/commands/profile/list.go
+++ b/pkg/commands/profile/list.go
@@ -73,7 +73,9 @@ func display(name string, at *config.AuthToken, isDefault bool, out io.Writer, s
 	text.Output(out, style(name))
 	text.Break(out)
 	text.Output(out, "%s: %t", style("Default"), isDefault)
-	text.Output(out, "%s: %s", style("Email"), at.Email)
+	if at.Email != "" {
+		text.Output(out, "%s: %s", style("Email"), at.Email)
+	}
 	text.Output(out, "%s: %s", style("Token"), at.Token)
 	isSSO := at.Type == config.AuthTokenTypeSSO
 	text.Output(out, "%s: %t", style("SSO"), isSSO)

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -11,8 +11,10 @@ import (
 
 	root "github.com/fastly/cli/pkg/commands/profile"
 	"github.com/fastly/cli/pkg/config"
+	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
+	"github.com/fastly/cli/pkg/threadsafe"
 	fsttime "github.com/fastly/cli/pkg/time"
 )
 
@@ -72,6 +74,19 @@ func TestProfileCreate(t *testing.T) {
 			WantOutputs: []string{
 				"Validating token",
 				"Profile 'foo' created",
+			},
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
+				t.Helper()
+				at := opts.Config.GetAuthToken("foo")
+				if at == nil {
+					t.Fatal("expected auth token 'foo' to exist")
+				}
+				if at.Email != "" {
+					t.Errorf("want empty email for service-limited token, got %s", at.Email)
+				}
+				if at.APITokenName != "Foo" {
+					t.Errorf("want APITokenName Foo, got %s", at.APITokenName)
+				}
 			},
 		},
 		{
@@ -733,6 +748,64 @@ func TestProfileUpdate(t *testing.T) {
 				"y", // we set the profile to be the default
 			},
 			WantOutput: "Profile 'bar' updated",
+		},
+		{
+			Name: "validate updating profile works with a service-limited token",
+			Args: "bar",
+			API: &mock.API{
+				GetCurrentUserFn: func(_ context.Context) (*fastly.User, error) {
+					return nil, fmt.Errorf("unauthorized")
+				},
+				GetTokenSelfFn: getToken,
+			},
+			Env: &testutil.EnvConfig{
+				Opts: &testutil.EnvOpts{
+					Copy: []testutil.FileIO{
+						{
+							Src: filepath.Join("testdata", "config.toml"),
+							Dst: "config.toml",
+						},
+					},
+				},
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
+					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
+				},
+			},
+			ConfigFile: &config.File{
+				Auth: config.Auth{
+					Default: "foo",
+					Tokens: config.AuthTokens{
+						"foo": &config.AuthToken{
+							Type:  config.AuthTokenTypeStatic,
+							Token: "123",
+							Email: "foo@example.com",
+						},
+						"bar": &config.AuthToken{
+							Type:  config.AuthTokenTypeStatic,
+							Token: "456",
+							Email: "bar@example.com",
+						},
+					},
+				},
+			},
+			Stdin: []string{
+				"scoped_token",
+				"y",
+			},
+			WantOutput: "Profile 'bar' updated",
+			Validator: func(t *testing.T, _ *testutil.CLIScenario, opts *global.Data, _ *threadsafe.Buffer) {
+				t.Helper()
+				at := opts.Config.GetAuthToken("bar")
+				if at == nil {
+					t.Fatal("expected auth token 'bar' to exist")
+				}
+				if at.Token != "scoped_token" {
+					t.Errorf("want token scoped_token, got %s", at.Token)
+				}
+				if at.Email != "" {
+					t.Errorf("want empty email for service-limited token, got %s", at.Email)
+				}
+			},
 		},
 	}
 

--- a/pkg/commands/profile/profile_test.go
+++ b/pkg/commands/profile/profile_test.go
@@ -47,6 +47,34 @@ func TestProfileCreate(t *testing.T) {
 			},
 		},
 		{
+			Name: "validate profile creation works with a service-limited token",
+			Args: "foo",
+			API: &mock.API{
+				GetCurrentUserFn: func(_ context.Context) (*fastly.User, error) {
+					return nil, fmt.Errorf("unauthorized")
+				},
+				GetTokenSelfFn: getToken,
+			},
+			Stdin: []string{"some_token"},
+			Env: &testutil.EnvConfig{
+				Opts: &testutil.EnvOpts{
+					Copy: []testutil.FileIO{
+						{
+							Src: filepath.Join("testdata", "config.toml"),
+							Dst: "config.toml",
+						},
+					},
+				},
+				EditScenario: func(scenario *testutil.CLIScenario, rootdir string) {
+					scenario.ConfigPath = filepath.Join(rootdir, "config.toml")
+				},
+			},
+			WantOutputs: []string{
+				"Validating token",
+				"Profile 'foo' created",
+			},
+		},
+		{
 			Name: "validate profile duplication",
 			Args: "foo",
 			Env: &testutil.EnvConfig{


### PR DESCRIPTION
### Change summary

`fastly profile create`, `profile update` and `auth login` validate a static token by looking up the current user, but that endpoint was recently made unavailable to service-limited tokens (a recent change), so these commands failed even with a valid token.

Fix that: tokens are now accepted as long as either `/current_user` or `/tokens/self` succeeds.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

No behavior change for full-access tokens. Profiles created from a service-limited token won't display an email or account ID, but this is expected.

### Are there any considerations that need to be addressed for release?

None. No breaking changes, no config format change.