### PR TITLE
(dep): bump go-fastly to v17.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - build(deps): `github.com/pierrec/lz4/v4` from 4.1.28 to 4.1.29 ([#1894](https://github.com/fastly/cli/pull/1894))
 - build(deps): `golang.org/x/net` from 0.57.0 to 0.58.0 ([#1894](https://github.com/fastly/cli/pull/1894))
 - build(deps): `github.com/nwaples/rardecode/v2` from 2.3.0 to 2.4.1 ([#1898](https://github.com/fastly/cli/pull/1898))
+- build(deps): `github.com/fastly/go-fastly` from 17.3.0 to 17.3.1 ([#1902](https://github.com/fastly/cli/pull/1902))
 
 ## [v16.0.0](https://github.com/fastly/cli/releases/tag/v16.0.0) (2026-08-13)
 

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 require (
 	4d63.com/optional v0.2.0
 	github.com/creack/pty v1.1.24
-	github.com/fastly/go-fastly/v17 v17.3.0
+	github.com/fastly/go-fastly/v17 v17.3.1
 	github.com/mholt/archives v0.1.5
 	github.com/mitchellh/go-ps v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:aYo8nnk3ojoQkP5iErif5Xxv0Mo0Ga/FR5+ffl/7+Nk=
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
-github.com/fastly/go-fastly/v17 v17.3.0 h1:P7MHxDojzyabx9wiAbThdtcpR5pFvAY0EwOrxbJPMJA=
-github.com/fastly/go-fastly/v17 v17.3.0/go.mod h1:YaQlSdPx/t754skYTbN6Q7qdQDdgKI2h4Que3leveY8=
+github.com/fastly/go-fastly/v17 v17.3.1 h1:FMe+2EDqT9Wu9D3ub6Y/z9HTnGUE15PfAe4Bt3HGs/o=
+github.com/fastly/go-fastly/v17 v17.3.1/go.mod h1:34DSOyjc75GVdZ2lRinyEJ173pZfAe/L7dkk0bXMuA8=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible h1:FhrXlfhgGCS+uc6YwyiFUt04alnjpoX7vgDKJxS6Qbk=
 github.com/fastly/kingpin v2.1.12-0.20191105091915-95d230a53780+incompatible/go.mod h1:U8UynVoU1SQaqD2I4ZqgYd5lx3A1ipQYn4aSt2Y5h6c=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
### Change summary

This PR bumps `go-fastly` from `v17.3.0` to `v17.3.1`. 

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/cli/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
