### PR TITLE
build(deps): ignore go-msix >= 1.0.0 in Dependabot tools updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
     ignore:
       # go-msix v1.0.0 has a breaking API change incompatible with the
       # nfpm v2.47.0 in use by goreleaser; held at v0.3.1 until that's resolved.
+      # pending commit for nfpm: https://github.com/goreleaser/nfpm/commit/ce81cb6
       - dependency-name: "go.digitalxero.dev/go-msix"
         versions: [">= 1.0.0"]
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
       go-dependencies:
         patterns:
           - "*"
+    ignore:
+      # go-msix v1.0.0 has a breaking API change incompatible with the
+      # nfpm v2.47.0 in use by goreleaser; held at v0.3.1 until that's resolved.
+      - dependency-name: "go.digitalxero.dev/go-msix"
+        versions: [">= 1.0.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Change summary

`go-msix` v1.0.0 introduced a breaking API change that `nfpm` v2.47.0 (pinned by `goreleaser` v2.17.0) isn't compatible with yet, breaking the `goreleaser` tools build. `nfpm` merged a fix on main but hasn't cut a release with it. Add a durable ignore rule instead of a one-off manual pin so Dependabot stops proposing this bump on every scan.
All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR addresses the failing CI in https://github.com/fastly/cli/pull/1859. 

