### PR TITLE
[CDTOOL-1707] add Python starter kit to the static config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes:
 
+- fix(compute): add Python starter kit to the static config ([#1877](https://github.com/fastly/cli/pull/1877))
+
 ### Enhancements:
 
 - feat(audit-log): add event-mapping command group ([#1875](https://github.com/fastly/cli/pull/1875))

--- a/pkg/commands/compute/language_test.go
+++ b/pkg/commands/compute/language_test.go
@@ -1,0 +1,40 @@
+package compute_test
+
+import (
+	"testing"
+
+	toml "github.com/pelletier/go-toml"
+
+	"github.com/fastly/cli/pkg/commands/compute"
+	"github.com/fastly/cli/pkg/config"
+)
+
+// TestStaticConfigStarterKits validates that every language the CLI offers at
+// the `compute init` prompt has at least one starter kit in the static config
+// embedded into the binary.
+//
+// The starter kits are injected into the static config at build time by
+// ./scripts/config.sh, which holds its own hardcoded list of starter kit
+// repositories. Adding a language without also updating that list leaves users
+// of the new language unable to init a project (see CDTOOL-1707), and this test
+// is here to catch that drift.
+//
+// NOTE: The static config is generated, not committed, so run `make config`
+// before running this test locally.
+func TestStaticConfigStarterKits(t *testing.T) {
+	var f config.File
+	if err := toml.Unmarshal(config.Static, &f); err != nil {
+		t.Fatalf("failed to unmarshal the static config: %s", err)
+	}
+
+	for _, language := range compute.NewLanguages(f.StarterKits) {
+		// The 'other' language is for users bringing their own Wasm binary and so
+		// has no starter kits by design.
+		if language.Name == "other" {
+			continue
+		}
+		if len(language.StarterKits) == 0 {
+			t.Errorf("no starter kits found in the static config for language %q: add its starter kit repositories to the 'kits' list in ./scripts/config.sh", language.Name)
+		}
+	}
+}

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -21,6 +21,7 @@ kits=(
 	compute-starter-kit-typescript
 	compute-starter-kit-cpp-default
 	compute-starter-kit-cpp-empty
+	compute-starter-kit-python-default
 )
 
 function parse() {


### PR DESCRIPTION
### Change summary

Fixes [CDTOOL-1707](https://fastly.atlassian.net/browse/CDTOOL-1707).

`fastly compute init --language python` reports that no starter kits exist:

```
$ fastly compute init --language python --non-interactive
ERROR: no default starter kits configured for this language; please specify a template using the --from flag.
```

Interactively it prints _"No default starter kits are currently configured for this language"_ and falls back to prompting for a template git URL.

The starter kits embedded into the CLI binary are injected into `pkg/config/config.toml` at build time by [`./scripts/config.sh`](https://github.com/fastly/cli/blob/main/scripts/config.sh), which holds its own hardcoded list of starter kit repositories. Python language support (#1811) added `[language.python]` to `.fastly/config.toml` and wired Python into `NewLanguages()`, but never added `compute-starter-kit-python-default` to that list — so `kits.Python` is empty and `PromptForStarterKit` takes its "no kits" branch. `[language.python]` is present, so `compute build` is unaffected; the gap is only starter kits.

This adds the repository to the list, plus a test asserting that every language offered at the `compute init` prompt has at least one starter kit in the static config, so the same drift is caught for the next language we add. CI generates the config with `make config` before running tests, so the test runs against the real generated config.

**Depends on fastly/compute-starter-kit-python-default#6**, which gives the kit a human-readable `name` in its `fastly.toml`. `config.sh` copies that field verbatim into the config, so until it merges the prompt renders `[1] fastly-compute-python-app` rather than `[1] Default starter for Python`. Nothing needs re-landing here once it merges — the config is regenerated on each build — but this PR should not be released before that one.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified end-to-end after `make config`:

```
$ fastly compute init --language python --non-interactive
...
SUCCESS: Initialized package proj
```

### User Impact

Python users can init a project from the default starter kit instead of having to supply `--from` or paste a git URL.

### Are there any considerations that need to be addressed for release?

No breaking changes and no `config_version` bump needed — `NeedsUpdating` already rewrites local configs when the CLI version changes, so existing users pick the new kit up on their next upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CDTOOL-1707]: https://fastly.atlassian.net/browse/CDTOOL-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
