### PR TITLE
add cooldowns for all dependencies except go-fastly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "github.com/fastly/go-fastly/*"
     allow:
       - dependency-type: "all"
     groups:
@@ -14,6 +18,8 @@ updates:
     directory: "/tools"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: "all"
     labels:
@@ -32,6 +38,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "github_actions"
     groups:


### PR DESCRIPTION
### Change summary

fix security warnings requiring cooldowns on dependabot, except go-fastly which we want to get picked up ASAP and we trust updates from

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?
