### PR TITLE
fix(service-version): honor service ID fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes:
 
+- fix(service-version): use FASTLY_SERVICE_ID and fastly.toml fallbacks when validating a service version.
 - fix(service-version): support autoclone when staging a service version. ([#1850](https://github.com/fastly/cli/pull/1850))
 - fix(logging): the `placement` flag for all loggging commands can now be reset back to `null` by setting it's value to `""` when it was previously set to another value ([#1855](https://github.com/fastly/cli/pull/1855))
 - fix(profile): profiles can now be created and updated with service-limited tokens, which cannot access `/current_user` ([#1856](https://github.com/fastly/cli/pull/1856))

--- a/pkg/commands/service/version/serviceversion_test.go
+++ b/pkg/commands/service/version/serviceversion_test.go
@@ -10,6 +10,7 @@ import (
 
 	root "github.com/fastly/cli/pkg/commands/service"
 	sub "github.com/fastly/cli/pkg/commands/service/version"
+	"github.com/fastly/cli/pkg/global"
 	"github.com/fastly/cli/pkg/mock"
 	"github.com/fastly/cli/pkg/testutil"
 )
@@ -564,14 +565,48 @@ func lockVersionError(_ context.Context, _ *fastly.LockVersionInput) (*fastly.Ve
 func TestVersionValidate(t *testing.T) {
 	scenarios := []testutil.CLIScenario{
 		{
-			Name:      "validate missing --service-id flag",
+			Name:      "validate missing service ID",
 			Args:      "--version 1",
-			WantError: "error parsing arguments: required flag --service-id not provided",
+			EnvVars:   map[string]string{"FASTLY_SERVICE_ID": ""},
+			WantError: "error reading service: no service ID found",
 		},
 		{
 			Name:      "validate missing --version flag",
 			Args:      "--service-id 123",
 			WantError: "error parsing arguments: required flag --version not provided",
+		},
+		{
+			Name:    "validate service ID from environment",
+			Args:    "--version latest",
+			EnvVars: map[string]string{"FASTLY_SERVICE_ID": "env-service"},
+			API: &mock.API{
+				ListVersionsFn:    testutil.ListVersions,
+				ValidateVersionFn: validateVersionForService("env-service", 4),
+			},
+			WantOutput: "Service env-service version 4 is valid",
+		},
+		{
+			Name:    "validate service ID from manifest",
+			Args:    "--version 1",
+			EnvVars: map[string]string{"FASTLY_SERVICE_ID": ""},
+			Setup: func(_ *testing.T, _ *testutil.CLIScenario, opts *global.Data) {
+				opts.Manifest.File.ServiceID = "manifest-service"
+			},
+			API: &mock.API{
+				GetVersionFn:      testutil.GetVersion,
+				ValidateVersionFn: validateVersionForService("manifest-service", 1),
+			},
+			WantOutput: "Service manifest-service version 1 is valid",
+		},
+		{
+			Name:    "validate explicit service ID overrides environment",
+			Args:    "--service-id flag-service --version 1",
+			EnvVars: map[string]string{"FASTLY_SERVICE_ID": "env-service"},
+			API: &mock.API{
+				GetVersionFn:      testutil.GetVersion,
+				ValidateVersionFn: validateVersionForService("flag-service", 1),
+			},
+			WantOutput: "Service flag-service version 1 is valid",
 		},
 		{
 			Name: "validate successful - valid version without message",
@@ -644,6 +679,19 @@ func TestVersionValidate(t *testing.T) {
 func validateVersionValid(message string) func(context.Context, *fastly.ValidateVersionInput) (bool, string, error) {
 	return func(_ context.Context, _ *fastly.ValidateVersionInput) (bool, string, error) {
 		return true, message, nil
+	}
+}
+
+func validateVersionForService(serviceID string, serviceVersion int) func(context.Context, *fastly.ValidateVersionInput) (bool, string, error) {
+	return func(_ context.Context, input *fastly.ValidateVersionInput) (bool, string, error) {
+		if input.ServiceID != serviceID || input.ServiceVersion != serviceVersion {
+			return false, "", fmt.Errorf(
+				"unexpected validate input: service ID %q, version %d",
+				input.ServiceID,
+				input.ServiceVersion,
+			)
+		}
+		return true, "", nil
 	}
 }
 

--- a/pkg/commands/service/version/validate.go
+++ b/pkg/commands/service/version/validate.go
@@ -35,7 +35,6 @@ func NewValidateCommand(parent argparser.Registerer, g *global.Data) *ValidateCo
 		Description: argparser.FlagServiceIDDesc,
 		Dst:         &g.Manifest.Flag.ServiceID,
 		Short:       's',
-		Required:    true,
 	})
 	c.RegisterFlag(argparser.StringFlagOpts{
 		Name:        argparser.FlagVersionName,


### PR DESCRIPTION
### Change summary

Fixes #1866.

`fastly service version validate` currently marks `--service-id` as a parser-level required flag, so argument parsing rejects calls that rely on `FASTLY_SERVICE_ID` or the `service_id` in `fastly.toml`. The command's execution path already uses `ServiceDetails`, which implements the CLI's existing `--service-id` > environment > manifest precedence.

This removes only the premature required constraint, keeps `--version` required, and adds regression coverage for environment, manifest, explicit-flag precedence, `latest`, and the all-sources-missing error path. It also adds the corresponding Unreleased changelog entry.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Local validation: `make all`, including race-enabled repository tests, golangci-lint, Semgrep, build, and install.

### User Impact

Users can validate a service version without repeating `--service-id` when the service is already configured through `FASTLY_SERVICE_ID` or `fastly.toml`. If no service ID source exists, the command now reaches the existing actionable `no service ID found` error. Explicit flags continue to take precedence.

### Are there any considerations that need to be addressed for release?

No breaking changes. The behavior aligns `service version validate` with the CLI's existing service-ID resolution path and is covered by an Unreleased bug-fix changelog entry.
