### PR TITLE
fix: Correctly resolve staged version parameter

### DIFF
--- a/pkg/argparser/flags.go
+++ b/pkg/argparser/flags.go
@@ -174,19 +174,19 @@ func (sv *OptionalServiceVersion) Parse(sid string, client api.Interface) (*fast
 		})
 		return vs[0], nil
 	case "staged":
-		serviceDetails, err := client.GetServiceDetails(context.TODO(), &fastly.GetServiceDetailsInput{
+		// Find staged version by listing all versions and searching for staging=true.
+		vs, err := client.ListVersions(context.TODO(), &fastly.ListVersionsInput{
 			ServiceID: sid,
-			Filters: []fastly.ServiceDetailsFilter{
-				{Key: "versions.staged", Value: true},
-			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error getting service details: %w", err)
+			return nil, fmt.Errorf("error listing service versions: %w", err)
 		}
-		if serviceDetails.Version == nil {
-			return nil, fmt.Errorf("no staged service version found")
+		for _, v := range vs {
+			if fastly.ToValue(v.Staging) {
+				return v, nil
+			}
 		}
-		return serviceDetails.Version, nil
+		return nil, fmt.Errorf("no staged service version found")
 	default:
 		return nil, fmt.Errorf("invalid version value %q: must be a version number, \"latest\", \"active\", or \"staged\"", sv.Value)
 	}

--- a/pkg/argparser/flags_test.go
+++ b/pkg/argparser/flags_test.go
@@ -17,6 +17,58 @@ import (
 	"github.com/fastly/cli/pkg/testutil"
 )
 
+// TestOptionalServiceVersionParseStagedVersionNotLatest validates that the staged version is correctly
+// identified even when the latest version number is higher. Tests that the code correctly filters for
+// staging=true rather than relying on version ordering.
+func TestOptionalServiceVersionParseStagedVersionNotLatest(t *testing.T) {
+	sv := &argparser.OptionalServiceVersion{
+		OptionalString: argparser.OptionalString{
+			Optional: argparser.Optional{WasSet: true},
+			Value:    "staged",
+		},
+	}
+
+	// Mock API that returns versions where latest (850) != staged (849)
+	v, err := sv.Parse("123", mock.API{
+		ListVersionsFn: func(_ context.Context, i *fastly.ListVersionsInput) ([]*fastly.Version, error) {
+			return []*fastly.Version{
+				{
+					ServiceID: fastly.ToPointer(i.ServiceID),
+					Number:    fastly.ToPointer(850),
+					Staging:   fastly.ToPointer(false),
+					UpdatedAt: testutil.MustParseTimeRFC3339("2026-07-31T14:28:00Z"),
+				},
+				{
+					ServiceID: fastly.ToPointer(i.ServiceID),
+					Number:    fastly.ToPointer(849),
+					Staging:   fastly.ToPointer(true),
+					UpdatedAt: testutil.MustParseTimeRFC3339("2026-06-23T10:23:00Z"),
+				},
+				{
+					ServiceID: fastly.ToPointer(i.ServiceID),
+					Number:    fastly.ToPointer(847),
+					Active:    fastly.ToPointer(true),
+					UpdatedAt: testutil.MustParseTimeRFC3339("2026-01-28T04:24:00Z"),
+				},
+			}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should return version 849 (staged), not 850 (latest)
+	want := 849
+	have := fastly.ToValue(v.Number)
+	if have != want {
+		t.Errorf("wanted %d, have %d", want, have)
+	}
+	if !fastly.ToValue(v.Staging) {
+		t.Errorf("returned version should have staging=true, got %v", fastly.ToValue(v.Staging))
+	}
+}
+
 func TestOptionalServiceVersionParse(t *testing.T) {
 	cases := map[string]struct {
 		flagValue   string


### PR DESCRIPTION
### Change summary

- Use ListVersions to find staged version instead of unsupported filter
- Add test for when latest ≠ staged version

This ensures that `--version staged` returns the actual staged version.

All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [X] Does your submission pass tests?

### Changes to Core Features:

* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### User Impact

This ensures that `--version staged` returns the actual staged version.

### Are there any considerations that need to be addressed for release?

This changes behaviour, but makes it correct.
