### PR TITLE
fix(app): order help sections consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes:
 
+- fix(app): display global flags after command-specific sections in help output.
 - fix(service-version): support autoclone when staging a service version. ([#1850](https://github.com/fastly/cli/pull/1850))
 - fix(logging): the `placement` flag for all loggging commands can now be reset back to `null` by setting it's value to `""` when it was previously set to another value ([#1855](https://github.com/fastly/cli/pull/1855))
 - fix(profile): profiles can now be created and updated with service-limited tokens, which cannot access `/current_user` ([#1856](https://github.com/fastly/cli/pull/1856))

--- a/pkg/app/usage.go
+++ b/pkg/app/usage.go
@@ -97,10 +97,6 @@ var CompactUsageTemplate = `{{define "FormatCommand" -}}
 {{T "OPTIONAL FLAGS"|Bold}}
 {{.Context.Flags|OptionalFlags|FlagsToTwoColumns|FormatTwoColumns}}
 {{end -}}
-{{if .Context.Flags|GlobalFlags -}}
-{{T "GLOBAL FLAGS"|Bold}}
-{{.Context.Flags|GlobalFlags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end -}}
 {{if .Context.Args -}}
 {{T "ARGS"|Bold}}
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
@@ -114,6 +110,10 @@ var CompactUsageTemplate = `{{define "FormatCommand" -}}
 {{else if .App.Commands -}}
 {{T "COMMANDS"|Bold}}
 {{.App.Commands|CommandsToTwoColumns|FormatTwoColumns}}
+{{end -}}
+{{if .Context.Flags|GlobalFlags -}}
+{{T "GLOBAL FLAGS"|Bold}}
+{{.Context.Flags|GlobalFlags|FlagsToTwoColumns|FormatTwoColumns}}
 {{end -}}
 ` + authGuideTemplate + `
 {{T "SEE ALSO"|Bold}}
@@ -213,11 +213,7 @@ const VerboseUsageTemplate = `{{define "FormatCommands" -}}
 {{else}}
 {{- T "USAGE"|Bold}}
   {{template "FormatUsage" .App -}}
-{{end -}}
-{{if .Context.Flags|GlobalFlags }}
-{{T "GLOBAL FLAGS"|Bold}}
-{{.Context.Flags|GlobalFlags|FlagsToTwoColumns|FormatTwoColumns}}
-{{end -}}
+{{end}}
 {{if .Context.Args -}}
 {{T "ARGS"|Bold}}
 {{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
@@ -230,6 +226,10 @@ const VerboseUsageTemplate = `{{define "FormatCommands" -}}
 {{else if .App.Commands -}}
 {{T "COMMANDS"|Bold -}}
   {{template "FormatCommands" .App}}
+{{end -}}
+{{if .Context.Flags|GlobalFlags }}
+{{T "GLOBAL FLAGS"|Bold}}
+{{.Context.Flags|GlobalFlags|FlagsToTwoColumns|FormatTwoColumns}}
 {{end -}}
 ` + authGuideTemplate + `
 {{T "SEE ALSO"|Bold}}

--- a/pkg/app/usage_section_order_test.go
+++ b/pkg/app/usage_section_order_test.go
@@ -1,0 +1,83 @@
+package app_test
+
+import (
+	"bytes"
+	stderrors "errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/fastly/cli/pkg/app"
+	"github.com/fastly/cli/pkg/errors"
+	"github.com/fastly/cli/pkg/global"
+	"github.com/fastly/cli/pkg/testutil"
+)
+
+func TestHelpSectionOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		sections []string
+	}{
+		{
+			name:     "compact category help",
+			args:     "service --help",
+			sections: []string{"USAGE", "COMMANDS", "GLOBAL FLAGS", "SEE ALSO"},
+		},
+		{
+			name:     "compact root help",
+			args:     "--help",
+			sections: []string{"USAGE", "COMMANDS", "GLOBAL FLAGS", "SEE ALSO"},
+		},
+		{
+			name:     "verbose category help",
+			args:     "help service",
+			sections: []string{"USAGE", "SUBCOMMANDS", "GLOBAL FLAGS", "SEE ALSO"},
+		},
+		{
+			name:     "verbose root help",
+			args:     "help",
+			sections: []string{"USAGE", "COMMANDS", "GLOBAL FLAGS", "SEE ALSO"},
+		},
+		{
+			name:     "compact leaf help",
+			args:     "compute publish --help",
+			sections: []string{"USAGE", "OPTIONAL FLAGS", "GLOBAL FLAGS", "SEE ALSO"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			args := testutil.SplitArgs(tt.args)
+
+			previousInit := app.Init
+			app.Init = func(_ []string, _ io.Reader) (*global.Data, error) {
+				return testutil.MockGlobalData(args, &stdout), nil
+			}
+			t.Cleanup(func() {
+				app.Init = previousInit
+			})
+
+			err := app.Run(args, nil)
+
+			var remediation errors.RemediationError
+			if !stderrors.As(err, &remediation) {
+				t.Fatalf("expected help output in a remediation error, got %v", err)
+			}
+
+			output := remediation.Prefix + stdout.String()
+			previousIndex := -1
+			for _, section := range tt.sections {
+				index := strings.Index(output, section)
+				if index < 0 {
+					t.Fatalf("missing section %q:\n%s", section, output)
+				}
+				if index <= previousIndex {
+					t.Fatalf("sections not in order %v:\n%s", tt.sections, output)
+				}
+				previousIndex = index
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Change summary

Fixes #1656.

This makes the help hierarchy consistent by displaying command-specific
sections before shared global flags:

- compact help now shows required/optional flags, arguments, and commands
  before global flags;
- verbose help now shows arguments and subcommands/commands before global
  flags;
- the auth guide and See Also footer remain after global flags.

The change only reorders the existing text templates. Flag classification,
command definitions, and JSON help output are unchanged.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Testing

- `GOTOOLCHAIN=go1.25.7 go test -race -run '^TestHelpSectionOrder$' -count=50 ./pkg/app`
- `GOTOOLCHAIN=go1.25.7 go test -race -shuffle=on -count=10 ./pkg/app`
- `GOTOOLCHAIN=go1.25.7 make all`

### User Impact

Users see the same command-specific-first ordering in compact and verbose help,
while all existing help content remains available.

### Are there any considerations that need to be addressed for release?

No breaking changes or special release steps.
